### PR TITLE
Prost spike

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,8 +252,6 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde-json-wasm 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -941,9 +939,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "serde"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "serde-bench"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,15 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "bytes"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "c2-chacha"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,6 +249,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "cosmwasm"
 version = "0.4.1"
 dependencies = [
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-json-wasm 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -435,6 +447,7 @@ name = "failure"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -516,6 +529,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "iovec"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "itertools"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -721,6 +750,28 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "prost"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1336,6 +1387,7 @@ dependencies = [
 "checksum block-padding 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6d4dc3af3ee2e12f3e5d224e5e1e3d73668abbeb69e566d361f7d5563a4fdf09"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
+"checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
 "checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
 "checksum cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)" = "0213d356d3c4ea2c18c40b037c3be23cd639825c18f25ee670ac7813beeef99c"
 "checksum cexpr 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a7fa24eb00d5ffab90eaeaf1092ac85c04c64aaf358ea6f84505b8116d24c6af"
@@ -1377,6 +1429,8 @@ dependencies = [
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 "checksum indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712d7b3ea5827fcb9d4fda14bf4da5f136f0db2ae9c8f4bd4e2d1c6fde4e6db2"
+"checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
+"checksum itertools 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "87fa75c9dea7b07be3138c49abbb83fd4bea199b5cdc76f9804458edc5da0d6e"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
@@ -1403,6 +1457,8 @@ dependencies = [
 "checksum proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)" = "ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
+"checksum prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96d14b1c185652833d24aaad41c5832b0be5616a590227c1fbff57c616754b23"
+"checksum prost-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5e7dc378b94ac374644181a2247cebf59a6ec1c88b49ac77f3a94b86b79d0e11"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,6 @@ members = [ "lib/vm" ]
 exclude = [ "contracts/hackatom" ]
 
 [dependencies]
-serde-json-wasm = "0.1.1"
-serde = { version = "1.0.60", default-features = false, features = ["derive", "alloc"] }
 snafu = { version = "0.5.0", default-features = false, features = ["rust_1_30"] }
 prost = "0.5.0"
 prost-derive = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ exclude = [ "contracts/hackatom" ]
 serde-json-wasm = "0.1.1"
 serde = { version = "1.0.60", default-features = false, features = ["derive", "alloc"] }
 snafu = { version = "0.5.0", default-features = false, features = ["rust_1_30"] }
+prost = "0.5.0"
+prost-derive = "0.5.0"
+bytes = "0.4.2"
 
 [features]
 backtraces = ["snafu/backtraces"]

--- a/contracts/hackatom/Cargo.lock
+++ b/contracts/hackatom/Cargo.lock
@@ -153,6 +153,15 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "bytes"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "c2-chacha"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,8 +254,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "cosmwasm"
 version = "0.4.1"
 dependencies = [
- "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde-json-wasm 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -261,10 +271,10 @@ dependencies = [
  "serde-json-wasm 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmer-clif-backend 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmer-middleware-common 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmer-runtime 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmer-runtime-core 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmer-singlepass-backend 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -373,30 +383,6 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "dynasm"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "dynasmrt"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "memmap 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "either"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,6 +423,7 @@ name = "failure"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -488,9 +475,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "hackatom"
 version = "0.4.1"
 dependencies = [
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "cosmwasm 0.4.1",
  "cosmwasm-vm 0.4.1",
- "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.52 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -524,6 +513,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "iovec"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "itertools"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -590,15 +595,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memmap"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "memmap"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -652,14 +648,6 @@ dependencies = [
 name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "owning_ref"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "page_size"
@@ -729,6 +717,28 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "prost"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -890,9 +900,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "serde"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "serde-bench"
@@ -981,11 +988,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "stable_deref_trait"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1020,11 +1022,6 @@ dependencies = [
  "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "take_mut"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "target-lexicon"
@@ -1246,22 +1243,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmer-singlepass-backend"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "dynasm 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "dynasmrt 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
- "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmer-runtime-core 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmparser 0.39.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "wasmer-win-exception-handler"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1352,6 +1333,7 @@ dependencies = [
 "checksum bumpalo 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad807f2fc2bf185eeb98ff3a901bd46dc5ad58163d0fa4577ba0d25674d71708"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
+"checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
 "checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
 "checksum cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)" = "0213d356d3c4ea2c18c40b037c3be23cd639825c18f25ee670ac7813beeef99c"
 "checksum cexpr 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a7fa24eb00d5ffab90eaeaf1092ac85c04c64aaf358ea6f84505b8116d24c6af"
@@ -1375,8 +1357,6 @@ dependencies = [
 "checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 "checksum doc-comment 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "923dea538cea0aa3025e8685b20d6ee21ef99c4f77e954a30febbaac5ec73a97"
-"checksum dynasm 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f36d49ab6f8ecc642d2c6ee10fda04ba68003ef0277300866745cdde160e6b40"
-"checksum dynasmrt 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a4c408a211e7f5762829f5e46bdff0c14bc3b1517a21a4bb781c716bf88b0c68"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 "checksum errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2a071601ed01b988f896ab14b95e67335d1eeb50190932a1320f7fe3cadc84e"
@@ -1392,6 +1372,8 @@ dependencies = [
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 "checksum indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712d7b3ea5827fcb9d4fda14bf4da5f136f0db2ae9c8f4bd4e2d1c6fde4e6db2"
+"checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
+"checksum itertools 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "87fa75c9dea7b07be3138c49abbb83fd4bea199b5cdc76f9804458edc5da0d6e"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
@@ -1401,7 +1383,6 @@ dependencies = [
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum lru 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0e542a8a0a1309ceed0614dbb910658c118f4ff40b0ed31a1bf77a869a5a1853"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
-"checksum memmap 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e2ffa2c986de11a9df78620c01eeaaf27d94d3ff02bf81bfcca953102dd0c6ff"
 "checksum memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
 "checksum memoffset 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ce6075db033bbbb7ee5a0bbd3a3186bbae616f57fb001c485c7ff77955f8177f"
 "checksum nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3b2e0b4f3320ed72aaedb9a5ac838690a8047c7b275da22711fddff4f8a14229"
@@ -1409,7 +1390,6 @@ dependencies = [
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 "checksum num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"
 "checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
-"checksum owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
 "checksum page_size 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f89ef58b3d32420dbd1a43d2f38ae92f6239ef12bb556ab09ca55445f5a67242"
 "checksum parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 "checksum parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
@@ -1418,6 +1398,8 @@ dependencies = [
 "checksum proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)" = "ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
+"checksum prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96d14b1c185652833d24aaad41c5832b0be5616a590227c1fbff57c616754b23"
+"checksum prost-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5e7dc378b94ac374644181a2247cebf59a6ec1c88b49ac77f3a94b86b79d0e11"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
@@ -1449,12 +1431,10 @@ dependencies = [
 "checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
 "checksum snafu 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9d0bf93d08d6a44363b47d737f1f5bebbf5e6a1eaaa3d4c128ceeaca6b718292"
 "checksum snafu-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "624e94bd38e471f67883b467711e7a7ad7dbe284f5fb7e661dc8a671fc5b26a0"
-"checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 "checksum syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"
 "checksum synstructure 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f085a5855930c0441ca1288cf044ea4aecf4f43a91668abdb870b4ba546a203"
-"checksum take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 "checksum target-lexicon 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7975cb2c6f37d77b190bc5004a2bb015971464756fde9514651a525ada2a741a"
 "checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
@@ -1478,7 +1458,6 @@ dependencies = [
 "checksum wasmer-middleware-common 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5af520a6781d6561bfb2be6d451ac290664996021053e8f061b5f75085ff0520"
 "checksum wasmer-runtime 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c4b1312944941d659634a65e0376fe2af62951af15443c8b7959cfcb0236bae0"
 "checksum wasmer-runtime-core 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "25ae12db70ebb4c15afacadaaa8b14d6583e5e7ca21323cf785627b8499e3add"
-"checksum wasmer-singlepass-backend 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f60d77696e80e6d5baf58fc9d6a6affcc308f296caab065cada53ec70b72d221"
 "checksum wasmer-win-exception-handler 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1e84b6f4fb0bd59a3db906c99aa956d5022e7fdb8e34570dbb904cca36f5a3"
 "checksum wasmparser 0.39.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e5083b449454f7de0b15f131eee17de54b5a71dcb9adcf11df2b2f78fad0cd82"
 "checksum which 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "240a31163872f7e8e49f35b42b58485e35355b07eb009d9f3686733541339a69"

--- a/contracts/hackatom/Cargo.toml
+++ b/contracts/hackatom/Cargo.toml
@@ -27,10 +27,12 @@ backtraces = [ "cosmwasm/backtraces", "cosmwasm-vm/backtraces" ]
 
 [dependencies]
 cosmwasm = { path = "../..", version = "0.4.1" }
-serde = { version = "1.0.60", default-features = false, features = ["derive"] }
+prost = "0.5.0"
+prost-derive = "0.5.0"
+bytes = "0.4.2"
 snafu = { version = "0.5.0", default-features = false, features = ["rust_1_30"] }
 # needed for wasm-pack build process
 wasm-bindgen = "0.2"
 
 [dev-dependencies]
-cosmwasm-vm = { path = "../../lib/vm", version = "0.4.0" }
+cosmwasm-vm = { path = "../../lib/vm", version = "0.4.0", default-features = false, features = ["default-cranelift"] }

--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -36,7 +36,7 @@ pub fn init<T: Storage>(store: &mut T, params: Params, msg: Vec<u8>) -> Result<R
         &to_vec(&State {
             verifier: msg.verifier,
             beneficiary: msg.beneficiary,
-            funder: params.message.unwrap().signer,
+            funder: params.message.signer,
         })
         .context(SerializeErr {})?,
     );
@@ -49,13 +49,12 @@ pub fn handle<T: Storage>(store: &mut T, params: Params, _: Vec<u8>) -> Result<R
     })?;
     let state: State = from_slice(&data).context(ParseErr {})?;
 
-    if params.message.unwrap().signer == state.verifier {
-        let contract = params.contract.unwrap();
+    if params.message.signer == state.verifier {
         let res = Response {
             messages: vec![Msg{msg: Some(CosmosMsg::Send(SendMsg {
-                from_address: contract.address,
+                from_address: params.contract.address,
                 to_address: state.beneficiary,
-                amount: contract.balance,
+                amount: params.contract.balance,
             }))}],
             log: Some("released funds!".to_string()),
             data: None,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -10,13 +10,13 @@ pub enum Error {
     },
     #[snafu(display("Parse error: {}", source))]
     ParseErr {
-        source: serde_json_wasm::de::Error,
+        source: prost::DecodeError,
         #[cfg(feature = "backtraces")]
         backtrace: snafu::Backtrace,
     },
     #[snafu(display("Serialize error: {}", source))]
     SerializeErr {
-        source: serde_json_wasm::ser::Error,
+        source: prost::EncodeError,
         #[cfg(feature = "backtraces")]
         backtrace: snafu::Backtrace,
     },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,6 @@ pub mod imports;
 pub mod errors;
 pub mod memory;
 pub mod mock;
-pub mod serde;
+pub mod prost;
 pub mod storage;
 pub mod types;

--- a/src/prost.rs
+++ b/src/prost.rs
@@ -1,0 +1,11 @@
+use prost::{DecodeError, EncodeError, Message};
+
+pub fn from_slice<T: Message + Default>(data: &[u8]) -> Result<T, DecodeError> {
+    T::decode(data)
+}
+
+pub fn to_vec<T: Message + Default>(obj: &T) -> Result<Vec<u8>, EncodeError> {
+    let mut buf = Vec::<u8>::new();
+    obj.encode(&mut buf)?;
+    Ok(buf)
+}

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,5 +1,0 @@
-// This file simply re-exports some methods from serde_json
-// The reason is two fold:
-// 1. To easily ensure that all calling libraries use the same version (minimize code size)
-// 2. To allow us to switch out to eg. serde-json-core more easily
-pub use serde_json_wasm::{from_slice, to_vec};

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,6 @@
 use prost_derive::{Message};
 
-#[derive(Message, PartialEq, Clone)]
+#[derive(Message)]
 pub struct Params {
     #[prost(message, optional, tag="1")]
     pub block: Option<BlockInfo>,
@@ -10,7 +10,7 @@ pub struct Params {
     pub contract: Option<ContractInfo>,
 }
 
-#[derive(Message, PartialEq, Clone)]
+#[derive(Message)]
 pub struct BlockInfo {
     #[prost(int64, tag="1")]
     pub height: i64,
@@ -21,7 +21,7 @@ pub struct BlockInfo {
     pub chain_id: String,
 }
 
-#[derive(Message, PartialEq, Clone)]
+#[derive(Message)]
 pub struct MessageInfo {
     #[prost(string, tag="1")]
     pub signer: String,
@@ -29,7 +29,7 @@ pub struct MessageInfo {
     pub sent_funds: Vec<Coin>,
 }
 
-#[derive(Message, PartialEq, Clone)]
+#[derive(Message)]
 pub struct ContractInfo {
     #[prost(string, tag="1")]
     pub address: String,
@@ -37,7 +37,7 @@ pub struct ContractInfo {
     pub balance: Vec<Coin>,
 }
 
-#[derive(Message, PartialEq, Clone)]
+#[derive(Message, Clone)]
 pub struct Coin {
     #[prost(string, tag="1")]
     pub denom: String,
@@ -45,13 +45,13 @@ pub struct Coin {
     pub amount: String,
 }
 
-#[derive(Message, PartialEq, Clone)]
+#[derive(Message)]
 pub struct Msg {
     #[prost(oneof = "CosmosMsg", tags = "1, 2, 3")]
     pub msg: Option<CosmosMsg>,
 }
 
-#[derive(prost::Oneof, Clone, PartialEq)]
+#[derive(prost::Oneof)]
 pub enum CosmosMsg {
     #[prost(message, tag = "1")]
     Send(SendMsg),
@@ -62,7 +62,7 @@ pub enum CosmosMsg {
 }
 
 // this moves tokens in the underlying sdk
-#[derive(Message, PartialEq, Clone)]
+#[derive(Message)]
 pub struct SendMsg {
     #[prost(string, tag="1")]
     pub from_address: String,
@@ -73,7 +73,7 @@ pub struct SendMsg {
 }
 // this dispatches a call to another contract at a known address (with known ABI)
 // msg is the json-encoded HandleMsg struct
-#[derive(Message, PartialEq, Clone)]
+#[derive(Message)]
 pub struct ContractMsg {
     #[prost(string, tag="1")]
     pub contract_addr: String,
@@ -81,20 +81,20 @@ pub struct ContractMsg {
     pub msg: String,
 }
 // this should never be created here, just passed in from the user and later dispatched
-#[derive(Message, PartialEq, Clone)]
+#[derive(Message)]
 pub struct OpaqueMsg {
     #[prost(string, tag="1")]
     pub data: String,
 }
 
-#[derive(Message, PartialEq, Clone)]
+#[derive(Message)]
 pub struct ContractResult {
     #[prost(oneof = "Result", tags = "1, 2")]
     pub res: Option<Result>,
 }
 
 
-#[derive(prost::Oneof, Clone, PartialEq)]
+#[derive(prost::Oneof)]
 pub enum Result {
     #[prost(message, tag = "1")]
     Ok(Response),
@@ -119,7 +119,7 @@ impl ContractResult {
     }
 }
 
-#[derive(Message, PartialEq, Clone)]
+#[derive(Message)]
 pub struct Response {
     // let's make the positive case a struct, it contrains Msg: {...}, but also Data, Log, maybe later Events, etc.
     #[prost(message, repeated, tag="1")]
@@ -168,9 +168,9 @@ mod test {
         let fail = ContractResult{res: Some(Result::Err("foobar".to_string()))};
         let bin = to_vec(&fail).expect("encode contract result");
         println!("error: {}", std::str::from_utf8(&bin).unwrap());
-        let back: ContractResult = from_slice(&bin).expect("decode contract result");
+        let _: ContractResult = from_slice(&bin).expect("decode contract result");
         // need Derive Debug and PartialEq for this, removed to save space
-        assert_eq!(fail, back);
+//        assert_eq!(fail, back);
     }
 
     #[test]
@@ -186,8 +186,8 @@ mod test {
         }))};
         let bin = to_vec(&send).expect("encode contract result");
         println!("ok: {}", std::str::from_utf8(&bin).unwrap());
-        let back: ContractResult = from_slice(&bin).expect("decode contract result");
+        let _: ContractResult = from_slice(&bin).expect("decode contract result");
         // need Derive Debug and PartialEq for this, removed to save space
-        assert_eq!(send, back);
+//        assert_eq!(send, back);
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -90,7 +90,7 @@ pub struct OpaqueMsg {
 #[derive(Message, PartialEq, Clone)]
 pub struct ContractResult {
     #[prost(oneof = "Result", tags = "1, 2")]
-    pub msg: Option<Result>,
+    pub res: Option<Result>,
 }
 
 
@@ -105,14 +105,14 @@ pub enum Result {
 impl ContractResult {
     // unwrap will panic on err, or give us the real data useful for tests
     pub fn unwrap(self) -> Response {
-        match self.msg.unwrap() {
+        match self.res.unwrap() {
             Result::Err(msg) => panic!("Unexpected error: {}", msg),
             Result::Ok(res) => res,
         }
     }
 
     pub fn is_err(&self) -> bool {
-        match self.msg.as_ref().unwrap() {
+        match self.res.as_ref().unwrap() {
             Result::Err(_) => true,
             _ => false,
         }
@@ -165,7 +165,7 @@ mod test {
 
     #[test]
     fn can_deser_error_result() {
-        let fail = ContractResult{msg: Some(Result::Err("foobar".to_string()))};
+        let fail = ContractResult{res: Some(Result::Err("foobar".to_string()))};
         let bin = to_vec(&fail).expect("encode contract result");
         println!("error: {}", std::str::from_utf8(&bin).unwrap());
         let back: ContractResult = from_slice(&bin).expect("decode contract result");
@@ -175,7 +175,7 @@ mod test {
 
     #[test]
     fn can_deser_ok_result() {
-        let send = ContractResult{msg: Some(Result::Ok(Response {
+        let send = ContractResult{res: Some(Result::Ok(Response {
             messages: vec![Msg{msg: Some(CosmosMsg::Send(SendMsg {
                 from_address: "me".to_string(),
                 to_address: "you".to_string(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -65,26 +65,26 @@ pub enum CosmosMsg {
 #[derive(Message, PartialEq, Clone)]
 pub struct SendMsg {
     #[prost(string, tag="1")]
-    from_address: String,
+    pub from_address: String,
     #[prost(string, tag="2")]
-    to_address: String,
+    pub to_address: String,
     #[prost(message, repeated, tag="3")]
-    amount: Vec<Coin>,
+    pub amount: Vec<Coin>,
 }
 // this dispatches a call to another contract at a known address (with known ABI)
 // msg is the json-encoded HandleMsg struct
 #[derive(Message, PartialEq, Clone)]
 pub struct ContractMsg {
     #[prost(string, tag="1")]
-    contract_addr: String,
+    pub contract_addr: String,
     #[prost(string, tag="2")]
-    msg: String,
+    pub msg: String,
 }
 // this should never be created here, just passed in from the user and later dispatched
 #[derive(Message, PartialEq, Clone)]
 pub struct OpaqueMsg {
     #[prost(string, tag="1")]
-    data: String,
+    pub data: String,
 }
 
 #[derive(Message, PartialEq, Clone)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,6 @@
 use prost_derive::{Message};
 
-#[derive(Message)]
+#[derive(Message, PartialEq, Clone)]
 pub struct Params {
     #[prost(message, optional, tag="1")]
     pub block: Option<BlockInfo>,
@@ -10,7 +10,7 @@ pub struct Params {
     pub contract: Option<ContractInfo>,
 }
 
-#[derive(Message)]
+#[derive(Message, PartialEq, Clone)]
 pub struct BlockInfo {
     #[prost(int64, tag="1")]
     pub height: i64,
@@ -21,7 +21,7 @@ pub struct BlockInfo {
     pub chain_id: String,
 }
 
-#[derive(Message)]
+#[derive(Message, PartialEq, Clone)]
 pub struct MessageInfo {
     #[prost(string, tag="1")]
     pub signer: String,
@@ -29,7 +29,7 @@ pub struct MessageInfo {
     pub sent_funds: Vec<Coin>,
 }
 
-#[derive(Message)]
+#[derive(Message, PartialEq, Clone)]
 pub struct ContractInfo {
     #[prost(string, tag="1")]
     pub address: String,
@@ -37,7 +37,7 @@ pub struct ContractInfo {
     pub balance: Vec<Coin>,
 }
 
-#[derive(Message, Clone)]
+#[derive(Message, PartialEq, Clone)]
 pub struct Coin {
     #[prost(string, tag="1")]
     pub denom: String,
@@ -45,13 +45,13 @@ pub struct Coin {
     pub amount: String,
 }
 
-#[derive(Message)]
+#[derive(Message, PartialEq, Clone)]
 pub struct Msg {
     #[prost(oneof = "CosmosMsg", tags = "1, 2, 3")]
     pub msg: Option<CosmosMsg>,
 }
 
-#[derive(prost::Oneof)]
+#[derive(prost::Oneof, Clone, PartialEq)]
 pub enum CosmosMsg {
     #[prost(message, tag = "1")]
     Send(SendMsg),
@@ -62,7 +62,7 @@ pub enum CosmosMsg {
 }
 
 // this moves tokens in the underlying sdk
-#[derive(Message)]
+#[derive(Message, PartialEq, Clone)]
 pub struct SendMsg {
     #[prost(string, tag="1")]
     pub from_address: String,
@@ -73,7 +73,7 @@ pub struct SendMsg {
 }
 // this dispatches a call to another contract at a known address (with known ABI)
 // msg is the json-encoded HandleMsg struct
-#[derive(Message)]
+#[derive(Message, PartialEq, Clone)]
 pub struct ContractMsg {
     #[prost(string, tag="1")]
     pub contract_addr: String,
@@ -81,20 +81,20 @@ pub struct ContractMsg {
     pub msg: String,
 }
 // this should never be created here, just passed in from the user and later dispatched
-#[derive(Message)]
+#[derive(Message, PartialEq, Clone)]
 pub struct OpaqueMsg {
     #[prost(string, tag="1")]
     pub data: String,
 }
 
-#[derive(Message)]
+#[derive(Message, PartialEq, Clone)]
 pub struct ContractResult {
     #[prost(oneof = "Result", tags = "1, 2")]
     pub res: Option<Result>,
 }
 
 
-#[derive(prost::Oneof)]
+#[derive(prost::Oneof, Clone, PartialEq)]
 pub enum Result {
     #[prost(message, tag = "1")]
     Ok(Response),
@@ -119,7 +119,7 @@ impl ContractResult {
     }
 }
 
-#[derive(Message)]
+#[derive(Message, PartialEq, Clone)]
 pub struct Response {
     // let's make the positive case a struct, it contrains Msg: {...}, but also Data, Log, maybe later Events, etc.
     #[prost(message, repeated, tag="1")]
@@ -168,9 +168,9 @@ mod test {
         let fail = ContractResult{res: Some(Result::Err("foobar".to_string()))};
         let bin = to_vec(&fail).expect("encode contract result");
         println!("error: {}", std::str::from_utf8(&bin).unwrap());
-        let _: ContractResult = from_slice(&bin).expect("decode contract result");
+        let back: ContractResult = from_slice(&bin).expect("decode contract result");
         // need Derive Debug and PartialEq for this, removed to save space
-//        assert_eq!(fail, back);
+        assert_eq!(fail, back);
     }
 
     #[test]
@@ -186,8 +186,8 @@ mod test {
         }))};
         let bin = to_vec(&send).expect("encode contract result");
         println!("ok: {}", std::str::from_utf8(&bin).unwrap());
-        let _: ContractResult = from_slice(&bin).expect("decode contract result");
+        let back: ContractResult = from_slice(&bin).expect("decode contract result");
         // need Derive Debug and PartialEq for this, removed to save space
-//        assert_eq!(send, back);
+        assert_eq!(send, back);
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,12 +2,12 @@ use prost_derive::{Message};
 
 #[derive(Message, PartialEq, Clone)]
 pub struct Params {
-    #[prost(message, optional, tag="1")]
-    pub block: Option<BlockInfo>,
-    #[prost(message, optional, tag="2")]
-    pub message: Option<MessageInfo>,
-    #[prost(message, optional, tag="3")]
-    pub contract: Option<ContractInfo>,
+    #[prost(message, required, tag="1")]
+    pub block: BlockInfo,
+    #[prost(message, required, tag="2")]
+    pub message: MessageInfo,
+    #[prost(message, required, tag="3")]
+    pub contract: ContractInfo,
 }
 
 #[derive(Message, PartialEq, Clone)]
@@ -134,19 +134,19 @@ pub struct Response {
 // this is intended for use in testcode only
 pub fn mock_params(signer: &str, sent: &[Coin], balance: &[Coin]) -> Params {
     Params {
-        block: Some(BlockInfo {
+        block: BlockInfo {
             height: 12_345,
             time: 1_571_797_419,
             chain_id: "cosmos-testnet-14002".to_string(),
-        }),
-        message: Some(MessageInfo {
+        },
+        message: MessageInfo {
             signer: signer.to_string(),
             sent_funds: sent.to_vec(),
-        }),
-        contract: Some(ContractInfo {
+        },
+        contract: ContractInfo {
             address: "cosmos2contract".to_string(),
             balance: balance.to_vec(),
-        }),
+        },
     }
 }
 


### PR DESCRIPTION
This is a short spike related to #52 

So far, got `cosmwasm` to compile to wasm and pass tests using prost instead of serde.
Then got `contracts/hackatom` to compile to wasm (tests a WIP, need updates to lib/vm).

First build results were: 61kB vs 48kB with serde. 

Doesn't seem to be a space winner... this one can go on the icebox