### PR TITLE
Fix schema type of Binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # CHANGELOG
 
-## (not yet released)
+## 0.7.2 (not yet released)
+
+**cosmwasm**
+
+- Fix JSON schema type of `Binary` from int array (wrong) to string (right).
 
 ## 0.7.1 (2020-03-11)
 

--- a/contracts/hackatom/schema/state.json
+++ b/contracts/hackatom/schema/state.json
@@ -20,12 +20,7 @@
   },
   "definitions": {
     "Binary": {
-      "type": "array",
-      "items": {
-        "type": "integer",
-        "format": "uint8",
-        "minimum": 0.0
-      }
+      "type": "string"
     },
     "CanonicalAddr": {
       "$ref": "#/definitions/Binary"

--- a/packages/std/schema/contract_result.json
+++ b/packages/std/schema/contract_result.json
@@ -27,12 +27,7 @@
   ],
   "definitions": {
     "Binary": {
-      "type": "array",
-      "items": {
-        "type": "integer",
-        "format": "uint8",
-        "minimum": 0.0
-      }
+      "type": "string"
     },
     "Coin": {
       "type": "object",

--- a/packages/std/schema/cosmos_msg.json
+++ b/packages/std/schema/cosmos_msg.json
@@ -87,12 +87,7 @@
   ],
   "definitions": {
     "Binary": {
-      "type": "array",
-      "items": {
-        "type": "integer",
-        "format": "uint8",
-        "minimum": 0.0
-      }
+      "type": "string"
     },
     "Coin": {
       "type": "object",

--- a/packages/std/schema/env.json
+++ b/packages/std/schema/env.json
@@ -20,12 +20,7 @@
   },
   "definitions": {
     "Binary": {
-      "type": "array",
-      "items": {
-        "type": "integer",
-        "format": "uint8",
-        "minimum": 0.0
-      }
+      "type": "string"
     },
     "BlockInfo": {
       "type": "object",

--- a/packages/std/schema/query_result.json
+++ b/packages/std/schema/query_result.json
@@ -27,12 +27,7 @@
   ],
   "definitions": {
     "Binary": {
-      "type": "array",
-      "items": {
-        "type": "integer",
-        "format": "uint8",
-        "minimum": 0.0
-      }
+      "type": "string"
     },
     "Coin": {
       "type": "object",

--- a/packages/std/src/encoding.rs
+++ b/packages/std/src/encoding.rs
@@ -11,7 +11,7 @@ use crate::errors::{Base64Err, Result};
 ///
 /// This is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>
 #[derive(Clone, Default, Debug, PartialEq, JsonSchema)]
-pub struct Binary(pub Vec<u8>);
+pub struct Binary(#[schemars(with = "String")] pub Vec<u8>);
 
 impl Binary {
     /// take an (untrusted) string and decode it into bytes.


### PR DESCRIPTION
It turned out that the mask contract has a wrong schema. The source of the problem is that `Binary` is serialized as string but schemars did not know about that. With this patch we let schemars know how `Binary` is serialized.

This is the same approach that [is documented here](https://graham.cool/schemars/examples/7-custom_serialization/): using custom serde serialization and then telling schemars about it.