### PR TITLE
Add some more std CI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,11 +27,11 @@ jobs:
           keys:
             - cargocache-std-rust:1.40.0-{{ checksum "Cargo.lock" }}
       - run:
-          name: Build standard library
+          name: Build library for native target
           working_directory: ~/project/packages/std
           command: cargo build --locked
       - run:
-          name: Run standard library tests
+          name: Run unit tests
           working_directory: ~/project/packages/std
           command: cargo test --locked
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,19 @@ jobs:
           name: Run unit tests
           working_directory: ~/project/packages/std
           command: cargo test --locked
+      - run:
+          name: Build and run schema generator
+          working_directory: ~/project/packages/std
+          command: cargo schema --locked
+      - run:
+          name: Ensure schemas are up-to-date
+          command: |
+            CHANGES_IN_REPO=$(git status --porcelain)
+            if [[ -n "$CHANGES_IN_REPO" ]]; then
+              echo "Repository is dirty. Showing 'git status' and 'git --no-pager diff' for debugging now:"
+              git status && git --no-pager diff
+              exit 1
+            fi
       - save_cache:
           paths:
             - /usr/local/cargo/registry

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,9 @@ jobs:
           keys:
             - cargocache-std-rust:1.40.0-{{ checksum "Cargo.lock" }}
       - run:
+          name: Add wasm32 target
+          command: rustup target add wasm32-unknown-unknown && rustup target list --installed
+      - run:
           name: Build library for native target
           working_directory: ~/project/packages/std
           command: cargo build --locked

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,10 @@ jobs:
           working_directory: ~/project/packages/std
           command: cargo build --locked
       - run:
+          name: Build library for wasm target
+          working_directory: ~/project/packages/std
+          command: cargo wasm --locked
+      - run:
           name: Run unit tests
           working_directory: ~/project/packages/std
           command: cargo test --locked

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,10 +134,7 @@ jobs:
             - cargocache-hackatom-rust:1.40.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Add wasm32 target
-          command: rustup target add wasm32-unknown-unknown
-      - run:
-          name: Show targets
-          command: rustup target list --installed
+          command: rustup target add wasm32-unknown-unknown && rustup target list --installed
       - run:
           name: Build wasm binary
           command: cargo wasm --locked
@@ -175,10 +172,7 @@ jobs:
             - cargocache-hackatom_in_singlepass_vm-rust:nightly-{{ checksum "Cargo.lock" }}
       - run:
           name: Add wasm32 target
-          command: rustup target add wasm32-unknown-unknown
-      - run:
-          name: Show targets
-          command: rustup target list --installed
+          command: rustup target add wasm32-unknown-unknown && rustup target list --installed
       - run:
           name: Build wasm binary
           command: cargo wasm --locked

--- a/packages/std/.cargo/config
+++ b/packages/std/.cargo/config
@@ -1,2 +1,3 @@
 [alias]
+wasm = "build --release --target wasm32-unknown-unknown"
 schema = "run --example schema"


### PR DESCRIPTION
Before, a syntactically correct but unavailable call like `i_dont_exist();` in `src/{imports,exports}.rs` was not detected in the `std` CI job.

This also ensures schema generation is correct.