### PR TITLE
Export all symbols directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 0.8.0 (not yet released)
+
+**cosmwasm**
+
+- Make all symbols from `cosmwasm::memory` crate internal, as those symbols are
+  not needed by users of the library.
+
 ## 0.7.2 (2020-03-23)
 
 **cosmwasm**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Make all symbols from `cosmwasm::memory` crate internal, as those symbols are
   not needed by users of the library.
+- Export all symbols at top level (e.g.
+  `use cosmwasm::traits::{Api, Storage};` + `use cosmwasm::encoding::Binary;`
+  becomes `use cosmwasm::{Api, Binary, Storage};`).
 
 ## 0.7.2 (2020-03-23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,12 @@
 
 - Make all symbols from `cosmwasm::memory` crate internal, as those symbols are
   not needed by users of the library.
-- Export all symbols at top level (e.g.
+- Rename `cosmwasm::mock::dependencies` -> `cosmwasm::mock::mock_dependencies`
+  to differentiate between testing and production `External`.
+- Export all symbols from `cosmwasm::mock` as the new non-wasm32 module
+  `cosmwasm::testing`. Export all remaining symbols at top level (e.g.
   `use cosmwasm::traits::{Api, Storage};` + `use cosmwasm::encoding::Binary;`
   becomes `use cosmwasm::{Api, Binary, Storage};`).
-- Rename `cosmwasm::dependencies` -> `cosmwasm::mock_dependencies` to
-  differentiate between testing and production `External`.
 
 ## 0.7.2 (2020-03-23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Export all symbols at top level (e.g.
   `use cosmwasm::traits::{Api, Storage};` + `use cosmwasm::encoding::Binary;`
   becomes `use cosmwasm::{Api, Binary, Storage};`).
+- Rename `cosmwasm::dependencies` -> `cosmwasm::mock_dependencies` to
+  differentiate between testing and production `External`.
 
 ## 0.7.2 (2020-03-23)
 

--- a/README.md
+++ b/README.md
@@ -114,8 +114,10 @@ the offset and length of some Wasm memory, to allow for safe access between the
 caller and the contract:
 
 ```rust
-/// Refers to some heap allocated data in wasm.
-/// A pointer to this can be returned over ffi boundaries.
+/// Refers to some heap allocated data in Wasm.
+/// A pointer to an instance of this can be returned over FFI boundaries.
+///
+/// This struct is crate internal since the VM defined the same type independently.
 #[repr(C)]
 pub struct Region {
     pub offset: u32,

--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -150,11 +150,11 @@ fn query_verifier<S: Storage, A: Api>(deps: &Extern<S, A>) -> Result<Vec<u8>> {
 mod tests {
     use super::*;
     // import trait ReadonlyStorage to get access to read
-    use cosmwasm::{coin, dependencies, mock_env, transactional_deps, ReadonlyStorage};
+    use cosmwasm::{coin, mock_dependencies, mock_env, transactional_deps, ReadonlyStorage};
 
     #[test]
     fn proper_initialization() {
-        let mut deps = dependencies(20);
+        let mut deps = mock_dependencies(20);
 
         let verifier = HumanAddr(String::from("verifies"));
         let beneficiary = HumanAddr(String::from("benefits"));
@@ -181,7 +181,7 @@ mod tests {
 
     #[test]
     fn init_and_query() {
-        let mut deps = dependencies(20);
+        let mut deps = mock_dependencies(20);
 
         let verifier = HumanAddr(String::from("verifies"));
         let beneficiary = HumanAddr(String::from("benefits"));
@@ -202,7 +202,7 @@ mod tests {
 
     #[test]
     fn checkpointing_works_on_contract() {
-        let mut deps = dependencies(20);
+        let mut deps = mock_dependencies(20);
 
         let verifier = HumanAddr(String::from("verifies"));
         let beneficiary = HumanAddr(String::from("benefits"));
@@ -234,7 +234,7 @@ mod tests {
 
     #[test]
     fn proper_handle() {
-        let mut deps = dependencies(20);
+        let mut deps = mock_dependencies(20);
 
         // initialize the store
         let verifier = HumanAddr(String::from("verifies"));
@@ -279,7 +279,7 @@ mod tests {
 
     #[test]
     fn failed_handle() {
-        let mut deps = dependencies(20);
+        let mut deps = mock_dependencies(20);
 
         // initialize the store
         let verifier = HumanAddr(String::from("verifies"));
@@ -320,7 +320,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "This page intentionally faulted")]
     fn handle_panic() {
-        let mut deps = dependencies(20);
+        let mut deps = mock_dependencies(20);
 
         // initialize the store
         let verifier = HumanAddr(String::from("verifies"));

--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -149,8 +149,9 @@ fn query_verifier<S: Storage, A: Api>(deps: &Extern<S, A>) -> Result<Vec<u8>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cosmwasm::testing::{mock_dependencies, mock_env};
     // import trait ReadonlyStorage to get access to read
-    use cosmwasm::{coin, mock_dependencies, mock_env, transactional_deps, ReadonlyStorage};
+    use cosmwasm::{coin, transactional_deps, ReadonlyStorage};
 
     #[test]
     fn proper_initialization() {

--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -2,10 +2,10 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use snafu::{OptionExt, ResultExt};
 
-use cosmwasm::errors::{unauthorized, NotFound, ParseErr, Result, SerializeErr};
-use cosmwasm::serde::{from_slice, to_vec};
-use cosmwasm::traits::{Api, Extern, Storage};
-use cosmwasm::types::{log, CanonicalAddr, CosmosMsg, Env, HumanAddr, Response};
+use cosmwasm::{
+    from_slice, log, to_vec, unauthorized, Api, CanonicalAddr, CosmosMsg, Env, Extern, HumanAddr,
+    NotFound, ParseErr, Response, Result, SerializeErr, Storage,
+};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct InitMsg {
@@ -149,11 +149,8 @@ fn query_verifier<S: Storage, A: Api>(deps: &Extern<S, A>) -> Result<Vec<u8>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cosmwasm::mock::{dependencies, mock_env};
-    use cosmwasm::storage::transactional_deps;
-    // import trait to get access to read
-    use cosmwasm::traits::ReadonlyStorage;
-    use cosmwasm::types::coin;
+    // import trait ReadonlyStorage to get access to read
+    use cosmwasm::{coin, dependencies, mock_env, transactional_deps, ReadonlyStorage};
 
     #[test]
     fn proper_initialization() {

--- a/contracts/hackatom/src/lib.rs
+++ b/contracts/hackatom/src/lib.rs
@@ -2,7 +2,7 @@ pub mod contract;
 
 /** Below we expose wasm exports **/
 #[cfg(target_arch = "wasm32")]
-pub use cosmwasm::exports::{allocate, deallocate};
+pub use cosmwasm::{allocate, deallocate};
 
 #[cfg(target_arch = "wasm32")]
 pub use wasm::{handle, init};
@@ -10,13 +10,13 @@ pub use wasm::{handle, init};
 #[cfg(target_arch = "wasm32")]
 mod wasm {
     use super::contract;
-    use cosmwasm::{exports, imports};
+    use cosmwasm::{do_handle, do_init, do_query, ExternalApi, ExternalStorage};
     use std::ffi::c_void;
 
     #[no_mangle]
     pub extern "C" fn init(env_ptr: *mut c_void, msg_ptr: *mut c_void) -> *mut c_void {
-        exports::do_init(
-            &contract::init::<imports::ExternalStorage, imports::ExternalApi>,
+        do_init(
+            &contract::init::<ExternalStorage, ExternalApi>,
             env_ptr,
             msg_ptr,
         )
@@ -24,8 +24,8 @@ mod wasm {
 
     #[no_mangle]
     pub extern "C" fn handle(env_ptr: *mut c_void, msg_ptr: *mut c_void) -> *mut c_void {
-        exports::do_handle(
-            &contract::handle::<imports::ExternalStorage, imports::ExternalApi>,
+        do_handle(
+            &contract::handle::<ExternalStorage, ExternalApi>,
             env_ptr,
             msg_ptr,
         )
@@ -33,9 +33,6 @@ mod wasm {
 
     #[no_mangle]
     pub extern "C" fn query(msg_ptr: *mut c_void) -> *mut c_void {
-        exports::do_query(
-            &contract::query::<imports::ExternalStorage, imports::ExternalApi>,
-            msg_ptr,
-        )
+        do_query(&contract::query::<ExternalStorage, ExternalApi>, msg_ptr)
     }
 }

--- a/contracts/hackatom/tests/integration.rs
+++ b/contracts/hackatom/tests/integration.rs
@@ -1,9 +1,8 @@
 use std::str::from_utf8;
 
-use cosmwasm::mock::mock_env;
-use cosmwasm::serde::from_slice;
-use cosmwasm::traits::{Api, ReadonlyStorage};
-use cosmwasm::types::{coin, log, CosmosMsg, HumanAddr, QueryResult};
+use cosmwasm::{
+    coin, from_slice, log, mock_env, Api, CosmosMsg, HumanAddr, QueryResult, ReadonlyStorage,
+};
 
 use cosmwasm_vm::testing::{handle, init, mock_instance, query, test_io};
 
@@ -197,7 +196,7 @@ fn passes_io_tests() {
 mod singlepass_tests {
     use super::*;
 
-    use cosmwasm::serde::to_vec;
+    use cosmwasm::to_vec;
     use cosmwasm_vm::call_handle;
     use cosmwasm_vm::testing::mock_instance_with_gas_limit;
 

--- a/contracts/hackatom/tests/integration.rs
+++ b/contracts/hackatom/tests/integration.rs
@@ -1,9 +1,7 @@
 use std::str::from_utf8;
 
-use cosmwasm::{
-    coin, from_slice, log, mock_env, Api, CosmosMsg, HumanAddr, QueryResult, ReadonlyStorage,
-};
-
+use cosmwasm::testing::mock_env;
+use cosmwasm::{coin, from_slice, log, Api, CosmosMsg, HumanAddr, QueryResult, ReadonlyStorage};
 use cosmwasm_vm::testing::{handle, init, mock_instance, query, test_io};
 
 use hackatom::contract::{HandleMsg, InitMsg, QueryMsg, State, CONFIG_KEY};

--- a/contracts/hackatom/tests/integration.rs
+++ b/contracts/hackatom/tests/integration.rs
@@ -19,7 +19,7 @@ Then running `cargo test` will validate we can properly call into that generated
 You can easily convert unit tests to integration tests.
 1. First copy them over verbatum,
 2. Then change
-    let mut deps = dependencies(20);
+    let mut deps = mock_dependencies(20);
 To
     let mut deps = mock_instance(WASM);
 3. If you access raw storage, where ever you see something like:

--- a/packages/std/examples/schema.rs
+++ b/packages/std/examples/schema.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use schemars::{schema::RootSchema, schema_for};
 
-use cosmwasm::types::{ContractResult, CosmosMsg, Env};
+use cosmwasm::{ContractResult, CosmosMsg, Env};
 
 fn main() {
     let mut pwd = current_dir().unwrap();

--- a/packages/std/src/demo.rs
+++ b/packages/std/src/demo.rs
@@ -112,7 +112,7 @@ impl<'a, T: Storage> Storage for PrefixedStorage<'a, T> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::mock::MockStorage;
+    use crate::testing::MockStorage;
 
     #[test]
     fn key_prefix_works() {

--- a/packages/std/src/exports.rs
+++ b/packages/std/src/exports.rs
@@ -1,5 +1,3 @@
-#![cfg(target_arch = "wasm32")]
-
 //! exports exposes the public wasm API
 //! allocate and deallocate should be re-exported as is
 //! do_init and do_wrapper should be wrapped with a extern "C" entry point

--- a/packages/std/src/imports.rs
+++ b/packages/std/src/imports.rs
@@ -1,5 +1,3 @@
-#![cfg(target_arch = "wasm32")]
-
 use std::ffi::c_void;
 use std::vec::Vec;
 

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -13,7 +13,7 @@ pub use crate::errors::{
     contract_err, dyn_contract_err, invalid, unauthorized, Error, NotFound, NullPointer, ParseErr,
     Result, SerializeErr,
 };
-pub use crate::mock::{dependencies, mock_env, MockApi, MockStorage};
+pub use crate::mock::{mock_dependencies, mock_env, MockApi, MockStorage};
 pub use crate::serde::{from_slice, to_vec};
 pub use crate::storage::{transactional, transactional_deps};
 pub use crate::traits::{Api, Extern, ReadonlyStorage, Storage};

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -2,7 +2,6 @@
 
 mod encoding;
 mod errors;
-mod mock;
 mod serde;
 mod storage;
 mod traits;
@@ -13,7 +12,6 @@ pub use crate::errors::{
     contract_err, dyn_contract_err, invalid, unauthorized, Error, NotFound, NullPointer, ParseErr,
     Result, SerializeErr,
 };
-pub use crate::mock::{mock_dependencies, mock_env, MockApi, MockStorage};
 pub use crate::serde::{from_slice, to_vec};
 pub use crate::storage::{
     transactional, transactional_deps, MemoryStorage, RepLog, StorageTransaction,
@@ -36,6 +34,16 @@ mod memory; // used by exports and imports only
 pub use crate::exports::{allocate, deallocate, do_handle, do_init, do_query};
 #[cfg(target_arch = "wasm32")]
 pub use crate::imports::{ExternalApi, ExternalStorage};
+
+// Exposed for testing only
+// Both unit tests and integration tests are compiled to native code, so everything in here does not need to compile to Wasm.
+
+#[cfg(not(target_arch = "wasm32"))]
+mod mock;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod testing {
+    pub use crate::mock::{mock_dependencies, mock_env, MockApi, MockStorage};
+}
 
 // Not exposed
 

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -1,15 +1,22 @@
-// these two are conditionally compiled, only for wasm32
-pub mod exports;
-pub mod imports;
+// Exposed on all platforms
 
 pub mod encoding;
 pub mod errors;
-pub mod memory;
 pub mod mock;
 pub mod serde;
 pub mod storage;
 pub mod traits;
 pub mod types;
 
-// not exposed
+// Exposed in wasm build only
+
+#[cfg(target_arch = "wasm32")]
+pub mod exports;
+#[cfg(target_arch = "wasm32")]
+pub mod imports;
+#[cfg(target_arch = "wasm32")]
+pub mod memory; // used by exports and imports only
+
+// Not exposed
+
 mod demo;

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -1,21 +1,39 @@
 // Exposed on all platforms
 
-pub mod encoding;
-pub mod errors;
-pub mod mock;
-pub mod serde;
-pub mod storage;
-pub mod traits;
-pub mod types;
+mod encoding;
+mod errors;
+mod mock;
+mod serde;
+mod storage;
+mod traits;
+mod types;
+
+pub use crate::encoding::Binary;
+pub use crate::errors::{
+    contract_err, dyn_contract_err, invalid, unauthorized, Error, NotFound, NullPointer, ParseErr,
+    Result, SerializeErr,
+};
+pub use crate::mock::{dependencies, mock_env, MockApi, MockStorage};
+pub use crate::serde::{from_slice, to_vec};
+pub use crate::storage::{transactional, transactional_deps};
+pub use crate::traits::{Api, Extern, ReadonlyStorage, Storage};
+pub use crate::types::{
+    coin, log, CanonicalAddr, ContractResult, CosmosMsg, Env, HumanAddr, QueryResult, Response,
+};
 
 // Exposed in wasm build only
 
 #[cfg(target_arch = "wasm32")]
-pub mod exports;
+mod exports;
 #[cfg(target_arch = "wasm32")]
-pub mod imports;
+mod imports;
 #[cfg(target_arch = "wasm32")]
-pub mod memory; // used by exports and imports only
+mod memory; // used by exports and imports only
+
+#[cfg(target_arch = "wasm32")]
+pub use crate::exports::{allocate, deallocate, do_handle, do_init, do_query};
+#[cfg(target_arch = "wasm32")]
+pub use crate::imports::{ExternalApi, ExternalStorage};
 
 // Not exposed
 

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -15,7 +15,9 @@ pub use crate::errors::{
 };
 pub use crate::mock::{mock_dependencies, mock_env, MockApi, MockStorage};
 pub use crate::serde::{from_slice, to_vec};
-pub use crate::storage::{transactional, transactional_deps};
+pub use crate::storage::{
+    transactional, transactional_deps, MemoryStorage, RepLog, StorageTransaction,
+};
 pub use crate::traits::{Api, Extern, ReadonlyStorage, Storage};
 pub use crate::types::{
     coin, log, CanonicalAddr, ContractResult, CosmosMsg, Env, HumanAddr, QueryResult, Response,

--- a/packages/std/src/memory.rs
+++ b/packages/std/src/memory.rs
@@ -4,8 +4,10 @@ use std::vec::Vec;
 
 use crate::errors::{Error, NullPointer};
 
-/// Refers to some heap allocated data in wasm.
-/// A pointer to this can be returned over ffi boundaries.
+/// Refers to some heap allocated data in Wasm.
+/// A pointer to an instance of this can be returned over FFI boundaries.
+///
+/// This struct is crate internal since the VM defined the same type independently.
 #[repr(C)]
 pub struct Region {
     pub offset: u32,

--- a/packages/std/src/mock.rs
+++ b/packages/std/src/mock.rs
@@ -7,8 +7,8 @@ use crate::errors::{ContractErr, Result, Utf8StringErr};
 use crate::traits::{Api, Extern, ReadonlyStorage, Storage};
 use crate::types::{BlockInfo, CanonicalAddr, Coin, ContractInfo, Env, HumanAddr, MessageInfo};
 
-// dependencies are all external requirements that can be injected for unit tests
-pub fn dependencies(canonical_length: usize) -> Extern<MockStorage, MockApi> {
+/// All external requirements that can be injected for unit tests
+pub fn mock_dependencies(canonical_length: usize) -> Extern<MockStorage, MockApi> {
     Extern {
         storage: MockStorage::new(),
         api: MockApi::new(canonical_length),

--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use lru::LruCache;
 use snafu::ResultExt;
 
-use cosmwasm::traits::{Api, Extern, Storage};
+use cosmwasm::{Api, Extern, Storage};
 
 use crate::backends::{backend, compile};
 use crate::compatability::check_wasm;
@@ -132,11 +132,9 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use tempfile::TempDir;
-
     use crate::calls::{call_handle, call_init};
-    use cosmwasm::mock::{dependencies, mock_env, MockApi, MockStorage};
-    use cosmwasm::types::coin;
+    use cosmwasm::{coin, dependencies, mock_env, MockApi, MockStorage};
+    use tempfile::TempDir;
 
     static TESTING_GAS_LIMIT: u64 = 400_000;
     static CONTRACT_0_7: &[u8] = include_bytes!("../testdata/contract_0.7.wasm");

--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -133,7 +133,8 @@ where
 mod test {
     use super::*;
     use crate::calls::{call_handle, call_init};
-    use cosmwasm::{coin, mock_dependencies, mock_env, MockApi, MockStorage};
+    use cosmwasm::coin;
+    use cosmwasm::testing::{mock_dependencies, mock_env, MockApi, MockStorage};
     use tempfile::TempDir;
 
     static TESTING_GAS_LIMIT: u64 = 400_000;

--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -133,7 +133,7 @@ where
 mod test {
     use super::*;
     use crate::calls::{call_handle, call_init};
-    use cosmwasm::{coin, dependencies, mock_env, MockApi, MockStorage};
+    use cosmwasm::{coin, mock_dependencies, mock_env, MockApi, MockStorage};
     use tempfile::TempDir;
 
     static TESTING_GAS_LIMIT: u64 = 400_000;
@@ -189,7 +189,7 @@ mod test {
         let tmp_dir = TempDir::new().unwrap();
         let mut cache = unsafe { CosmCache::new(tmp_dir.path(), 10).unwrap() };
         let id = cache.save_wasm(CONTRACT_0_7).unwrap();
-        let deps = dependencies(20);
+        let deps = mock_dependencies(20);
         let _instance = cache.get_instance(&id, deps, TESTING_GAS_LIMIT).unwrap();
         assert_eq!(cache.stats.hits_instance, 0);
         assert_eq!(cache.stats.hits_module, 1);
@@ -201,9 +201,9 @@ mod test {
         let tmp_dir = TempDir::new().unwrap();
         let mut cache = unsafe { CosmCache::new(tmp_dir.path(), 10).unwrap() };
         let id = cache.save_wasm(CONTRACT_0_7).unwrap();
-        let deps1 = dependencies(20);
-        let deps2 = dependencies(20);
-        let deps3 = dependencies(20);
+        let deps1 = mock_dependencies(20);
+        let deps2 = mock_dependencies(20);
+        let deps3 = mock_dependencies(20);
         let instance1 = cache.get_instance(&id, deps1, TESTING_GAS_LIMIT).unwrap();
         cache.store_instance(&id, instance1);
         let instance2 = cache.get_instance(&id, deps2, TESTING_GAS_LIMIT).unwrap();
@@ -220,7 +220,7 @@ mod test {
         let tmp_dir = TempDir::new().unwrap();
         let mut cache = unsafe { CosmCache::new(tmp_dir.path(), 10).unwrap() };
         let id = cache.save_wasm(CONTRACT_0_7).unwrap();
-        let deps = dependencies(20);
+        let deps = mock_dependencies(20);
         let mut instance = cache.get_instance(&id, deps, TESTING_GAS_LIMIT).unwrap();
 
         // run contract
@@ -238,7 +238,7 @@ mod test {
         let tmp_dir = TempDir::new().unwrap();
         let mut cache = unsafe { CosmCache::new(tmp_dir.path(), 10).unwrap() };
         let id = cache.save_wasm(CONTRACT_0_7).unwrap();
-        let deps = dependencies(20);
+        let deps = mock_dependencies(20);
         let mut instance = cache.get_instance(&id, deps, TESTING_GAS_LIMIT).unwrap();
 
         // init contract
@@ -268,8 +268,8 @@ mod test {
         let id = cache.save_wasm(CONTRACT_0_7).unwrap();
 
         // these differentiate the two instances of the same contract
-        let deps1 = dependencies(20);
-        let deps2 = dependencies(20);
+        let deps1 = mock_dependencies(20);
+        let deps2 = mock_dependencies(20);
 
         // init instance 1
         let mut instance = cache.get_instance(&id, deps1, TESTING_GAS_LIMIT).unwrap();
@@ -325,8 +325,8 @@ mod test {
         let mut cache = unsafe { CosmCache::new(tmp_dir.path(), 10).unwrap() };
         let id = cache.save_wasm(CONTRACT_0_7).unwrap();
 
-        let deps1 = dependencies(20);
-        let deps2 = dependencies(20);
+        let deps1 = mock_dependencies(20);
+        let deps2 = mock_dependencies(20);
 
         // Init from module cache
         let mut instance1 = cache.get_instance(&id, deps1, TESTING_GAS_LIMIT).unwrap();
@@ -357,8 +357,8 @@ mod test {
         let mut cache = unsafe { CosmCache::new(tmp_dir.path(), 10).unwrap() };
         let id = cache.save_wasm(CONTRACT_0_7).unwrap();
 
-        let deps1 = dependencies(20);
-        let deps2 = dependencies(20);
+        let deps1 = mock_dependencies(20);
+        let deps2 = mock_dependencies(20);
 
         // Init from module cache
         let mut instance1 = cache.get_instance(&id, deps1, 10).unwrap();

--- a/packages/vm/src/calls.rs
+++ b/packages/vm/src/calls.rs
@@ -1,8 +1,6 @@
 use snafu::ResultExt;
 
-use cosmwasm::serde::{from_slice, to_vec};
-use cosmwasm::traits::{Api, Storage};
-use cosmwasm::types::{ContractResult, Env, QueryResult};
+use cosmwasm::{from_slice, to_vec, Api, ContractResult, Env, QueryResult, Storage};
 
 use crate::errors::{Error, ParseErr, RuntimeErr, SerializeErr};
 use crate::instance::{Func, Instance};

--- a/packages/vm/src/context.rs
+++ b/packages/vm/src/context.rs
@@ -7,12 +7,10 @@ use std::mem;
 
 use wasmer_runtime_core::vm::Ctx;
 
-use cosmwasm::traits::{Api, Storage};
+use cosmwasm::{Api, Binary, CanonicalAddr, HumanAddr, Storage};
 
 use crate::errors::Error;
 use crate::memory::{read_region, write_region};
-use cosmwasm::encoding::Binary;
-use cosmwasm::types::{CanonicalAddr, HumanAddr};
 
 /// An unknown error occurred when writing to region
 static ERROR_WRITE_TO_REGION_UNKNONW: i32 = -1000001;

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -146,7 +146,8 @@ where
 mod test {
     use crate::calls::{call_handle, call_init, call_query};
     use crate::testing::{mock_instance, mock_instance_with_gas_limit};
-    use cosmwasm::{coin, mock_env};
+    use cosmwasm::coin;
+    use cosmwasm::testing::mock_env;
 
     static CONTRACT_0_7: &[u8] = include_bytes!("../testdata/contract_0.7.wasm");
 

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -9,7 +9,7 @@ use wasmer_runtime_core::{
     vm::Ctx,
 };
 
-use cosmwasm::traits::{Api, Extern, Storage};
+use cosmwasm::{Api, Extern, Storage};
 
 use crate::backends::{compile, get_gas, set_gas};
 use crate::context::{
@@ -146,8 +146,7 @@ where
 mod test {
     use crate::calls::{call_handle, call_init, call_query};
     use crate::testing::{mock_instance, mock_instance_with_gas_limit};
-    use cosmwasm::mock::mock_env;
-    use cosmwasm::types::coin;
+    use cosmwasm::{coin, mock_env};
 
     static CONTRACT_0_7: &[u8] = include_bytes!("../testdata/contract_0.7.wasm");
 

--- a/packages/vm/src/memory.rs
+++ b/packages/vm/src/memory.rs
@@ -7,11 +7,11 @@ use wasmer_runtime_core::{
 
 /****** read/write to wasm memory buffer ****/
 
-/// Refers to some heap allocated data in wasm.
-/// A pointer to this can be returned over ffi boundaries.
+/// Refers to some heap allocated data in Wasm.
+/// A pointer to an instance of this can be returned over FFI boundaries.
 ///
 /// This is the same as cosmwasm::memory::Region
-/// but defined here to allow wasm impl
+/// but defined here to allow Wasmer specific implementation.
 #[repr(C)]
 #[derive(Default, Clone, Copy, Debug)]
 pub struct Region {

--- a/packages/vm/src/testing.rs
+++ b/packages/vm/src/testing.rs
@@ -5,9 +5,8 @@ use serde::Serialize;
 // JsonSchema is a flag for types meant to be publically exposed
 use schemars::JsonSchema;
 
-use cosmwasm::{
-    mock_dependencies, to_vec, Api, ContractResult, Env, MockApi, MockStorage, QueryResult, Storage,
-};
+use cosmwasm::testing::{mock_dependencies, MockApi, MockStorage};
+use cosmwasm::{to_vec, Api, ContractResult, Env, QueryResult, Storage};
 
 use crate::calls::{call_handle, call_init, call_query};
 use crate::compatability::check_wasm;

--- a/packages/vm/src/testing.rs
+++ b/packages/vm/src/testing.rs
@@ -5,10 +5,9 @@ use serde::Serialize;
 // JsonSchema is a flag for types meant to be publically exposed
 use schemars::JsonSchema;
 
-use cosmwasm::mock::{dependencies, MockApi, MockStorage};
-use cosmwasm::serde::to_vec;
-use cosmwasm::traits::{Api, Storage};
-use cosmwasm::types::{ContractResult, Env, QueryResult};
+use cosmwasm::{
+    dependencies, to_vec, Api, ContractResult, Env, MockApi, MockStorage, QueryResult, Storage,
+};
 
 use crate::calls::{call_handle, call_init, call_query};
 use crate::compatability::check_wasm;

--- a/packages/vm/src/testing.rs
+++ b/packages/vm/src/testing.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 use schemars::JsonSchema;
 
 use cosmwasm::{
-    dependencies, to_vec, Api, ContractResult, Env, MockApi, MockStorage, QueryResult, Storage,
+    mock_dependencies, to_vec, Api, ContractResult, Env, MockApi, MockStorage, QueryResult, Storage,
 };
 
 use crate::calls::{call_handle, call_init, call_query};
@@ -22,7 +22,7 @@ pub fn mock_instance(wasm: &[u8]) -> Instance<MockStorage, MockApi> {
 
 pub fn mock_instance_with_gas_limit(wasm: &[u8], gas_limit: u64) -> Instance<MockStorage, MockApi> {
     check_wasm(wasm).unwrap();
-    let deps = dependencies(20);
+    let deps = mock_dependencies(20);
     Instance::from_code(wasm, deps, gas_limit).unwrap()
 }
 


### PR DESCRIPTION
~Based on #175.~

Closes #173.

API breaking and should go into 0.8.