### PR TITLE
Upgrade schemars to 0.6.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,18 @@ jobs:
       - run:
           name: Integration tests
           command: cargo integration-test --locked
+      - run:
+          name: Build and run schema generator
+          command: cargo schema --locked
+      - run:
+          name: Ensure schemas are up-to-date
+          command: |
+            CHANGES_IN_REPO=$(git status --porcelain)
+            if [[ -n "$CHANGES_IN_REPO" ]]; then
+              echo "Repository is dirty. Showing 'git status' and 'git --no-pager diff' for debugging now:"
+              git status && git --no-pager diff
+              exit 1
+            fi
       - save_cache:
           paths:
             - /usr/local/cargo/registry

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,6 +169,7 @@ jobs:
           key: cargocache-v2-hackatom-rust:1.40.0-{{ checksum "Cargo.lock" }}
 
   # In this job we use singlepass as the VM to execute integration tests. This requires Rust nightly.
+  # Avoid duplicating generic checks like unit tests or schema generation – they belong in the generic hackatom job.
   hackatom_in_singlepass_vm:
     docker:
       - image: rustlang/rust:nightly
@@ -188,10 +189,6 @@ jobs:
       - run:
           name: Build wasm binary
           command: cargo wasm --locked
-      - run:
-          name: Unit tests
-          env: RUST_BACKTRACE=1
-          command: cargo unit-test --locked
       - run:
           name: Integration tests
           command: cargo integration-test --no-default-features --features singlepass --locked

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.8.0 (not yet released)
 
+**all**
+
+- Upgrade schemars to 0.6.
+
 **cosmwasm**
 
 - Make all symbols from `cosmwasm::memory` crate internal, as those symbols are

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ name = "cosmwasm"
 version = "0.7.2"
 dependencies = [
  "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "schemars 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "schemars 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-json-wasm 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -180,7 +180,7 @@ dependencies = [
  "lru 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "schemars 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "schemars 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-json-wasm 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -707,17 +707,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "schemars"
-version = "0.5.1"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "schemars_derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "schemars_derive 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "schemars_derive"
-version = "0.5.0"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1186,8 +1186,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
-"checksum schemars 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "273d9b56198caf703e271dcc07b28f2e794971750ace6585399d40e2af9f4823"
-"checksum schemars_derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "73ab7f0b9b64633747a68dce4ed6318bbf30e3befe67df7624ad83abb7295c09"
+"checksum schemars 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "07569773d6aaf3324812c6572244aec08521b64ce056f2be3b5cc135fb63caec"
+"checksum schemars_derive 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38535ecef477d8495dc6c288e876c03c4428b8141ffa57803111348cf14230a9"
 "checksum scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"

--- a/contracts/hackatom/Cargo.lock
+++ b/contracts/hackatom/Cargo.lock
@@ -164,7 +164,7 @@ name = "cosmwasm"
 version = "0.7.2"
 dependencies = [
  "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "schemars 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "schemars 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-json-wasm 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -179,7 +179,7 @@ dependencies = [
  "lru 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "schemars 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "schemars 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-json-wasm 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -389,7 +389,7 @@ version = "0.7.2"
 dependencies = [
  "cosmwasm 0.7.2",
  "cosmwasm-vm 0.7.2",
- "schemars 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "schemars 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -661,17 +661,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "schemars"
-version = "0.5.1"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "schemars_derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "schemars_derive 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "schemars_derive"
-version = "0.5.0"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1099,8 +1099,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
-"checksum schemars 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "273d9b56198caf703e271dcc07b28f2e794971750ace6585399d40e2af9f4823"
-"checksum schemars_derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "73ab7f0b9b64633747a68dce4ed6318bbf30e3befe67df7624ad83abb7295c09"
+"checksum schemars 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "07569773d6aaf3324812c6572244aec08521b64ce056f2be3b5cc135fb63caec"
+"checksum schemars_derive 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38535ecef477d8495dc6c288e876c03c4428b8141ffa57803111348cf14230a9"
 "checksum scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"

--- a/contracts/hackatom/Cargo.toml
+++ b/contracts/hackatom/Cargo.toml
@@ -29,7 +29,7 @@ singlepass = ["cosmwasm-vm/default-singlepass"]
 
 [dependencies]
 cosmwasm = { path = "../../packages/std" }
-schemars = "0.5"
+schemars = "0.6"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 snafu = { version = "0.5.0", default-features = false, features = ["rust_1_30"] }
 

--- a/contracts/hackatom/schema/state.json
+++ b/contracts/hackatom/schema/state.json
@@ -20,6 +20,7 @@
   },
   "definitions": {
     "Binary": {
+      "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>",
       "type": "string"
     },
     "CanonicalAddr": {

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -15,7 +15,7 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 base64 = "0.11.0"
 serde-json-wasm = "0.1.2"
-schemars = "0.5"
+schemars = "0.6"
 serde = { version = "1.0.103", default-features = false, features = ["derive", "alloc"] }
 snafu = { version = "0.5.0", default-features = false, features = ["rust_1_30"] }
 

--- a/packages/std/schema/contract_result.json
+++ b/packages/std/schema/contract_result.json
@@ -27,6 +27,7 @@
   ],
   "definitions": {
     "Binary": {
+      "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>",
       "type": "string"
     },
     "Coin": {

--- a/packages/std/schema/cosmos_msg.json
+++ b/packages/std/schema/cosmos_msg.json
@@ -87,6 +87,7 @@
   ],
   "definitions": {
     "Binary": {
+      "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>",
       "type": "string"
     },
     "Coin": {

--- a/packages/std/schema/env.json
+++ b/packages/std/schema/env.json
@@ -20,6 +20,7 @@
   },
   "definitions": {
     "Binary": {
+      "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>",
       "type": "string"
     },
     "BlockInfo": {

--- a/packages/std/schema/query_result.json
+++ b/packages/std/schema/query_result.json
@@ -27,6 +27,7 @@
   ],
   "definitions": {
     "Binary": {
+      "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>",
       "type": "string"
     },
     "Coin": {

--- a/packages/vm/Cargo.toml
+++ b/packages/vm/Cargo.toml
@@ -29,7 +29,7 @@ wasmer-runtime-core = "0.14.0"
 wasmer-middleware-common = "0.14.0"
 wasmer-clif-backend = {version = "0.14.0", optional = true }
 wasmer-singlepass-backend = {version = "0.14.0", optional = true }
-schemars = "0.5"
+schemars = "0.6"
 serde = { version = "1.0.103", default-features = false, features = ["derive", "alloc"] }
 snafu = { version = "0.5.0", default-features = false, features = ["rust_1_30"] }
 sha2 = "0.8.0"


### PR DESCRIPTION
Draft PR to ensure both `std` and `hackatom` CI jobs fail due to outdated schemas.

Closes #168