### PR TITLE
FIx lifetimes, to allow lazy iterators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@
   capacity is the number of bytes available and `length` is the number of bytes
   used. This is a breaking change in the contract-vm interface, which requires
   the same memory layout of the `Region` struct on both sides.
+- Add `remove` method to `Storage` trait.
+- (feature-flagged) Add `range` method to `ReadonlyStorage` trait. This returns an iterator that covers
+all or a subset of the items in the db ordered ascending or descending by key.
+- Add new feature flag `iterator` to both packages to enable `range` functionality. This is used
+to allow potential porting to chains that use Merkle Tries (which don't allow iterating over
+ranges).
 
 **cosmwasm**
 
@@ -24,6 +30,8 @@
   becomes `use cosmwasm::{Api, Binary, Storage};`).
 - Rename package `cosmwasm` to `cosmwasm-std`.
 - The export `allocate` does not zero-fill the allocated memory anymore.
+- Add `remove_db` to the required imports of a contract.
+- (feature-flagged) add `scan_db` and `next_db` callbacks from wasm contract to VM.
 
 **cosmwasm-vm**
 
@@ -35,6 +43,7 @@
   is success and values greater than 0 are reserved for future use.
 - Change the required interface version guard export from `cosmwasm_api_0_6` to
   `cosmwasm_vm_version_1`.
+- Provide implementations for `remove-db` and (feature-flagged)`scan_db` and `next_db`
 
 ## 0.7.2 (2020-03-23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ ranges).
   is success and values greater than 0 are reserved for future use.
 - Change the required interface version guard export from `cosmwasm_api_0_6` to
   `cosmwasm_vm_version_1`.
-- Provide implementations for `remove-db` and (feature-flagged)`scan_db` and `next_db`
+- Provide implementations for `remove_db` and (feature-flagged) `scan_db` and `next_db`
 
 ## 0.7.2 (2020-03-23)
 

--- a/packages/std/src/storage.rs
+++ b/packages/std/src/storage.rs
@@ -25,12 +25,12 @@ impl ReadonlyStorage for MemoryStorage {
     #[cfg(feature = "iterator")]
     /// range allows iteration over a set of keys, either forwards or backwards
     /// uses standard rust range notation, and eg db.range(b"foo"..b"bar") also works reverse
-    fn range(
-        &self,
+    fn range<'a>(
+        &'a self,
         start: Option<&[u8]>,
         end: Option<&[u8]>,
         order: Order,
-    ) -> Box<dyn Iterator<Item = KV>> {
+    ) -> Box<dyn Iterator<Item = KV> + 'a> {
         let bounds = range_bounds(start, end);
         let iter = self.data.range(bounds);
 

--- a/packages/std/src/storage.rs
+++ b/packages/std/src/storage.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use std::ops::{Bound, RangeBounds};
 
 #[cfg(feature = "iterator")]
-use crate::traits::{Order, KV};
+use crate::traits::{KVRef, Order, KV};
 use crate::traits::{ReadonlyStorage, Storage};
 
 #[derive(Default)]
@@ -33,14 +33,10 @@ impl ReadonlyStorage for MemoryStorage {
     ) -> Box<dyn Iterator<Item = KV> + 'a> {
         let bounds = range_bounds(start, end);
         let iter = self.data.range(bounds);
-
-        // We brute force this a bit to deal with lifetimes.... should do this lazy
-        // TODO: if we use memory storage for anything over a few dozen entries, we should definitely make this lazy
-        let res: Vec<_> = match order {
-            Order::Ascending => iter.map(|(k, v)| (k.clone(), v.clone())).collect(),
-            Order::Descending => iter.rev().map(|(k, v)| (k.clone(), v.clone())).collect(),
-        };
-        Box::new(res.into_iter())
+        match order {
+            Order::Ascending => Box::new(IterVec { iter }),
+            Order::Descending => Box::new(IterVec { iter: iter.rev() }),
+        }
     }
 }
 
@@ -50,6 +46,24 @@ pub(crate) fn range_bounds(start: Option<&[u8]>, end: Option<&[u8]>) -> impl Ran
         start.map_or(Bound::Unbounded, |x| Bound::Included(x.to_vec())),
         end.map_or(Bound::Unbounded, |x| Bound::Excluded(x.to_vec())),
     )
+}
+
+#[cfg(feature = "iterator")]
+struct IterVec<'a, T: Iterator<Item = KVRef<'a>>> {
+    iter: T,
+}
+
+#[cfg(feature = "iterator")]
+impl<'a, T: Iterator<Item = KVRef<'a>>> Iterator for IterVec<'a, T> {
+    type Item = KV;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let n = self.iter.next();
+        match n {
+            Some((k, v)) => Some((k.clone(), v.clone())),
+            None => None,
+        }
+    }
 }
 
 impl Storage for MemoryStorage {

--- a/packages/std/src/traits.rs
+++ b/packages/std/src/traits.rs
@@ -20,12 +20,12 @@ pub trait ReadonlyStorage {
     /// range allows iteration over a set of keys, either forwards or backwards
     /// start is inclusive and end is exclusive
     /// start must be lexicographically before end
-    fn range(
-        &self,
+    fn range<'a>(
+        &'a self,
         start: Option<&[u8]>,
         end: Option<&[u8]>,
         order: Order,
-    ) -> Box<dyn Iterator<Item = KV>>;
+    ) -> Box<dyn Iterator<Item = KV> + 'a>;
 }
 
 // Storage extends ReadonlyStorage to give mutable access

--- a/packages/std/src/transactions.rs
+++ b/packages/std/src/transactions.rs
@@ -65,11 +65,7 @@ impl<'a, S: ReadonlyStorage> ReadonlyStorage for StorageTransaction<'a, S> {
         };
         let base = self.storage.range(start, end, order);
         let merged = MergeOverlay::new(local, base, order);
-
-        // again, ugliness fighting lifetimes...
-        // TODO: fix this along with MemoryStorage.range trick
-        let all: Vec<_> = merged.collect();
-        Box::new(all.into_iter())
+        Box::new(merged)
     }
 }
 

--- a/packages/std/src/transactions.rs
+++ b/packages/std/src/transactions.rs
@@ -52,12 +52,12 @@ impl<'a, S: ReadonlyStorage> ReadonlyStorage for StorageTransaction<'a, S> {
     #[cfg(feature = "iterator")]
     /// range allows iteration over a set of keys, either forwards or backwards
     /// uses standard rust range notation, and eg db.range(b"foo"..b"bar") also works reverse
-    fn range(
-        &self,
+    fn range<'b>(
+        &'b self,
         start: Option<&[u8]>,
         end: Option<&[u8]>,
         order: Order,
-    ) -> Box<dyn Iterator<Item = KV>> {
+    ) -> Box<dyn Iterator<Item = KV> + 'b> {
         let local_raw = self.local_state.range(range_bounds(start, end));
         let local: Box<dyn Iterator<Item = KVRef<Delta>>> = match order {
             Order::Ascending => Box::new(local_raw),

--- a/packages/vm/src/context.rs
+++ b/packages/vm/src/context.rs
@@ -60,7 +60,7 @@ pub fn do_remove<T: Storage>(ctx: &Ctx, key_ptr: u32) {
 }
 
 #[cfg(feature = "iterator")]
-pub fn do_scan<T: Storage>(ctx: &Ctx, start_ptr: u32, end_ptr: u32, order: i32) -> i32 {
+pub fn do_scan<T: Storage + 'static>(ctx: &Ctx, start_ptr: u32, end_ptr: u32, order: i32) -> i32 {
     let start = maybe_read_region(ctx, start_ptr);
     let end = maybe_read_region(ctx, end_ptr);
     let order: Order = match order.try_into() {
@@ -68,10 +68,10 @@ pub fn do_scan<T: Storage>(ctx: &Ctx, start_ptr: u32, end_ptr: u32, order: i32) 
         Err(_) => return ERROR_SCAN_INVALID_ORDER,
     };
     let mut storage: Option<T> = take_storage(ctx);
-    if let Some(store) = &mut storage {
+    if let Some(store) = storage {
         let iter = store.range(start.as_deref(), end.as_deref(), order);
         leave_iterator::<T>(ctx, iter);
-        leave_storage(ctx, storage);
+        leave_storage(ctx, Some(store));
         return 0;
     } else {
         leave_storage(ctx, storage);

--- a/packages/vm/src/context.rs
+++ b/packages/vm/src/context.rs
@@ -67,10 +67,13 @@ pub fn do_scan<T: Storage + 'static>(ctx: &Ctx, start_ptr: u32, end_ptr: u32, or
         Ok(o) => o,
         Err(_) => return ERROR_SCAN_INVALID_ORDER,
     };
-    let mut storage: Option<T> = take_storage(ctx);
+    let storage: Option<T> = take_storage(ctx);
     if let Some(store) = storage {
         let iter = store.range(start.as_deref(), end.as_deref(), order);
-        leave_iterator::<T>(ctx, iter);
+        // TODO: we want to do this lazy as well, but even more lifetime tiwddling needed
+        //        leave_iterator::<T>(ctx, iter);
+        let res: Vec<_> = iter.collect();
+        leave_iterator::<T>(ctx, Box::new(res.into_iter()));
         leave_storage(ctx, Some(store));
         return 0;
     } else {

--- a/packages/vm/src/context.rs
+++ b/packages/vm/src/context.rs
@@ -172,11 +172,19 @@ unsafe fn get_data<S: Storage>(ptr: *mut c_void) -> Box<ContextData<S>> {
     Box::from_raw(ptr as *mut ContextData<S>)
 }
 
+#[cfg(feature = "iterator")]
 fn destroy_unmanaged_storage<S: Storage>(ptr: *mut c_void) {
     if !ptr.is_null() {
         let mut dead = unsafe { get_data::<S>(ptr) };
         // ensure the iterator is dropped before the storage
-        dead.storage.clear_iterator();
+        let _ = dead.iter.take();
+    }
+}
+
+#[cfg(not(feature = "iterator"))]
+fn destroy_unmanaged_storage<S: Storage>(ptr: *mut c_void) {
+    if !ptr.is_null() {
+        let _ = unsafe { get_data::<S>(ptr) };
     }
 }
 

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -69,7 +69,11 @@ where
                 // Returns negative code on error, 0 on success
                 "scan_db" => Func::new(move |ctx: &mut Ctx, start_ptr: u32, end_ptr: u32, order: i32| -> i32{
                     #[cfg(not(feature = "iterator"))]
-                    return 0;
+                    {
+                        // get rid of unused argument warning
+                        let (_, _, _, _) = (ctx, start_ptr, end_ptr, order);
+                        return 0;
+                    }
                     #[cfg(feature = "iterator")]
                     do_scan::<S>(ctx, start_ptr, end_ptr, order)
                 }),
@@ -78,7 +82,11 @@ where
                 // Ownership of both start and end pointer is not transferred to the host.
                 "next_db" => Func::new(move |ctx: &mut Ctx, key_ptr: u32, value_ptr: u32| -> i32 {
                     #[cfg(not(feature = "iterator"))]
-                    return 0;
+                    {
+                        // get rid of unused argument warning
+                        let (_, _, _) = (ctx, key_ptr, value_ptr);
+                        return 0;
+                    }
                     #[cfg(feature = "iterator")]
                     do_next::<S>(ctx, key_ptr, value_ptr)
                 }),


### PR DESCRIPTION
Until now, for `range`, we collect all results into a Vec and then return an iterator over that, removing all references to the underlying storage. This was done as lifetime struggling was confusing.

This PR makes a non-static lifetime for the iterator, related to outstanding references and makes them lazy. It *almost* works, except for the use of the iterator in the context (which has a bunch of `unsafe` code as well).

I added some more unsafe assertion to allow lazy iterators in the VM as well. A bit of magic, but I checked all logic flows and it looks safe.
