### PR TITLE
Update commands in doc comment to cargo wasm and cargo integration-test

### DIFF
--- a/contracts/hackatom/tests/integration.rs
+++ b/contracts/hackatom/tests/integration.rs
@@ -10,11 +10,9 @@ use hackatom::contract::{HandleMsg, InitMsg, QueryMsg, State, CONFIG_KEY};
 
 /**
 This integration test tries to run and call the generated wasm.
-It depends on a release build being available already. You can create that with:
+It depends on a release build being available already. You can create that with `cargo wasm`.
 
-cargo wasm && wasm-gc ./target/wasm32-unknown-unknown/release/hackatom.wasm
-
-Then running `cargo test` will validate we can properly call into that generated data.
+Then running `cargo integration-test` will validate we can properly call into that generated data.
 
 You can easily convert unit tests to integration tests.
 1. First copy them over verbatum,

--- a/contracts/queue/tests/integration.rs
+++ b/contracts/queue/tests/integration.rs
@@ -7,11 +7,9 @@ use queue::contract::{CountResponse, HandleMsg, InitMsg, Item, QueryMsg, SumResp
 
 /**
 This integration test tries to run and call the generated wasm.
-It depends on a release build being available already. You can create that with:
+It depends on a release build being available already. You can create that with `cargo wasm`.
 
-RUSTFLAGS='-C link-arg=-s' cargo wasm
-
-Then running `cargo test` will validate we can properly call into that generated data.
+Then running `cargo integration-test` will validate we can properly call into that generated data.
 
 You can easily convert unit tests to integration tests.
 1. First copy them over verbatum,


### PR DESCRIPTION
Let's avoid confronting the user with compiler flags and focus in the two types of wasm builds:
1. `cargo wasm` (includes debug symbols that do nothing to the integration test's behaviour)
2. use cosmwasm-opt (containing an up-to-date set of compiler and optimizer flags, maintained by us)