### PR TITLE
Define querier types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@ a breaking change for the clients.
 - The exports `cosmwasm_vm_version_1`, `allocate` and `deallocate` are now
   private and can only be called via the Wasm export. Make sure to `use`
   `cosmwasm_std` at least once in the contract to pull in the C exports.
+- Add new `ApiResult` and `ApiError` types to represent serializable counterparts to
+`errors::Result` and `errors::Error`. This has a powerful `Into` and `From` implementations
+to transfer back and forth between `Result` and `ApiResult`.
+- Add `Querier` trait and `QueryRequest` for future query callbacks from the contract,
+along with `SystemError` type for the runtime rejecting messages.
 
 **cosmwasm-vm**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,8 +45,9 @@ a breaking change for the clients.
   private and can only be called via the Wasm export. Make sure to `use`
   `cosmwasm_std` at least once in the contract to pull in the C exports.
 - Add new `ApiResult` and `ApiError` types to represent serializable counterparts to
-`errors::Result` and `errors::Error`. This has a powerful `Into` and `From` implementations
-to transfer back and forth between `Result` and `ApiResult`.
+`errors::Result` and `errors::Error`. There are conversions from `Error` into
+serializable `ApiError` (dropping runtime info), and back and forth between `Result`
+and `ApiResult` (with the same serializable error types).
 - Add `Querier` trait and `QueryRequest` for future query callbacks from the contract,
 along with `SystemError` type for the runtime rejecting messages.
 

--- a/packages/std/src/api.rs
+++ b/packages/std/src/api.rs
@@ -1,0 +1,62 @@
+/// This maintains types needed for a public API
+/// In particular managing serializing and deserializing errors through API boundaries
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::errors::ApiError;
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum ApiResult<T, E: std::error::Error = ApiError> {
+    Ok(T),
+    Err(E),
+}
+
+impl<T, E: std::error::Error> ApiResult<T, E> {
+    pub fn result<U: From<T>>(self) -> Result<U, E> {
+        match self {
+            ApiResult::Ok(t) => Ok(t.into()),
+            ApiResult::Err(e) => Err(e),
+        }
+    }
+}
+
+impl<T, U: From<T>, E: std::error::Error> Into<Result<U, E>> for ApiResult<T, E> {
+    fn into(self) -> Result<U, E> {
+        self.result()
+    }
+}
+
+impl<T, U: Into<T>, E: std::error::Error, F: Into<E>> From<Result<U, F>> for ApiResult<T, E> {
+    fn from(res: Result<U, F>) -> Self {
+        match res {
+            Ok(t) => ApiResult::Ok(t.into()),
+            Err(e) => ApiResult::Err(e.into()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::errors::{contract_err, Result};
+
+    #[test]
+    fn convert_ok_result() {
+        let input: Result<Vec<u8>> = Ok(b"foo".to_vec());
+        let convert: ApiResult<Vec<u8>> = input.into();
+        assert_eq!(convert, ApiResult::Ok(b"foo".to_vec()));
+    }
+
+    #[test]
+    fn convert_err_result() {
+        let input: Result<()> = contract_err("sample error");
+        let convert: ApiResult<()> = input.into();
+        assert_eq!(
+            convert,
+            ApiResult::Err(ApiError::ContractErr {
+                msg: "sample error".to_string()
+            })
+        );
+    }
+}

--- a/packages/std/src/api.rs
+++ b/packages/std/src/api.rs
@@ -3,7 +3,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::errors::ApiError;
+use crate::errors::Error;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "lowercase")]
@@ -36,10 +36,102 @@ impl<T, U: Into<T>, E: std::error::Error, F: Into<E>> From<Result<U, F>> for Api
     }
 }
 
+/// ApiError is a "converted" Error that can be serialized and deserialized.
+/// It can be created via `error.into()`
+/// This will not contain all information of the original (source error and backtrace cannot be serialized),
+/// but we ensure the following:
+/// 1. An ApiError will have the same type as the original Error
+/// 2. An ApiError will have the same display as the original
+/// 3. Serializing and deserializing an ApiError will give you an identical struct
+///
+/// Rather than use Display to pass Errors over API/FFI boundaries, we can use ApiError
+/// and provide much more context to the client.
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub enum ApiError {
+    Base64Err { source: String },
+    ContractErr { msg: String },
+    DynContractErr { msg: String },
+    NotFound { kind: String },
+    NullPointer {},
+    ParseErr { kind: String, source: String },
+    SerializeErr { kind: String, source: String },
+    // This is used for std::str::from_utf8, which we may well deprecate
+    Utf8Err { source: String },
+    // This is used for String::from_utf8, which does zero-copy from Vec<u8>, moving towards this
+    Utf8StringErr { source: String },
+    Unauthorized {},
+    ValidationErr { field: String, msg: String },
+}
+
+impl std::error::Error for ApiError {}
+
+impl std::fmt::Display for ApiError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ApiError::Base64Err { source } => write!(f, "Invalid Base64 string: {}", source),
+            ApiError::ContractErr { msg } => write!(f, "Contract error: {}", msg),
+            ApiError::DynContractErr { msg } => write!(f, "Contract error: {}", msg),
+            ApiError::NotFound { kind } => write!(f, "{} not found", kind),
+            ApiError::NullPointer {} => write!(f, "Received null pointer, refuse to use"),
+            ApiError::ParseErr { kind, source } => write!(f, "Error parsing {}: {}", kind, source),
+            ApiError::SerializeErr { kind, source } => {
+                write!(f, "Error serializing {}: {}", kind, source)
+            }
+            ApiError::Utf8Err { source } => write!(f, "UTF8 encoding error: {}", source),
+            ApiError::Utf8StringErr { source } => write!(f, "UTF8 encoding error: {}", source),
+            ApiError::Unauthorized {} => write!(f, "Unauthorized"),
+            ApiError::ValidationErr { field, msg } => write!(f, "Invalid {}: {}", field, msg),
+        }
+    }
+}
+
+impl From<Error> for ApiError {
+    fn from(value: Error) -> Self {
+        match value {
+            Error::Base64Err { source, .. } => ApiError::Base64Err {
+                source: format!("{}", source),
+            },
+            Error::ContractErr { msg, .. } => ApiError::ContractErr {
+                msg: msg.to_string(),
+            },
+            Error::DynContractErr { msg, .. } => ApiError::DynContractErr { msg },
+            Error::NotFound { kind, .. } => ApiError::NotFound {
+                kind: kind.to_string(),
+            },
+            Error::NullPointer { .. } => ApiError::NullPointer {},
+            Error::ParseErr { kind, source, .. } => ApiError::ParseErr {
+                kind: kind.to_string(),
+                source: format!("{}", source),
+            },
+            Error::SerializeErr { kind, source, .. } => ApiError::SerializeErr {
+                kind: kind.to_string(),
+                source: format!("{}", source),
+            },
+            Error::Utf8Err { source, .. } => ApiError::Utf8Err {
+                source: format!("{}", source),
+            },
+            Error::Utf8StringErr { source, .. } => ApiError::Utf8StringErr {
+                source: format!("{}", source),
+            },
+            Error::Unauthorized { .. } => ApiError::Unauthorized {},
+            Error::ValidationErr { field, msg, .. } => ApiError::ValidationErr {
+                field: field.to_string(),
+                msg: msg.to_string(),
+            },
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
+    use snafu::ResultExt;
+
     use super::*;
-    use crate::errors::{contract_err, Result};
+    use crate::errors::{
+        contract_err, dyn_contract_err, invalid, unauthorized, Base64Err, NotFound, NullPointer,
+        Result, SerializeErr,
+    };
+    use crate::serde::{from_slice, to_vec};
 
     #[test]
     fn convert_ok_result() {
@@ -58,5 +150,62 @@ mod test {
                 msg: "sample error".to_string()
             })
         );
+    }
+
+    fn assert_conversion(r: Result<()>) {
+        let error = r.unwrap_err();
+        let msg = format!("{}", error);
+        let converted: ApiError = error.into();
+        assert_eq!(msg, format!("{}", converted));
+        let round_trip: ApiError = from_slice(&to_vec(&converted).unwrap()).unwrap();
+        assert_eq!(round_trip, converted);
+    }
+
+    #[test]
+    fn base64_conversion() {
+        let source = Err(base64::DecodeError::InvalidLength);
+        assert_conversion(source.context(Base64Err {}));
+    }
+
+    #[test]
+    fn contract_conversion() {
+        assert_conversion(contract_err("foobar"));
+    }
+
+    #[test]
+    fn dyn_contract_conversion() {
+        assert_conversion(dyn_contract_err("dynamic".to_string()));
+    }
+
+    #[test]
+    fn invalid_conversion() {
+        assert_conversion(invalid("name", "too short"));
+    }
+
+    #[test]
+    fn unauthorized_conversion() {
+        assert_conversion(unauthorized());
+    }
+
+    #[test]
+    fn null_pointer_conversion() {
+        assert_conversion(NullPointer {}.fail());
+    }
+
+    #[test]
+    fn not_found_conversion() {
+        assert_conversion(NotFound { kind: "State" }.fail());
+    }
+
+    #[test]
+    fn parse_err_conversion() {
+        let err = from_slice::<String>(b"123").map(|_| ());
+        assert_conversion(err);
+    }
+
+    #[test]
+    fn serialize_err_conversion() {
+        let source = Err(serde_json_wasm::ser::Error::BufferFull);
+        assert_conversion(source.context(SerializeErr { kind: "faker" }));
     }
 }

--- a/packages/std/src/errors.rs
+++ b/packages/std/src/errors.rs
@@ -109,6 +109,8 @@ pub enum ApiError {
     ValidationErr { field: String, msg: String },
 }
 
+impl std::error::Error for ApiError {}
+
 impl std::fmt::Display for ApiError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/packages/std/src/errors.rs
+++ b/packages/std/src/errors.rs
@@ -1,3 +1,4 @@
+use crate::HumanAddr;
 use snafu::Snafu;
 
 #[derive(Debug, Snafu)]
@@ -57,6 +58,27 @@ pub enum Error {
     ValidationErr {
         field: &'static str,
         msg: &'static str,
+        backtrace: snafu::Backtrace,
+    },
+}
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility = "pub")]
+/// SystemError is used for errors inside the runtime.
+/// This is used on return values for Querier as a nested Result -
+/// Result<Result<T, Error>, SystemError>
+/// The first wrap (SystemError) will trigger if the contract address doesn't exist,
+/// the QueryRequest is malformated, etc. The second wrap will be an error message from
+/// the contract itself.
+pub enum SystemError {
+    #[snafu(display("Cannot parse request: {}", source))]
+    InvalidRequest {
+        source: serde_json_wasm::de::Error,
+        backtrace: snafu::Backtrace,
+    },
+    #[snafu(display("No such contract: {}", addr))]
+    NoSuchContract {
+        addr: HumanAddr,
         backtrace: snafu::Backtrace,
     },
 }

--- a/packages/std/src/errors.rs
+++ b/packages/std/src/errors.rs
@@ -1,4 +1,3 @@
-use serde::{Deserialize, Serialize};
 use snafu::Snafu;
 
 #[derive(Debug, Snafu)]
@@ -82,97 +81,9 @@ pub fn unauthorized<T>() -> Result<T> {
     Unauthorized {}.fail()
 }
 
-/// ApiError is a "converted" Error that can be serialized and deserialized.
-/// It can be created via `error.into()`
-/// This will not contain all information of the original (source error and backtrace cannot be serialized),
-/// but we ensure the following:
-/// 1. An ApiError will have the same type as the original Error
-/// 2. An ApiError will have the same display as the original
-/// 3. Serializing and deserializing an ApiError will give you an identical struct
-///
-/// Rather than use Display to pass Errors over API/FFI boundaries, we can use ApiError
-/// and provide much more context to the client.
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
-pub enum ApiError {
-    Base64Err { source: String },
-    ContractErr { msg: String },
-    DynContractErr { msg: String },
-    NotFound { kind: String },
-    NullPointer {},
-    ParseErr { kind: String, source: String },
-    SerializeErr { kind: String, source: String },
-    // This is used for std::str::from_utf8, which we may well deprecate
-    Utf8Err { source: String },
-    // This is used for String::from_utf8, which does zero-copy from Vec<u8>, moving towards this
-    Utf8StringErr { source: String },
-    Unauthorized {},
-    ValidationErr { field: String, msg: String },
-}
-
-impl std::error::Error for ApiError {}
-
-impl std::fmt::Display for ApiError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ApiError::Base64Err { source } => write!(f, "Invalid Base64 string: {}", source),
-            ApiError::ContractErr { msg } => write!(f, "Contract error: {}", msg),
-            ApiError::DynContractErr { msg } => write!(f, "Contract error: {}", msg),
-            ApiError::NotFound { kind } => write!(f, "{} not found", kind),
-            ApiError::NullPointer {} => write!(f, "Received null pointer, refuse to use"),
-            ApiError::ParseErr { kind, source } => write!(f, "Error parsing {}: {}", kind, source),
-            ApiError::SerializeErr { kind, source } => {
-                write!(f, "Error serializing {}: {}", kind, source)
-            }
-            ApiError::Utf8Err { source } => write!(f, "UTF8 encoding error: {}", source),
-            ApiError::Utf8StringErr { source } => write!(f, "UTF8 encoding error: {}", source),
-            ApiError::Unauthorized {} => write!(f, "Unauthorized"),
-            ApiError::ValidationErr { field, msg } => write!(f, "Invalid {}: {}", field, msg),
-        }
-    }
-}
-
-impl From<Error> for ApiError {
-    fn from(value: Error) -> Self {
-        match value {
-            Error::Base64Err { source, .. } => ApiError::Base64Err {
-                source: format!("{}", source),
-            },
-            Error::ContractErr { msg, .. } => ApiError::ContractErr {
-                msg: msg.to_string(),
-            },
-            Error::DynContractErr { msg, .. } => ApiError::DynContractErr { msg },
-            Error::NotFound { kind, .. } => ApiError::NotFound {
-                kind: kind.to_string(),
-            },
-            Error::NullPointer { .. } => ApiError::NullPointer {},
-            Error::ParseErr { kind, source, .. } => ApiError::ParseErr {
-                kind: kind.to_string(),
-                source: format!("{}", source),
-            },
-            Error::SerializeErr { kind, source, .. } => ApiError::SerializeErr {
-                kind: kind.to_string(),
-                source: format!("{}", source),
-            },
-            Error::Utf8Err { source, .. } => ApiError::Utf8Err {
-                source: format!("{}", source),
-            },
-            Error::Utf8StringErr { source, .. } => ApiError::Utf8StringErr {
-                source: format!("{}", source),
-            },
-            Error::Unauthorized { .. } => ApiError::Unauthorized {},
-            Error::ValidationErr { field, msg, .. } => ApiError::ValidationErr {
-                field: field.to_string(),
-                msg: msg.to_string(),
-            },
-        }
-    }
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::serde::{from_slice, to_vec};
-    use snafu::ResultExt;
 
     #[test]
     fn use_invalid() {
@@ -212,62 +123,5 @@ mod test {
             Err(e) => panic!("unexpected error, {:?}", e),
             Ok(_) => panic!("dyn_contract_err must return error"),
         }
-    }
-
-    fn assert_conversion(r: Result<()>) {
-        let error = r.unwrap_err();
-        let msg = format!("{}", error);
-        let converted: ApiError = error.into();
-        assert_eq!(msg, format!("{}", converted));
-        let round_trip: ApiError = from_slice(&to_vec(&converted).unwrap()).unwrap();
-        assert_eq!(round_trip, converted);
-    }
-
-    #[test]
-    fn base64_conversion() {
-        let source = Err(base64::DecodeError::InvalidLength);
-        assert_conversion(source.context(Base64Err {}));
-    }
-
-    #[test]
-    fn contract_conversion() {
-        assert_conversion(contract_err("foobar"));
-    }
-
-    #[test]
-    fn dyn_contract_conversion() {
-        assert_conversion(dyn_contract_err("dynamic".to_string()));
-    }
-
-    #[test]
-    fn invalid_conversion() {
-        assert_conversion(invalid("name", "too short"));
-    }
-
-    #[test]
-    fn unauthorized_conversion() {
-        assert_conversion(unauthorized());
-    }
-
-    #[test]
-    fn null_pointer_conversion() {
-        assert_conversion(NullPointer {}.fail());
-    }
-
-    #[test]
-    fn not_found_conversion() {
-        assert_conversion(NotFound { kind: "State" }.fail());
-    }
-
-    #[test]
-    fn parse_err_conversion() {
-        let err = from_slice::<String>(b"123").map(|_| ());
-        assert_conversion(err);
-    }
-
-    #[test]
-    fn serialize_err_conversion() {
-        let source = Err(serde_json_wasm::ser::Error::BufferFull);
-        assert_conversion(source.context(SerializeErr { kind: "faker" }));
     }
 }

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -50,5 +50,5 @@ pub use crate::imports::{ExternalApi, ExternalStorage};
 mod mock;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod testing {
-    pub use crate::mock::{mock_dependencies, mock_env, MockApi, MockStorage};
+    pub use crate::mock::{mock_dependencies, mock_env, MockApi, MockQuerier, MockStorage};
 }

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -11,10 +11,11 @@ mod traits;
 mod transactions;
 mod types;
 
+pub use crate::api::{ApiError, ApiResult};
 pub use crate::encoding::Binary;
 pub use crate::errors::{
-    contract_err, dyn_contract_err, invalid, unauthorized, ApiError, Error, NotFound, NullPointer,
-    ParseErr, Result, SerializeErr,
+    contract_err, dyn_contract_err, invalid, unauthorized, Error, NotFound, NullPointer, ParseErr,
+    Result, SerializeErr,
 };
 pub use crate::init_handle::{
     log, CosmosMsg, HandleResponse, HandleResult, InitResponse, InitResult, LogAttribute,

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -1,5 +1,6 @@
 // Exposed on all platforms
 
+mod api;
 mod encoding;
 mod errors;
 mod init_handle;

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -18,7 +18,7 @@ pub use crate::errors::{
 pub use crate::init_handle::{
     log, CosmosMsg, HandleResponse, HandleResult, InitResponse, InitResult, LogAttribute,
 };
-pub use crate::query::{QueryResponse, QueryResult};
+pub use crate::query::{BalanceResponse, QueryRequest, QueryResponse, QueryResult};
 pub use crate::serde::{from_slice, to_vec};
 pub use crate::storage::MemoryStorage;
 pub use crate::traits::{Api, Extern, ReadonlyStorage, Storage};

--- a/packages/std/src/mock.rs
+++ b/packages/std/src/mock.rs
@@ -126,9 +126,9 @@ impl Querier for MockQuerier {
             QueryRequest::Balance { address } => {
                 // proper error on not found, serialize result on found
                 let bank_res = BalanceResponse {
-                    amount: self.balances.get(&address).map(|t| t.clone()),
+                    amount: self.balances.get(&address).cloned(),
                 };
-                let api_res = to_vec(&bank_res).map(|t| Binary(t)).map_err(|e| e.into());
+                let api_res = to_vec(&bank_res).map(Binary).map_err(|e| e.into());
                 Ok(api_res)
             }
             QueryRequest::Contract { contract_addr, .. } => Err(ApiSystemError::NoSuchContract {

--- a/packages/std/src/mock.rs
+++ b/packages/std/src/mock.rs
@@ -1,9 +1,13 @@
 use snafu::ResultExt;
+use std::collections::HashMap;
 
+use crate::api::{ApiError, ApiSystemError};
 use crate::encoding::Binary;
 use crate::errors::{ContractErr, Result, Utf8StringErr};
+use crate::query::{BalanceResponse, QueryRequest};
+use crate::serde::to_vec;
 use crate::storage::MemoryStorage;
-use crate::traits::{Api, Extern};
+use crate::traits::{Api, Extern, Querier};
 use crate::types::{BlockInfo, CanonicalAddr, Coin, ContractInfo, Env, HumanAddr, MessageInfo};
 
 /// All external requirements that can be injected for unit tests
@@ -101,6 +105,30 @@ pub fn mock_env<T: Api, U: Into<HumanAddr>>(
                 Some(balance.to_vec())
             },
         },
+    }
+}
+
+/// MockQuerier holds an immutable table of bank balances
+/// TODO: also allow querying contracts
+pub struct MockQuerier {
+    balances: HashMap<HumanAddr, Vec<Coin>>,
+}
+
+impl Querier for MockQuerier {
+    fn query(&self, request: QueryRequest) -> Result<Result<Binary, ApiError>, ApiSystemError> {
+        match request {
+            QueryRequest::Balance { address } => {
+                // proper error on not found, serialize result on found
+                let bank_res = BalanceResponse {
+                    amount: self.balances.get(&address).map(|t| t.clone()),
+                };
+                let api_res = to_vec(&bank_res).map(|t| Binary(t)).map_err(|e| e.into());
+                Ok(api_res)
+            }
+            QueryRequest::Contract { contract_addr, .. } => Err(ApiSystemError::NoSuchContract {
+                addr: contract_addr,
+            }),
+        }
     }
 }
 

--- a/packages/std/src/mock.rs
+++ b/packages/std/src/mock.rs
@@ -114,6 +114,12 @@ pub struct MockQuerier {
     balances: HashMap<HumanAddr, Vec<Coin>>,
 }
 
+impl MockQuerier {
+    pub fn new(balances: HashMap<HumanAddr, Vec<Coin>>) -> Self {
+        MockQuerier { balances }
+    }
+}
+
 impl Querier for MockQuerier {
     fn query(&self, request: QueryRequest) -> Result<Result<Binary, ApiError>, ApiSystemError> {
         match request {

--- a/packages/std/src/query.rs
+++ b/packages/std/src/query.rs
@@ -50,5 +50,5 @@ pub enum QueryRequest {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct BalanceResponse {
-    amount: Option<Vec<Coin>>,
+    pub amount: Option<Vec<Coin>>,
 }

--- a/packages/std/src/query.rs
+++ b/packages/std/src/query.rs
@@ -2,6 +2,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::encoding::Binary;
+use crate::types::{Coin, HumanAddr};
 
 pub type QueryResponse = Binary;
 
@@ -27,4 +28,27 @@ impl QueryResult {
             _ => false,
         }
     }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum QueryRequest {
+    // this queries the public API of another contract at a known address (with known ABI)
+    // msg is the json-encoded QueryMsg struct
+    // return value is whatever the contract returns (caller should know)
+    Contract {
+        contract_addr: HumanAddr,
+        msg: Binary, // we pass this in as Vec<u8> to the contract, so allow any binary encoding (later, limit to rawjson?)
+    },
+    // this calls into the native bank module
+    // return value is BalanceResponse
+    Balance {
+        address: HumanAddr,
+    },
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct BalanceResponse {
+    amount: Option<Vec<Coin>>,
 }

--- a/packages/std/src/traits.rs
+++ b/packages/std/src/traits.rs
@@ -1,4 +1,4 @@
-use crate::api::ApiError;
+use crate::api::{ApiError, ApiSystemError};
 use crate::encoding::Binary;
 use crate::errors::Result;
 use crate::query::QueryRequest;
@@ -54,7 +54,10 @@ pub trait Api: Copy + Clone + Send {
 pub trait Querier {
     // Note: ApiError type can be serialized, and the below can be reconstituted over a WASM/FFI call.
     // Since this is information that is returned from outside, we define it this way.
-    fn query(&self, request: QueryRequest) -> Result<Binary, ApiError>;
+    //
+    // ApiResult is a format that can capture this info in a serialized form. We parse it into
+    // a typical Result for the implementing object
+    fn query(&self, request: QueryRequest) -> Result<Result<Binary, ApiError>, ApiSystemError>;
 }
 
 // put them here to avoid so many feature flags

--- a/packages/std/src/traits.rs
+++ b/packages/std/src/traits.rs
@@ -35,22 +35,27 @@ pub trait Storage: ReadonlyStorage {
     fn remove(&mut self, key: &[u8]);
 }
 
-// Api are callbacks to system functions defined outside of the wasm modules.
-// This is a trait to allow Mocks in the test code.
-//
-// Currently it just supports address conversion, we could add eg. crypto functions here.
-// These should all be pure (stateless) functions. If you need state, you probably want
-// to use the Querier (TODO)
-//
-// We should consider if there is a way for modules to opt-in to only a subset of these
-// Api for backwards compatibility in systems that don't have them all.
+/// Api are callbacks to system functions defined outside of the wasm modules.
+/// This is a trait to allow Mocks in the test code.
+///
+/// Currently it just supports address conversion, we could add eg. crypto functions here.
+/// These should all be pure (stateless) functions. If you need state, you probably want
+/// to use the Querier (TODO)
+///
+/// We can use feature flags to opt-in to non-essential methods
+/// for backwards compatibility in systems that don't have them all.
 pub trait Api: Copy + Clone + Send {
     fn canonical_address(&self, human: &HumanAddr) -> Result<CanonicalAddr>;
     fn human_address(&self, canonical: &CanonicalAddr) -> Result<HumanAddr>;
 }
 
 pub trait Querier {
-    // TODO: look into how to return nicer errors
+    // Note: I considered returning Result<Binary> (as in Api), but figured that would be misleading.
+    // In rust unit tests, it would return a specific snafu::Error enum. But if passed over wasm FFI,
+    // it will always be Error::ContractErr.
+    //
+    // Ideas on better way to represent knowing this must work transparently over FFI?
+    // I could not find a way to serialize/deserialize the snafu error
     fn query(&self, request: QueryRequest) -> QueryResult;
 }
 

--- a/packages/std/src/traits.rs
+++ b/packages/std/src/traits.rs
@@ -1,5 +1,6 @@
+use crate::api::ApiError;
 use crate::encoding::Binary;
-use crate::errors::{ApiError, Result};
+use crate::errors::Result;
 use crate::query::QueryRequest;
 use crate::types::{CanonicalAddr, HumanAddr};
 

--- a/packages/std/src/traits.rs
+++ b/packages/std/src/traits.rs
@@ -1,5 +1,6 @@
-use crate::errors::Result;
-use crate::query::{QueryRequest, QueryResult};
+use crate::encoding::Binary;
+use crate::errors::{ApiError, Result};
+use crate::query::QueryRequest;
 use crate::types::{CanonicalAddr, HumanAddr};
 
 #[cfg(feature = "iterator")]
@@ -50,13 +51,9 @@ pub trait Api: Copy + Clone + Send {
 }
 
 pub trait Querier {
-    // Note: I considered returning Result<Binary> (as in Api), but figured that would be misleading.
-    // In rust unit tests, it would return a specific snafu::Error enum. But if passed over wasm FFI,
-    // it will always be Error::ContractErr.
-    //
-    // Ideas on better way to represent knowing this must work transparently over FFI?
-    // I could not find a way to serialize/deserialize the snafu error
-    fn query(&self, request: QueryRequest) -> QueryResult;
+    // Note: ApiError type can be serialized, and the below can be reconstituted over a WASM/FFI call.
+    // Since this is information that is returned from outside, we define it this way.
+    fn query(&self, request: QueryRequest) -> Result<Binary, ApiError>;
 }
 
 // put them here to avoid so many feature flags

--- a/packages/std/src/traits.rs
+++ b/packages/std/src/traits.rs
@@ -1,4 +1,5 @@
 use crate::errors::Result;
+use crate::query::{QueryRequest, QueryResult};
 use crate::types::{CanonicalAddr, HumanAddr};
 
 #[cfg(feature = "iterator")]
@@ -46,6 +47,11 @@ pub trait Storage: ReadonlyStorage {
 pub trait Api: Copy + Clone + Send {
     fn canonical_address(&self, human: &HumanAddr) -> Result<CanonicalAddr>;
     fn human_address(&self, canonical: &CanonicalAddr) -> Result<HumanAddr>;
+}
+
+pub trait Querier {
+    // TODO: look into how to return nicer errors
+    fn query(&self, request: QueryRequest) -> QueryResult;
 }
 
 // put them here to avoid so many feature flags

--- a/packages/std/src/types.rs
+++ b/packages/std/src/types.rs
@@ -5,7 +5,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::encoding::Binary;
 
-#[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq, JsonSchema)]
+// Added Eq and Hash to allow this to be a key in a HashMap (MockQuerier)
+#[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq, Eq, JsonSchema, Hash)]
 pub struct HumanAddr(pub String);
 
 #[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq, JsonSchema)]


### PR DESCRIPTION
Begin work on #100 

This is my proposal for a generic Querier interface, with an enum Request we can easily extend (more than adding new methods). I am trying to figure out how to pass rich errors over an FFI boundary (see #199) and will improve the error reporting here once that is merged

@KamiD I would appreciate your review and feedback (as I know you want this feature for a long time and we had some discussions on it)