### PR TITLE
Make cosmwasm_std::Error serializable

### DIFF
--- a/packages/std/src/errors.rs
+++ b/packages/std/src/errors.rs
@@ -255,9 +255,7 @@ mod test {
 
     #[test]
     fn parse_err_conversion() {
-        let err = from_slice::<String>(b"123")
-            .context(ParseErr { kind: "String" })
-            .map(|_| ());
+        let err = from_slice::<String>(b"123").map(|_| ());
         assert_conversion(err);
     }
 

--- a/packages/std/src/errors.rs
+++ b/packages/std/src/errors.rs
@@ -1,60 +1,81 @@
+use serde::Serialize;
 use snafu::Snafu;
 
-#[derive(Debug, Snafu)]
+#[derive(Debug, Snafu, Serialize)]
 #[snafu(visibility = "pub")]
 pub enum Error {
     #[snafu(display("Invalid Base64 string: {}", source))]
     Base64Err {
+        #[serde(serialize_with = "serialize_as_string")]
         source: base64::DecodeError,
+        #[serde(skip)]
         backtrace: snafu::Backtrace,
     },
     #[snafu(display("Contract error: {}", msg))]
     ContractErr {
         msg: &'static str,
+        #[serde(skip)]
         backtrace: snafu::Backtrace,
     },
     #[snafu(display("Contract error: {}", msg))]
     DynContractErr {
         msg: String,
+        #[serde(skip)]
         backtrace: snafu::Backtrace,
     },
     #[snafu(display("{} not found", kind))]
     NotFound {
         kind: &'static str,
+        #[serde(skip)]
         backtrace: snafu::Backtrace,
     },
     #[snafu(display("Received null pointer, refuse to use"))]
-    NullPointer { backtrace: snafu::Backtrace },
+    NullPointer {
+        #[serde(skip)]
+        backtrace: snafu::Backtrace,
+    },
     #[snafu(display("Error parsing {}: {}", kind, source))]
     ParseErr {
-        source: serde_json_wasm::de::Error,
         kind: &'static str,
+        #[serde(serialize_with = "serialize_as_string")]
+        source: serde_json_wasm::de::Error,
+        #[serde(skip)]
         backtrace: snafu::Backtrace,
     },
     #[snafu(display("Error serializing {}: {}", kind, source))]
     SerializeErr {
-        source: serde_json_wasm::ser::Error,
         kind: &'static str,
+        #[serde(serialize_with = "serialize_as_string")]
+        source: serde_json_wasm::ser::Error,
+        #[serde(skip)]
         backtrace: snafu::Backtrace,
     },
     // This is used for std::str::from_utf8, which we may well deprecate
     #[snafu(display("UTF8 encoding error: {}", source))]
     Utf8Err {
+        #[serde(serialize_with = "serialize_as_string")]
         source: std::str::Utf8Error,
+        #[serde(skip)]
         backtrace: snafu::Backtrace,
     },
     // This is used for String::from_utf8, which does zero-copy from Vec<u8>, moving towards this
     #[snafu(display("UTF8 encoding error: {}", source))]
     Utf8StringErr {
+        #[serde(serialize_with = "serialize_as_string")]
         source: std::string::FromUtf8Error,
+        #[serde(skip)]
         backtrace: snafu::Backtrace,
     },
     #[snafu(display("Unauthorized"))]
-    Unauthorized { backtrace: snafu::Backtrace },
+    Unauthorized {
+        #[serde(skip)]
+        backtrace: snafu::Backtrace,
+    },
     #[snafu(display("Invalid {}: {}", field, msg))]
     ValidationErr {
         field: &'static str,
         msg: &'static str,
+        #[serde(skip)]
         backtrace: snafu::Backtrace,
     },
 }
@@ -75,6 +96,75 @@ pub fn dyn_contract_err<T>(msg: String) -> Result<T> {
 
 pub fn unauthorized<T>() -> Result<T> {
     Unauthorized {}.fail()
+}
+
+/// serialize_as_string allows us to serialize source errors with the important info
+fn serialize_as_string<T, S>(err: &T, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+    T: std::fmt::Display,
+{
+    let msg = format!("{}", err);
+    serde::Serialize::serialize(&msg, serializer)
+}
+
+pub use api::ApiError;
+
+// place this in a submod, so the auto-generated contexts don't conflict with same-named context from above
+mod api {
+    use serde::{Deserialize, Serialize};
+    use snafu::Snafu;
+
+    /// ApiError is a "rehydrated" Error after it has been Serialized and restored.
+    /// This will not contain all information of the original (source error and backtrace cannot be serialized),
+    /// but we aim to ensure the following:
+    /// 1. A rehydrated ApiError will have the same type as the original Error
+    /// 2. A rehydrated ApiError will have the same display as the original
+    /// 3. Serializing and Deserializing an ApiError will give you an identical struct
+    #[derive(Debug, Snafu, Serialize, Deserialize)]
+    pub enum ApiError {
+        #[snafu(display("Invalid Base64 string: {}", source))]
+        Base64Err {
+            #[snafu(source(false))]
+            source: String,
+        },
+        #[snafu(display("Contract error: {}", msg))]
+        ContractErr { msg: String },
+        #[snafu(display("Contract error: {}", msg))]
+        DynContractErr { msg: String },
+        #[snafu(display("{} not found", kind))]
+        NotFound { kind: String },
+        #[snafu(display("Received null pointer, refuse to use"))]
+        NullPointer {},
+        #[snafu(display("Error parsing {}: {}", kind, source))]
+        ParseErr {
+            kind: String,
+            #[snafu(source(false))]
+            source: String,
+        },
+        #[snafu(display("Error serializing {}: {}", kind, source))]
+        SerializeErr {
+            kind: String,
+            #[snafu(source(false))]
+            source: String,
+        },
+        // This is used for std::str::from_utf8, which we may well deprecate
+        #[snafu(display("UTF8 encoding error: {}", source))]
+        Utf8Err {
+            #[snafu(source(false))]
+            source: String,
+        },
+        // This is used for String::from_utf8, which does zero-copy from Vec<u8>, moving towards this
+        #[snafu(display("UTF8 encoding error: {}", source))]
+        Utf8StringErr {
+            #[snafu(source(false))]
+            source: String,
+        },
+        #[snafu(display("Unauthorized"))]
+        Unauthorized {},
+        #[snafu(display("Invalid {}: {}", field, msg))]
+        ValidationErr { field: String, msg: String },
+    }
 }
 
 #[cfg(test)]

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -10,8 +10,8 @@ mod types;
 
 pub use crate::encoding::Binary;
 pub use crate::errors::{
-    contract_err, dyn_contract_err, invalid, unauthorized, Error, NotFound, NullPointer, ParseErr,
-    Result, SerializeErr,
+    contract_err, dyn_contract_err, invalid, unauthorized, ApiError, Error, NotFound, NullPointer,
+    ParseErr, Result, SerializeErr,
 };
 pub use crate::serde::{from_slice, to_vec};
 pub use crate::storage::MemoryStorage;


### PR DESCRIPTION
When passing info over API boundaries, we lose all type info. This issue has been faced with all integration tests, where we have to adapt the error handling from matching on type to string compares.  While beginning work on the `Querier` trait in #197 I realized this becomes an issue.

In unit tests, `Querier` would have access to a full Result. However, when running in integration, we would either have QueryResult(`Err(String)`) or fake a Result like we do in `ExternalApi.canonical_address`. The other approach would be to downgrade all local errors into `QueryResult` as well....

This PR is an experiment of making the `cosmwasm_std::Error` type something we can pass through an API (serialization boundary). Naturally the source error field and backtraces fields cannot be de/serialized properly, so I create a custom `ApiError` type for deserialization which captures all information in a serializable form. And use a bit of serde magic to make this all work together.

Before actually using these richer errors in the `Querier`, I want to see if such transforms are acceptable. They should create no overhead (runtime or bytecode) if not used. But will make usage of `Querier` a bit bulkier in runtime. We would also want to update the `Query` implementation in general to return this richer data.