### PR TITLE
Better serde errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ ranges).
 - The export `allocate` does not zero-fill the allocated memory anymore.
 - Add `remove_db` to the required imports of a contract.
 - (feature-flagged) add `scan_db` and `next_db` callbacks from wasm contract to VM.
+- `serde::{from_slice, to_vec}` return `cosmwasm_std::Result`, no more need to use
+`.context(...)` when calling these functions
 
 **cosmwasm-vm**
 
@@ -45,6 +47,8 @@ ranges).
 - Change the required interface version guard export from `cosmwasm_api_0_6` to
   `cosmwasm_vm_version_1`.
 - Provide implementations for `remove_db` and (feature-flagged) `scan_db` and `next_db`
+- Provide custom `serde::{from_slice, to_vec}` implementation separate from `cosmwasm_std`,
+so we can return cosmwasm-vm specific `Result` (only used internally).
 
 ## 0.7.2 (2020-03-23)
 

--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -1,10 +1,10 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use snafu::{OptionExt, ResultExt};
+use snafu::OptionExt;
 
 use cosmwasm_std::{
     from_slice, log, to_vec, unauthorized, Api, CanonicalAddr, CosmosMsg, Env, Extern, HumanAddr,
-    NotFound, ParseErr, Response, Result, SerializeErr, Storage,
+    NotFound, Response, Result, Storage,
 };
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -56,8 +56,7 @@ pub fn init<S: Storage, A: Api>(
             verifier: deps.api.canonical_address(&msg.verifier)?,
             beneficiary: deps.api.canonical_address(&msg.beneficiary)?,
             funder: env.message.signer,
-        })
-        .context(SerializeErr { kind: "State" })?,
+        })?,
     );
     Ok(Response::default())
 }
@@ -80,7 +79,7 @@ fn do_release<S: Storage, A: Api>(deps: &mut Extern<S, A>, env: Env) -> Result<R
         .storage
         .get(CONFIG_KEY)
         .context(NotFound { kind: "State" })?;
-    let state: State = from_slice(&data).context(ParseErr { kind: "State" })?;
+    let state: State = from_slice(&data)?;
 
     if env.message.signer == state.verifier {
         let to_addr = deps.api.human_address(&state.beneficiary)?;
@@ -137,7 +136,7 @@ fn query_verifier<S: Storage, A: Api>(deps: &Extern<S, A>) -> Result<Vec<u8>> {
         .storage
         .get(CONFIG_KEY)
         .context(NotFound { kind: "State" })?;
-    let state: State = from_slice(&data).context(ParseErr { kind: "State" })?;
+    let state: State = from_slice(&data)?;
     let addr = deps.api.human_address(&state.verifier)?;
     // we just pass the address as raw bytes
     // these will be base64 encoded into the json we return, and parsed on the way out.

--- a/contracts/hackatom/tests/integration.rs
+++ b/contracts/hackatom/tests/integration.rs
@@ -83,7 +83,10 @@ fn init_and_query() {
     // bad query returns parse error (pass wrong type - this connection is not enforced)
     let qres = query(&mut deps, HandleMsg::Release {});
     match qres {
-        QueryResult::Err(msg) => assert!(msg.starts_with("Error parsing QueryMsg:"), msg),
+        QueryResult::Err(msg) => assert!(
+            msg.starts_with("Error parsing hackatom::contract::QueryMsg:"),
+            msg
+        ),
         _ => panic!("Call should fail"),
     }
 }

--- a/packages/std/src/serde.rs
+++ b/packages/std/src/serde.rs
@@ -2,4 +2,26 @@
 // The reason is two fold:
 // 1. To easily ensure that all calling libraries use the same version (minimize code size)
 // 2. To allow us to switch out to eg. serde-json-core more easily
-pub use serde_json_wasm::{from_slice, to_vec};
+use serde::{Deserialize, Serialize};
+use snafu::ResultExt;
+use std::any::type_name;
+
+use crate::errors::{ParseErr, Result, SerializeErr};
+
+pub fn from_slice<'a, T>(value: &'a [u8]) -> Result<T>
+where
+    T: Deserialize<'a>,
+{
+    serde_json_wasm::from_slice(value).context(ParseErr {
+        kind: type_name::<T>(),
+    })
+}
+
+pub fn to_vec<T>(data: &T) -> Result<Vec<u8>>
+where
+    T: Serialize + ?Sized,
+{
+    serde_json_wasm::to_vec(data).context(SerializeErr {
+        kind: type_name::<T>(),
+    })
+}

--- a/packages/vm/src/calls.rs
+++ b/packages/vm/src/calls.rs
@@ -1,8 +1,10 @@
 use snafu::ResultExt;
 
-use cosmwasm_std::{from_slice, to_vec, Api, ContractResult, Env, QueryResult, Storage};
+use cosmwasm_std::{Api, ContractResult, Env, QueryResult, Storage};
 
-use crate::errors::{Error, ParseErr, RuntimeErr, SerializeErr};
+use crate::serde::{from_slice, to_vec};
+
+use crate::errors::{Error, RuntimeErr};
 use crate::instance::{Func, Instance};
 
 pub fn call_init<S: Storage + 'static, A: Api + 'static>(
@@ -10,9 +12,9 @@ pub fn call_init<S: Storage + 'static, A: Api + 'static>(
     env: &Env,
     msg: &[u8],
 ) -> Result<ContractResult, Error> {
-    let env = to_vec(env).context(SerializeErr {})?;
+    let env = to_vec(env)?;
     let data = call_init_raw(instance, &env, msg)?;
-    let res: ContractResult = from_slice(&data).context(ParseErr {})?;
+    let res: ContractResult = from_slice(&data)?;
     Ok(res)
 }
 
@@ -21,9 +23,9 @@ pub fn call_handle<S: Storage + 'static, A: Api + 'static>(
     env: &Env,
     msg: &[u8],
 ) -> Result<ContractResult, Error> {
-    let env = to_vec(env).context(SerializeErr {})?;
+    let env = to_vec(env)?;
     let data = call_handle_raw(instance, &env, msg)?;
-    let res: ContractResult = from_slice(&data).context(ParseErr {})?;
+    let res: ContractResult = from_slice(&data)?;
     Ok(res)
 }
 
@@ -32,7 +34,7 @@ pub fn call_query<S: Storage + 'static, A: Api + 'static>(
     msg: &[u8],
 ) -> Result<QueryResult, Error> {
     let data = call_query_raw(instance, msg)?;
-    let res: QueryResult = from_slice(&data).context(ParseErr {})?;
+    let res: QueryResult = from_slice(&data)?;
     Ok(res)
 }
 

--- a/packages/vm/src/errors.rs
+++ b/packages/vm/src/errors.rs
@@ -27,11 +27,13 @@ pub enum Error {
     IntegrityErr { backtrace: snafu::Backtrace },
     #[snafu(display("Parse error: {}", source))]
     ParseErr {
+        kind: &'static str,
         source: serde_json_wasm::de::Error,
         backtrace: snafu::Backtrace,
     },
     #[snafu(display("Serialize error: {}", source))]
     SerializeErr {
+        kind: &'static str,
         source: serde_json_wasm::ser::Error,
         backtrace: snafu::Backtrace,
     },

--- a/packages/vm/src/lib.rs
+++ b/packages/vm/src/lib.rs
@@ -8,6 +8,7 @@ mod instance;
 mod memory;
 mod middleware;
 mod modules;
+mod serde;
 pub mod testing;
 mod wasm_store;
 

--- a/packages/vm/src/serde.rs
+++ b/packages/vm/src/serde.rs
@@ -1,0 +1,27 @@
+// This file simply re-exports some methods from serde_json
+// The reason is two fold:
+// 1. To easily ensure that all calling libraries use the same version (minimize code size)
+// 2. To allow us to switch out to eg. serde-json-core more easily
+use serde::{Deserialize, Serialize};
+use snafu::ResultExt;
+use std::any::type_name;
+
+use crate::errors::{ParseErr, Result, SerializeErr};
+
+pub fn from_slice<'a, T>(value: &'a [u8]) -> Result<T>
+where
+    T: Deserialize<'a>,
+{
+    serde_json_wasm::from_slice(value).context(ParseErr {
+        kind: type_name::<T>(),
+    })
+}
+
+pub fn to_vec<T>(data: &T) -> Result<Vec<u8>>
+where
+    T: Serialize + ?Sized,
+{
+    serde_json_wasm::to_vec(data).context(SerializeErr {
+        kind: type_name::<T>(),
+    })
+}


### PR DESCRIPTION
We returned `serde_json_wasm::{de, ser}::Error` and needed to call `.context()` on every call to it. However, we had a great simplification in `cw-storage` that only required the new `std::any::type_name` function. 

I bring this into the main `cosmwasm-std` package an update internal usage and contracts to eliminate lots of unneeded `.context{}` conversions.