### PR TITLE
Add Querier to Extern

### DIFF
--- a/contracts/hackatom/examples/schema.rs
+++ b/contracts/hackatom/examples/schema.rs
@@ -2,6 +2,7 @@ use std::env::current_dir;
 use std::fs::{create_dir_all, write};
 use std::path::PathBuf;
 
+use cosmwasm_std::BalanceResponse;
 use schemars::{schema::RootSchema, schema_for};
 
 use hackatom::contract::{HandleMsg, InitMsg, QueryMsg, State, VerifierResponse};
@@ -16,6 +17,7 @@ fn main() {
     export_schema(&schema_for!(QueryMsg), &out_dir);
     export_schema(&schema_for!(State), &out_dir);
     export_schema(&schema_for!(VerifierResponse), &out_dir);
+    export_schema(&schema_for!(BalanceResponse), &out_dir);
 }
 
 /// Writes schema to file. Overwrites existing file.

--- a/contracts/hackatom/schema/balance_response.json
+++ b/contracts/hackatom/schema/balance_response.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "BalanceResponse",
+  "type": "object",
+  "properties": {
+    "amount": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/Coin"
+      }
+    }
+  },
+  "definitions": {
+    "Coin": {
+      "type": "object",
+      "required": [
+        "amount",
+        "denom"
+      ],
+      "properties": {
+        "amount": {
+          "type": "string"
+        },
+        "denom": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/contracts/hackatom/schema/query_msg.json
+++ b/contracts/hackatom/schema/query_msg.json
@@ -12,6 +12,30 @@
           "type": "object"
         }
       }
+    },
+    {
+      "type": "object",
+      "required": [
+        "other_balance"
+      ],
+      "properties": {
+        "other_balance": {
+          "type": "object",
+          "required": [
+            "address"
+          ],
+          "properties": {
+            "address": {
+              "$ref": "#/definitions/HumanAddr"
+            }
+          }
+        }
+      }
     }
-  ]
+  ],
+  "definitions": {
+    "HumanAddr": {
+      "type": "string"
+    }
+  }
 }

--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -162,7 +162,7 @@ fn query_other_balance<S: Storage, A: Api, Q: Querier>(
     deps: &Extern<S, A, Q>,
     address: HumanAddr,
 ) -> Result<QueryResponse> {
-    let request = QueryRequest::Balance { address: address };
+    let request = QueryRequest::Balance { address };
     let response = match deps.querier.query(&request) {
         Err(sys_err) => dyn_contract_err(format!("Querier SystemError: {}", sys_err)),
         Ok(Err(err)) => dyn_contract_err(format!("Querier ContractError: {}", err)),

--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -3,9 +3,9 @@ use serde::{Deserialize, Serialize};
 use snafu::OptionExt;
 
 use cosmwasm_std::{
-    dyn_contract_err, from_slice, log, to_vec, unauthorized, Api, BalanceResponse, Binary,
-    CanonicalAddr, CosmosMsg, Env, Extern, HandleResponse, HumanAddr, InitResponse, NotFound,
-    Querier, QueryRequest, QueryResponse, Result, Storage,
+    dyn_contract_err, from_slice, log, to_vec, unauthorized, Api, Binary, CanonicalAddr, CosmosMsg,
+    Env, Extern, HandleResponse, HumanAddr, InitResponse, NotFound, Querier, QueryRequest,
+    QueryResponse, Result, Storage,
 };
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -177,7 +177,7 @@ mod tests {
     use super::*;
     use cosmwasm_std::testing::{mock_dependencies, mock_dependencies_with_balances, mock_env};
     // import trait ReadonlyStorage to get access to read
-    use cosmwasm_std::{coin, transactional_deps, Error, ReadonlyStorage};
+    use cosmwasm_std::{coin, transactional_deps, BalanceResponse, Error, ReadonlyStorage};
 
     #[test]
     fn proper_initialization() {

--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -3,9 +3,9 @@ use serde::{Deserialize, Serialize};
 use snafu::OptionExt;
 
 use cosmwasm_std::{
-    dyn_contract_err, from_slice, log, to_vec, unauthorized, Api, Binary, CanonicalAddr, CosmosMsg,
-    Env, Extern, HandleResponse, HumanAddr, InitResponse, NotFound, Querier, QueryRequest,
-    QueryResponse, Result, Storage,
+    dyn_contract_err, from_binary, from_slice, log, to_vec, unauthorized, Api, Binary,
+    CanonicalAddr, CosmosMsg, Env, Extern, HandleResponse, HumanAddr, InitResponse, NotFound,
+    Querier, QueryRequest, QueryResponse, Result, Storage,
 };
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -246,7 +246,7 @@ mod tests {
             address: HumanAddr::from("someone else"),
         };
         let query_response = query(&deps, query_msg).unwrap();
-        let bal: BalanceResponse = from_slice(query_response.as_slice()).unwrap();
+        let bal: BalanceResponse = from_binary(&query_response).unwrap();
         assert_eq!(bal.amount, None);
     }
 

--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -4,7 +4,7 @@ use snafu::OptionExt;
 
 use cosmwasm_std::{
     from_slice, log, to_vec, unauthorized, Api, Binary, CanonicalAddr, CosmosMsg, Env, Extern,
-    HandleResponse, HumanAddr, InitResponse, NotFound, QueryResponse, Result, Storage,
+    HandleResponse, HumanAddr, InitResponse, NotFound, Querier, QueryResponse, Result, Storage,
 };
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -50,8 +50,8 @@ pub struct VerifierResponse {
 
 pub static CONFIG_KEY: &[u8] = b"config";
 
-pub fn init<S: Storage, A: Api>(
-    deps: &mut Extern<S, A>,
+pub fn init<S: Storage, A: Api, Q: Querier>(
+    deps: &mut Extern<S, A, Q>,
     env: Env,
     msg: InitMsg,
 ) -> Result<InitResponse> {
@@ -66,8 +66,8 @@ pub fn init<S: Storage, A: Api>(
     Ok(InitResponse::default())
 }
 
-pub fn handle<S: Storage, A: Api>(
-    deps: &mut Extern<S, A>,
+pub fn handle<S: Storage, A: Api, Q: Querier>(
+    deps: &mut Extern<S, A, Q>,
     env: Env,
     msg: HandleMsg,
 ) -> Result<HandleResponse> {
@@ -79,7 +79,10 @@ pub fn handle<S: Storage, A: Api>(
     }
 }
 
-fn do_release<S: Storage, A: Api>(deps: &mut Extern<S, A>, env: Env) -> Result<HandleResponse> {
+fn do_release<S: Storage, A: Api, Q: Querier>(
+    deps: &mut Extern<S, A, Q>,
+    env: Env,
+) -> Result<HandleResponse> {
     let data = deps
         .storage
         .get(CONFIG_KEY)
@@ -117,7 +120,9 @@ fn do_cpu_loop() -> Result<HandleResponse> {
     }
 }
 
-fn do_storage_loop<S: Storage, A: Api>(deps: &mut Extern<S, A>) -> Result<HandleResponse> {
+fn do_storage_loop<S: Storage, A: Api, Q: Querier>(
+    deps: &mut Extern<S, A, Q>,
+) -> Result<HandleResponse> {
     let mut test_case = 0u64;
     loop {
         deps.storage
@@ -130,13 +135,16 @@ fn do_panic() -> Result<HandleResponse> {
     panic!("This page intentionally faulted");
 }
 
-pub fn query<S: Storage, A: Api>(deps: &Extern<S, A>, msg: QueryMsg) -> Result<QueryResponse> {
+pub fn query<S: Storage, A: Api, Q: Querier>(
+    deps: &Extern<S, A, Q>,
+    msg: QueryMsg,
+) -> Result<QueryResponse> {
     match msg {
         QueryMsg::Verifier {} => query_verifier(deps),
     }
 }
 
-fn query_verifier<S: Storage, A: Api>(deps: &Extern<S, A>) -> Result<QueryResponse> {
+fn query_verifier<S: Storage, A: Api, Q: Querier>(deps: &Extern<S, A, Q>) -> Result<QueryResponse> {
     let data = deps
         .storage
         .get(CONFIG_KEY)

--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -163,13 +163,12 @@ fn query_other_balance<S: Storage, A: Api, Q: Querier>(
     address: HumanAddr,
 ) -> Result<QueryResponse> {
     let request = QueryRequest::Balance { address };
-    let response = match deps.querier.query(&request) {
+    match deps.querier.query(&request) {
         Err(sys_err) => dyn_contract_err(format!("Querier SystemError: {}", sys_err)),
         Ok(Err(err)) => dyn_contract_err(format!("Querier ContractError: {}", err)),
+        // in theory we would process the response, but here it is the same type, so just pass through
         Ok(Ok(res)) => Ok(res),
-    }?;
-    // in theory we would process the response, but here it is the same type, so just pass through
-    Ok(response)
+    }
 }
 
 #[cfg(test)]

--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -3,9 +3,9 @@ use serde::{Deserialize, Serialize};
 use snafu::OptionExt;
 
 use cosmwasm_std::{
-    dyn_contract_err, from_binary, from_slice, log, to_vec, unauthorized, Api, Binary,
-    CanonicalAddr, CosmosMsg, Env, Extern, HandleResponse, HumanAddr, InitResponse, NotFound,
-    Querier, QueryRequest, QueryResponse, Result, Storage,
+    dyn_contract_err, from_slice, log, to_vec, unauthorized, Api, Binary, CanonicalAddr, CosmosMsg,
+    Env, Extern, HandleResponse, HumanAddr, InitResponse, NotFound, Querier, QueryRequest,
+    QueryResponse, Result, Storage,
 };
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -177,7 +177,9 @@ mod tests {
     use super::*;
     use cosmwasm_std::testing::{mock_dependencies, mock_dependencies_with_balances, mock_env};
     // import trait ReadonlyStorage to get access to read
-    use cosmwasm_std::{coin, transactional_deps, BalanceResponse, Error, ReadonlyStorage};
+    use cosmwasm_std::{
+        coin, from_binary, transactional_deps, BalanceResponse, Error, ReadonlyStorage,
+    };
 
     #[test]
     fn proper_initialization() {
@@ -238,7 +240,7 @@ mod tests {
             address: rich_addr.clone(),
         };
         let query_response = query(&deps, query_msg).unwrap();
-        let bal: BalanceResponse = from_slice(query_response.as_slice()).unwrap();
+        let bal: BalanceResponse = from_binary(&query_response).unwrap();
         assert_eq!(bal.amount, Some(rich_balance));
 
         // querying other accounts gets none

--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -232,13 +232,10 @@ mod tests {
     fn querier_callbacks_work() {
         let rich_addr = HumanAddr::from("foobar");
         let rich_balance = coin("10000", "gold");
-        let deps =
-            mock_dependencies_with_balances(20, vec![(rich_addr.clone(), rich_balance.clone())]);
+        let deps = mock_dependencies_with_balances(20, &[(&rich_addr, &rich_balance)]);
 
         // querying with balance gets the balance
-        let query_msg = QueryMsg::OtherBalance {
-            address: rich_addr.clone(),
-        };
+        let query_msg = QueryMsg::OtherBalance { address: rich_addr };
         let query_response = query(&deps, query_msg).unwrap();
         let bal: BalanceResponse = from_binary(&query_response).unwrap();
         assert_eq!(bal.amount, Some(rich_balance));

--- a/contracts/hackatom/src/lib.rs
+++ b/contracts/hackatom/src/lib.rs
@@ -3,13 +3,15 @@ pub mod contract;
 #[cfg(target_arch = "wasm32")]
 mod wasm {
     use super::contract;
-    use cosmwasm_std::{do_handle, do_init, do_query, ExternalApi, ExternalStorage};
+    use cosmwasm_std::{
+        do_handle, do_init, do_query, ExternalApi, ExternalQuerier, ExternalStorage,
+    };
     use std::ffi::c_void;
 
     #[no_mangle]
     extern "C" fn init(env_ptr: *mut c_void, msg_ptr: *mut c_void) -> *mut c_void {
         do_init(
-            &contract::init::<ExternalStorage, ExternalApi>,
+            &contract::init::<ExternalStorage, ExternalApi, ExternalQuerier>,
             env_ptr,
             msg_ptr,
         )
@@ -18,7 +20,7 @@ mod wasm {
     #[no_mangle]
     extern "C" fn handle(env_ptr: *mut c_void, msg_ptr: *mut c_void) -> *mut c_void {
         do_handle(
-            &contract::handle::<ExternalStorage, ExternalApi>,
+            &contract::handle::<ExternalStorage, ExternalApi, ExternalQuerier>,
             env_ptr,
             msg_ptr,
         )
@@ -26,7 +28,10 @@ mod wasm {
 
     #[no_mangle]
     extern "C" fn query(msg_ptr: *mut c_void) -> *mut c_void {
-        do_query(&contract::query::<ExternalStorage, ExternalApi>, msg_ptr)
+        do_query(
+            &contract::query::<ExternalStorage, ExternalApi, ExternalQuerier>,
+            msg_ptr,
+        )
     }
 
     // Other C externs like cosmwasm_vm_version_1, allocate, deallocate are available

--- a/contracts/hackatom/tests/integration.rs
+++ b/contracts/hackatom/tests/integration.rs
@@ -100,13 +100,10 @@ fn init_and_query() {
 fn querier_callbacks_work() {
     let rich_addr = HumanAddr::from("foobar");
     let rich_balance = coin("10000", "gold");
-    let mut deps =
-        mock_instance_with_balances(WASM, vec![(rich_addr.clone(), rich_balance.clone())]);
+    let mut deps = mock_instance_with_balances(WASM, &[(&rich_addr, &rich_balance)]);
 
     // querying with balance gets the balance
-    let query_msg = QueryMsg::OtherBalance {
-        address: rich_addr.clone(),
-    };
+    let query_msg = QueryMsg::OtherBalance { address: rich_addr };
     let query_response = query(&mut deps, query_msg).unwrap();
     let bal: BalanceResponse = from_binary(&query_response).unwrap();
     assert_eq!(bal.amount, Some(rich_balance));

--- a/contracts/hackatom/tests/integration.rs
+++ b/contracts/hackatom/tests/integration.rs
@@ -238,7 +238,7 @@ mod singlepass_tests {
     #[test]
     fn handle_panic_and_loops() {
         // Gas must be set so we die early on infinite loop
-        let mut deps = mock_instance_with_gas_limit(WASM, 1_000_000);
+        let mut deps = mock_instance_with_gas_limit(WASM, vec![], 1_000_000);
 
         // initialize the store
         let verifier = HumanAddr(String::from("verifies"));

--- a/contracts/hackatom/tests/integration.rs
+++ b/contracts/hackatom/tests/integration.rs
@@ -30,7 +30,8 @@
 
 use cosmwasm_std::testing::mock_env;
 use cosmwasm_std::{
-    coin, from_slice, log, Api, ApiError, BalanceResponse, CosmosMsg, HumanAddr, ReadonlyStorage,
+    coin, from_binary, from_slice, log, Api, ApiError, BalanceResponse, CosmosMsg, HumanAddr,
+    ReadonlyStorage,
 };
 use cosmwasm_vm::testing::{
     handle, init, mock_instance, mock_instance_with_balances, query, test_io,
@@ -107,7 +108,7 @@ fn querier_callbacks_work() {
         address: rich_addr.clone(),
     };
     let query_response = query(&mut deps, query_msg).unwrap();
-    let bal: BalanceResponse = from_slice(query_response.as_slice()).unwrap();
+    let bal: BalanceResponse = from_binary(&query_response).unwrap();
     assert_eq!(bal.amount, Some(rich_balance));
 
     // querying other accounts gets none
@@ -115,7 +116,7 @@ fn querier_callbacks_work() {
         address: HumanAddr::from("someone else"),
     };
     let query_response = query(&mut deps, query_msg).unwrap();
-    let bal: BalanceResponse = from_slice(query_response.as_slice()).unwrap();
+    let bal: BalanceResponse = from_binary(&query_response).unwrap();
     assert_eq!(bal.amount, None);
 }
 

--- a/contracts/hackatom/tests/integration.rs
+++ b/contracts/hackatom/tests/integration.rs
@@ -236,7 +236,7 @@ mod singlepass_tests {
     #[test]
     fn handle_panic_and_loops() {
         // Gas must be set so we die early on infinite loop
-        let mut deps = mock_instance_with_gas_limit(WASM, vec![], 1_000_000);
+        let mut deps = mock_instance_with_gas_limit(WASM, &[], 1_000_000);
 
         // initialize the store
         let verifier = HumanAddr(String::from("verifies"));

--- a/contracts/queue/src/contract.rs
+++ b/contracts/queue/src/contract.rs
@@ -2,7 +2,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use cosmwasm_std::{
-    from_slice, to_vec, Api, Binary, Env, Extern, HandleResponse, InitResponse, Order,
+    from_slice, to_vec, Api, Binary, Env, Extern, HandleResponse, InitResponse, Order, Querier,
     QueryResponse, Result, Storage,
 };
 
@@ -48,16 +48,16 @@ pub struct SumResponse {
 }
 
 // init is a no-op, just empty data
-pub fn init<S: Storage, A: Api>(
-    _deps: &mut Extern<S, A>,
+pub fn init<S: Storage, A: Api, Q: Querier>(
+    _deps: &mut Extern<S, A, Q>,
     _env: Env,
     _msg: InitMsg,
 ) -> Result<InitResponse> {
     Ok(InitResponse::default())
 }
 
-pub fn handle<S: Storage, A: Api>(
-    deps: &mut Extern<S, A>,
+pub fn handle<S: Storage, A: Api, Q: Querier>(
+    deps: &mut Extern<S, A, Q>,
     env: Env,
     msg: HandleMsg,
 ) -> Result<HandleResponse> {
@@ -69,8 +69,8 @@ pub fn handle<S: Storage, A: Api>(
 
 const FIRST_KEY: u8 = 0;
 
-fn enqueue<S: Storage, A: Api>(
-    deps: &mut Extern<S, A>,
+fn enqueue<S: Storage, A: Api, Q: Querier>(
+    deps: &mut Extern<S, A, Q>,
     _env: Env,
     value: i32,
 ) -> Result<HandleResponse> {
@@ -92,7 +92,10 @@ fn enqueue<S: Storage, A: Api>(
     Ok(HandleResponse::default())
 }
 
-fn dequeue<S: Storage, A: Api>(deps: &mut Extern<S, A>, _env: Env) -> Result<HandleResponse> {
+fn dequeue<S: Storage, A: Api, Q: Querier>(
+    deps: &mut Extern<S, A, Q>,
+    _env: Env,
+) -> Result<HandleResponse> {
     // find the first element in the queue and extract value
     let first = deps.storage.range(None, None, Order::Ascending).next();
 
@@ -107,19 +110,22 @@ fn dequeue<S: Storage, A: Api>(deps: &mut Extern<S, A>, _env: Env) -> Result<Han
     }
 }
 
-pub fn query<S: Storage, A: Api>(deps: &Extern<S, A>, msg: QueryMsg) -> Result<QueryResponse> {
+pub fn query<S: Storage, A: Api, Q: Querier>(
+    deps: &Extern<S, A, Q>,
+    msg: QueryMsg,
+) -> Result<QueryResponse> {
     match msg {
         QueryMsg::Count {} => query_count(deps),
         QueryMsg::Sum {} => query_sum(deps),
     }
 }
 
-fn query_count<S: Storage, A: Api>(deps: &Extern<S, A>) -> Result<QueryResponse> {
+fn query_count<S: Storage, A: Api, Q: Querier>(deps: &Extern<S, A, Q>) -> Result<QueryResponse> {
     let count = deps.storage.range(None, None, Order::Ascending).count() as u32;
     Ok(Binary(to_vec(&CountResponse { count })?))
 }
 
-fn query_sum<S: Storage, A: Api>(deps: &Extern<S, A>) -> Result<QueryResponse> {
+fn query_sum<S: Storage, A: Api, Q: Querier>(deps: &Extern<S, A, Q>) -> Result<QueryResponse> {
     let values: Result<Vec<Item>> = deps
         .storage
         .range(None, None, Order::Ascending)
@@ -132,10 +138,10 @@ fn query_sum<S: Storage, A: Api>(deps: &Extern<S, A>) -> Result<QueryResponse> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cosmwasm_std::testing::{mock_dependencies, mock_env, MockApi, MockStorage};
+    use cosmwasm_std::testing::{mock_dependencies, mock_env, MockApi, MockQuerier, MockStorage};
     use cosmwasm_std::{coin, HumanAddr};
 
-    fn create_contract() -> (Extern<MockStorage, MockApi>, Env) {
+    fn create_contract() -> (Extern<MockStorage, MockApi, MockQuerier>, Env) {
         let mut deps = mock_dependencies(20);
         let creator = HumanAddr(String::from("creator"));
         let env = mock_env(&deps.api, creator.as_str(), &coin("1000", "earth"), &[]);
@@ -144,13 +150,13 @@ mod tests {
         (deps, env)
     }
 
-    fn get_count(deps: &Extern<MockStorage, MockApi>) -> u32 {
+    fn get_count(deps: &Extern<MockStorage, MockApi, MockQuerier>) -> u32 {
         let data = query(deps, QueryMsg::Count {}).unwrap();
         let res: CountResponse = from_slice(data.as_slice()).unwrap();
         res.count
     }
 
-    fn get_sum(deps: &Extern<MockStorage, MockApi>) -> i32 {
+    fn get_sum(deps: &Extern<MockStorage, MockApi, MockQuerier>) -> i32 {
         let data = query(deps, QueryMsg::Sum {}).unwrap();
         let res: SumResponse = from_slice(data.as_slice()).unwrap();
         res.sum

--- a/contracts/queue/src/contract.rs
+++ b/contracts/queue/src/contract.rs
@@ -139,7 +139,7 @@ fn query_sum<S: Storage, A: Api, Q: Querier>(deps: &Extern<S, A, Q>) -> Result<Q
 mod tests {
     use super::*;
     use cosmwasm_std::testing::{mock_dependencies, mock_env, MockApi, MockQuerier, MockStorage};
-    use cosmwasm_std::{coin, HumanAddr};
+    use cosmwasm_std::{coin, from_binary, HumanAddr};
 
     fn create_contract() -> (Extern<MockStorage, MockApi, MockQuerier>, Env) {
         let mut deps = mock_dependencies(20);
@@ -152,13 +152,13 @@ mod tests {
 
     fn get_count(deps: &Extern<MockStorage, MockApi, MockQuerier>) -> u32 {
         let data = query(deps, QueryMsg::Count {}).unwrap();
-        let res: CountResponse = from_slice(data.as_slice()).unwrap();
+        let res: CountResponse = from_binary(&data).unwrap();
         res.count
     }
 
     fn get_sum(deps: &Extern<MockStorage, MockApi, MockQuerier>) -> i32 {
         let data = query(deps, QueryMsg::Sum {}).unwrap();
-        let res: SumResponse = from_slice(data.as_slice()).unwrap();
+        let res: SumResponse = from_binary(&data).unwrap();
         res.sum
     }
 

--- a/contracts/queue/src/lib.rs
+++ b/contracts/queue/src/lib.rs
@@ -3,13 +3,15 @@ pub mod contract;
 #[cfg(target_arch = "wasm32")]
 mod wasm {
     use super::contract;
-    use cosmwasm_std::{do_handle, do_init, do_query, ExternalApi, ExternalStorage};
+    use cosmwasm_std::{
+        do_handle, do_init, do_query, ExternalApi, ExternalQuerier, ExternalStorage,
+    };
     use std::ffi::c_void;
 
     #[no_mangle]
     extern "C" fn init(env_ptr: *mut c_void, msg_ptr: *mut c_void) -> *mut c_void {
         do_init(
-            &contract::init::<ExternalStorage, ExternalApi>,
+            &contract::init::<ExternalStorage, ExternalApi, ExternalQuerier>,
             env_ptr,
             msg_ptr,
         )
@@ -18,7 +20,7 @@ mod wasm {
     #[no_mangle]
     extern "C" fn handle(env_ptr: *mut c_void, msg_ptr: *mut c_void) -> *mut c_void {
         do_handle(
-            &contract::handle::<ExternalStorage, ExternalApi>,
+            &contract::handle::<ExternalStorage, ExternalApi, ExternalQuerier>,
             env_ptr,
             msg_ptr,
         )
@@ -26,7 +28,10 @@ mod wasm {
 
     #[no_mangle]
     extern "C" fn query(msg_ptr: *mut c_void) -> *mut c_void {
-        do_query(&contract::query::<ExternalStorage, ExternalApi>, msg_ptr)
+        do_query(
+            &contract::query::<ExternalStorage, ExternalApi, ExternalQuerier>,
+            msg_ptr,
+        )
     }
 
     // Other C externs like cosmwasm_vm_version_1, allocate, deallocate are available

--- a/contracts/queue/tests/integration.rs
+++ b/contracts/queue/tests/integration.rs
@@ -29,7 +29,7 @@
 //!      }
 
 use cosmwasm_std::testing::{mock_env, MockApi, MockQuerier, MockStorage};
-use cosmwasm_std::{coin, from_slice, Env, HumanAddr};
+use cosmwasm_std::{coin, from_binary, from_slice, Env, HumanAddr};
 use cosmwasm_vm::testing::{handle, init, mock_instance, query};
 use cosmwasm_vm::Instance;
 
@@ -48,13 +48,13 @@ fn create_contract() -> (Instance<MockStorage, MockApi, MockQuerier>, Env) {
 
 fn get_count(deps: &mut Instance<MockStorage, MockApi, MockQuerier>) -> u32 {
     let data = query(deps, QueryMsg::Count {}).unwrap();
-    let res: CountResponse = from_slice(data.as_slice()).unwrap();
+    let res: CountResponse = from_binary(&data).unwrap();
     res.count
 }
 
 fn get_sum(deps: &mut Instance<MockStorage, MockApi, MockQuerier>) -> i32 {
     let data = query(deps, QueryMsg::Sum {}).unwrap();
-    let res: SumResponse = from_slice(data.as_slice()).unwrap();
+    let res: SumResponse = from_binary(&data).unwrap();
     res.sum
 }
 

--- a/contracts/queue/tests/integration.rs
+++ b/contracts/queue/tests/integration.rs
@@ -28,7 +28,7 @@
 //!          _ => panic!("Must return unauthorized error"),
 //!      }
 
-use cosmwasm_std::testing::{mock_env, MockApi, MockStorage};
+use cosmwasm_std::testing::{mock_env, MockApi, MockQuerier, MockStorage};
 use cosmwasm_std::{coin, from_slice, Env, HumanAddr};
 use cosmwasm_vm::testing::{handle, init, mock_instance, query};
 use cosmwasm_vm::Instance;
@@ -37,7 +37,7 @@ use queue::contract::{CountResponse, HandleMsg, InitMsg, Item, QueryMsg, SumResp
 
 static WASM: &[u8] = include_bytes!("../target/wasm32-unknown-unknown/release/queue.wasm");
 
-fn create_contract() -> (Instance<MockStorage, MockApi>, Env) {
+fn create_contract() -> (Instance<MockStorage, MockApi, MockQuerier>, Env) {
     let mut deps = mock_instance(WASM);
     let creator = HumanAddr(String::from("creator"));
     let env = mock_env(&deps.api, creator.as_str(), &coin("1000", "earth"), &[]);
@@ -46,13 +46,13 @@ fn create_contract() -> (Instance<MockStorage, MockApi>, Env) {
     (deps, env)
 }
 
-fn get_count(deps: &mut Instance<MockStorage, MockApi>) -> u32 {
+fn get_count(deps: &mut Instance<MockStorage, MockApi, MockQuerier>) -> u32 {
     let data = query(deps, QueryMsg::Count {}).unwrap();
     let res: CountResponse = from_slice(data.as_slice()).unwrap();
     res.count
 }
 
-fn get_sum(deps: &mut Instance<MockStorage, MockApi>) -> i32 {
+fn get_sum(deps: &mut Instance<MockStorage, MockApi, MockQuerier>) -> i32 {
     let data = query(deps, QueryMsg::Sum {}).unwrap();
     let res: SumResponse = from_slice(data.as_slice()).unwrap();
     res.sum

--- a/packages/std/src/api.rs
+++ b/packages/std/src/api.rs
@@ -123,6 +123,7 @@ impl From<Error> for ApiError {
 pub enum ApiSystemError {
     InvalidRequest { source: String },
     NoSuchContract { addr: HumanAddr },
+    UnknownError {},
 }
 
 impl std::error::Error for ApiSystemError {}
@@ -134,6 +135,7 @@ impl std::fmt::Display for ApiSystemError {
                 write!(f, "Cannot parse request: {}", source)
             }
             ApiSystemError::NoSuchContract { addr } => write!(f, "No such contract: {}", addr),
+            ApiSystemError::UnknownError {} => write!(f, "Unknown system error"),
         }
     }
 }
@@ -145,6 +147,7 @@ impl From<SystemError> for ApiSystemError {
                 source: format!("{}", source),
             },
             SystemError::NoSuchContract { addr, .. } => ApiSystemError::NoSuchContract { addr },
+            SystemError::UnknownError { .. } => ApiSystemError::UnknownError {},
         }
     }
 }

--- a/packages/std/src/api.rs
+++ b/packages/std/src/api.rs
@@ -123,7 +123,7 @@ impl From<Error> for ApiError {
 pub enum ApiSystemError {
     InvalidRequest { source: String },
     NoSuchContract { addr: HumanAddr },
-    UnknownError {},
+    Unknown {},
 }
 
 impl std::error::Error for ApiSystemError {}
@@ -135,7 +135,7 @@ impl std::fmt::Display for ApiSystemError {
                 write!(f, "Cannot parse request: {}", source)
             }
             ApiSystemError::NoSuchContract { addr } => write!(f, "No such contract: {}", addr),
-            ApiSystemError::UnknownError {} => write!(f, "Unknown system error"),
+            ApiSystemError::Unknown {} => write!(f, "Unknown system error"),
         }
     }
 }
@@ -147,7 +147,7 @@ impl From<SystemError> for ApiSystemError {
                 source: format!("{}", source),
             },
             SystemError::NoSuchContract { addr, .. } => ApiSystemError::NoSuchContract { addr },
-            SystemError::UnknownError { .. } => ApiSystemError::UnknownError {},
+            SystemError::Unknown { .. } => ApiSystemError::Unknown {},
         }
     }
 }

--- a/packages/std/src/errors.rs
+++ b/packages/std/src/errors.rs
@@ -82,7 +82,7 @@ pub enum SystemError {
         backtrace: snafu::Backtrace,
     },
     #[snafu(display("Unknown system error"))]
-    UnknownError { backtrace: snafu::Backtrace },
+    Unknown { backtrace: snafu::Backtrace },
 }
 
 /// Result for init, handle and query. Since the error type cannot be serialized to JSON,

--- a/packages/std/src/errors.rs
+++ b/packages/std/src/errors.rs
@@ -81,6 +81,8 @@ pub enum SystemError {
         addr: HumanAddr,
         backtrace: snafu::Backtrace,
     },
+    #[snafu(display("Unknown system error"))]
+    UnknownError { backtrace: snafu::Backtrace },
 }
 
 /// Result for init, handle and query. Since the error type cannot be serialized to JSON,

--- a/packages/std/src/imports.rs
+++ b/packages/std/src/imports.rs
@@ -38,7 +38,9 @@ extern "C" {
     fn canonicalize_address(human: *const c_void, canonical: *mut c_void) -> i32;
     fn humanize_address(canonical: *const c_void, human: *mut c_void) -> i32;
 
-    fn query(request: *const c_void, response: *mut c_void) -> i32;
+    // query_chain will launch a query on the chain (import)
+    // different than query which will query the state of the contract (export)
+    fn query_chain(request: *const c_void, response: *mut c_void) -> i32;
 }
 
 /// A stateless convenience wrapper around database imports provided by the VM.
@@ -227,7 +229,7 @@ impl Querier for ExternalQuerier {
         let req_ptr = &*req as *const Region as *const c_void;
         let resp = alloc(QUERY_BUFFER);
 
-        let ret = unsafe { query(req_ptr, resp) };
+        let ret = unsafe { query_chain(req_ptr, resp) };
         if ret < 0 {
             return Err(ApiSystemError::UnknownError {});
         }

--- a/packages/std/src/imports.rs
+++ b/packages/std/src/imports.rs
@@ -224,14 +224,14 @@ impl ExternalQuerier {
 
 impl Querier for ExternalQuerier {
     fn query(&self, request: &QueryRequest) -> QuerierResponse {
-        let bin_request = to_vec(request).or(Err(ApiSystemError::UnknownError {}))?;
+        let bin_request = to_vec(request).or(Err(ApiSystemError::Unknown {}))?;
         let req = build_region(&bin_request);
         let req_ptr = &*req as *const Region as *const c_void;
         let resp = alloc(QUERY_BUFFER);
 
         let ret = unsafe { query_chain(req_ptr, resp) };
         if ret < 0 {
-            return Err(ApiSystemError::UnknownError {});
+            return Err(ApiSystemError::Unknown {});
         }
 
         let parse = |r| -> Result<QuerierResponse> {

--- a/packages/std/src/imports.rs
+++ b/packages/std/src/imports.rs
@@ -15,8 +15,9 @@ use crate::types::{CanonicalAddr, HumanAddr};
 // this is the buffer we pre-allocate in get - we should configure this somehow later
 static MAX_READ: usize = 2000;
 
-// this should be plenty for any address representation
-static ADDR_BUFFER: usize = 100;
+// this is the maximum allowed size for bech32
+// https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#bech32
+static ADDR_BUFFER: usize = 90;
 
 // this is the space we allocate for query responses
 static QUERY_BUFFER: usize = 4000;

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -21,7 +21,7 @@ pub use crate::init_handle::{
     log, CosmosMsg, HandleResponse, HandleResult, InitResponse, InitResult, LogAttribute,
 };
 pub use crate::query::{BalanceResponse, QueryRequest, QueryResponse, QueryResult};
-pub use crate::serde::{from_slice, to_vec};
+pub use crate::serde::{from_binary, from_slice, to_binary, to_vec};
 pub use crate::storage::MemoryStorage;
 pub use crate::traits::{
     Api, ApiQuerierResponse, Extern, Querier, QuerierResponse, ReadonlyStorage, Storage,

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -23,7 +23,7 @@ pub use crate::init_handle::{
 pub use crate::query::{BalanceResponse, QueryRequest, QueryResponse, QueryResult};
 pub use crate::serde::{from_slice, to_vec};
 pub use crate::storage::MemoryStorage;
-pub use crate::traits::{Api, Extern, ReadonlyStorage, Storage};
+pub use crate::traits::{Api, Extern, Querier, QuerierResponse, ReadonlyStorage, Storage};
 #[cfg(feature = "iterator")]
 pub use crate::traits::{Order, KV};
 pub use crate::transactions::{transactional, transactional_deps, RepLog, StorageTransaction};

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -11,7 +11,7 @@ mod traits;
 mod transactions;
 mod types;
 
-pub use crate::api::{ApiError, ApiResult};
+pub use crate::api::{ApiError, ApiResult, ApiSystemError};
 pub use crate::encoding::Binary;
 pub use crate::errors::{
     contract_err, dyn_contract_err, invalid, unauthorized, Error, NotFound, NullPointer, ParseErr,
@@ -23,7 +23,9 @@ pub use crate::init_handle::{
 pub use crate::query::{BalanceResponse, QueryRequest, QueryResponse, QueryResult};
 pub use crate::serde::{from_slice, to_vec};
 pub use crate::storage::MemoryStorage;
-pub use crate::traits::{Api, Extern, Querier, QuerierResponse, ReadonlyStorage, Storage};
+pub use crate::traits::{
+    Api, ApiQuerierResponse, Extern, Querier, QuerierResponse, ReadonlyStorage, Storage,
+};
 #[cfg(feature = "iterator")]
 pub use crate::traits::{Order, KV};
 pub use crate::transactions::{transactional, transactional_deps, RepLog, StorageTransaction};

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -29,7 +29,7 @@ pub use crate::traits::{
 #[cfg(feature = "iterator")]
 pub use crate::traits::{Order, KV};
 pub use crate::transactions::{transactional, transactional_deps, RepLog, StorageTransaction};
-pub use crate::types::{coin, CanonicalAddr, Env, HumanAddr};
+pub use crate::types::{coin, CanonicalAddr, Coin, Env, HumanAddr};
 
 // Exposed in wasm build only
 

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -41,7 +41,7 @@ mod memory; // Used by exports and imports only. This assumes pointers are 32 bi
 #[cfg(target_arch = "wasm32")]
 pub use crate::exports::{do_handle, do_init, do_query};
 #[cfg(target_arch = "wasm32")]
-pub use crate::imports::{ExternalApi, ExternalStorage};
+pub use crate::imports::{ExternalApi, ExternalQuerier, ExternalStorage};
 
 // Exposed for testing only
 // Both unit tests and integration tests are compiled to native code, so everything in here does not need to compile to Wasm.

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -14,8 +14,8 @@ mod types;
 pub use crate::api::{ApiError, ApiResult, ApiSystemError};
 pub use crate::encoding::Binary;
 pub use crate::errors::{
-    contract_err, dyn_contract_err, invalid, unauthorized, Error, NotFound, NullPointer, ParseErr,
-    Result, SerializeErr,
+    contract_err, dyn_contract_err, invalid, unauthorized, Error, InvalidRequest, NotFound,
+    NullPointer, ParseErr, Result, SerializeErr,
 };
 pub use crate::init_handle::{
     log, CosmosMsg, HandleResponse, HandleResult, InitResponse, InitResult, LogAttribute,

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -50,5 +50,8 @@ pub use crate::imports::{ExternalApi, ExternalStorage};
 mod mock;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod testing {
-    pub use crate::mock::{mock_dependencies, mock_env, MockApi, MockQuerier, MockStorage};
+    pub use crate::mock::{
+        mock_dependencies, mock_dependencies_with_balances, mock_env, MockApi, MockQuerier,
+        MockStorage,
+    };
 }

--- a/packages/std/src/mock.rs
+++ b/packages/std/src/mock.rs
@@ -11,10 +11,23 @@ use crate::traits::{Api, Extern, Querier};
 use crate::types::{BlockInfo, CanonicalAddr, Coin, ContractInfo, Env, HumanAddr, MessageInfo};
 
 /// All external requirements that can be injected for unit tests
-pub fn mock_dependencies(canonical_length: usize) -> Extern<MockStorage, MockApi> {
+pub fn mock_dependencies(canonical_length: usize) -> Extern<MockStorage, MockApi, MockQuerier> {
     Extern {
         storage: MockStorage::new(),
         api: MockApi::new(canonical_length),
+        querier: MockQuerier::new(vec![]),
+    }
+}
+
+// This initializes the querier along with the mock_dependencies
+pub fn mock_dependencies_with_balances(
+    canonical_length: usize,
+    balances: Vec<(HumanAddr, Vec<Coin>)>,
+) -> Extern<MockStorage, MockApi, MockQuerier> {
+    Extern {
+        storage: MockStorage::new(),
+        api: MockApi::new(canonical_length),
+        querier: MockQuerier::new(balances),
     }
 }
 
@@ -110,13 +123,18 @@ pub fn mock_env<T: Api, U: Into<HumanAddr>>(
 
 /// MockQuerier holds an immutable table of bank balances
 /// TODO: also allow querying contracts
+#[derive(Clone)]
 pub struct MockQuerier {
     balances: HashMap<HumanAddr, Vec<Coin>>,
 }
 
 impl MockQuerier {
-    pub fn new(balances: HashMap<HumanAddr, Vec<Coin>>) -> Self {
-        MockQuerier { balances }
+    pub fn new(balances: Vec<(HumanAddr, Vec<Coin>)>) -> Self {
+        let mut map = HashMap::new();
+        for (addr, coins) in balances.into_iter() {
+            map.insert(addr, coins);
+        }
+        MockQuerier { balances: map }
     }
 }
 

--- a/packages/std/src/mock.rs
+++ b/packages/std/src/mock.rs
@@ -139,18 +139,18 @@ impl MockQuerier {
 }
 
 impl Querier for MockQuerier {
-    fn query(&self, request: QueryRequest) -> Result<Result<Binary, ApiError>, ApiSystemError> {
+    fn query(&self, request: &QueryRequest) -> Result<Result<Binary, ApiError>, ApiSystemError> {
         match request {
             QueryRequest::Balance { address } => {
                 // proper error on not found, serialize result on found
                 let bank_res = BalanceResponse {
-                    amount: self.balances.get(&address).cloned(),
+                    amount: self.balances.get(address).cloned(),
                 };
                 let api_res = to_vec(&bank_res).map(Binary).map_err(|e| e.into());
                 Ok(api_res)
             }
             QueryRequest::Contract { contract_addr, .. } => Err(ApiSystemError::NoSuchContract {
-                addr: contract_addr,
+                addr: contract_addr.clone(),
             }),
         }
     }

--- a/packages/std/src/mock.rs
+++ b/packages/std/src/mock.rs
@@ -15,14 +15,14 @@ pub fn mock_dependencies(canonical_length: usize) -> Extern<MockStorage, MockApi
     Extern {
         storage: MockStorage::new(),
         api: MockApi::new(canonical_length),
-        querier: MockQuerier::new(vec![]),
+        querier: MockQuerier::new(&[]),
     }
 }
 
 // This initializes the querier along with the mock_dependencies
 pub fn mock_dependencies_with_balances(
     canonical_length: usize,
-    balances: Vec<(HumanAddr, Vec<Coin>)>,
+    balances: &[(&HumanAddr, &[Coin])],
 ) -> Extern<MockStorage, MockApi, MockQuerier> {
     Extern {
         storage: MockStorage::new(),
@@ -129,10 +129,10 @@ pub struct MockQuerier {
 }
 
 impl MockQuerier {
-    pub fn new(balances: Vec<(HumanAddr, Vec<Coin>)>) -> Self {
+    pub fn new(balances: &[(&HumanAddr, &[Coin])]) -> Self {
         let mut map = HashMap::new();
-        for (addr, coins) in balances.into_iter() {
-            map.insert(addr, coins);
+        for (addr, coins) in balances.iter() {
+            map.insert(HumanAddr::from(addr), coins.to_vec());
         }
         MockQuerier { balances: map }
     }

--- a/packages/std/src/serde.rs
+++ b/packages/std/src/serde.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 use std::any::type_name;
 
+use crate::encoding::Binary;
 use crate::errors::{ParseErr, Result, SerializeErr};
 
 pub fn from_slice<'a, T>(value: &'a [u8]) -> Result<T>
@@ -17,6 +18,13 @@ where
     })
 }
 
+pub fn from_binary<'a, T>(value: &'a Binary) -> Result<T>
+where
+    T: Deserialize<'a>,
+{
+    from_slice(value.as_slice())
+}
+
 pub fn to_vec<T>(data: &T) -> Result<Vec<u8>>
 where
     T: Serialize + ?Sized,
@@ -24,4 +32,11 @@ where
     serde_json_wasm::to_vec(data).context(SerializeErr {
         kind: type_name::<T>(),
     })
+}
+
+pub fn to_binary<T>(data: &T) -> Result<Binary>
+where
+    T: Serialize + ?Sized,
+{
+    to_vec(data).map(|t| Binary(t))
 }

--- a/packages/std/src/serde.rs
+++ b/packages/std/src/serde.rs
@@ -38,5 +38,5 @@ pub fn to_binary<T>(data: &T) -> Result<Binary>
 where
     T: Serialize + ?Sized,
 {
-    to_vec(data).map(|t| Binary(t))
+    to_vec(data).map(Binary)
 }

--- a/packages/std/src/traits.rs
+++ b/packages/std/src/traits.rs
@@ -52,13 +52,16 @@ pub trait Api: Copy + Clone + Send {
     fn human_address(&self, canonical: &CanonicalAddr) -> Result<HumanAddr>;
 }
 
+// QuerierResponse is a short-hand alias as this type is long to write
+pub type QuerierResponse = Result<Result<Binary, ApiError>, ApiSystemError>;
+
 pub trait Querier: Clone + Send {
     // Note: ApiError type can be serialized, and the below can be reconstituted over a WASM/FFI call.
     // Since this is information that is returned from outside, we define it this way.
     //
     // ApiResult is a format that can capture this info in a serialized form. We parse it into
     // a typical Result for the implementing object
-    fn query(&self, request: QueryRequest) -> Result<Result<Binary, ApiError>, ApiSystemError>;
+    fn query(&self, request: QueryRequest) -> QuerierResponse;
 }
 
 // put them here to avoid so many feature flags

--- a/packages/std/src/traits.rs
+++ b/packages/std/src/traits.rs
@@ -61,7 +61,7 @@ pub trait Querier: Clone + Send {
     //
     // ApiResult is a format that can capture this info in a serialized form. We parse it into
     // a typical Result for the implementing object
-    fn query(&self, request: QueryRequest) -> QuerierResponse;
+    fn query(&self, request: &QueryRequest) -> QuerierResponse;
 }
 
 // put them here to avoid so many feature flags

--- a/packages/std/src/traits.rs
+++ b/packages/std/src/traits.rs
@@ -11,9 +11,10 @@ pub use iter_support::{KVRef, Order, KV};
 /// Designed to allow easy dependency injection at runtime.
 /// This cannot be copied or cloned since it would behave differently
 /// for mock storages and a bridge storage in the VM.
-pub struct Extern<S: Storage, A: Api> {
+pub struct Extern<S: Storage, A: Api, Q: Querier> {
     pub storage: S,
     pub api: A,
+    pub querier: Q,
 }
 
 /// ReadonlyStorage is access to the contracts persistent data store
@@ -51,7 +52,7 @@ pub trait Api: Copy + Clone + Send {
     fn human_address(&self, canonical: &CanonicalAddr) -> Result<HumanAddr>;
 }
 
-pub trait Querier {
+pub trait Querier: Clone + Send {
     // Note: ApiError type can be serialized, and the below can be reconstituted over a WASM/FFI call.
     // Since this is information that is returned from outside, we define it this way.
     //

--- a/packages/std/src/traits.rs
+++ b/packages/std/src/traits.rs
@@ -1,4 +1,4 @@
-use crate::api::{ApiError, ApiSystemError};
+use crate::api::{ApiError, ApiResult, ApiSystemError};
 use crate::encoding::Binary;
 use crate::errors::Result;
 use crate::query::QueryRequest;
@@ -54,6 +54,9 @@ pub trait Api: Copy + Clone + Send {
 
 // QuerierResponse is a short-hand alias as this type is long to write
 pub type QuerierResponse = Result<Result<Binary, ApiError>, ApiSystemError>;
+
+// ApiQuerierResponse is QuerierResponse converted to be serialized (short-hand for other modules)
+pub type ApiQuerierResponse = ApiResult<ApiResult<Binary, ApiError>, ApiSystemError>;
 
 pub trait Querier: Clone + Send {
     // Note: ApiError type can be serialized, and the below can be reconstituted over a WASM/FFI call.

--- a/packages/std/src/types.rs
+++ b/packages/std/src/types.rs
@@ -42,6 +42,12 @@ impl From<&HumanAddr> for HumanAddr {
     }
 }
 
+impl From<&&HumanAddr> for HumanAddr {
+    fn from(addr: &&HumanAddr) -> Self {
+        HumanAddr(addr.0.to_string())
+    }
+}
+
 impl CanonicalAddr {
     pub fn as_slice(&self) -> &[u8] {
         &self.0.as_slice()

--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -141,7 +141,7 @@ mod test {
     use super::*;
     use crate::calls::{call_handle, call_init};
     use cosmwasm_std::coin;
-    use cosmwasm_std::testing::{mock_dependencies, mock_env, MockApi, MockStorage};
+    use cosmwasm_std::testing::{mock_dependencies, mock_env, MockApi, MockQuerier, MockStorage};
     use tempfile::TempDir;
 
     static TESTING_GAS_LIMIT: u64 = 400_000;
@@ -150,7 +150,7 @@ mod test {
     #[test]
     fn save_wasm_works() {
         let tmp_dir = TempDir::new().unwrap();
-        let mut cache: CosmCache<MockStorage, MockApi> =
+        let mut cache: CosmCache<MockStorage, MockApi, MockQuerier> =
             unsafe { CosmCache::new(tmp_dir.path(), 10).unwrap() };
         cache.save_wasm(CONTRACT).unwrap();
     }
@@ -159,7 +159,7 @@ mod test {
     // This property is required when the same bytecode is uploaded multiple times
     fn save_wasm_allows_saving_multiple_times() {
         let tmp_dir = TempDir::new().unwrap();
-        let mut cache: CosmCache<MockStorage, MockApi> =
+        let mut cache: CosmCache<MockStorage, MockApi, MockQuerier> =
             unsafe { CosmCache::new(tmp_dir.path(), 10).unwrap() };
         cache.save_wasm(CONTRACT).unwrap();
         cache.save_wasm(CONTRACT).unwrap();
@@ -182,7 +182,7 @@ mod test {
         let wasm = wat2wasm(WAT).unwrap();
 
         let tmp_dir = TempDir::new().unwrap();
-        let mut cache: CosmCache<MockStorage, MockApi> =
+        let mut cache: CosmCache<MockStorage, MockApi, MockQuerier> =
             unsafe { CosmCache::new(tmp_dir.path(), 10).unwrap() };
         let save_result = cache.save_wasm(&wasm);
         match save_result {

--- a/packages/vm/src/calls.rs
+++ b/packages/vm/src/calls.rs
@@ -1,8 +1,8 @@
 use snafu::ResultExt;
 
 use cosmwasm_std::{
-    Api, ApiError, Env, HandleResponse, HandleResult, InitResponse, InitResult, QueryResponse,
-    QueryResult, Storage,
+    Api, ApiError, Env, HandleResponse, HandleResult, InitResponse, InitResult, Querier,
+    QueryResponse, QueryResult, Storage,
 };
 
 use crate::errors::{Error, RuntimeErr, WasmerRuntimeErr};
@@ -13,8 +13,8 @@ static MAX_LENGTH_INIT: usize = 100_000;
 static MAX_LENGTH_HANDLE: usize = 100_000;
 static MAX_LENGTH_QUERY: usize = 100_000;
 
-pub fn call_init<S: Storage + 'static, A: Api + 'static>(
-    instance: &mut Instance<S, A>,
+pub fn call_init<S: Storage + 'static, A: Api + 'static, Q: Querier + 'static>(
+    instance: &mut Instance<S, A, Q>,
     env: &Env,
     msg: &[u8],
 ) -> Result<Result<InitResponse, ApiError>, Error> {
@@ -24,8 +24,8 @@ pub fn call_init<S: Storage + 'static, A: Api + 'static>(
     Ok(res.into())
 }
 
-pub fn call_handle<S: Storage + 'static, A: Api + 'static>(
-    instance: &mut Instance<S, A>,
+pub fn call_handle<S: Storage + 'static, A: Api + 'static, Q: Querier + 'static>(
+    instance: &mut Instance<S, A, Q>,
     env: &Env,
     msg: &[u8],
 ) -> Result<Result<HandleResponse, ApiError>, Error> {
@@ -35,8 +35,8 @@ pub fn call_handle<S: Storage + 'static, A: Api + 'static>(
     Ok(res.into())
 }
 
-pub fn call_query<S: Storage + 'static, A: Api + 'static>(
-    instance: &mut Instance<S, A>,
+pub fn call_query<S: Storage + 'static, A: Api + 'static, Q: Querier + 'static>(
+    instance: &mut Instance<S, A, Q>,
     msg: &[u8],
 ) -> Result<Result<QueryResponse, ApiError>, Error> {
     let data = call_query_raw(instance, msg)?;
@@ -58,8 +58,8 @@ pub fn call_query<S: Storage + 'static, A: Api + 'static>(
 
 /// Calls Wasm export "init" and returns raw data from the contract.
 /// The result is length limited to prevent abuse but otherwise unchecked.
-pub fn call_init_raw<S: Storage + 'static, A: Api + 'static>(
-    instance: &mut Instance<S, A>,
+pub fn call_init_raw<S: Storage + 'static, A: Api + 'static, Q: Querier + 'static>(
+    instance: &mut Instance<S, A, Q>,
     env: &[u8],
     msg: &[u8],
 ) -> Result<Vec<u8>, Error> {
@@ -68,8 +68,8 @@ pub fn call_init_raw<S: Storage + 'static, A: Api + 'static>(
 
 /// Calls Wasm export "handle" and returns raw data from the contract.
 /// The result is length limited to prevent abuse but otherwise unchecked.
-pub fn call_handle_raw<S: Storage + 'static, A: Api + 'static>(
-    instance: &mut Instance<S, A>,
+pub fn call_handle_raw<S: Storage + 'static, A: Api + 'static, Q: Querier + 'static>(
+    instance: &mut Instance<S, A, Q>,
     env: &[u8],
     msg: &[u8],
 ) -> Result<Vec<u8>, Error> {
@@ -78,15 +78,15 @@ pub fn call_handle_raw<S: Storage + 'static, A: Api + 'static>(
 
 /// Calls Wasm export "query" and returns raw data from the contract.
 /// The result is length limited to prevent abuse but otherwise unchecked.
-pub fn call_query_raw<S: Storage + 'static, A: Api + 'static>(
-    instance: &mut Instance<S, A>,
+pub fn call_query_raw<S: Storage + 'static, A: Api + 'static, Q: Querier + 'static>(
+    instance: &mut Instance<S, A, Q>,
     msg: &[u8],
 ) -> Result<Vec<u8>, Error> {
     call_raw(instance, "query", &[msg], MAX_LENGTH_QUERY)
 }
 
-fn call_raw<S: Storage + 'static, A: Api + 'static>(
-    instance: &mut Instance<S, A>,
+fn call_raw<S: Storage + 'static, A: Api + 'static, Q: Querier + 'static>(
+    instance: &mut Instance<S, A, Q>,
     name: &str,
     args: &[&[u8]],
     result_max_length: usize,

--- a/packages/vm/src/compatability.rs
+++ b/packages/vm/src/compatability.rs
@@ -10,6 +10,7 @@ static SUPPORTED_IMPORTS: &[&str] = &[
     "env.remove_db",
     "env.canonicalize_address",
     "env.humanize_address",
+    "env.query_chain",
     #[cfg(feature = "iterator")]
     "env.scan_db",
     #[cfg(feature = "iterator")]

--- a/packages/vm/src/context.rs
+++ b/packages/vm/src/context.rs
@@ -23,9 +23,10 @@ use crate::errors::Error;
 use crate::memory::{read_region, write_region};
 use crate::serde::{from_slice, to_vec};
 
-static MAX_LENGTH_DB_KEY: usize = 100_000;
+static MAX_LENGTH_DB_KEY: usize = 2_000;
 static MAX_LENGTH_DB_VALUE: usize = 100_000;
 static MAX_LENGTH_ADDRESS: usize = 200;
+static MAX_LENGTH_QUERY: usize = 2_000;
 
 /// An unknown error occurred when writing to region
 static ERROR_WRITE_TO_REGION_UNKNOWN: i32 = -1_000_001;
@@ -120,7 +121,7 @@ pub fn do_query_chain<A: Api, S: Storage, Q: Querier>(
     request_ptr: u32,
     response_ptr: u32,
 ) -> i32 {
-    let request = match read_region(ctx, request_ptr, MAX_LENGTH_ADDRESS) {
+    let request = match read_region(ctx, request_ptr, MAX_LENGTH_QUERY) {
         Ok(data) => data,
         Err(_) => return ERROR_READ_FROM_REGION_UNKNOWN,
     };

--- a/packages/vm/src/context.rs
+++ b/packages/vm/src/context.rs
@@ -188,7 +188,7 @@ mod iter_support {
             let live_forever: Box<dyn Iterator<Item = KV> + 'static> =
                 unsafe { mem::transmute(iter) };
             leave_iterator::<S, Q>(ctx, live_forever);
-            leave_storage(ctx, Some(store));
+            leave_storage::<S, Q>(ctx, Some(store));
             0
         } else {
             ERROR_NO_STORAGE
@@ -196,7 +196,7 @@ mod iter_support {
     }
 
     pub fn do_next<S: Storage, Q: Querier>(ctx: &Ctx, key_ptr: u32, value_ptr: u32) -> i32 {
-        let mut iter = match take_iterator::<T>(ctx) {
+        let mut iter = match take_iterator::<S, Q>(ctx) {
             Some(i) => i,
             None => return ERROR_NEXT_INVALID_ITERATOR,
         };

--- a/packages/vm/src/context.rs
+++ b/packages/vm/src/context.rs
@@ -24,10 +24,10 @@ use crate::errors::Error;
 use crate::memory::{read_region, write_region};
 use crate::serde::to_vec;
 
-static MAX_LENGTH_DB_KEY: usize = 2_000;
+static MAX_LENGTH_DB_KEY: usize = 100_000;
 static MAX_LENGTH_DB_VALUE: usize = 100_000;
 static MAX_LENGTH_ADDRESS: usize = 200;
-static MAX_LENGTH_QUERY: usize = 2_000;
+static MAX_LENGTH_QUERY: usize = 100_000;
 
 /// An unknown error occurred when writing to region
 static ERROR_WRITE_TO_REGION_UNKNOWN: i32 = -1_000_001;

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -109,9 +109,6 @@ where
                 "humanize_address" => Func::new(move |ctx: &mut Ctx, canonical_ptr: u32, human_ptr: u32| -> i32 {
                     do_human_address(api, ctx, canonical_ptr, human_ptr)
                 }),
-                "humanize_address" => Func::new(move |ctx: &mut Ctx, canonical_ptr: u32, human_ptr: u32| -> i32 {
-                    do_human_address(api, ctx, canonical_ptr, human_ptr)
-                }),
                 "query_chain" => Func::new(move |ctx: &mut Ctx, request_ptr: u32, response_ptr: u32| -> i32 {
                     do_query_chain::<_, S, Q>(api, ctx, request_ptr, response_ptr)
                 }),
@@ -329,7 +326,7 @@ mod test {
     #[test]
     #[cfg(feature = "default-cranelift")]
     fn set_get_and_gas_cranelift_noop() {
-        let instance = mock_instance_with_gas_limit(&CONTRACT, vec![], 123321);
+        let instance = mock_instance_with_gas_limit(&CONTRACT, &[], 123321);
         let orig_gas = instance.get_gas();
         assert_eq!(orig_gas, 1_000_000);
     }
@@ -337,7 +334,7 @@ mod test {
     #[test]
     #[cfg(feature = "default-singlepass")]
     fn set_get_and_gas_singlepass_works() {
-        let instance = mock_instance_with_gas_limit(&CONTRACT, vec![], 123321);
+        let instance = mock_instance_with_gas_limit(&CONTRACT, &[], 123321);
         let orig_gas = instance.get_gas();
         assert_eq!(orig_gas, 123321);
     }
@@ -395,7 +392,7 @@ mod test {
     #[test]
     #[cfg(feature = "default-singlepass")]
     fn contract_enforces_gas_limit() {
-        let mut instance = mock_instance_with_gas_limit(&CONTRACT, vec![], 20_000);
+        let mut instance = mock_instance_with_gas_limit(&CONTRACT, &[], 20_000);
 
         // init contract
         let env = mock_env(&instance.api, "creator", &coin("1000", "earth"), &[]);

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -14,7 +14,7 @@ use cosmwasm_std::{Api, Extern, Querier, Storage};
 use crate::backends::{compile, get_gas, set_gas};
 use crate::context::{
     do_canonical_address, do_human_address, do_query_chain, do_read, do_remove, do_write,
-    leave_storage, setup_context, take_storage, with_storage_from_context,
+    leave_context_data, setup_context, take_context_data, with_storage_from_context,
 };
 #[cfg(feature = "iterator")]
 use crate::context::{do_next, do_scan};
@@ -27,9 +27,7 @@ pub struct Instance<S: Storage + 'static, A: Api + 'static, Q: Querier + 'static
     pub api: A,
     // This does not store data but only fixes type information
     type_storage: PhantomData<S>,
-    // TODO: we need this in context, not here
-    // type_querier: PhantomData<Q>,
-    querier: Q,
+    type_querier: PhantomData<Q>,
 }
 
 impl<S, A, Q> Instance<S, A, Q>
@@ -47,7 +45,7 @@ where
         // copy this so it can be moved into the closures, without pulling in deps
         let api = deps.api;
         let import_obj = imports! {
-            || { setup_context::<S>() },
+            || { setup_context::<S, Q>() },
             "env" => {
                 // Reads the database entry at the given key into the the value.
                 // A prepared and sufficiently large memory Region is expected at value_ptr that points to pre-allocated memory.
@@ -55,20 +53,20 @@ where
                 //   value region too small: -1000002
                 // Ownership of both input and output pointer is not transferred to the host.
                 "read_db" => Func::new(move |ctx: &mut Ctx, key_ptr: u32, value_ptr: u32| -> i32 {
-                    do_read::<S>(ctx, key_ptr, value_ptr)
+                    do_read::<S, Q>(ctx, key_ptr, value_ptr)
                 }),
                 // Writes the given value into the database entry at the given key.
                 // Ownership of both input and output pointer is not transferred to the host.
                 // Returns 0 on success. Returns negative value on error.
                 "write_db" => Func::new(move |ctx: &mut Ctx, key_ptr: u32, value_ptr: u32| -> i32 {
-                    do_write::<S>(ctx, key_ptr, value_ptr)
+                    do_write::<S, Q>(ctx, key_ptr, value_ptr)
                 }),
                 // Removes the value at the given key. Different than writing &[] as future
                 // scans will not find this key.
                 // Ownership of both key pointer is not transferred to the host.
                 // Returns 0 on success. Returns negative value on error.
                 "remove_db" => Func::new(move |ctx: &mut Ctx, key_ptr: u32| -> i32 {
-                    do_remove::<S>(ctx, key_ptr)
+                    do_remove::<S, Q>(ctx, key_ptr)
                 }),
                 // Creates an iterator that will go from start to end
                 // Order is defined in cosmwasm::traits::Order and may be 1/Ascending or 2/Descending.
@@ -82,7 +80,7 @@ where
                         0
                     }
                     #[cfg(feature = "iterator")]
-                    do_scan::<S>(ctx, start_ptr, end_ptr, order)
+                    do_scan::<S, Q>(ctx, start_ptr, end_ptr, order)
                 }),
                 // Creates an iterator that will go from start to end
                 // Order is defined in cosmwasm::traits::Order and may be 1/Ascending or 2/Descending.
@@ -95,7 +93,7 @@ where
                         0
                     }
                     #[cfg(feature = "iterator")]
-                    do_next::<S>(ctx, key_ptr, value_ptr)
+                    do_next::<S, Q>(ctx, key_ptr, value_ptr)
                 }),
                 // Reads human address from human_ptr and writes canonicalized representation to canonical_ptr.
                 // A prepared and sufficiently large memory Region is expected at canonical_ptr that points to pre-allocated memory.
@@ -115,7 +113,7 @@ where
                     do_human_address(api, ctx, canonical_ptr, human_ptr)
                 }),
                 "query_chain" => Func::new(move |ctx: &mut Ctx, request_ptr: u32, response_ptr: u32| -> i32 {
-                    do_query_chain(api, ctx, request_ptr, response_ptr)
+                    do_query_chain::<_, S, Q>(api, ctx, request_ptr, response_ptr)
                 }),
             },
         };
@@ -129,26 +127,29 @@ where
         gas_limit: u64,
     ) -> Self {
         set_gas(&mut wasmer_instance, gas_limit);
-        // TODO: store querier in the context as well
-        leave_storage(wasmer_instance.context(), Some(deps.storage));
+        leave_context_data(
+            wasmer_instance.context(),
+            Some(deps.storage),
+            Some(deps.querier),
+        );
         Instance {
             wasmer_instance,
             api: deps.api,
             type_storage: PhantomData::<S> {},
-            querier: deps.querier,
-            // type_querier: PhantomData::<Q> {},
+            type_querier: PhantomData::<Q> {},
         }
     }
 
     /// Takes ownership of instance and decomposes it into its components.
     /// The components we want to preserve are returned, the rest is dropped.
     pub fn recycle(instance: Self) -> (wasmer_runtime_core::Instance, Option<Extern<S, A, Q>>) {
-        let ext = if let Some(storage) = take_storage(instance.wasmer_instance.context()) {
+        let ext = if let (Some(storage), Some(querier)) =
+            take_context_data(instance.wasmer_instance.context())
+        {
             Some(Extern {
                 storage,
                 api: instance.api,
-                // TODO: load querier from context
-                querier: instance.querier,
+                querier: querier,
             })
         } else {
             None
@@ -162,7 +163,7 @@ where
     }
 
     pub fn with_storage<F: FnMut(&mut S)>(&self, func: F) {
-        with_storage_from_context(self.wasmer_instance.context(), func)
+        with_storage_from_context::<S, Q, F>(self.wasmer_instance.context(), func)
     }
 
     /// Requests memory allocation by the instance and returns a pointer
@@ -328,7 +329,7 @@ mod test {
     #[test]
     #[cfg(feature = "default-cranelift")]
     fn set_get_and_gas_cranelift_noop() {
-        let instance = mock_instance_with_gas_limit(&CONTRACT, 123321);
+        let instance = mock_instance_with_gas_limit(&CONTRACT, vec![], 123321);
         let orig_gas = instance.get_gas();
         assert_eq!(orig_gas, 1_000_000);
     }
@@ -336,7 +337,7 @@ mod test {
     #[test]
     #[cfg(feature = "default-singlepass")]
     fn set_get_and_gas_singlepass_works() {
-        let instance = mock_instance_with_gas_limit(&CONTRACT, 123321);
+        let instance = mock_instance_with_gas_limit(&CONTRACT, vec![], 123321);
         let orig_gas = instance.get_gas();
         assert_eq!(orig_gas, 123321);
     }
@@ -394,7 +395,7 @@ mod test {
     #[test]
     #[cfg(feature = "default-singlepass")]
     fn contract_enforces_gas_limit() {
-        let mut instance = mock_instance_with_gas_limit(&CONTRACT, 20_000);
+        let mut instance = mock_instance_with_gas_limit(&CONTRACT, vec![], 20_000);
 
         // init contract
         let env = mock_env(&instance.api, "creator", &coin("1000", "earth"), &[]);

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -13,8 +13,8 @@ use cosmwasm_std::{Api, Extern, Querier, Storage};
 
 use crate::backends::{compile, get_gas, set_gas};
 use crate::context::{
-    do_canonical_address, do_human_address, do_read, do_remove, do_write, leave_storage,
-    setup_context, take_storage, with_storage_from_context,
+    do_canonical_address, do_human_address, do_query_chain, do_read, do_remove, do_write,
+    leave_storage, setup_context, take_storage, with_storage_from_context,
 };
 #[cfg(feature = "iterator")]
 use crate::context::{do_next, do_scan};
@@ -111,7 +111,12 @@ where
                 "humanize_address" => Func::new(move |ctx: &mut Ctx, canonical_ptr: u32, human_ptr: u32| -> i32 {
                     do_human_address(api, ctx, canonical_ptr, human_ptr)
                 }),
-                // TODO: add querier callback
+                "humanize_address" => Func::new(move |ctx: &mut Ctx, canonical_ptr: u32, human_ptr: u32| -> i32 {
+                    do_human_address(api, ctx, canonical_ptr, human_ptr)
+                }),
+                "query_chain" => Func::new(move |ctx: &mut Ctx, request_ptr: u32, response_ptr: u32| -> i32 {
+                    do_query_chain(api, ctx, request_ptr, response_ptr)
+                }),
             },
         };
         let wasmer_instance = module.instantiate(&import_obj).context(WasmerErr {})?;

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -149,7 +149,7 @@ where
             Some(Extern {
                 storage,
                 api: instance.api,
-                querier: querier,
+                querier,
             })
         } else {
             None

--- a/packages/vm/src/testing.rs
+++ b/packages/vm/src/testing.rs
@@ -19,19 +19,19 @@ use crate::instance::Instance;
 static DEFAULT_GAS_LIMIT: u64 = 500_000;
 
 pub fn mock_instance(wasm: &[u8]) -> Instance<MockStorage, MockApi, MockQuerier> {
-    mock_instance_with_gas_limit(wasm, vec![], DEFAULT_GAS_LIMIT)
+    mock_instance_with_gas_limit(wasm, &[], DEFAULT_GAS_LIMIT)
 }
 
 pub fn mock_instance_with_balances(
     wasm: &[u8],
-    balances: Vec<(HumanAddr, Vec<Coin>)>,
+    balances: &[(&HumanAddr, &[Coin])],
 ) -> Instance<MockStorage, MockApi, MockQuerier> {
     mock_instance_with_gas_limit(wasm, balances, DEFAULT_GAS_LIMIT)
 }
 
 pub fn mock_instance_with_gas_limit(
     wasm: &[u8],
-    balances: Vec<(HumanAddr, Vec<Coin>)>,
+    balances: &[(&HumanAddr, &[Coin])],
     gas_limit: u64,
 ) -> Instance<MockStorage, MockApi, MockQuerier> {
     check_wasm(wasm).unwrap();

--- a/packages/vm/src/testing.rs
+++ b/packages/vm/src/testing.rs
@@ -5,9 +5,9 @@ use serde::Serialize;
 // JsonSchema is a flag for types meant to be publically exposed
 use schemars::JsonSchema;
 
-use cosmwasm_std::testing::{mock_dependencies, MockApi, MockStorage};
+use cosmwasm_std::testing::{mock_dependencies, MockApi, MockQuerier, MockStorage};
 use cosmwasm_std::{
-    to_vec, Api, ApiError, Env, HandleResponse, InitResponse, QueryResponse, Storage,
+    to_vec, Api, ApiError, Env, HandleResponse, InitResponse, Querier, QueryResponse, Storage,
 };
 
 use crate::calls::{call_handle, call_init, call_query};
@@ -17,11 +17,14 @@ use crate::instance::Instance;
 /// Gas limit for testing
 static DEFAULT_GAS_LIMIT: u64 = 500_000;
 
-pub fn mock_instance(wasm: &[u8]) -> Instance<MockStorage, MockApi> {
+pub fn mock_instance(wasm: &[u8]) -> Instance<MockStorage, MockApi, MockQuerier> {
     mock_instance_with_gas_limit(wasm, DEFAULT_GAS_LIMIT)
 }
 
-pub fn mock_instance_with_gas_limit(wasm: &[u8], gas_limit: u64) -> Instance<MockStorage, MockApi> {
+pub fn mock_instance_with_gas_limit(
+    wasm: &[u8],
+    gas_limit: u64,
+) -> Instance<MockStorage, MockApi, MockQuerier> {
     check_wasm(wasm).unwrap();
     let deps = mock_dependencies(20);
     Instance::from_code(wasm, deps, gas_limit).unwrap()
@@ -30,8 +33,13 @@ pub fn mock_instance_with_gas_limit(wasm: &[u8], gas_limit: u64) -> Instance<Moc
 // init mimicks the call signature of the smart contracts.
 // thus it moves env and msg rather than take them as reference.
 // this is inefficient here, but only used in test code
-pub fn init<S: Storage + 'static, A: Api + 'static, T: Serialize + JsonSchema>(
-    instance: &mut Instance<S, A>,
+pub fn init<
+    S: Storage + 'static,
+    A: Api + 'static,
+    Q: Querier + 'static,
+    T: Serialize + JsonSchema,
+>(
+    instance: &mut Instance<S, A, Q>,
     env: Env,
     msg: T,
 ) -> Result<InitResponse, ApiError> {
@@ -44,8 +52,13 @@ pub fn init<S: Storage + 'static, A: Api + 'static, T: Serialize + JsonSchema>(
 // handle mimicks the call signature of the smart contracts.
 // thus it moves env and msg rather than take them as reference.
 // this is inefficient here, but only used in test code
-pub fn handle<S: Storage + 'static, A: Api + 'static, T: Serialize + JsonSchema>(
-    instance: &mut Instance<S, A>,
+pub fn handle<
+    S: Storage + 'static,
+    A: Api + 'static,
+    Q: Querier + 'static,
+    T: Serialize + JsonSchema,
+>(
+    instance: &mut Instance<S, A, Q>,
     env: Env,
     msg: T,
 ) -> Result<HandleResponse, ApiError> {
@@ -58,8 +71,13 @@ pub fn handle<S: Storage + 'static, A: Api + 'static, T: Serialize + JsonSchema>
 // query mimicks the call signature of the smart contracts.
 // thus it moves env and msg rather than take them as reference.
 // this is inefficient here, but only used in test code
-pub fn query<S: Storage + 'static, A: Api + 'static, T: Serialize + JsonSchema>(
-    instance: &mut Instance<S, A>,
+pub fn query<
+    S: Storage + 'static,
+    A: Api + 'static,
+    Q: Querier + 'static,
+    T: Serialize + JsonSchema,
+>(
+    instance: &mut Instance<S, A, Q>,
     msg: T,
 ) -> Result<QueryResponse, ApiError> {
     match to_vec(&msg) {
@@ -70,7 +88,9 @@ pub fn query<S: Storage + 'static, A: Api + 'static, T: Serialize + JsonSchema>(
 
 /// Runs a series of IO tests, hammering especially on allocate and deallocate.
 /// This could be especially useful when run with some kind of leak detector.
-pub fn test_io<S: Storage + 'static, A: Api + 'static>(instance: &mut Instance<S, A>) {
+pub fn test_io<S: Storage + 'static, A: Api + 'static, Q: Querier + 'static>(
+    instance: &mut Instance<S, A, Q>,
+) {
     let sizes: Vec<usize> = vec![0, 1, 3, 10, 200, 2000, 5 * 1024];
     let bytes: Vec<u8> = vec![0x00, 0xA5, 0xFF];
 

--- a/packages/vm/src/testing.rs
+++ b/packages/vm/src/testing.rs
@@ -5,9 +5,10 @@ use serde::Serialize;
 // JsonSchema is a flag for types meant to be publically exposed
 use schemars::JsonSchema;
 
-use cosmwasm_std::testing::{mock_dependencies, MockApi, MockQuerier, MockStorage};
+use cosmwasm_std::testing::{mock_dependencies_with_balances, MockApi, MockQuerier, MockStorage};
 use cosmwasm_std::{
-    to_vec, Api, ApiError, Env, HandleResponse, InitResponse, Querier, QueryResponse, Storage,
+    to_vec, Api, ApiError, Coin, Env, HandleResponse, HumanAddr, InitResponse, Querier,
+    QueryResponse, Storage,
 };
 
 use crate::calls::{call_handle, call_init, call_query};
@@ -18,15 +19,23 @@ use crate::instance::Instance;
 static DEFAULT_GAS_LIMIT: u64 = 500_000;
 
 pub fn mock_instance(wasm: &[u8]) -> Instance<MockStorage, MockApi, MockQuerier> {
-    mock_instance_with_gas_limit(wasm, DEFAULT_GAS_LIMIT)
+    mock_instance_with_gas_limit(wasm, vec![], DEFAULT_GAS_LIMIT)
+}
+
+pub fn mock_instance_with_balances(
+    wasm: &[u8],
+    balances: Vec<(HumanAddr, Vec<Coin>)>,
+) -> Instance<MockStorage, MockApi, MockQuerier> {
+    mock_instance_with_gas_limit(wasm, balances, DEFAULT_GAS_LIMIT)
 }
 
 pub fn mock_instance_with_gas_limit(
     wasm: &[u8],
+    balances: Vec<(HumanAddr, Vec<Coin>)>,
     gas_limit: u64,
 ) -> Instance<MockStorage, MockApi, MockQuerier> {
     check_wasm(wasm).unwrap();
-    let deps = mock_dependencies(20);
+    let deps = mock_dependencies_with_balances(20, balances);
     Instance::from_code(wasm, deps, gas_limit).unwrap()
 }
 


### PR DESCRIPTION
Closes #100 

Also add to the whole stack (including between vm and wasm).
I have updated all generic usages of Extern and tests pass again.

TODO:
- [x] Add query_chain to the context
- [x] Use external Querier from sample contract and test it