### PR TITLE
Define msg and query types for Terra swap integration

### DIFF
--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -18,10 +18,17 @@ maintenance = { status = "actively-developed" }
 # given Ethereum 1.0, 2.0, Substrate, and other major projects use Tries
 # we keep this optional, to allow possible future integration (or different Cosmos Backends)
 iterator = []
-# staking exposes bindings to a required staking modulde in the runtime, via new
+# staking exposes bindings to a required staking moudle in the runtime, via new
 # CosmosMsg types, and new QueryRequest types. This should only be enabled on contracts
 # that require these types, so other contracts can be used on systems with eg. PoA consensus
 staking = []
+# swap exposes bindings to a required swap/exchange module in the runtime, via new
+# CosmosMsg types, and new QueryRequest types. This is designed explicitly for Terra's
+# implementation and may or may not be compatible with other DEX's. Noteably,
+# it works more like Uniswap, than an exchange with Orderbooks where you can make
+# standing orders and possibly cancel them later. It assumes the swap is executed (or fails)
+# in the same transaction.
+swap = []
 # backtraces provides much better context at runtime errors (in non-wasm code)
 # at the cost of a bit of code size and performance.
 backtraces = ["snafu/backtraces"]

--- a/packages/std/src/init_handle.rs
+++ b/packages/std/src/init_handle.rs
@@ -29,6 +29,12 @@ pub enum CosmosMsg {
     },
     #[cfg(feature = "staking")]
     Staking(StakingMsg),
+    #[cfg(feature = "swap")]
+    Swap {
+        trader_addr: HumanAddr,
+        offer_coin: Coin,
+        ask_denom: String,
+    },
 }
 
 #[cfg(feature = "staking")]

--- a/packages/std/src/mock.rs
+++ b/packages/std/src/mock.rs
@@ -138,6 +138,10 @@ impl Querier for MockQuerier {
             QueryRequest::Staking(_) => Err(ApiSystemError::InvalidRequest {
                 source: "staking not yet implemented".to_string(),
             }),
+            #[cfg(feature = "swap")]
+            QueryRequest::Swap(_) => Err(ApiSystemError::InvalidRequest {
+                source: "swap not yet implemented".to_string(),
+            }),
         }
     }
 }

--- a/packages/std/src/query.rs
+++ b/packages/std/src/query.rs
@@ -26,6 +26,8 @@ pub enum QueryRequest {
     },
     #[cfg(feature = "staking")]
     Staking(StakingRequest),
+    #[cfg(feature = "swap")]
+    Swap(SwapRequest),
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -45,6 +47,36 @@ pub enum StakingRequest {
         delegator: HumanAddr,
         validator: Option<HumanAddr>,
     },
+}
+
+#[cfg(feature = "swap")]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum SwapRequest {
+    ExchangeRate { offer: String, ask: String },
+    // Delegations will return all delegations by the delegator,
+    // or just those to the given validator (if set)
+    Simulate { offer: Coin, ask: String },
+}
+
+#[cfg(feature = "swap")]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+/// ExchangeRateResponse is data format returned from SwapRequest::ExchangeRate query
+pub struct ExchangeRateResponse {
+    // TODO: make more complex decimal, with non-fixed digits?
+    // Note: Coin only have integer representation (serialized as Strings)
+    // rate is denominated in 10^-9
+    // 1_000_000_000 means 1 ask for 1 offer
+    // 10_000_000_000 means 10 ask for 1 offer
+    // 1_000_000 means 1 ask for 1000 offer
+    pub rate: u64,
+}
+
+#[cfg(feature = "swap")]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+/// SimulateSwapResponse is data format returned from SwapRequest::Simulate query
+pub struct SimulateSwapResponse {
+    pub receive: Coin,
 }
 
 #[cfg(feature = "staking")]

--- a/packages/std/src/query.rs
+++ b/packages/std/src/query.rs
@@ -63,12 +63,10 @@ pub enum SwapRequest {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 /// ExchangeRateResponse is data format returned from SwapRequest::ExchangeRate query
 pub struct ExchangeRateResponse {
-    // TODO: make more complex decimal, with non-fixed digits?
-    // Note: Coin only have integer representation (serialized as Strings)
-    // rate is denominated in 10^-9
-    // 1_000_000_000 means 1 ask for 1 offer
-    // 10_000_000_000 means 10 ask for 1 offer
-    // 1_000_000 means 1 ask for 1000 offer
+    // rate is denominated in 10^-6
+    // 1_000_000 means 1 ask for 1 offer
+    // 10_000_000 means 10 ask for 1 offer
+    // 1_000 means 1 ask for 1000 offer
     pub rate: u64,
 }
 


### PR DESCRIPTION
This builds off of #211 to specify the desired interfaces for Terra integrations. This adds support for contracts to integrate with Terra's swap module.

Note that this interface will allow a module to make trades on response to a user-defined transaction. Adding hooks (eg. to auto-trade when rates change below some predefined value) is out of scope - and probably not the best idea to do on-chain. (If you disagree, please add a comment).

One open question, do we want a query to list all possible exchange pairs? Or assume that the contract knows which pairs it is interested in a priori?