### PR TITLE
Split imports in read-only and rw

### DIFF
--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -36,14 +36,22 @@ where
     A: Api + 'static,
     Q: Querier + 'static,
 {
-    pub fn from_code(code: &[u8], deps: Extern<S, A, Q>, gas_limit: u64) -> Result<Self> {
+    pub fn from_code(
+        code: &[u8],
+        deps: Extern<S, A, Q>,
+        gas_limit: u64,
+        allow_db_write: bool,
+    ) -> Result<Self> {
         let module = compile(code)?;
-        Instance::from_module(&module, deps, gas_limit)
+        Instance::from_module(&module, deps, gas_limit, allow_db_write)
     }
 
-    pub fn from_module(module: &Module, deps: Extern<S, A, Q>, gas_limit: u64) -> Result<Self> {
-        let allow_db_write = true;
-
+    pub fn from_module(
+        module: &Module,
+        deps: Extern<S, A, Q>,
+        gas_limit: u64,
+        allow_db_write: bool,
+    ) -> Result<Self> {
         // copy this so it can be moved into the closures, without pulling in deps
         let api = deps.api;
 

--- a/packages/vm/src/testing.rs
+++ b/packages/vm/src/testing.rs
@@ -34,9 +34,10 @@ pub fn mock_instance_with_gas_limit(
     balances: &[(&HumanAddr, &[Coin])],
     gas_limit: u64,
 ) -> Instance<MockStorage, MockApi, MockQuerier> {
+    let allow_db_write = true;
     check_wasm(wasm).unwrap();
     let deps = mock_dependencies_with_balances(20, balances);
-    Instance::from_code(wasm, deps, gas_limit).unwrap()
+    Instance::from_code(wasm, deps, gas_limit, allow_db_write).unwrap()
 }
 
 // init mimicks the call signature of the smart contracts.


### PR DESCRIPTION
An attempt to tackle #226.

Would this do the job if `allow_db_write` was converted to an instance argument that is set along with gas limit?