### PR TITLE
Cleanup context data

### DIFF
--- a/contracts/hackatom/tests/integration.rs
+++ b/contracts/hackatom/tests/integration.rs
@@ -30,9 +30,9 @@
 
 use cosmwasm_std::testing::mock_env;
 use cosmwasm_std::{
-    coin, from_binary, from_slice, log, Api, ApiError, BalanceResponse, CosmosMsg, HumanAddr,
-    ReadonlyStorage,
+    coin, from_binary, log, Api, ApiError, BalanceResponse, CosmosMsg, HumanAddr, ReadonlyStorage,
 };
+use cosmwasm_vm::from_slice;
 use cosmwasm_vm::testing::{
     handle, init, mock_instance, mock_instance_with_balances, query, test_io,
 };
@@ -62,11 +62,13 @@ fn proper_initialization() {
     assert_eq!(0, res.messages.len());
 
     // it worked, let's check the state
-    deps.with_storage(|store| {
-        let data = store.get(CONFIG_KEY).expect("no data stored");
-        let state: State = from_slice(&data).unwrap();
-        assert_eq!(state, expected_state);
-    });
+    let state: State = deps
+        .with_storage(|store| {
+            let data = store.get(CONFIG_KEY).expect("no data stored");
+            from_slice(&data)
+        })
+        .unwrap();
+    assert_eq!(state, expected_state);
 }
 
 #[test]
@@ -205,18 +207,20 @@ fn failed_handle() {
     }
 
     // state should not change
-    deps.with_storage(|store| {
-        let data = store.get(CONFIG_KEY).expect("no data stored");
-        let state: State = from_slice(&data).unwrap();
-        assert_eq!(
-            state,
-            State {
-                verifier: deps.api.canonical_address(&verifier).unwrap(),
-                beneficiary: deps.api.canonical_address(&beneficiary).unwrap(),
-                funder: deps.api.canonical_address(&creator).unwrap(),
-            }
-        );
-    });
+    let state: State = deps
+        .with_storage(|store| {
+            let data = store.get(CONFIG_KEY).expect("no data stored");
+            from_slice(&data)
+        })
+        .unwrap();
+    assert_eq!(
+        state,
+        State {
+            verifier: deps.api.canonical_address(&verifier).unwrap(),
+            beneficiary: deps.api.canonical_address(&beneficiary).unwrap(),
+            funder: deps.api.canonical_address(&creator).unwrap(),
+        }
+    );
 }
 
 #[test]

--- a/packages/vm/src/context.rs
+++ b/packages/vm/src/context.rs
@@ -306,12 +306,12 @@ unsafe fn get_data<S: Storage, Q: Querier>(ptr: *mut c_void) -> Box<ContextData<
 }
 
 #[cfg(feature = "iterator")]
-fn free_iterator<S: Storage, Q: Querier>(context: &mut Box<ContextData<S, Q>>) {
+fn free_iterator<S: Storage, Q: Querier>(context: &mut ContextData<S, Q>) {
     let _ = context.iter.take();
 }
 
 #[cfg(not(feature = "iterator"))]
-fn free_iterator<S: Storage, Q: Querier>(_context: &mut Box<ContextData<S, Q>>) {}
+fn free_iterator<S: Storage, Q: Querier>(_context: &mut ContextData<S, Q>) {}
 
 pub fn with_storage_from_context<S: Storage, Q: Querier, F: FnMut(&mut S)>(ctx: &Ctx, mut func: F) {
     let b = unsafe { get_data::<S, Q>(ctx.data) };

--- a/packages/vm/src/context.rs
+++ b/packages/vm/src/context.rs
@@ -13,8 +13,7 @@ use cosmwasm_std::{
 
 #[cfg(feature = "iterator")]
 pub use iter_support::{
-    do_next, do_scan, leave_iterator, take_iterator, ERROR_NEXT_INVALID_ITERATOR, ERROR_NO_STORAGE,
-    ERROR_SCAN_INVALID_ORDER,
+    do_next, do_scan, ERROR_NEXT_INVALID_ITERATOR, ERROR_NO_STORAGE, ERROR_SCAN_INVALID_ORDER,
 };
 
 use crate::errors::Error;
@@ -257,7 +256,7 @@ mod iter_support {
 
     // if ptr is None, find a new slot.
     // otherwise, place in slot defined by ptr (only after take)
-    pub fn leave_iterator<S: Storage, Q: Querier>(ctx: &Ctx, iter: Box<dyn Iterator<Item = KV>>) {
+    fn leave_iterator<S: Storage, Q: Querier>(ctx: &Ctx, iter: Box<dyn Iterator<Item = KV>>) {
         let mut b = unsafe { get_data::<S, Q>(ctx.data) };
         // clean up old one if there was one
         let _ = b.iter.take();
@@ -265,9 +264,7 @@ mod iter_support {
         mem::forget(b); // we do this to avoid cleanup
     }
 
-    pub fn take_iterator<S: Storage, Q: Querier>(
-        ctx: &Ctx,
-    ) -> Option<Box<dyn Iterator<Item = KV>>> {
+    fn take_iterator<S: Storage, Q: Querier>(ctx: &Ctx) -> Option<Box<dyn Iterator<Item = KV>>> {
         let mut b = unsafe { get_data::<S, Q>(ctx.data) };
         let res = b.iter.take();
         mem::forget(b); // we do this to avoid cleanup

--- a/packages/vm/src/context.rs
+++ b/packages/vm/src/context.rs
@@ -175,6 +175,7 @@ pub fn do_query_chain<A: Api, S: Storage, Q: Querier>(
     }
 }
 
+#[cfg(feature = "iterator")]
 mod iter_support {
     use super::*;
     use crate::memory::maybe_read_region;
@@ -371,7 +372,7 @@ mod test {
     use super::*;
     use crate::backends::compile;
     use cosmwasm_std::testing::{MockQuerier, MockStorage};
-    use cosmwasm_std::{coin, Order, ReadonlyStorage};
+    use cosmwasm_std::{coin, ReadonlyStorage};
     use wasmer_runtime_core::{imports, instance::Instance, typed_func::Func};
 
     #[cfg(feature = "iterator")]

--- a/packages/vm/src/errors.rs
+++ b/packages/vm/src/errors.rs
@@ -67,6 +67,11 @@ pub enum Error {
         msg: String,
         backtrace: snafu::Backtrace,
     },
+    #[snafu(display("Uninitialized Context Data: {}", kind))]
+    UninitializedContextData {
+        kind: &'static str,
+        backtrace: snafu::Backtrace,
+    },
     #[snafu(display("Validating Wasm: {}", msg))]
     ValidationErr {
         msg: String,

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -14,7 +14,7 @@ use cosmwasm_std::{Api, Extern, Querier, Storage};
 use crate::backends::{compile, get_gas, set_gas};
 use crate::context::{
     do_canonicalize_address, do_humanize_address, do_query_chain, do_read, do_remove, do_write,
-    leave_context_data, setup_context, take_context_data, with_storage_from_context,
+    move_from_context, move_into_context, setup_context, with_storage_from_context,
 };
 #[cfg(feature = "iterator")]
 use crate::context::{do_next, do_scan};
@@ -118,7 +118,7 @@ where
         gas_limit: u64,
     ) -> Self {
         set_gas(&mut wasmer_instance, gas_limit);
-        leave_context_data(wasmer_instance.context(), deps.storage, deps.querier);
+        move_from_context(wasmer_instance.context(), deps.storage, deps.querier);
         Instance {
             wasmer_instance,
             api: deps.api,
@@ -131,7 +131,7 @@ where
     /// The components we want to preserve are returned, the rest is dropped.
     pub fn recycle(instance: Self) -> (wasmer_runtime_core::Instance, Option<Extern<S, A, Q>>) {
         let ext = if let (Some(storage), Some(querier)) =
-            take_context_data(instance.wasmer_instance.context())
+            move_into_context(instance.wasmer_instance.context())
         {
             Some(Extern {
                 storage,

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -118,11 +118,7 @@ where
         gas_limit: u64,
     ) -> Self {
         set_gas(&mut wasmer_instance, gas_limit);
-        leave_context_data(
-            wasmer_instance.context(),
-            Some(deps.storage),
-            Some(deps.querier),
-        );
+        leave_context_data(wasmer_instance.context(), deps.storage, deps.querier);
         Instance {
             wasmer_instance,
             api: deps.api,

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -149,8 +149,8 @@ where
         get_gas(&self.wasmer_instance)
     }
 
-    pub fn with_storage<F: FnMut(&mut S)>(&self, func: F) {
-        with_storage_from_context::<S, Q, F>(self.wasmer_instance.context(), func)
+    pub fn with_storage<F: FnMut(&mut S) -> Result<T>, T>(&self, func: F) -> Result<T> {
+        with_storage_from_context::<S, Q, F, T>(self.wasmer_instance.context(), func)
     }
 
     /// Requests memory allocation by the instance and returns a pointer
@@ -334,7 +334,9 @@ mod test {
     fn with_context_safe_for_panic() {
         // this should fail with the assertion, but not cause a double-free crash (issue #59)
         let instance = mock_instance(&CONTRACT);
-        instance.with_storage(|_store| assert_eq!(1, 2));
+        instance
+            .with_storage::<_, ()>(|_store| panic!("trigger failure"))
+            .unwrap();
     }
 
     #[test]

--- a/packages/vm/src/lib.rs
+++ b/packages/vm/src/lib.rs
@@ -19,3 +19,4 @@ pub use crate::calls::{
 };
 pub use crate::instance::Instance;
 pub use crate::modules::FileSystemCache;
+pub use crate::serde::{from_slice, to_vec};


### PR DESCRIPTION
Closes  #225 

- [x] Simplify a whole lot of the flows around ContextData and make many fewer (potentially dangerous) methods public.
- [x] Test panics in `with_**` context methods
- [x] Improve interaction / independence between various data points in `ContextData`

