### PR TITLE
Multiple iterators in wasm

### DIFF
--- a/contracts/queue/schema/query_msg.json
+++ b/contracts/queue/schema/query_msg.json
@@ -23,6 +23,17 @@
           "type": "object"
         }
       }
+    },
+    {
+      "type": "object",
+      "required": [
+        "reducer"
+      ],
+      "properties": {
+        "reducer": {
+          "type": "object"
+        }
+      }
     }
   ]
 }

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -102,8 +102,8 @@ where
                 // Creates an iterator that will go from start to end
                 // Order is defined in cosmwasm::traits::Order and may be 1/Ascending or 2/Descending.
                 // Ownership of both start and end pointer is not transferred to the host.
-                "next_db" => Func::new(move |ctx: &mut Ctx, key_ptr: u32, value_ptr: u32| -> i32 {
-                    do_next::<S, Q>(ctx, key_ptr, value_ptr)
+                "next_db" => Func::new(move |ctx: &mut Ctx, counter: i32, key_ptr: u32, value_ptr: u32| -> i32 {
+                    do_next::<S, Q>(ctx, counter, key_ptr, value_ptr)
                 }),
             },
         });


### PR DESCRIPTION
Closes #190

Allows multiple iterators to be open at once over the rust-wasm boundary, by maintaining a `HashMap` of iterators, not just `Option`.

