### PR TITLE
Call allocate from read_db implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The imports provided to give the contract access to the environment are:
 // TODO: use feature switches to enable precompile dependencies in the future,
 // so contracts that need less
 extern "C" {
-    fn read_db(key: *const c_void, value: *mut c_void) -> i32;
+    fn read_db(key: *const c_void) -> i32;
     fn write_db(key: *const c_void, value: *mut c_void) -> i32;
     fn remove_db(key: *const c_void) -> i32;
     fn canonicalize_address(human: *const c_void, canonical: *mut c_void) -> i32;

--- a/packages/vm/src/context.rs
+++ b/packages/vm/src/context.rs
@@ -1,7 +1,7 @@
 //! Internal details to be used by instance.rs only
 use std::ffi::c_void;
 use std::mem;
-use std::ptr::{null_mut, NonNull};
+use std::ptr::NonNull;
 
 use snafu::ResultExt;
 use wasmer_runtime_core::{
@@ -19,7 +19,8 @@ use cosmwasm_std::{
 #[cfg(feature = "iterator")]
 pub(crate) use iter_support::{do_next, do_scan};
 
-use crate::errors::{Error, ResolveErr, Result, UninitializedContextData};
+use crate::conversion::{to_i32, to_u32};
+use crate::errors::{Error, ResolveErr, Result, UninitializedContextData, WasmerRuntimeErr};
 use crate::memory::{read_region, write_region};
 use crate::serde::{from_slice, to_vec};
 
@@ -51,7 +52,7 @@ pub static ERROR_NO_CONTEXT_DATA: i32 = -1_000_501;
 static ERROR_DB_UNKNOWN: i32 = -1_000_502;
 
 /// Reads a storage entry from the VM's storage into Wasm memory
-pub fn do_read<S: Storage, Q: Querier>(ctx: &Ctx, key_ptr: u32, value_ptr: u32) -> i32 {
+pub fn do_read<S: Storage, Q: Querier>(ctx: &Ctx, key_ptr: u32) -> i32 {
     let key = match read_region(ctx, key_ptr, MAX_LENGTH_DB_KEY) {
         Ok(data) => data,
         Err(Error::RegionLengthTooBigErr { .. }) => return ERROR_REGION_READ_LENGTH_TOO_BIG,
@@ -63,13 +64,36 @@ pub fn do_read<S: Storage, Q: Querier>(ctx: &Ctx, key_ptr: u32, value_ptr: u32) 
             Err(Error::UninitializedContextData { .. }) => return ERROR_NO_CONTEXT_DATA,
             Err(_) => return ERROR_DB_UNKNOWN,
         };
-    match value {
-        Some(buf) => match write_region(ctx, value_ptr, &buf) {
-            Ok(()) => SUCCESS,
-            Err(Error::RegionTooSmallErr { .. }) => ERROR_REGION_WRITE_TOO_SMALL,
-            Err(_) => ERROR_REGION_WRITE_UNKNOWN,
+
+    let data = match value {
+        Some(d) => d,
+        None => return SUCCESS,
+    };
+
+    println!("Data len: {}", data.len());
+
+    let value_ptr =
+        match with_func_from_context::<S, Q, u32, u32, _, _>(ctx, "allocate", |allocate_func| {
+            println!("Found allocate function");
+            let size = to_u32(data.len())?;
+            allocate_func.call(size).context(WasmerRuntimeErr {})
+        }) {
+            Ok(ptr) => ptr,
+            Err(_) => {
+                println!("Error executing allocate");
+                return -34567890; // error executing allocate
+            }
+        };
+
+    println!("value_ptr = {}", value_ptr);
+
+    match write_region(ctx, value_ptr, &data) {
+        Ok(()) => match to_i32(value_ptr) {
+            Ok(iptr) => iptr,
+            Err(_) => return -98765, // Error converting to i32 range
         },
-        None => SUCCESS,
+        Err(Error::RegionTooSmallErr { .. }) => ERROR_REGION_WRITE_TOO_SMALL,
+        Err(_) => ERROR_REGION_WRITE_UNKNOWN,
     }
 }
 
@@ -297,7 +321,7 @@ mod iter_support {
 struct ContextData<S: Storage, Q: Querier> {
     storage: Option<S>,
     querier: Option<Q>,
-    wasmer_instance: *mut wasmer_runtime_core::instance::Instance,
+    wasmer_instance: Option<NonNull<wasmer_runtime_core::instance::Instance>>,
     #[cfg(feature = "iterator")]
     iter: Option<Box<dyn Iterator<Item = KV>>>,
 }
@@ -313,7 +337,7 @@ fn create_unmanaged_context_data<S: Storage, Q: Querier>() -> *mut c_void {
     let data = ContextData::<S, Q> {
         storage: None,
         querier: None,
-        wasmer_instance: null_mut(),
+        wasmer_instance: None,
         #[cfg(feature = "iterator")]
         iter: None,
     };
@@ -332,11 +356,11 @@ fn destroy_unmanaged_context_data<S: Storage, Q: Querier>(ptr: *mut c_void) {
 /// Creates a back reference from a contact to its partent instance
 pub fn set_wasmer_instance<S: Storage, Q: Querier>(
     ctx: &Ctx,
-    wasmer_instance: *mut wasmer_runtime_core::instance::Instance,
+    wasmer_instance: NonNull<wasmer_runtime_core::instance::Instance>,
 ) {
     let context_data = ctx.data as *mut ContextData<S, Q>;
     unsafe {
-        (*context_data).wasmer_instance = wasmer_instance;
+        (*context_data).wasmer_instance = Some(wasmer_instance);
     }
 }
 
@@ -365,9 +389,25 @@ where
     Callback: FnMut(Func<Args, Rets, Wasm>) -> Result<CallbackData, Error>,
 {
     let context_data = ctx.data as *mut ContextData<S, Q>;
-    match NonNull::new(unsafe { (*context_data).wasmer_instance }) {
+    println!("Got context");
+    match unsafe { (*context_data).wasmer_instance } {
         Some(ptr) => {
-            let func = unsafe { ptr.as_ref().func(name).context(ResolveErr {}) }?;
+            println!("Got wasmer instance pointer");
+            let instance = unsafe { ptr.as_ref() };
+            println!("Got wasmer instance ref");
+            let _context = instance.context();
+            println!("Could execute context function on wasmer instance ref");
+            let func = match instance.func(name) {
+                Ok(func) => {
+                    println!("Found func");
+                    func
+                }
+                Err(e) => {
+                    println!("Error in func(): {:?}", e);
+                    panic!("Error in func(): {:?}", e);
+                }
+            }; // .context(ResolveErr {})?;
+            println!("Executing func ...");
             callback(func)
         }
         None => UninitializedContextData {
@@ -438,7 +478,6 @@ pub(crate) fn move_from_context<S: Storage, Q: Querier>(ctx: &Ctx, storage: S, q
 mod test {
     use super::*;
     use crate::backends::compile;
-    use crate::errors::WasmerRuntimeErr;
     use cosmwasm_std::testing::{MockQuerier, MockStorage};
     use cosmwasm_std::{coin, from_binary, BalanceResponse, ReadonlyStorage};
     use wasmer_runtime_core::{imports, instance::Instance, typed_func::Func};
@@ -466,7 +505,7 @@ mod test {
         let import_obj = imports! {
             || { setup_context::<MockStorage, MockQuerier>() },
             "env" => {
-                "read_db" => Func::new(|_a: i32, _b: i32| -> i32 { 0 }),
+                "read_db" => Func::new(|_a: i32| -> i32 { 0 }),
                 "write_db" => Func::new(|_a: i32, _b: i32| -> i32 { 0 }),
                 "remove_db" => Func::new(|_a: i32| -> i32 { 0 }),
                 "scan_db" => Func::new(|_a: i32, _b: i32, _c: i32| -> i32 { 0 }),
@@ -516,7 +555,7 @@ mod test {
     fn with_func_from_context_works() {
         let mut instance = make_instance();
         leave_default_data(&instance);
-        let instance_ptr = &mut instance as *mut Instance;
+        let instance_ptr = NonNull::from(&mut instance);
         set_wasmer_instance::<S, Q>(instance.context(), instance_ptr);
 
         let ctx = instance.context();

--- a/packages/vm/src/context.rs
+++ b/packages/vm/src/context.rs
@@ -1,9 +1,13 @@
 //! Internal details to be used by instance.rs only
 use std::ffi::c_void;
 use std::mem;
-use std::ptr::null_mut;
+use std::ptr::{null_mut, NonNull};
 
-use wasmer_runtime_core::vm::Ctx;
+use snafu::ResultExt;
+use wasmer_runtime_core::{
+    typed_func::{Func, Wasm, WasmTypeList},
+    vm::Ctx,
+};
 
 #[cfg(feature = "iterator")]
 use cosmwasm_std::KV;
@@ -15,7 +19,7 @@ use cosmwasm_std::{
 #[cfg(feature = "iterator")]
 pub(crate) use iter_support::{do_next, do_scan};
 
-use crate::errors::{Error, Result, UninitializedContextData};
+use crate::errors::{Error, ResolveErr, Result, UninitializedContextData};
 use crate::memory::{read_region, write_region};
 use crate::serde::{from_slice, to_vec};
 
@@ -348,6 +352,31 @@ fn free_iterator<S: Storage, Q: Querier>(context: &mut ContextData<S, Q>) {
 #[cfg(not(feature = "iterator"))]
 fn free_iterator<S: Storage, Q: Querier>(_context: &mut ContextData<S, Q>) {}
 
+pub(crate) fn with_func_from_context<S, Q, Args, Rets, Callback, CallbackData>(
+    ctx: &Ctx,
+    name: &str,
+    mut callback: Callback,
+) -> Result<CallbackData, Error>
+where
+    S: Storage,
+    Q: Querier,
+    Args: WasmTypeList,
+    Rets: WasmTypeList,
+    Callback: FnMut(Func<Args, Rets, Wasm>) -> Result<CallbackData, Error>,
+{
+    let context_data = ctx.data as *mut ContextData<S, Q>;
+    match NonNull::new(unsafe { (*context_data).wasmer_instance }) {
+        Some(ptr) => {
+            let func = unsafe { ptr.as_ref().func(name).context(ResolveErr {}) }?;
+            callback(func)
+        }
+        None => UninitializedContextData {
+            kind: "wasmer_instance",
+        }
+        .fail(),
+    }
+}
+
 pub(crate) fn with_storage_from_context<S, Q, F, T>(ctx: &Ctx, mut func: F) -> Result<T, Error>
 where
     S: Storage,
@@ -409,6 +438,7 @@ pub(crate) fn move_from_context<S: Storage, Q: Querier>(ctx: &Ctx, storage: S, q
 mod test {
     use super::*;
     use crate::backends::compile;
+    use crate::errors::WasmerRuntimeErr;
     use cosmwasm_std::testing::{MockQuerier, MockStorage};
     use cosmwasm_std::{coin, from_binary, BalanceResponse, ReadonlyStorage};
     use wasmer_runtime_core::{imports, instance::Instance, typed_func::Func};
@@ -480,6 +510,39 @@ mod test {
         let (ends, endq) = move_into_context::<S, Q>(instance.context());
         assert!(ends.is_none());
         assert!(endq.is_none());
+    }
+
+    #[test]
+    fn with_func_from_context_works() {
+        let mut instance = make_instance();
+        leave_default_data(&instance);
+        let instance_ptr = &mut instance as *mut Instance;
+        set_wasmer_instance::<S, Q>(instance.context(), instance_ptr);
+
+        let ctx = instance.context();
+        let _ptr = with_func_from_context::<S, Q, u32, u32, _, _>(ctx, "allocate", |alloc_func| {
+            alloc_func.call(10).context(WasmerRuntimeErr {})
+        })
+        .expect("with_func_from_context should not fail");
+    }
+
+    #[test]
+    fn with_func_from_context_fails_for_missing_instance() {
+        let instance = make_instance();
+        leave_default_data(&instance);
+        let ctx = instance.context();
+
+        let res = with_func_from_context::<S, Q, u32, u32, _, _>(ctx, "allocate", |alloc_func| {
+            alloc_func.call(10).expect("error calling allocate");
+            Ok(())
+        });
+        match res {
+            Ok(_) => panic!("this must not succeed"),
+            Err(Error::UninitializedContextData { kind, .. }) => {
+                assert_eq!(kind, "wasmer_instance")
+            }
+            Err(e) => panic!("Unexpected error: {}", e),
+        }
     }
 
     #[test]

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -1,4 +1,5 @@
 use std::marker::PhantomData;
+use std::ptr::NonNull;
 
 use snafu::ResultExt;
 pub use wasmer_runtime_core::typed_func::Func;
@@ -54,8 +55,8 @@ where
                 // Returns 0 on success. Returns negative value on error. An incomplete list of error codes is:
                 //   value region too small: -1000002
                 // Ownership of both input and output pointer is not transferred to the host.
-                "read_db" => Func::new(move |ctx: &mut Ctx, key_ptr: u32, value_ptr: u32| -> i32 {
-                    do_read::<S, Q>(ctx, key_ptr, value_ptr)
+                "read_db" => Func::new(move |ctx: &mut Ctx, key_ptr: u32| -> i32 {
+                    do_read::<S, Q>(ctx, key_ptr)
                 }),
                 // Writes the given value into the database entry at the given key.
                 // Ownership of both input and output pointer is not transferred to the host.
@@ -119,7 +120,7 @@ where
         gas_limit: u64,
     ) -> Self {
         set_gas(&mut wasmer_instance, gas_limit);
-        let instance_ptr = &mut wasmer_instance as *mut wasmer_runtime_core::instance::Instance;
+        let instance_ptr = NonNull::from(&mut wasmer_instance);
         set_wasmer_instance::<S, Q>(wasmer_instance.context(), instance_ptr);
         move_from_context(wasmer_instance.context(), deps.storage, deps.querier);
         Instance {

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -14,7 +14,8 @@ use cosmwasm_std::{Api, Extern, Querier, Storage};
 use crate::backends::{compile, get_gas, set_gas};
 use crate::context::{
     do_canonicalize_address, do_humanize_address, do_query_chain, do_read, do_remove, do_write,
-    move_from_context, move_into_context, setup_context, with_storage_from_context,
+    move_from_context, move_into_context, set_wasmer_instance, setup_context,
+    with_storage_from_context,
 };
 #[cfg(feature = "iterator")]
 use crate::context::{do_next, do_scan};
@@ -118,6 +119,8 @@ where
         gas_limit: u64,
     ) -> Self {
         set_gas(&mut wasmer_instance, gas_limit);
+        let instance_ptr = &mut wasmer_instance as *mut wasmer_runtime_core::instance::Instance;
+        set_wasmer_instance::<S, Q>(wasmer_instance.context(), instance_ptr);
         move_from_context(wasmer_instance.context(), deps.storage, deps.querier);
         Instance {
             wasmer_instance,


### PR DESCRIPTION
This is an implementation attempt for #126.

The basic idea is that the context stores a weak reference (implemented via raw pointer) to its parent, the wasmer instance. Then `do_read_db` could call into Wasm's `allocate` export ad part of the `read_db` import implementation.

However, this crashes at

```rust
    let context_data = ctx.data as *mut ContextData<S, Q>;
    println!("Got context");
    match unsafe { (*context_data).wasmer_instance } {
        Some(ptr) => {
            println!("Got wasmer instance pointer");
            let instance = unsafe { ptr.as_ref() };
            println!("Got wasmer instance ref");
            let _context = instance.context();
            println!("Could execute context function on wasmer instance ref");
            let func = match instance.func(name) { // crash here
```

with something like 

> thread 'proper_handle' panicked at 'called `Result::unwrap()` on an `Err` value: WasmerRuntimeErr { source: "unknown trap at 0x0 - segmentation violation", backtrace: Backtrace(()) }'

It is completely unclear if such kind of circles (user -> export -> Wasm -> import -> VM -> export -> Wasm) in a single call could ever work or if this is unsupported by design. Even if it can work, it's a massive unsafe construction.

Could not get this to work after 1 day. Giving up now.