### PR TITLE
Use some commits from read_db PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,12 +97,12 @@ If you haven't worked with WebAssembly before, please read an overview on
 The required exports provided by the cosmwasm smart contract are:
 
 ```rust
-pub extern "C" fn allocate(size: usize) -> *mut c_void;
-pub extern "C" fn deallocate(pointer: *mut c_void);
+extern "C" fn allocate(size: usize) -> u32;
+extern "C" fn deallocate(pointer: u32);
 
-pub extern "C" fn init(env_ptr: *mut c_void, msg_ptr: *mut c_void) -> *mut c_void;
-pub extern "C" fn handle(env_ptr: *mut c_void, msg_ptr: *mut c_void) -> *mut c_void;
-pub extern "C" fn query(msg_ptr: *mut c_void) -> *mut c_void;
+extern "C" fn init(env_ptr: u32, msg_ptr: u32) -> u32;
+extern "C" fn handle(env_ptr: u32, msg_ptr: u32) -> u32;
+extern "C" fn query(msg_ptr: u32) -> u32;
 ```
 
 `allocate`/`deallocate` allow the host to manage data within the Wasm VM. If

--- a/contracts/hackatom/.cargo/config
+++ b/contracts/hackatom/.cargo/config
@@ -1,5 +1,6 @@
 [alias]
 wasm = "build --release --target wasm32-unknown-unknown"
+wasm-debug = "build --target wasm32-unknown-unknown"
 unit-test = "test --lib --features backtraces"
 integration-test = "test --test integration"
 schema = "run --example schema"

--- a/contracts/hackatom/src/lib.rs
+++ b/contracts/hackatom/src/lib.rs
@@ -6,10 +6,9 @@ mod wasm {
     use cosmwasm_std::{
         do_handle, do_init, do_query, ExternalApi, ExternalQuerier, ExternalStorage,
     };
-    use std::ffi::c_void;
 
     #[no_mangle]
-    extern "C" fn init(env_ptr: *mut c_void, msg_ptr: *mut c_void) -> *mut c_void {
+    extern "C" fn init(env_ptr: u32, msg_ptr: u32) -> u32 {
         do_init(
             &contract::init::<ExternalStorage, ExternalApi, ExternalQuerier>,
             env_ptr,
@@ -18,7 +17,7 @@ mod wasm {
     }
 
     #[no_mangle]
-    extern "C" fn handle(env_ptr: *mut c_void, msg_ptr: *mut c_void) -> *mut c_void {
+    extern "C" fn handle(env_ptr: u32, msg_ptr: u32) -> u32 {
         do_handle(
             &contract::handle::<ExternalStorage, ExternalApi, ExternalQuerier>,
             env_ptr,
@@ -27,7 +26,7 @@ mod wasm {
     }
 
     #[no_mangle]
-    extern "C" fn query(msg_ptr: *mut c_void) -> *mut c_void {
+    extern "C" fn query(msg_ptr: u32) -> u32 {
         do_query(
             &contract::query::<ExternalStorage, ExternalApi, ExternalQuerier>,
             msg_ptr,

--- a/contracts/queue/.cargo/config
+++ b/contracts/queue/.cargo/config
@@ -1,5 +1,6 @@
 [alias]
 wasm = "build --release --target wasm32-unknown-unknown"
+wasm-debug = "build --target wasm32-unknown-unknown"
 unit-test = "test --lib --features backtraces"
 integration-test = "test --test integration"
 schema = "run --example schema"

--- a/contracts/queue/src/lib.rs
+++ b/contracts/queue/src/lib.rs
@@ -6,10 +6,9 @@ mod wasm {
     use cosmwasm_std::{
         do_handle, do_init, do_query, ExternalApi, ExternalQuerier, ExternalStorage,
     };
-    use std::ffi::c_void;
 
     #[no_mangle]
-    extern "C" fn init(env_ptr: *mut c_void, msg_ptr: *mut c_void) -> *mut c_void {
+    extern "C" fn init(env_ptr: u32, msg_ptr: u32) -> u32 {
         do_init(
             &contract::init::<ExternalStorage, ExternalApi, ExternalQuerier>,
             env_ptr,
@@ -18,7 +17,7 @@ mod wasm {
     }
 
     #[no_mangle]
-    extern "C" fn handle(env_ptr: *mut c_void, msg_ptr: *mut c_void) -> *mut c_void {
+    extern "C" fn handle(env_ptr: u32, msg_ptr: u32) -> u32 {
         do_handle(
             &contract::handle::<ExternalStorage, ExternalApi, ExternalQuerier>,
             env_ptr,
@@ -27,7 +26,7 @@ mod wasm {
     }
 
     #[no_mangle]
-    extern "C" fn query(msg_ptr: *mut c_void) -> *mut c_void {
+    extern "C" fn query(msg_ptr: u32) -> u32 {
         do_query(
             &contract::query::<ExternalStorage, ExternalApi, ExternalQuerier>,
             msg_ptr,

--- a/packages/std/.cargo/config
+++ b/packages/std/.cargo/config
@@ -1,3 +1,4 @@
 [alias]
 wasm = "build --release --target wasm32-unknown-unknown"
+wasm-debug = "build --target wasm32-unknown-unknown"
 schema = "run --example schema"


### PR DESCRIPTION
Two commits from #239:

1. Have `cargo wasm-debug` for faster wasm build results diring development
2. Make Wasm pointers explicitely u32 in FFI. Before, they were converted implicitely, e.g. when calling

```rust
extern "C" fn allocate(size: usize) -> *mut c_void {
```

via

```rust
let alloc: Func<u32, u32> = self.func("allocate")?;
```