### PR TITLE
Fix length limit in ExternalStorage.get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
   contract, along with `SystemError` type for the runtime rejecting messages.
 - `{Init,Handle,Query}Result` are now just aliases for a concrete `ApiResult`
   type.
+- Support results up to 128 KiB in `ExternalStorage.get`.
 
 **cosmwasm-vm**
 

--- a/packages/std/src/imports.rs
+++ b/packages/std/src/imports.rs
@@ -19,7 +19,7 @@ static KI: usize = 1024;
 static RESULT_BUFFER_LENGTH: usize = 128 * KI;
 
 /// The number of bytes of the memory region we pre-allocate for the result data in queries
-static QUERY_BUFFER_LENGTH: usize = 4 * KI;
+static QUERY_RESULT_BUFFER_LENGTH: usize = 128 * KI;
 
 // this is the maximum allowed size for bech32
 // https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#bech32
@@ -238,7 +238,7 @@ impl Querier for ExternalQuerier {
         let bin_request = to_vec(request).or(Err(ApiSystemError::Unknown {}))?;
         let req = build_region(&bin_request);
         let req_ptr = &*req as *const Region as *const c_void;
-        let resp = alloc(QUERY_BUFFER_LENGTH);
+        let resp = alloc(QUERY_RESULT_BUFFER_LENGTH);
 
         let ret = unsafe { query_chain(req_ptr, resp) };
         if ret < 0 {


### PR DESCRIPTION
Closes #126

1. Length limit for the result of ExternalStorage.get was increased to 128 KiB
2. Contracts that really really (really really111!!) need it, can use `ExternalStorage.get_with_result_length`. This is inconvenient by design as it is not included in the Storage trait.

The usability of this change in blockchains is limited by https://github.com/CosmWasm/go-cosmwasm/issues/59