### PR TITLE
Deallocate value region in case of empty key

### DIFF
--- a/packages/std/src/imports.rs
+++ b/packages/std/src/imports.rs
@@ -157,10 +157,10 @@ impl Iterator for ExternalIterator {
         }
 
         let key = unsafe { consume_region(key_ptr).unwrap() };
+        let value = unsafe { consume_region(value_ptr).unwrap() };
         if key.is_empty() {
             return None;
         }
-        let value = unsafe { consume_region(value_ptr).unwrap() };
         Some((key, value))
     }
 }


### PR DESCRIPTION
Before, the value region was leaked in because of an early return