### PR TITLE
Make iterator IDs unsigned

### DIFF
--- a/packages/std/src/imports.rs
+++ b/packages/std/src/imports.rs
@@ -34,7 +34,7 @@ extern "C" {
     #[cfg(feature = "iterator")]
     fn db_scan(start: *const c_void, end: *const c_void, order: i32) -> i32;
     #[cfg(feature = "iterator")]
-    fn db_next(iterator_id: i32, key: *mut c_void, value: *mut c_void) -> i32;
+    fn db_next(iterator_id: u32, key: *mut c_void, value: *mut c_void) -> i32;
 
     fn canonicalize_address(human: *const c_void, canonical: *mut c_void) -> i32;
     fn humanize_address(canonical: *const c_void, human: *mut c_void) -> i32;
@@ -106,7 +106,9 @@ impl ReadonlyStorage for ExternalStorage {
         if iterator_id < 0 {
             panic!(format!("Error creating iterator: {}", iterator_id));
         }
-        let iter = ExternalIterator { iterator_id };
+        let iter = ExternalIterator {
+            iterator_id: iterator_id as u32, // Cast is safe since we tested for negative values above
+        };
         Box::new(iter)
     }
 }
@@ -141,7 +143,7 @@ impl Storage for ExternalStorage {
 /// ExternalIterator makes a call out to next.
 /// We use the pointer to differentiate between multiple open iterators.
 struct ExternalIterator {
-    iterator_id: i32,
+    iterator_id: u32,
 }
 
 #[cfg(feature = "iterator")]

--- a/packages/vm/src/context.rs
+++ b/packages/vm/src/context.rs
@@ -13,6 +13,8 @@ use cosmwasm_std::{
     QuerierResponse, QueryRequest, Storage,
 };
 
+#[cfg(feature = "iterator")]
+use crate::conversion::to_i32;
 use crate::errors::{Error, Result, UninitializedContextData};
 use crate::memory::{read_region, write_region};
 use crate::serde::{from_slice, to_vec};
@@ -228,8 +230,11 @@ mod iter_support {
             // But there is no way for the compiler to know. So... let's just lie to the compiler a little bit.
             let live_forever: Box<dyn Iterator<Item = KV> + 'static> =
                 unsafe { mem::transmute(iter) };
-            let count = set_iterator::<S, Q>(ctx, live_forever);
-            Ok(count)
+            let new_id = set_iterator::<S, Q>(ctx, live_forever);
+            Ok(match to_i32(new_id) {
+                Ok(new_id_signed) => new_id_signed,
+                Err(_) => ERROR_DB_UNKNOWN,
+            })
         });
         match res {
             Ok(cnt) => cnt,
@@ -239,12 +244,14 @@ mod iter_support {
 
     pub fn do_next<S: Storage, Q: Querier>(
         ctx: &Ctx,
-        counter: i32,
+        iterator_id: u32,
         key_ptr: u32,
         value_ptr: u32,
     ) -> i32 {
         let item =
-            match with_iterator_from_context::<S, Q, _, _>(ctx, counter, |iter| Ok(iter.next())) {
+            match with_iterator_from_context::<S, Q, _, _>(ctx, iterator_id as usize, |iter| {
+                Ok(iter.next())
+            }) {
                 Ok(i) => i,
                 Err(Error::UninitializedContextData { .. }) => return ERROR_NO_CONTEXT_DATA,
                 Err(_) => return ERROR_NEXT_INVALID_ITERATOR,
@@ -271,7 +278,7 @@ mod iter_support {
 
     pub(crate) fn with_iterator_from_context<S, Q, F, T>(
         ctx: &Ctx,
-        counter: i32,
+        iterator_id: usize,
         mut func: F,
     ) -> Result<T, Error>
     where
@@ -281,11 +288,11 @@ mod iter_support {
     {
         let b = unsafe { get_data::<S, Q>(ctx.data) };
         let mut b = mem::ManuallyDrop::new(b);
-        let iter = b.iter.remove(&counter);
+        let iter = b.iter.remove(&iterator_id);
         match iter {
             Some(mut data) => {
                 let res = func(&mut data);
-                b.iter.insert(counter, data);
+                b.iter.insert(iterator_id, data);
                 res
             }
             None => UninitializedContextData { kind: "iterator" }.fail(),
@@ -293,16 +300,15 @@ mod iter_support {
     }
 
     // set the iterator, overwriting any possible iterator previously set
-    fn set_iterator<S: Storage, Q: Querier>(ctx: &Ctx, iter: Box<dyn Iterator<Item = KV>>) -> i32 {
+    fn set_iterator<S: Storage, Q: Querier>(
+        ctx: &Ctx,
+        iter: Box<dyn Iterator<Item = KV>>,
+    ) -> usize {
         let b = unsafe { get_data::<S, Q>(ctx.data) };
         let mut b = mem::ManuallyDrop::new(b); // we do this to avoid cleanup
-        let mut counter: i32 = match b.iter.len().try_into() {
-            Ok(v) => v,
-            Err(_) => return ERROR_DB_UNKNOWN,
-        };
-        counter += 1;
-        b.iter.insert(counter, iter);
-        counter
+        let new_id = b.iter.len() + 1;
+        b.iter.insert(new_id, iter);
+        new_id
     }
 }
 
@@ -312,7 +318,7 @@ struct ContextData<S: Storage, Q: Querier> {
     storage: Option<S>,
     querier: Option<Q>,
     #[cfg(feature = "iterator")]
-    iter: HashMap<i32, Box<dyn Iterator<Item = KV>>>,
+    iter: HashMap<usize, Box<dyn Iterator<Item = KV>>>,
 }
 
 pub fn setup_context<S: Storage, Q: Querier>() -> (*mut c_void, fn(*mut c_void)) {
@@ -347,7 +353,7 @@ unsafe fn get_data<S: Storage, Q: Querier>(ptr: *mut c_void) -> Box<ContextData<
 
 #[cfg(feature = "iterator")]
 fn free_iterator<S: Storage, Q: Querier>(context: &mut ContextData<S, Q>) {
-    let keys: Vec<i32> = context.iter.keys().cloned().collect();
+    let keys: Vec<usize> = context.iter.keys().cloned().collect();
     for key in keys {
         let _ = context.iter.remove(&key);
     }
@@ -448,7 +454,7 @@ mod test {
                 "db_write" => Func::new(|_a: i32, _b: i32| -> i32 { 0 }),
                 "db_remove" => Func::new(|_a: i32| -> i32 { 0 }),
                 "db_scan" => Func::new(|_a: i32, _b: i32, _c: i32| -> i32 { 0 }),
-                "db_next" => Func::new(|_a: i32, _b: i32, _c: i32| -> i32 { 0 }),
+                "db_next" => Func::new(|_a: u32, _b: i32, _c: i32| -> i32 { 0 }),
                 "query_chain" => Func::new(|_a: i32, _b: i32| -> i32 { 0 }),
                 "canonicalize_address" => Func::new(|_a: i32, _b: i32| -> i32 { 0 }),
                 "humanize_address" => Func::new(|_a: i32, _b: i32| -> i32 { 0 }),

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -99,11 +99,12 @@ where
                 "db_scan" => Func::new(move |ctx: &mut Ctx, start_ptr: u32, end_ptr: u32, order: i32| -> i32 {
                     do_scan::<S, Q>(ctx, start_ptr, end_ptr, order)
                 }),
-                // Creates an iterator that will go from start to end
-                // Order is defined in cosmwasm::traits::Order and may be 1/Ascending or 2/Descending.
-                // Ownership of both start and end pointer is not transferred to the host.
-                "db_next" => Func::new(move |ctx: &mut Ctx, counter: i32, key_ptr: u32, value_ptr: u32| -> i32 {
-                    do_next::<S, Q>(ctx, counter, key_ptr, value_ptr)
+                // Get next element of iterator with ID `iterator_id`.
+                // Expectes Regions in key_ptr and value_ptr, in which the result is written.
+                // An empty key value (Region of length 0) means no more element.
+                // Ownership of both key and value pointer is not transferred to the host.
+                "db_next" => Func::new(move |ctx: &mut Ctx, iterator_id: u32, key_ptr: u32, value_ptr: u32| -> i32 {
+                    do_next::<S, Q>(ctx, iterator_id, key_ptr, value_ptr)
                 }),
             },
         });


### PR DESCRIPTION
The IDs are unsigned and are transported in the non-negative range of i32.