### PR TITLE
Copy cw-storage into storage sub-package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ workflows:
     jobs:
       - package_schema
       - package_std
+      - package_storage
       - package_vm_cranelift
       - package_vm_singlepass
       - hackatom
@@ -99,6 +100,37 @@ jobs:
             - target/debug/build
             - target/debug/deps
           key: cargocache-v2-package_std-rust:1.41.1-{{ checksum "Cargo.lock" }}
+
+  package_storage:
+    docker:
+      - image: rust:1.41.1
+    steps:
+      - checkout
+      - run:
+          name: Version information
+          command: rustc --version; cargo --version; rustup --version; rustup target list --installed
+      - restore_cache:
+          keys:
+            - cargocache-v2-package_storage-rust:1.41.1-{{ checksum "Cargo.lock" }}
+      - run:
+          name: Build library for native target
+          working_directory: ~/project/packages/storage
+          command: cargo build --locked
+      - run:
+          name: Run unit tests
+          working_directory: ~/project/packages/storage
+          command: cargo test --locked
+      - run:
+          name: Run unit tests (with iterator support)
+          working_directory: ~/project/packages/storage
+          command: cargo test --locked --features iterator
+      - save_cache:
+          paths:
+            - /usr/local/cargo/registry
+            - target/debug/.fingerprint
+            - target/debug/build
+            - target/debug/deps
+          key: cargocache-v2-package_storage-rust:1.41.1-{{ checksum "Cargo.lock" }}
 
   package_vm_cranelift:
     docker:
@@ -351,6 +383,10 @@ jobs:
       - run:
           name: Clippy linting on std
           working_directory: ~/project/packages/std
+          command: cargo clippy -- -D warnings
+      - run:
+          name: Clippy linting on storage
+          working_directory: ~/project/packages/storage
           command: cargo clippy -- -D warnings
       - run:
           name: Clippy linting on vm (use flags for Rust stable support)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
 - Return value from `env.write_db` and `env.remove_db` to allow error reporting.
 - Query responses are now required to contain valid JSON.
 - Renamed all `*_db` wasm imports to `db_*`
+- Merge `cw-storage` repo as subpackage, now `cosmwasm-storage`
+- Add iterator support to `cosmwasm-storage`
 
 **cosmwasm-schema**
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,18 +160,6 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "cosmwasm"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "schemars 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde-json-wasm 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "snafu 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "cosmwasm-schema"
 version = "0.8.0-dev"
 dependencies = [
@@ -195,10 +183,9 @@ dependencies = [
 name = "cosmwasm-storage"
 version = "0.8.0-dev"
 dependencies = [
- "cosmwasm 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "schemars 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cosmwasm-std 0.8.0-dev",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "snafu 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snafu 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -615,26 +602,10 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "proc-macro2"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "quote"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -747,33 +718,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "schemars"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "schemars_derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "schemars"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "schemars_derive 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "schemars_derive"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive_internals 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -894,31 +844,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "snafu"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "doc-comment 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "snafu-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "snafu"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace 0.3.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "doc-comment 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu-derive 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "snafu-derive"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -940,16 +871,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "subtle"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "syn"
-version = "0.15.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "syn"
@@ -1005,11 +926,6 @@ dependencies = [
 [[package]]
 name = "typenum"
 version = "1.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "unicode-xid"
-version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1209,7 +1125,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum const-random 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "2f1af9ac737b2dd2d577701e59fd09ba34822f6f2ebdb30a7647405d9e55e16a"
 "checksum const-random-macro 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "25e4c606eb459dd29f7c57b2e0879f2b6f14ee130918c2b78ccb58a9624e6c7a"
 "checksum constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-"checksum cosmwasm 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8709ce7dabeac33f4132cab84fda3796ac484d82c91ff5ccfb4ed61227af4bb5"
 "checksum cranelift-bforest 0.59.0 (registry+https://github.com/rust-lang/crates.io-index)" = "45a9c21f8042b9857bda93f6c1910b9f9f24100187a3d3d52f214a34e3dc5818"
 "checksum cranelift-codegen 0.59.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7853f77a6e4a33c67a69c40f5e1bb982bd2dc5c4a22e17e67b65bbccf9b33b2e"
 "checksum cranelift-codegen-meta 0.59.0 (registry+https://github.com/rust-lang/crates.io-index)" = "084cd6d5fb0d1da28acd72c199471bfb09acc703ec8f3bf07b1699584272a3b9"
@@ -1258,9 +1173,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum parking_lot_core 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7582838484df45743c8434fbff785e8edf260c28748353d44bc0da32e0ceabf1"
 "checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 "checksum proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)" = "ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5"
-"checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6c09721c6781493a2a492a96b5a5bf19b65917fe6728884e7c44dd0c60ca3435"
-"checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
 "checksum rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 "checksum rand_chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
@@ -1274,9 +1187,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
-"checksum schemars 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "273d9b56198caf703e271dcc07b28f2e794971750ace6585399d40e2af9f4823"
 "checksum schemars 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "10db1d3c2260e94570e1a492c762e62c11e1aac8869a2c3d869137995e6810d4"
-"checksum schemars_derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "73ab7f0b9b64633747a68dce4ed6318bbf30e3befe67df7624ad83abb7295c09"
 "checksum schemars_derive 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "706d022205b93f710ea83037db4fc103358dd24e61a330d287d45d93fe1dc250"
 "checksum scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
@@ -1291,13 +1202,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "27044adfd2e1f077f649f59deb9490d3941d674002f7d062870a60ebe9bd47a0"
 "checksum smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
 "checksum smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
-"checksum snafu 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9d0bf93d08d6a44363b47d737f1f5bebbf5e6a1eaaa3d4c128ceeaca6b718292"
 "checksum snafu 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "48492e4f51c6e679217e80c11290edfdedf3133e358f4f432a6296f4c820f95b"
-"checksum snafu-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "624e94bd38e471f67883b467711e7a7ad7dbe284f5fb7e661dc8a671fc5b26a0"
 "checksum snafu-derive 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b5d1c41856cbfa99befda5034c72539dd9d7dd6f3e61058bdb804ac40715bc2a"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
-"checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 "checksum syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)" = "123bd9499cfb380418d509322d7a6d52e5315f064fe4b3ad18a53d6b92c07859"
 "checksum target-lexicon 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ab0e7238dcc7b40a7be719a25365910f6807bd864f4cce6b2e6b873658e2b19d"
 "checksum target-lexicon 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6f4c118a7a38378f305a9e111fcb2f7f838c0be324bfb31a77ea04f7f6e684b4"
@@ -1305,7 +1213,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum thiserror 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "ee14bf8e6767ab4c687c9e8bc003879e042a96fd67a3ba5934eadb6536bef4db"
 "checksum thiserror-impl 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "a7b51e1fbc44b5a0840be594fbc0f960be09050f2617e61e6aa43bef97cd3ef4"
 "checksum typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
-"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum wabt 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3c5c5c1286c6e578416982609f47594265f9d489f9b836157d403ad605a46693"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,6 +160,18 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "cosmwasm"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "schemars 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde-json-wasm 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snafu 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cosmwasm-schema"
 version = "0.8.0-dev"
 dependencies = [
@@ -177,6 +189,16 @@ dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-json-wasm 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cosmwasm-storage"
+version = "0.8.0-dev"
+dependencies = [
+ "cosmwasm 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "schemars 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snafu 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -593,10 +615,26 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "proc-macro2"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quote"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -709,12 +747,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "schemars"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "schemars_derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "schemars"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "schemars_derive 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive_internals 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -835,12 +894,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "snafu"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "doc-comment 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snafu-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "snafu"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace 0.3.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "doc-comment 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu-derive 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -862,6 +940,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "subtle"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "syn"
+version = "0.15.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "syn"
@@ -917,6 +1005,11 @@ dependencies = [
 [[package]]
 name = "typenum"
 version = "1.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-xid"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1116,6 +1209,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum const-random 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "2f1af9ac737b2dd2d577701e59fd09ba34822f6f2ebdb30a7647405d9e55e16a"
 "checksum const-random-macro 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "25e4c606eb459dd29f7c57b2e0879f2b6f14ee130918c2b78ccb58a9624e6c7a"
 "checksum constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+"checksum cosmwasm 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8709ce7dabeac33f4132cab84fda3796ac484d82c91ff5ccfb4ed61227af4bb5"
 "checksum cranelift-bforest 0.59.0 (registry+https://github.com/rust-lang/crates.io-index)" = "45a9c21f8042b9857bda93f6c1910b9f9f24100187a3d3d52f214a34e3dc5818"
 "checksum cranelift-codegen 0.59.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7853f77a6e4a33c67a69c40f5e1bb982bd2dc5c4a22e17e67b65bbccf9b33b2e"
 "checksum cranelift-codegen-meta 0.59.0 (registry+https://github.com/rust-lang/crates.io-index)" = "084cd6d5fb0d1da28acd72c199471bfb09acc703ec8f3bf07b1699584272a3b9"
@@ -1164,7 +1258,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum parking_lot_core 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7582838484df45743c8434fbff785e8edf260c28748353d44bc0da32e0ceabf1"
 "checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 "checksum proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)" = "ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5"
+"checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6c09721c6781493a2a492a96b5a5bf19b65917fe6728884e7c44dd0c60ca3435"
+"checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
 "checksum rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 "checksum rand_chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
@@ -1178,7 +1274,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
+"checksum schemars 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "273d9b56198caf703e271dcc07b28f2e794971750ace6585399d40e2af9f4823"
 "checksum schemars 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "10db1d3c2260e94570e1a492c762e62c11e1aac8869a2c3d869137995e6810d4"
+"checksum schemars_derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "73ab7f0b9b64633747a68dce4ed6318bbf30e3befe67df7624ad83abb7295c09"
 "checksum schemars_derive 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "706d022205b93f710ea83037db4fc103358dd24e61a330d287d45d93fe1dc250"
 "checksum scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
@@ -1193,10 +1291,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "27044adfd2e1f077f649f59deb9490d3941d674002f7d062870a60ebe9bd47a0"
 "checksum smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
 "checksum smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
+"checksum snafu 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9d0bf93d08d6a44363b47d737f1f5bebbf5e6a1eaaa3d4c128ceeaca6b718292"
 "checksum snafu 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "48492e4f51c6e679217e80c11290edfdedf3133e358f4f432a6296f4c820f95b"
+"checksum snafu-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "624e94bd38e471f67883b467711e7a7ad7dbe284f5fb7e661dc8a671fc5b26a0"
 "checksum snafu-derive 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b5d1c41856cbfa99befda5034c72539dd9d7dd6f3e61058bdb804ac40715bc2a"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
+"checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 "checksum syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)" = "123bd9499cfb380418d509322d7a6d52e5315f064fe4b3ad18a53d6b92c07859"
 "checksum target-lexicon 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ab0e7238dcc7b40a7be719a25365910f6807bd864f4cce6b2e6b873658e2b19d"
 "checksum target-lexicon 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6f4c118a7a38378f305a9e111fcb2f7f838c0be324bfb31a77ea04f7f6e684b4"
@@ -1204,6 +1305,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum thiserror 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "ee14bf8e6767ab4c687c9e8bc003879e042a96fd67a3ba5934eadb6536bef4db"
 "checksum thiserror-impl 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "a7b51e1fbc44b5a0840be594fbc0f960be09050f2617e61e6aa43bef97cd3ef4"
 "checksum typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
+"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum wabt 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3c5c5c1286c6e578416982609f47594265f9d489f9b836157d403ad605a46693"

--- a/packages/storage/Cargo.toml
+++ b/packages/storage/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "cosmwasm-storage"
+version = "0.8.0-dev"
+authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
+edition = "2018"
+description = "CosmWasm library with useful helpers for Storage patterns"
+repository = "https://github.com/CosmWasm/cosmwasm/tree/master/packages/storage"
+license = "Apache-2.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[badges]
+circle-ci = { repository = "CosmWasm/cosmwasm", branch = "master" }
+maintenance = { status = "actively-developed" }
+
+[features]
+# TODO: enable cosmwasm-std/iterator
+iterator = []
+
+[dependencies]
+#cosmwasm-std = { path = "../std" }
+cosmwasm = "0.7"
+serde = { version = "~1.0.103", default-features = false, features = ["derive", "alloc"] }
+snafu = { version = "~0.5.0", default-features = false, features = ["rust_1_30"] }
+schemars = "~0.5"

--- a/packages/storage/Cargo.toml
+++ b/packages/storage/Cargo.toml
@@ -18,8 +18,6 @@ maintenance = { status = "actively-developed" }
 iterator = []
 
 [dependencies]
-#cosmwasm-std = { path = "../std" }
-cosmwasm = "0.7"
-serde = { version = "~1.0.103", default-features = false, features = ["derive", "alloc"] }
-snafu = { version = "~0.5.0", default-features = false, features = ["rust_1_30"] }
-schemars = "~0.5"
+cosmwasm-std = { path = "../std" }
+serde = { version = "1.0.103", default-features = false, features = ["derive", "alloc"] }
+snafu = { version = "0.6.3" }

--- a/packages/storage/Cargo.toml
+++ b/packages/storage/Cargo.toml
@@ -14,10 +14,11 @@ circle-ci = { repository = "CosmWasm/cosmwasm", branch = "master" }
 maintenance = { status = "actively-developed" }
 
 [features]
-# TODO: enable cosmwasm-std/iterator
 iterator = []
 
 [dependencies]
 cosmwasm-std = { path = "../std" }
 serde = { version = "1.0.103", default-features = false, features = ["derive", "alloc"] }
+
+[dev-dependencies]
 snafu = { version = "0.6.3" }

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -1,35 +1,33 @@
-# cw-storage
+# cosmwasm-storage
 
-[![CircleCI](https://circleci.com/gh/CosmWasm/cw-storage/tree/master.svg?style=shield)](https://circleci.com/gh/CosmWasm/cw-storage/tree/master) 
+[![CircleCI](https://circleci.com/gh/CosmWasm/cosmwasm/tree/master.svg?style=shield)](https://circleci.com/gh/CosmWasm/cosmwasm/tree/master)
 
-CosmWasm library with useful helpers for Storage patterns.
-This is not in the core library, so feel free to fork it and modify or extend as desired for your contracts.
-Pull Requests back to upstream repo with new or improved features are always welcome.
-
-Requires Rust v1.38+ (for `std::any::type_name` used to generate serialization error messages)
-
-Compatible with CosmWasm v0.7.x
+CosmWasm library with useful helpers for Storage patterns. You can use `Storage`
+implementations in `cosmwasm-std`, or rely on these to remove some common
+boilterplate.
 
 ## Contents
 
-* [PrefixedStorage](#prefixed-storage)
-* [TypedStoreage](#typed-storage)
-* [Bucket](#bucket)
-* [Singleton](#singleton)
+- [PrefixedStorage](#prefixed-storage)
+- [TypedStoreage](#typed-storage)
+- [Bucket](#bucket)
+- [Singleton](#singleton)
 
 ### Prefixed Storage
 
 One common technique in smart contracts, especially when multiple types of data
-are being stored, is to create separate sub-stores with unique prefixes. Thus instead
-of directly dealing with storage, we wrap it and put all `Foo` in a Storage with
-key `"foo" + id`, and all `Bar` in a Storage with key `"bar" + id`. This lets us add multiple
-types of objects without too much cognitive overhead. Similar separation like Mongo collections
-or SQL tables.
+are being stored, is to create separate sub-stores with unique prefixes. Thus
+instead of directly dealing with storage, we wrap it and put all `Foo` in a
+Storage with key `"foo" + id`, and all `Bar` in a Storage with key `"bar" + id`.
+This lets us add multiple types of objects without too much cognitive overhead.
+Similar separation like Mongo collections or SQL tables.
 
-Since we have different types for `Storage` and `ReadonlyStorage`, we use two different constructors:
+Since we have different types for `Storage` and `ReadonlyStorage`, we use two
+different constructors:
 
 ```rust
-use cw_storage::{prefixed, prefixed_read};
+use cosmwasm_std::testing::MockStorage;
+use cosmwasm_storage::{prefixed, prefixed_read};
 
 let mut store = MockStorage::new();
 
@@ -46,26 +44,28 @@ let read_bar = prefixed_read(b"bar", &store);
 assert_eq!(b"bar".to_vec(), read_bar.get(b"one").unwrap());
 ```
 
-Please note that only one mutable reference to the underlying store may be valid at one point.
-The compiler sees we do not ever use `foos` after constructing `bars`, so this example is valid.
-However, if we did use `foos` again at the bottom, it would properly complain about violating
-unique mutable reference. 
+Please note that only one mutable reference to the underlying store may be valid
+at one point. The compiler sees we do not ever use `foos` after constructing
+`bars`, so this example is valid. However, if we did use `foos` again at the
+bottom, it would properly complain about violating unique mutable reference.
 
-The takeaway is to create the `PrefixedStorage` objects when needed and not to hang around to them too long.
+The takeaway is to create the `PrefixedStorage` objects when needed and not to
+hang around to them too long.
 
 ### Typed Storage
 
-As we divide our storage space into different subspaces or "buckets", we will quickly notice that each
-"bucket" works on a unique type. This leads to a lot of repeated serialization and deserialization
-boilerplate that can be removed. We do this by wrapping a `Storage` with a type-aware `TypedStorage`
-struct that provides us a higher-level access to the data. 
+As we divide our storage space into different subspaces or "buckets", we will
+quickly notice that each "bucket" works on a unique type. This leads to a lot of
+repeated serialization and deserialization boilerplate that can be removed. We
+do this by wrapping a `Storage` with a type-aware `TypedStorage` struct that
+provides us a higher-level access to the data.
 
-Note that `TypedStorage` itself does not implement the `Storage` interface, so when combining 
-with `PrefixStorage`, make sure to wrap the prefix first.
+Note that `TypedStorage` itself does not implement the `Storage` interface, so
+when combining with `PrefixStorage`, make sure to wrap the prefix first.
 
 ```rust
-use cosmwasm::mock::MockStorage;
-use cw_storage::{prefixed, typed};
+use cosmwasm_std::testing::MockStorage;
+use cosmwasm_storage::{prefixed, typed};
 
 let mut store = MockStorage::new();
 let mut space = prefixed(b"data", &mut store);
@@ -87,15 +87,16 @@ assert!(bucket.load(b"john").is_err());
 assert_eq!(bucket.may_load(b"john"), Ok(None));
 ```
 
-Beyond the basic `save`, `load`, and `may_load`, there is a higher-level API exposed, `update`.
-`Update` will load the data, apply an operation and save it again (if the operation was successful).
-It will also return any error that occurred, or the final state that was written if successful.
+Beyond the basic `save`, `load`, and `may_load`, there is a higher-level API
+exposed, `update`. `Update` will load the data, apply an operation and save it
+again (if the operation was successful). It will also return any error that
+occurred, or the final state that was written if successful.
 
 ```rust
 let birthday = |mut m: Option<Data>| match m {
-    Some(mut d) => { 
-        d.age += 1; 
-        Ok(d) 
+    Some(mut d) => {
+        d.age += 1;
+        Ok(d)
     },
     None =>  NotFound{ kind: 'Data'}.fail(),
 };
@@ -105,19 +106,19 @@ let expected = Data {
     age: 43,
 };
 assert_eq!(output, expected);
-``` 
+```
 
 ### Bucket
 
-Since the above idiom (a subspace for a class of items) is so common and useful, 
-and there is no easy way to return this from a function 
-(bucket holds a reference to space, and cannot live longer than the local variable), the two are often
-combined into a `Bucket`. A Bucket works just like the example above, except the creation can be
-in another function:
+Since the above idiom (a subspace for a class of items) is so common and useful,
+and there is no easy way to return this from a function (bucket holds a
+reference to space, and cannot live longer than the local variable), the two are
+often combined into a `Bucket`. A Bucket works just like the example above,
+except the creation can be in another function:
 
 ```rust
-use cosmwasm::mock::MockStorage;
-use cw_storage::{bucket, Bucket};
+use cosmwasm_std::testing::MockStorage;
+use cosmwasm_storage::{bucket, Bucket};
 
 fn people<'a, S: Storage>(storage: &'a mut S) -> Bucket<'a, S, Data> {
     bucket(b"people", storage)
@@ -135,18 +136,19 @@ fn do_stuff() -> Result <()> {
 
 ### Singleton
 
-Singleton is another wrapper around the `TypedStorage` API. There are cases when we don't need
-a whole subspace to hold arbitrary key-value lookup for typed data, but rather one single instance.
-The simplest example is some *configuration* information for a contract. For example, in the 
+Singleton is another wrapper around the `TypedStorage` API. There are cases when
+we don't need a whole subspace to hold arbitrary key-value lookup for typed
+data, but rather one single instance. The simplest example is some
+_configuration_ information for a contract. For example, in the
 [name service example](https://github.com/CosmWasm/cosmwasm-examples/tree/master/nameservice),
-there is a `Bucket` to look up name to name data, but we also have a `Singleton` to store
-global configuration - namely the price of buying a name.
+there is a `Bucket` to look up name to name data, but we also have a `Singleton`
+to store global configuration - namely the price of buying a name.
 
 ```rust
-use cosmwasm::mock::MockStorage;
-use cosmwasm::types::{Coin, coin};
+use cosmwasm_std::{Coin, coin};
+use cosmwasm_std::testing::MockStorage;
 
-use cw_storage::{singleton};
+use cosmwasm_storage::{singleton};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Config {
@@ -170,12 +172,12 @@ fn initialize() -> Result<()> {
 }
 ```
 
-`Singleton` works just like `Bucket`, except the `save`, `load`, `update` methods don't take
-a key, and `update` requires the object to already exist, so the closure takes
-type `T`, rather than `Option<T>`. (Use `save` to create the object the first time).
-For `Buckets`, we often don't know which keys exist, but `Singletons` should be
-initialized when the contract is instantiated.
+`Singleton` works just like `Bucket`, except the `save`, `load`, `update`
+methods don't take a key, and `update` requires the object to already exist, so
+the closure takes type `T`, rather than `Option<T>`. (Use `save` to create the
+object the first time). For `Buckets`, we often don't know which keys exist, but
+`Singletons` should be initialized when the contract is instantiated.
 
-Since the heart of much of the smart contract code is simply transformations upon some stored state,
-We may be able to just code the state transitions and let the `TypedStorage` APIs take care of all
-the boilerplate.
+Since the heart of much of the smart contract code is simply transformations
+upon some stored state, We may be able to just code the state transitions and
+let the `TypedStorage` APIs take care of all the boilerplate.

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -1,0 +1,181 @@
+# cw-storage
+
+[![CircleCI](https://circleci.com/gh/CosmWasm/cw-storage/tree/master.svg?style=shield)](https://circleci.com/gh/CosmWasm/cw-storage/tree/master) 
+
+CosmWasm library with useful helpers for Storage patterns.
+This is not in the core library, so feel free to fork it and modify or extend as desired for your contracts.
+Pull Requests back to upstream repo with new or improved features are always welcome.
+
+Requires Rust v1.38+ (for `std::any::type_name` used to generate serialization error messages)
+
+Compatible with CosmWasm v0.7.x
+
+## Contents
+
+* [PrefixedStorage](#prefixed-storage)
+* [TypedStoreage](#typed-storage)
+* [Bucket](#bucket)
+* [Singleton](#singleton)
+
+### Prefixed Storage
+
+One common technique in smart contracts, especially when multiple types of data
+are being stored, is to create separate sub-stores with unique prefixes. Thus instead
+of directly dealing with storage, we wrap it and put all `Foo` in a Storage with
+key `"foo" + id`, and all `Bar` in a Storage with key `"bar" + id`. This lets us add multiple
+types of objects without too much cognitive overhead. Similar separation like Mongo collections
+or SQL tables.
+
+Since we have different types for `Storage` and `ReadonlyStorage`, we use two different constructors:
+
+```rust
+use cw_storage::{prefixed, prefixed_read};
+
+let mut store = MockStorage::new();
+
+let mut foos = prefixed(b"foo", &mut store);
+foos.set(b"one", b"foo");
+
+let mut bars = prefixed(b"bar", &mut store);
+bars.set(b"one", b"bar");
+
+let read_foo = prefixed_read(b"foo", &store);
+assert_eq!(b"foo".to_vec(), read_foo.get(b"one").unwrap());
+
+let read_bar = prefixed_read(b"bar", &store);
+assert_eq!(b"bar".to_vec(), read_bar.get(b"one").unwrap());
+```
+
+Please note that only one mutable reference to the underlying store may be valid at one point.
+The compiler sees we do not ever use `foos` after constructing `bars`, so this example is valid.
+However, if we did use `foos` again at the bottom, it would properly complain about violating
+unique mutable reference. 
+
+The takeaway is to create the `PrefixedStorage` objects when needed and not to hang around to them too long.
+
+### Typed Storage
+
+As we divide our storage space into different subspaces or "buckets", we will quickly notice that each
+"bucket" works on a unique type. This leads to a lot of repeated serialization and deserialization
+boilerplate that can be removed. We do this by wrapping a `Storage` with a type-aware `TypedStorage`
+struct that provides us a higher-level access to the data. 
+
+Note that `TypedStorage` itself does not implement the `Storage` interface, so when combining 
+with `PrefixStorage`, make sure to wrap the prefix first.
+
+```rust
+use cosmwasm::mock::MockStorage;
+use cw_storage::{prefixed, typed};
+
+let mut store = MockStorage::new();
+let mut space = prefixed(b"data", &mut store);
+let mut bucket = typed::<_, Data>(&mut space);
+
+// save data
+let data = Data {
+    name: "Maria".to_string(),
+    age: 42,
+};
+bucket.save(b"maria", &data).unwrap();
+
+// load it properly
+let loaded = bucket.load(b"maria").unwrap();
+assert_eq!(data, loaded);
+
+// loading empty can return Ok(None) or Err depending on the chosen method:
+assert!(bucket.load(b"john").is_err());
+assert_eq!(bucket.may_load(b"john"), Ok(None));
+```
+
+Beyond the basic `save`, `load`, and `may_load`, there is a higher-level API exposed, `update`.
+`Update` will load the data, apply an operation and save it again (if the operation was successful).
+It will also return any error that occurred, or the final state that was written if successful.
+
+```rust
+let birthday = |mut m: Option<Data>| match m {
+    Some(mut d) => { 
+        d.age += 1; 
+        Ok(d) 
+    },
+    None =>  NotFound{ kind: 'Data'}.fail(),
+};
+let output = bucket.update(b"maria", &birthday).unwrap();
+let expected = Data {
+    name: "Maria".to_string(),
+    age: 43,
+};
+assert_eq!(output, expected);
+``` 
+
+### Bucket
+
+Since the above idiom (a subspace for a class of items) is so common and useful, 
+and there is no easy way to return this from a function 
+(bucket holds a reference to space, and cannot live longer than the local variable), the two are often
+combined into a `Bucket`. A Bucket works just like the example above, except the creation can be
+in another function:
+
+```rust
+use cosmwasm::mock::MockStorage;
+use cw_storage::{bucket, Bucket};
+
+fn people<'a, S: Storage>(storage: &'a mut S) -> Bucket<'a, S, Data> {
+    bucket(b"people", storage)
+}
+
+fn do_stuff() -> Result <()> {
+    let mut store = MockStorage::new();
+    people(&mut store).save(b"john", &Data{
+        name: "John",
+        age: 314,
+    })?;
+    OK(())
+}
+```
+
+### Singleton
+
+Singleton is another wrapper around the `TypedStorage` API. There are cases when we don't need
+a whole subspace to hold arbitrary key-value lookup for typed data, but rather one single instance.
+The simplest example is some *configuration* information for a contract. For example, in the 
+[name service example](https://github.com/CosmWasm/cosmwasm-examples/tree/master/nameservice),
+there is a `Bucket` to look up name to name data, but we also have a `Singleton` to store
+global configuration - namely the price of buying a name.
+
+```rust
+use cosmwasm::mock::MockStorage;
+use cosmwasm::types::{Coin, coin};
+
+use cw_storage::{singleton};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct Config {
+    pub purchase_price: Option<Coin>,
+    pub transfer_price: Option<Coin>,
+}
+
+fn initialize() -> Result<()> {
+    let mut store = MockStorage::new();
+    let config = singleton(&mut store, b"config");
+    config.save(&Config{
+        purchase_price: Some(coin("5", "FEE")),
+        transfer_price: None,
+    })?;
+    config.update(|mut cfg| {
+        cfg.transfer_price = Some(coin(2, "FEE"));
+        Ok(cfg)
+    })?;
+    let loaded = config.load()?;
+    OK(())
+}
+```
+
+`Singleton` works just like `Bucket`, except the `save`, `load`, `update` methods don't take
+a key, and `update` requires the object to already exist, so the closure takes
+type `T`, rather than `Option<T>`. (Use `save` to create the object the first time).
+For `Buckets`, we often don't know which keys exist, but `Singletons` should be
+initialized when the contract is instantiated.
+
+Since the heart of much of the smart contract code is simply transformations upon some stored state,
+We may be able to just code the state transitions and let the `TypedStorage` APIs take care of all
+the boilerplate.

--- a/packages/storage/src/bucket.rs
+++ b/packages/storage/src/bucket.rs
@@ -1,0 +1,298 @@
+use serde::{de::DeserializeOwned, ser::Serialize};
+use std::marker::PhantomData;
+
+use cosmwasm::errors::Result;
+use cosmwasm::traits::{ReadonlyStorage, Storage};
+
+use crate::namespace_helpers::{get_with_prefix, key_prefix, key_prefix_nested, set_with_prefix};
+use crate::type_helpers::{may_deserialize, must_deserialize, serialize};
+
+pub fn bucket<'a, S: Storage, T>(namespace: &[u8], storage: &'a mut S) -> Bucket<'a, S, T>
+where
+    T: Serialize + DeserializeOwned,
+{
+    Bucket::new(namespace, storage)
+}
+
+pub fn bucket_read<'a, S: ReadonlyStorage, T>(
+    namespace: &[u8],
+    storage: &'a S,
+) -> ReadonlyBucket<'a, S, T>
+where
+    T: Serialize + DeserializeOwned,
+{
+    ReadonlyBucket::new(namespace, storage)
+}
+
+pub struct Bucket<'a, S: Storage, T>
+where
+    T: Serialize + DeserializeOwned,
+{
+    storage: &'a mut S,
+    // see https://doc.rust-lang.org/std/marker/struct.PhantomData.html#unused-type-parameters for why this is needed
+    data: PhantomData<&'a T>,
+    prefix: Vec<u8>,
+}
+
+impl<'a, S: Storage, T> Bucket<'a, S, T>
+where
+    T: Serialize + DeserializeOwned,
+{
+    pub fn new(namespace: &[u8], storage: &'a mut S) -> Self {
+        Bucket {
+            prefix: key_prefix(namespace),
+            storage,
+            data: PhantomData,
+        }
+    }
+
+    pub fn multilevel(namespaces: &[&[u8]], storage: &'a mut S) -> Self {
+        Bucket {
+            prefix: key_prefix_nested(namespaces),
+            storage,
+            data: PhantomData,
+        }
+    }
+
+    /// save will serialize the model and store, returns an error on serialization issues
+    pub fn save(&mut self, key: &[u8], data: &T) -> Result<()> {
+        set_with_prefix(self.storage, &self.prefix, key, &serialize(data)?);
+        Ok(())
+    }
+
+    /// load will return an error if no data is set at the given key, or on parse error
+    pub fn load(&self, key: &[u8]) -> Result<T> {
+        let value = get_with_prefix(self.storage, &self.prefix, key);
+        must_deserialize(&value)
+    }
+
+    /// may_load will parse the data stored at the key if present, returns Ok(None) if no data there.
+    /// returns an error on issues parsing
+    pub fn may_load(&self, key: &[u8]) -> Result<Option<T>> {
+        let value = get_with_prefix(self.storage, &self.prefix, key);
+        may_deserialize(&value)
+    }
+
+    /// update will load the data, perform the specified action, and store the result
+    /// in the database. This is shorthand for some common sequences, which may be useful.
+    /// Note that this only updates *pre-existing* values. If you want to modify possibly
+    /// non-existent values, please use `may_update`
+    ///
+    /// This is the least stable of the APIs, and definitely needs some usage
+    pub fn update(&mut self, key: &[u8], action: &dyn Fn(Option<T>) -> Result<T>) -> Result<T> {
+        let input = self.may_load(key)?;
+        let output = action(input)?;
+        self.save(key, &output)?;
+        Ok(output)
+    }
+}
+
+pub struct ReadonlyBucket<'a, S: ReadonlyStorage, T>
+where
+    T: Serialize + DeserializeOwned,
+{
+    storage: &'a S,
+    // see https://doc.rust-lang.org/std/marker/struct.PhantomData.html#unused-type-parameters for why this is needed
+    data: PhantomData<&'a T>,
+    prefix: Vec<u8>,
+}
+
+impl<'a, S: ReadonlyStorage, T> ReadonlyBucket<'a, S, T>
+where
+    T: Serialize + DeserializeOwned,
+{
+    pub fn new(namespace: &[u8], storage: &'a S) -> Self {
+        ReadonlyBucket {
+            prefix: key_prefix(namespace),
+            storage,
+            data: PhantomData,
+        }
+    }
+
+    pub fn multilevel(namespaces: &[&[u8]], storage: &'a S) -> Self {
+        ReadonlyBucket {
+            prefix: key_prefix_nested(namespaces),
+            storage,
+            data: PhantomData,
+        }
+    }
+
+    /// load will return an error if no data is set at the given key, or on parse error
+    pub fn load(&self, key: &[u8]) -> Result<T> {
+        let value = get_with_prefix(self.storage, &self.prefix, key);
+        must_deserialize(&value)
+    }
+
+    /// may_load will parse the data stored at the key if present, returns Ok(None) if no data there.
+    /// returns an error on issues parsing
+    pub fn may_load(&self, key: &[u8]) -> Result<Option<T>> {
+        let value = get_with_prefix(self.storage, &self.prefix, key);
+        may_deserialize(&value)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use cosmwasm::errors::{contract_err, NotFound};
+    use cosmwasm::mock::MockStorage;
+    use serde::{Deserialize, Serialize};
+    use snafu::OptionExt;
+
+    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+    struct Data {
+        pub name: String,
+        pub age: i32,
+    }
+
+    #[test]
+    fn store_and_load() {
+        let mut store = MockStorage::new();
+        let mut bucket = bucket::<_, Data>(b"data", &mut store);
+
+        // save data
+        let data = Data {
+            name: "Maria".to_string(),
+            age: 42,
+        };
+        bucket.save(b"maria", &data).unwrap();
+
+        // load it properly
+        let loaded = bucket.load(b"maria").unwrap();
+        assert_eq!(data, loaded);
+    }
+
+    #[test]
+    fn readonly_works() {
+        let mut store = MockStorage::new();
+        let mut bucket = bucket::<_, Data>(b"data", &mut store);
+
+        // save data
+        let data = Data {
+            name: "Maria".to_string(),
+            age: 42,
+        };
+        bucket.save(b"maria", &data).unwrap();
+
+        let reader = bucket_read::<_, Data>(b"data", &mut store);
+
+        // check empty data handling
+        assert!(reader.load(b"john").is_err());
+        assert_eq!(reader.may_load(b"john").unwrap(), None);
+
+        // load it properly
+        let loaded = reader.load(b"maria").unwrap();
+        assert_eq!(data, loaded);
+    }
+
+    #[test]
+    fn buckets_isolated() {
+        let mut store = MockStorage::new();
+        let mut bucket1 = bucket::<_, Data>(b"data", &mut store);
+
+        // save data
+        let data = Data {
+            name: "Maria".to_string(),
+            age: 42,
+        };
+        bucket1.save(b"maria", &data).unwrap();
+
+        let mut bucket2 = bucket::<_, Data>(b"dat", &mut store);
+
+        // save data (dat, amaria) vs (data, maria)
+        let data2 = Data {
+            name: "Amen".to_string(),
+            age: 67,
+        };
+        bucket2.save(b"amaria", &data2).unwrap();
+
+        // load one
+        let reader = bucket_read::<_, Data>(b"data", &store);
+        let loaded = reader.load(b"maria").unwrap();
+        assert_eq!(data, loaded);
+        // no cross load
+        assert_eq!(None, reader.may_load(b"amaria").unwrap());
+
+        // load the other
+        let reader2 = bucket_read::<_, Data>(b"dat", &store);
+        let loaded2 = reader2.load(b"amaria").unwrap();
+        assert_eq!(data2, loaded2);
+        // no cross load
+        assert_eq!(None, reader2.may_load(b"maria").unwrap());
+    }
+
+    #[test]
+    fn update_success() {
+        let mut store = MockStorage::new();
+        let mut bucket = bucket::<_, Data>(b"data", &mut store);
+
+        // initial data
+        let init = Data {
+            name: "Maria".to_string(),
+            age: 42,
+        };
+        bucket.save(b"maria", &init).unwrap();
+
+        // it's my birthday
+        let birthday = |mayd: Option<Data>| -> Result<Data> {
+            let mut d = mayd.context(NotFound { kind: "Data" })?;
+            d.age += 1;
+            Ok(d)
+        };
+        let output = bucket.update(b"maria", &birthday).unwrap();
+        let expected = Data {
+            name: "Maria".to_string(),
+            age: 43,
+        };
+        assert_eq!(output, expected);
+
+        // load it properly
+        let loaded = bucket.load(b"maria").unwrap();
+        assert_eq!(loaded, expected);
+    }
+
+    #[test]
+    fn update_fails_on_error() {
+        let mut store = MockStorage::new();
+        let mut bucket = bucket::<_, Data>(b"data", &mut store);
+
+        // initial data
+        let init = Data {
+            name: "Maria".to_string(),
+            age: 42,
+        };
+        bucket.save(b"maria", &init).unwrap();
+
+        // it's my birthday
+        let output = bucket.update(b"maria", &|_d| contract_err("cuz i feel like it"));
+        assert!(output.is_err());
+
+        // load it properly
+        let loaded = bucket.load(b"maria").unwrap();
+        assert_eq!(loaded, init);
+    }
+
+    #[test]
+    fn update_handles_on_no_data() {
+        let mut store = MockStorage::new();
+        let mut bucket = bucket::<_, Data>(b"data", &mut store);
+
+        let init_value = Data {
+            name: "Maria".to_string(),
+            age: 42,
+        };
+
+        // it's my birthday
+        let output = bucket
+            .update(b"maria", &|d| match d {
+                Some(_) => contract_err("Ensure this was empty"),
+                None => Ok(init_value.clone()),
+            })
+            .unwrap();
+        assert_eq!(output, init_value);
+
+        // nothing stored
+        let loaded = bucket.load(b"maria").unwrap();
+        assert_eq!(loaded, init_value);
+    }
+}

--- a/packages/storage/src/bucket.rs
+++ b/packages/storage/src/bucket.rs
@@ -1,11 +1,10 @@
 use serde::{de::DeserializeOwned, ser::Serialize};
 use std::marker::PhantomData;
 
-use cosmwasm::errors::Result;
-use cosmwasm::traits::{ReadonlyStorage, Storage};
+use cosmwasm_std::{to_vec, ReadonlyStorage, Result, Storage};
 
 use crate::namespace_helpers::{get_with_prefix, key_prefix, key_prefix_nested, set_with_prefix};
-use crate::type_helpers::{may_deserialize, must_deserialize, serialize};
+use crate::type_helpers::{may_deserialize, must_deserialize};
 
 pub fn bucket<'a, S: Storage, T>(namespace: &[u8], storage: &'a mut S) -> Bucket<'a, S, T>
 where
@@ -56,7 +55,7 @@ where
 
     /// save will serialize the model and store, returns an error on serialization issues
     pub fn save(&mut self, key: &[u8], data: &T) -> Result<()> {
-        set_with_prefix(self.storage, &self.prefix, key, &serialize(data)?);
+        set_with_prefix(self.storage, &self.prefix, key, &to_vec(data)?);
         Ok(())
     }
 
@@ -134,8 +133,8 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use cosmwasm::errors::{contract_err, NotFound};
-    use cosmwasm::mock::MockStorage;
+    use cosmwasm_std::testing::MockStorage;
+    use cosmwasm_std::{contract_err, NotFound};
     use serde::{Deserialize, Serialize};
     use snafu::OptionExt;
 

--- a/packages/storage/src/lib.rs
+++ b/packages/storage/src/lib.rs
@@ -1,0 +1,14 @@
+mod bucket;
+mod namespace_helpers;
+mod prefix;
+mod sequence;
+mod singleton;
+mod type_helpers;
+mod typed;
+
+pub use bucket::{bucket, bucket_read, Bucket, ReadonlyBucket};
+pub use prefix::{prefixed, prefixed_read, PrefixedStorage, ReadonlyPrefixedStorage};
+pub use sequence::{currval, nextval, sequence};
+pub use singleton::{singleton, singleton_read, ReadonlySingleton, Singleton};
+pub use type_helpers::{deserialize, serialize};
+pub use typed::{typed, typed_read, ReadonlyTypedStorage, TypedStorage};

--- a/packages/storage/src/lib.rs
+++ b/packages/storage/src/lib.rs
@@ -10,5 +10,4 @@ pub use bucket::{bucket, bucket_read, Bucket, ReadonlyBucket};
 pub use prefix::{prefixed, prefixed_read, PrefixedStorage, ReadonlyPrefixedStorage};
 pub use sequence::{currval, nextval, sequence};
 pub use singleton::{singleton, singleton_read, ReadonlySingleton, Singleton};
-pub use type_helpers::{deserialize, serialize};
 pub use typed::{typed, typed_read, ReadonlyTypedStorage, TypedStorage};

--- a/packages/storage/src/namespace_helpers.rs
+++ b/packages/storage/src/namespace_helpers.rs
@@ -1,0 +1,131 @@
+use cosmwasm::traits::{ReadonlyStorage, Storage};
+
+pub(crate) fn get_with_prefix<S: ReadonlyStorage>(
+    storage: &S,
+    namespace: &[u8],
+    key: &[u8],
+) -> Option<Vec<u8>> {
+    let mut k = namespace.to_vec();
+    k.extend_from_slice(key);
+    storage.get(&k)
+}
+
+pub(crate) fn set_with_prefix<S: Storage>(
+    storage: &mut S,
+    namespace: &[u8],
+    key: &[u8],
+    value: &[u8],
+) {
+    let mut k = namespace.to_vec();
+    k.extend_from_slice(key);
+    storage.set(&k, value)
+}
+
+// Calculates the raw key prefix for a given namespace
+// as documented in https://github.com/webmaster128/key-namespacing#length-prefixed-keys
+pub(crate) fn key_prefix(namespace: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(namespace.len() + 2);
+    extend_with_prefix(&mut out, namespace);
+    out
+}
+
+// Calculates the raw key prefix for a given nested namespace
+// as documented in https://github.com/webmaster128/key-namespacing#nesting
+pub(crate) fn key_prefix_nested(namespaces: &[&[u8]]) -> Vec<u8> {
+    let mut size = namespaces.len();
+    for &namespace in namespaces {
+        size += namespace.len() + 2;
+    }
+
+    let mut out = Vec::with_capacity(size);
+    for &namespace in namespaces {
+        extend_with_prefix(&mut out, namespace);
+    }
+    out
+}
+
+// extend_with_prefix is only for internal use to unify key_prefix and key_prefix_nested efficiently
+// as documented in https://github.com/webmaster128/key-namespacing#nesting
+fn extend_with_prefix(out: &mut Vec<u8>, namespace: &[u8]) {
+    out.extend_from_slice(&key_len(namespace));
+    out.extend_from_slice(namespace);
+}
+
+// returns the length as a 2 byte big endian encoded integer
+fn key_len(prefix: &[u8]) -> [u8; 2] {
+    if prefix.len() > 0xFFFF {
+        panic!("only supports namespaces up to length 0xFFFF")
+    }
+    let length_bytes = (prefix.len() as u64).to_be_bytes();
+    [length_bytes[6], length_bytes[7]]
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use cosmwasm::mock::MockStorage;
+
+    #[test]
+    fn key_prefix_works() {
+        assert_eq!(key_prefix(b""), b"\x00\x00");
+        assert_eq!(key_prefix(b"a"), b"\x00\x01a");
+        assert_eq!(key_prefix(b"ab"), b"\x00\x02ab");
+        assert_eq!(key_prefix(b"abc"), b"\x00\x03abc");
+    }
+
+    #[test]
+    fn key_prefix_works_for_long_prefix() {
+        let long_namespace1 = vec![0; 256];
+        let prefix1 = key_prefix(&long_namespace1);
+        assert_eq!(prefix1.len(), 256 + 2);
+        assert_eq!(&prefix1[0..2], b"\x01\x00");
+
+        let long_namespace2 = vec![0; 30000];
+        let prefix2 = key_prefix(&long_namespace2);
+        assert_eq!(prefix2.len(), 30000 + 2);
+        assert_eq!(&prefix2[0..2], b"\x75\x30");
+
+        let long_namespace3 = vec![0; 0xFFFF];
+        let prefix3 = key_prefix(&long_namespace3);
+        assert_eq!(prefix3.len(), 0xFFFF + 2);
+        assert_eq!(&prefix3[0..2], b"\xFF\xFF");
+    }
+
+    #[test]
+    #[should_panic(expected = "only supports namespaces up to length 0xFFFF")]
+    fn key_prefix_panics_for_too_long_prefix() {
+        let limit = 0xFFFF;
+        let long_namespace = vec![0; limit + 1];
+        key_prefix(&long_namespace);
+    }
+
+    #[test]
+    fn key_prefix_nested_works() {
+        assert_eq!(key_prefix_nested(&[]), b"");
+        assert_eq!(key_prefix_nested(&[b""]), b"\x00\x00");
+        assert_eq!(key_prefix_nested(&[b"", b""]), b"\x00\x00\x00\x00");
+
+        assert_eq!(key_prefix_nested(&[b"a"]), b"\x00\x01a");
+        assert_eq!(key_prefix_nested(&[b"a", b"ab"]), b"\x00\x01a\x00\x02ab");
+        assert_eq!(
+            key_prefix_nested(&[b"a", b"ab", b"abc"]),
+            b"\x00\x01a\x00\x02ab\x00\x03abc"
+        );
+    }
+
+    #[test]
+    fn prefix_get_set() {
+        let mut storage = MockStorage::new();
+        let prefix = key_prefix(b"foo");
+
+        // we use a block scope here to release the &mut before we use it in the next storage
+        set_with_prefix(&mut storage, &prefix, b"bar", b"gotcha");
+        let rfoo = get_with_prefix(&storage, &prefix, b"bar");
+        assert_eq!(Some(b"gotcha".to_vec()), rfoo);
+
+        // no collisions with other prefixes
+        let other_prefix = key_prefix(b"fo");
+        let collision = get_with_prefix(&storage, &other_prefix, b"obar");
+        assert_eq!(None, collision);
+    }
+}

--- a/packages/storage/src/namespace_helpers.rs
+++ b/packages/storage/src/namespace_helpers.rs
@@ -1,4 +1,4 @@
-use cosmwasm::traits::{ReadonlyStorage, Storage};
+use cosmwasm_std::{ReadonlyStorage, Storage};
 
 pub(crate) fn get_with_prefix<S: ReadonlyStorage>(
     storage: &S,
@@ -19,6 +19,12 @@ pub(crate) fn set_with_prefix<S: Storage>(
     let mut k = namespace.to_vec();
     k.extend_from_slice(key);
     storage.set(&k, value)
+}
+
+pub(crate) fn remove_with_prefix<S: Storage>(storage: &mut S, namespace: &[u8], key: &[u8]) {
+    let mut k = namespace.to_vec();
+    k.extend_from_slice(key);
+    storage.remove(&k)
 }
 
 // Calculates the raw key prefix for a given namespace
@@ -63,7 +69,7 @@ fn key_len(prefix: &[u8]) -> [u8; 2] {
 #[cfg(test)]
 mod test {
     use super::*;
-    use cosmwasm::mock::MockStorage;
+    use cosmwasm_std::testing::MockStorage;
 
     #[test]
     fn key_prefix_works() {

--- a/packages/storage/src/prefix.rs
+++ b/packages/storage/src/prefix.rs
@@ -1,0 +1,130 @@
+use cosmwasm::traits::{ReadonlyStorage, Storage};
+
+use crate::namespace_helpers::{get_with_prefix, key_prefix, key_prefix_nested, set_with_prefix};
+
+// prefixed_read is a helper function for less verbose usage
+pub fn prefixed_read<'a, T: ReadonlyStorage>(
+    prefix: &[u8],
+    storage: &'a T,
+) -> ReadonlyPrefixedStorage<'a, T> {
+    ReadonlyPrefixedStorage::new(prefix, storage)
+}
+
+// prefixed_rw is a helper function for less verbose usage
+pub fn prefixed<'a, T: Storage>(prefix: &[u8], storage: &'a mut T) -> PrefixedStorage<'a, T> {
+    PrefixedStorage::new(prefix, storage)
+}
+
+pub struct ReadonlyPrefixedStorage<'a, T: ReadonlyStorage> {
+    prefix: Vec<u8>,
+    storage: &'a T,
+}
+
+impl<'a, T: ReadonlyStorage> ReadonlyPrefixedStorage<'a, T> {
+    pub fn new(namespace: &[u8], storage: &'a T) -> Self {
+        ReadonlyPrefixedStorage {
+            prefix: key_prefix(namespace),
+            storage,
+        }
+    }
+
+    // Nested namespaces as documented in
+    // https://github.com/webmaster128/key-namespacing#nesting
+    pub fn multilevel(namespaces: &[&[u8]], storage: &'a T) -> Self {
+        ReadonlyPrefixedStorage {
+            prefix: key_prefix_nested(namespaces),
+            storage,
+        }
+    }
+}
+
+impl<'a, T: ReadonlyStorage> ReadonlyStorage for ReadonlyPrefixedStorage<'a, T> {
+    fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
+        get_with_prefix(self.storage, &self.prefix, key)
+    }
+}
+
+pub struct PrefixedStorage<'a, T: Storage> {
+    prefix: Vec<u8>,
+    storage: &'a mut T,
+}
+
+impl<'a, T: Storage> PrefixedStorage<'a, T> {
+    pub fn new(namespace: &[u8], storage: &'a mut T) -> Self {
+        PrefixedStorage {
+            prefix: key_prefix(namespace),
+            storage,
+        }
+    }
+
+    // Nested namespaces as documented in
+    // https://github.com/webmaster128/key-namespacing#nesting
+    pub fn multilevel(namespaces: &[&[u8]], storage: &'a mut T) -> Self {
+        PrefixedStorage {
+            prefix: key_prefix_nested(namespaces),
+            storage,
+        }
+    }
+}
+
+impl<'a, T: Storage> ReadonlyStorage for PrefixedStorage<'a, T> {
+    fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
+        get_with_prefix(self.storage, &self.prefix, key)
+    }
+}
+
+impl<'a, T: Storage> Storage for PrefixedStorage<'a, T> {
+    fn set(&mut self, key: &[u8], value: &[u8]) {
+        set_with_prefix(self.storage, &self.prefix, key, value)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use cosmwasm::mock::MockStorage;
+
+    #[test]
+    fn prefix_safe() {
+        let mut storage = MockStorage::new();
+
+        // we use a block scope here to release the &mut before we use it in the next storage
+        let mut foo = PrefixedStorage::new(b"foo", &mut storage);
+        foo.set(b"bar", b"gotcha");
+        assert_eq!(Some(b"gotcha".to_vec()), foo.get(b"bar"));
+
+        // try readonly correctly
+        let rfoo = ReadonlyPrefixedStorage::new(b"foo", &storage);
+        assert_eq!(Some(b"gotcha".to_vec()), rfoo.get(b"bar"));
+
+        // no collisions with other prefixes
+        let fo = ReadonlyPrefixedStorage::new(b"fo", &storage);
+        assert_eq!(None, fo.get(b"obar"));
+
+        // Note: explicit scoping is not required, but you must not refer to `foo` anytime after you
+        // initialize a different PrefixedStorage. Uncomment this to see errors:
+        //        assert_eq!(Some(b"gotcha".to_vec()), foo.get(b"bar"));
+    }
+
+    #[test]
+    fn multi_level() {
+        let mut storage = MockStorage::new();
+
+        // set with nested
+        let mut foo = PrefixedStorage::new(b"foo", &mut storage);
+        let mut bar = PrefixedStorage::new(b"bar", &mut foo);
+        bar.set(b"baz", b"winner");
+
+        // we can nest them the same encoding with one operation
+        let loader = ReadonlyPrefixedStorage::multilevel(&[b"foo", b"bar"], &storage);
+        assert_eq!(Some(b"winner".to_vec()), loader.get(b"baz"));
+
+        // set with multilevel
+        let mut foobar = PrefixedStorage::multilevel(&[b"foo", b"bar"], &mut storage);
+        foobar.set(b"second", b"time");
+
+        let a = ReadonlyPrefixedStorage::new(b"foo", &storage);
+        let b = ReadonlyPrefixedStorage::new(b"bar", &a);
+        assert_eq!(Some(b"time".to_vec()), b.get(b"second"));
+    }
+}

--- a/packages/storage/src/prefix.rs
+++ b/packages/storage/src/prefix.rs
@@ -1,6 +1,8 @@
-use cosmwasm::traits::{ReadonlyStorage, Storage};
+use cosmwasm_std::{ReadonlyStorage, Storage};
 
-use crate::namespace_helpers::{get_with_prefix, key_prefix, key_prefix_nested, set_with_prefix};
+use crate::namespace_helpers::{
+    get_with_prefix, key_prefix, key_prefix_nested, remove_with_prefix, set_with_prefix,
+};
 
 // prefixed_read is a helper function for less verbose usage
 pub fn prefixed_read<'a, T: ReadonlyStorage>(
@@ -77,12 +79,16 @@ impl<'a, T: Storage> Storage for PrefixedStorage<'a, T> {
     fn set(&mut self, key: &[u8], value: &[u8]) {
         set_with_prefix(self.storage, &self.prefix, key, value)
     }
+
+    fn remove(&mut self, key: &[u8]) {
+        remove_with_prefix(self.storage, &self.prefix, key)
+    }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
-    use cosmwasm::mock::MockStorage;
+    use cosmwasm_std::testing::MockStorage;
 
     #[test]
     fn prefix_safe() {

--- a/packages/storage/src/sequence.rs
+++ b/packages/storage/src/sequence.rs
@@ -1,0 +1,73 @@
+use cosmwasm::errors::Result;
+use cosmwasm::traits::Storage;
+
+use crate::Singleton;
+
+/// Sequence creates a custom Singleton to hold an empty sequence
+pub fn sequence<'a, S: Storage>(storage: &'a mut S, key: &[u8]) -> Singleton<'a, S, u64> {
+    Singleton::new(storage, key)
+}
+
+/// currval returns the last value returned by nextval. If the sequence has never been used,
+/// then it will return 0.
+pub fn currval<S: Storage>(seq: &Singleton<S, u64>) -> Result<u64> {
+    Ok(seq.may_load()?.unwrap_or_default())
+}
+
+/// nextval increments the counter by 1 and returns the new value.
+/// On the first time it is called (no sequence info in db) it will return 1.
+pub fn nextval<S: Storage>(seq: &mut Singleton<S, u64>) -> Result<u64> {
+    let val = currval(&seq)? + 1;
+    seq.save(&val)?;
+    Ok(val)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use cosmwasm::mock::MockStorage;
+
+    #[test]
+    fn walk_through_sequence() {
+        let mut store = MockStorage::new();
+        let mut seq = sequence(&mut store, b"seq");
+
+        assert_eq!(currval(&seq).unwrap(), 0);
+        assert_eq!(nextval(&mut seq).unwrap(), 1);
+        assert_eq!(nextval(&mut seq).unwrap(), 2);
+        assert_eq!(nextval(&mut seq).unwrap(), 3);
+        assert_eq!(currval(&seq).unwrap(), 3);
+        assert_eq!(currval(&seq).unwrap(), 3);
+    }
+
+    #[test]
+    fn sequences_independent() {
+        let mut store = MockStorage::new();
+
+        let mut seq = sequence(&mut store, b"seq");
+        assert_eq!(nextval(&mut seq).unwrap(), 1);
+        assert_eq!(nextval(&mut seq).unwrap(), 2);
+        assert_eq!(nextval(&mut seq).unwrap(), 3);
+
+        let mut seq2 = sequence(&mut store, b"seq2");
+        assert_eq!(nextval(&mut seq2).unwrap(), 1);
+        assert_eq!(nextval(&mut seq2).unwrap(), 2);
+
+        let mut seq3 = sequence(&mut store, b"seq");
+        assert_eq!(nextval(&mut seq3).unwrap(), 4);
+    }
+
+    #[test]
+    fn set_sequence() {
+        let mut store = MockStorage::new();
+        let mut seq = sequence(&mut store, b"seq");
+
+        assert_eq!(nextval(&mut seq).unwrap(), 1);
+        assert_eq!(nextval(&mut seq).unwrap(), 2);
+
+        seq.save(&20).unwrap();
+
+        assert_eq!(currval(&seq).unwrap(), 20);
+        assert_eq!(nextval(&mut seq).unwrap(), 21);
+    }
+}

--- a/packages/storage/src/sequence.rs
+++ b/packages/storage/src/sequence.rs
@@ -1,5 +1,4 @@
-use cosmwasm::errors::Result;
-use cosmwasm::traits::Storage;
+use cosmwasm_std::{Result, Storage};
 
 use crate::Singleton;
 
@@ -25,7 +24,7 @@ pub fn nextval<S: Storage>(seq: &mut Singleton<S, u64>) -> Result<u64> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use cosmwasm::mock::MockStorage;
+    use cosmwasm_std::testing::MockStorage;
 
     #[test]
     fn walk_through_sequence() {

--- a/packages/storage/src/singleton.rs
+++ b/packages/storage/src/singleton.rs
@@ -1,0 +1,214 @@
+use serde::{de::DeserializeOwned, ser::Serialize};
+use std::marker::PhantomData;
+
+use cosmwasm::errors::Result;
+use cosmwasm::traits::{ReadonlyStorage, Storage};
+
+use crate::namespace_helpers::key_prefix;
+use crate::type_helpers::{may_deserialize, must_deserialize, serialize};
+
+// singleton is a helper function for less verbose usage
+pub fn singleton<'a, S: Storage, T>(storage: &'a mut S, key: &[u8]) -> Singleton<'a, S, T>
+where
+    T: Serialize + DeserializeOwned,
+{
+    Singleton::new(storage, key)
+}
+
+// singleton_read is a helper function for less verbose usage
+pub fn singleton_read<'a, S: ReadonlyStorage, T>(
+    storage: &'a S,
+    key: &[u8],
+) -> ReadonlySingleton<'a, S, T>
+where
+    T: Serialize + DeserializeOwned,
+{
+    ReadonlySingleton::new(storage, key)
+}
+
+/// Singleton effectively combines PrefixedStorage with TypedStorage to
+/// work on one single value. It performs the key_prefix transformation
+/// on the given name to ensure no collisions, and then provides the standard
+/// TypedStorage accessors, without requiring a key (which is defined in the constructor)
+pub struct Singleton<'a, S: Storage, T>
+where
+    T: Serialize + DeserializeOwned,
+{
+    storage: &'a mut S,
+    key: Vec<u8>,
+    // see https://doc.rust-lang.org/std/marker/struct.PhantomData.html#unused-type-parameters for why this is needed
+    data: PhantomData<&'a T>,
+}
+
+impl<'a, S: Storage, T> Singleton<'a, S, T>
+where
+    T: Serialize + DeserializeOwned,
+{
+    pub fn new(storage: &'a mut S, key: &[u8]) -> Self {
+        Singleton {
+            storage,
+            key: key_prefix(key),
+            data: PhantomData,
+        }
+    }
+
+    /// save will serialize the model and store, returns an error on serialization issues
+    pub fn save(&mut self, data: &T) -> Result<()> {
+        self.storage.set(&self.key, &serialize(data)?);
+        Ok(())
+    }
+
+    /// load will return an error if no data is set at the given key, or on parse error
+    pub fn load(&self) -> Result<T> {
+        let value = self.storage.get(&self.key);
+        must_deserialize(&value)
+    }
+
+    /// may_load will parse the data stored at the key if present, returns Ok(None) if no data there.
+    /// returns an error on issues parsing
+    pub fn may_load(&self) -> Result<Option<T>> {
+        let value = self.storage.get(&self.key);
+        may_deserialize(&value)
+    }
+
+    /// update will load the data, perform the specified action, and store the result
+    /// in the database. This is shorthand for some common sequences, which may be useful
+    ///
+    /// This is the least stable of the APIs, and definitely needs some usage
+    pub fn update(&mut self, action: &dyn Fn(T) -> Result<T>) -> Result<T> {
+        let input = self.load()?;
+        let output = action(input)?;
+        self.save(&output)?;
+        Ok(output)
+    }
+}
+
+/// ReadonlySingleton only requires a ReadonlyStorage and exposes only the
+/// methods of Singleton that don't modify state.
+pub struct ReadonlySingleton<'a, S: ReadonlyStorage, T>
+where
+    T: Serialize + DeserializeOwned,
+{
+    storage: &'a S,
+    key: Vec<u8>,
+    // see https://doc.rust-lang.org/std/marker/struct.PhantomData.html#unused-type-parameters for why this is needed
+    data: PhantomData<&'a T>,
+}
+
+impl<'a, S: ReadonlyStorage, T> ReadonlySingleton<'a, S, T>
+where
+    T: Serialize + DeserializeOwned,
+{
+    pub fn new(storage: &'a S, key: &[u8]) -> Self {
+        ReadonlySingleton {
+            storage,
+            key: key_prefix(key),
+            data: PhantomData,
+        }
+    }
+
+    /// load will return an error if no data is set at the given key, or on parse error
+    pub fn load(&self) -> Result<T> {
+        let value = self.storage.get(&self.key);
+        must_deserialize(&value)
+    }
+
+    /// may_load will parse the data stored at the key if present, returns Ok(None) if no data there.
+    /// returns an error on issues parsing
+    pub fn may_load(&self) -> Result<Option<T>> {
+        let value = self.storage.get(&self.key);
+        may_deserialize(&value)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use cosmwasm::mock::MockStorage;
+    use serde::{Deserialize, Serialize};
+
+    use cosmwasm::errors::{Error, Unauthorized};
+
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    struct Config {
+        pub owner: String,
+        pub max_tokens: i32,
+    }
+
+    #[test]
+    fn save_and_load() {
+        let mut store = MockStorage::new();
+        let mut single = Singleton::<_, Config>::new(&mut store, b"config");
+
+        assert!(single.load().is_err());
+        assert_eq!(single.may_load().unwrap(), None);
+
+        let cfg = Config {
+            owner: "admin".to_string(),
+            max_tokens: 1234,
+        };
+        single.save(&cfg).unwrap();
+
+        assert_eq!(cfg, single.load().unwrap());
+    }
+
+    #[test]
+    fn isolated_reads() {
+        let mut store = MockStorage::new();
+        let mut writer = singleton::<_, Config>(&mut store, b"config");
+
+        let cfg = Config {
+            owner: "admin".to_string(),
+            max_tokens: 1234,
+        };
+        writer.save(&cfg).unwrap();
+
+        let reader = singleton_read::<_, Config>(&store, b"config");
+        assert_eq!(cfg, reader.load().unwrap());
+
+        let other_reader = singleton_read::<_, Config>(&store, b"config2");
+        assert_eq!(other_reader.may_load().unwrap(), None);
+    }
+
+    #[test]
+    fn update_success() {
+        let mut store = MockStorage::new();
+        let mut writer = singleton::<_, Config>(&mut store, b"config");
+
+        let cfg = Config {
+            owner: "admin".to_string(),
+            max_tokens: 1234,
+        };
+        writer.save(&cfg).unwrap();
+
+        let output = writer.update(&|mut c| {
+            c.max_tokens *= 2;
+            Ok(c)
+        });
+        let expected = Config {
+            owner: "admin".to_string(),
+            max_tokens: 2468,
+        };
+        assert_eq!(output.unwrap(), expected);
+        assert_eq!(writer.load().unwrap(), expected);
+    }
+
+    #[test]
+    fn update_failure() {
+        let mut store = MockStorage::new();
+        let mut writer = singleton::<_, Config>(&mut store, b"config");
+
+        let cfg = Config {
+            owner: "admin".to_string(),
+            max_tokens: 1234,
+        };
+        writer.save(&cfg).unwrap();
+
+        let output = writer.update(&|_c| Unauthorized {}.fail());
+        match output {
+            Err(Error::Unauthorized { .. }) => {}
+            _ => panic!("Unexpected output: {:?}", output),
+        }
+        assert_eq!(writer.load().unwrap(), cfg);
+    }
+}

--- a/packages/storage/src/type_helpers.rs
+++ b/packages/storage/src/type_helpers.rs
@@ -1,0 +1,96 @@
+use serde::{de::DeserializeOwned, ser::Serialize};
+use snafu::ResultExt;
+use std::any::type_name;
+
+use cosmwasm::errors::{NotFound, ParseErr, Result, SerializeErr};
+use cosmwasm::serde::{from_slice, to_vec};
+
+// how we can make these names simpler if so desired
+//fn short_type_name<T>() -> &'static str {
+//    let long = std::any::type_name::<T>();
+//    long.rsplit("::").next().unwrap_or(long)
+//}
+
+/// serialize makes json bytes, but returns a cosmwasm::Error
+pub fn serialize<T: Serialize>(data: &T) -> Result<Vec<u8>> {
+    to_vec(data).context(SerializeErr {
+        kind: type_name::<T>(),
+    })
+}
+
+/// may_deserialize parses json bytes from storage (Option), returning Ok(None) if no data present
+///
+/// value is an odd type, but this is meant to be easy to use with output from storage.get (Option<Vec<u8>>)
+/// and value.map(|s| s.as_slice()) seems trickier than &value
+pub(crate) fn may_deserialize<T: DeserializeOwned>(value: &Option<Vec<u8>>) -> Result<Option<T>> {
+    match value {
+        Some(d) => Ok(Some(deserialize(d.as_slice())?)),
+        None => Ok(None),
+    }
+}
+
+/// must_deserialize parses json bytes from storage (Option), returning NotFound error if no data present
+pub(crate) fn must_deserialize<T: DeserializeOwned>(value: &Option<Vec<u8>>) -> Result<T> {
+    match value {
+        Some(d) => deserialize(&d),
+        None => NotFound {
+            kind: type_name::<T>(),
+        }
+        .fail(),
+    }
+}
+
+// deserialize is a reflection of serialize and probably what most people outside the crate expect
+pub fn deserialize<T: DeserializeOwned>(value: &[u8]) -> Result<T> {
+    from_slice(value).context(ParseErr {
+        kind: type_name::<T>(),
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use cosmwasm::errors::Error;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    struct Data {
+        pub name: String,
+        pub age: i32,
+    }
+
+    #[test]
+    fn serialize_and_deserialize() {
+        // save data
+        let data = Data {
+            name: "Maria".to_string(),
+            age: 42,
+        };
+        let value = serialize(&data).unwrap();
+        let loaded = Some(value);
+
+        //        let parsed: Data = deserialize(loaded.map(|s| s.as_slice())).unwrap();
+        //        assert_eq!(parsed, data);
+        let parsed: Data = must_deserialize(&loaded).unwrap();
+        assert_eq!(parsed, data);
+
+        let may_parse: Option<Data> = may_deserialize(&loaded).unwrap();
+        assert_eq!(may_parse, Some(data));
+    }
+
+    #[test]
+    fn handle_none() {
+        let may_parse = may_deserialize::<Data>(&None).unwrap();
+        assert_eq!(may_parse, None);
+
+        let parsed = must_deserialize::<Data>(&None);
+        match parsed {
+            // if we used short_type_name, this would just be Data
+            Err(Error::NotFound { kind }) => {
+                assert_eq!(kind, "cosmwasm_storage::type_helpers::test::Data")
+            }
+            Err(e) => panic!("Unexpected error {}", e),
+            Ok(_) => panic!("should error"),
+        }
+    }
+}

--- a/packages/storage/src/typed.rs
+++ b/packages/storage/src/typed.rs
@@ -1,0 +1,260 @@
+use serde::{de::DeserializeOwned, ser::Serialize};
+use std::marker::PhantomData;
+
+use cosmwasm::errors::Result;
+use cosmwasm::traits::{ReadonlyStorage, Storage};
+
+use crate::type_helpers::{may_deserialize, must_deserialize, serialize};
+
+pub fn typed<S: Storage, T>(storage: &mut S) -> TypedStorage<S, T>
+where
+    T: Serialize + DeserializeOwned,
+{
+    TypedStorage::new(storage)
+}
+
+pub fn typed_read<S: ReadonlyStorage, T>(storage: &S) -> ReadonlyTypedStorage<S, T>
+where
+    T: Serialize + DeserializeOwned,
+{
+    ReadonlyTypedStorage::new(storage)
+}
+
+pub struct TypedStorage<'a, S: Storage, T>
+where
+    T: Serialize + DeserializeOwned,
+{
+    storage: &'a mut S,
+    // see https://doc.rust-lang.org/std/marker/struct.PhantomData.html#unused-type-parameters for why this is needed
+    data: PhantomData<&'a T>,
+}
+
+impl<'a, S: Storage, T> TypedStorage<'a, S, T>
+where
+    T: Serialize + DeserializeOwned,
+{
+    pub fn new(storage: &'a mut S) -> Self {
+        TypedStorage {
+            storage,
+            data: PhantomData,
+        }
+    }
+
+    /// save will serialize the model and store, returns an error on serialization issues
+    pub fn save(&mut self, key: &[u8], data: &T) -> Result<()> {
+        self.storage.set(key, &serialize(data)?);
+        Ok(())
+    }
+
+    /// load will return an error if no data is set at the given key, or on parse error
+    pub fn load(&self, key: &[u8]) -> Result<T> {
+        let value = self.storage.get(key);
+        must_deserialize(&value)
+    }
+
+    /// may_load will parse the data stored at the key if present, returns Ok(None) if no data there.
+    /// returns an error on issues parsing
+    pub fn may_load(&self, key: &[u8]) -> Result<Option<T>> {
+        let value = self.storage.get(key);
+        may_deserialize(&value)
+    }
+
+    /// update will load the data, perform the specified action, and store the result
+    /// in the database. This is shorthand for some common sequences, which may be useful
+    ///
+    /// This is the least stable of the APIs, and definitely needs some usage
+    pub fn update(&mut self, key: &[u8], action: &dyn Fn(Option<T>) -> Result<T>) -> Result<T> {
+        let input = self.may_load(key)?;
+        let output = action(input)?;
+        self.save(key, &output)?;
+        Ok(output)
+    }
+}
+
+pub struct ReadonlyTypedStorage<'a, S: ReadonlyStorage, T>
+where
+    T: Serialize + DeserializeOwned,
+{
+    storage: &'a S,
+    // see https://doc.rust-lang.org/std/marker/struct.PhantomData.html#unused-type-parameters for why this is needed
+    data: PhantomData<&'a T>,
+}
+
+impl<'a, S: ReadonlyStorage, T> ReadonlyTypedStorage<'a, S, T>
+where
+    T: Serialize + DeserializeOwned,
+{
+    pub fn new(storage: &'a S) -> Self {
+        ReadonlyTypedStorage {
+            storage,
+            data: PhantomData,
+        }
+    }
+
+    /// load will return an error if no data is set at the given key, or on parse error
+    pub fn load(&self, key: &[u8]) -> Result<T> {
+        let value = self.storage.get(key);
+        must_deserialize(&value)
+    }
+
+    /// may_load will parse the data stored at the key if present, returns Ok(None) if no data there.
+    /// returns an error on issues parsing
+    pub fn may_load(&self, key: &[u8]) -> Result<Option<T>> {
+        let value = self.storage.get(key);
+        may_deserialize(&value)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use cosmwasm::errors::{contract_err, NotFound};
+    use cosmwasm::mock::MockStorage;
+    use serde::{Deserialize, Serialize};
+    use snafu::OptionExt;
+
+    use crate::prefixed;
+
+    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+    struct Data {
+        pub name: String,
+        pub age: i32,
+    }
+
+    #[test]
+    fn store_and_load() {
+        let mut store = MockStorage::new();
+        let mut bucket = TypedStorage::<_, Data>::new(&mut store);
+
+        // check empty data handling
+        assert!(bucket.load(b"maria").is_err());
+        assert_eq!(bucket.may_load(b"maria").unwrap(), None);
+
+        // save data
+        let data = Data {
+            name: "Maria".to_string(),
+            age: 42,
+        };
+        bucket.save(b"maria", &data).unwrap();
+
+        // load it properly
+        let loaded = bucket.load(b"maria").unwrap();
+        assert_eq!(data, loaded);
+    }
+
+    #[test]
+    fn store_with_prefix() {
+        let mut store = MockStorage::new();
+        let mut space = prefixed(b"data", &mut store);
+        let mut bucket = typed::<_, Data>(&mut space);
+
+        // save data
+        let data = Data {
+            name: "Maria".to_string(),
+            age: 42,
+        };
+        bucket.save(b"maria", &data).unwrap();
+
+        // load it properly
+        let loaded = bucket.load(b"maria").unwrap();
+        assert_eq!(data, loaded);
+    }
+
+    #[test]
+    fn readonly_works() {
+        let mut store = MockStorage::new();
+        let mut bucket = typed::<_, Data>(&mut store);
+
+        // save data
+        let data = Data {
+            name: "Maria".to_string(),
+            age: 42,
+        };
+        bucket.save(b"maria", &data).unwrap();
+
+        let reader = typed_read::<_, Data>(&mut store);
+
+        // check empty data handling
+        assert!(reader.load(b"john").is_err());
+        assert_eq!(reader.may_load(b"john").unwrap(), None);
+
+        // load it properly
+        let loaded = reader.load(b"maria").unwrap();
+        assert_eq!(data, loaded);
+    }
+
+    #[test]
+    fn update_success() {
+        let mut store = MockStorage::new();
+        let mut bucket = typed::<_, Data>(&mut store);
+
+        // initial data
+        let init = Data {
+            name: "Maria".to_string(),
+            age: 42,
+        };
+        bucket.save(b"maria", &init).unwrap();
+
+        // it's my birthday (fail if no data)
+        let birthday = |mayd: Option<Data>| -> Result<Data> {
+            let mut d = mayd.context(NotFound { kind: "Data" })?;
+            d.age += 1;
+            Ok(d)
+        };
+        let output = bucket.update(b"maria", &birthday).unwrap();
+        let expected = Data {
+            name: "Maria".to_string(),
+            age: 43,
+        };
+        assert_eq!(output, expected);
+
+        // load it properly
+        let loaded = bucket.load(b"maria").unwrap();
+        assert_eq!(loaded, expected);
+    }
+
+    #[test]
+    fn update_fails_on_error() {
+        let mut store = MockStorage::new();
+        let mut bucket = typed::<_, Data>(&mut store);
+
+        // initial data
+        let init = Data {
+            name: "Maria".to_string(),
+            age: 42,
+        };
+        bucket.save(b"maria", &init).unwrap();
+
+        // it's my birthday
+        let output = bucket.update(b"maria", &|_d| contract_err("cuz i feel like it"));
+        assert!(output.is_err());
+
+        // load it properly
+        let loaded = bucket.load(b"maria").unwrap();
+        assert_eq!(loaded, init);
+    }
+
+    #[test]
+    fn update_handles_on_no_data() {
+        let mut store = MockStorage::new();
+        let mut bucket = typed::<_, Data>(&mut store);
+
+        let init_value = Data {
+            name: "Maria".to_string(),
+            age: 42,
+        };
+
+        // it's my birthday
+        let output = bucket
+            .update(b"maria", &|d| match d {
+                Some(_) => contract_err("Ensure this was empty"),
+                None => Ok(init_value.clone()),
+            })
+            .unwrap();
+        assert_eq!(output, init_value);
+
+        // nothing stored
+        let loaded = bucket.load(b"maria").unwrap();
+        assert_eq!(loaded, init_value);
+    }
+}

--- a/packages/storage/src/typed.rs
+++ b/packages/storage/src/typed.rs
@@ -1,10 +1,9 @@
 use serde::{de::DeserializeOwned, ser::Serialize};
 use std::marker::PhantomData;
 
-use cosmwasm::errors::Result;
-use cosmwasm::traits::{ReadonlyStorage, Storage};
+use cosmwasm_std::{to_vec, ReadonlyStorage, Result, Storage};
 
-use crate::type_helpers::{may_deserialize, must_deserialize, serialize};
+use crate::type_helpers::{may_deserialize, must_deserialize};
 
 pub fn typed<S: Storage, T>(storage: &mut S) -> TypedStorage<S, T>
 where
@@ -42,7 +41,7 @@ where
 
     /// save will serialize the model and store, returns an error on serialization issues
     pub fn save(&mut self, key: &[u8], data: &T) -> Result<()> {
-        self.storage.set(key, &serialize(data)?);
+        self.storage.set(key, &to_vec(data)?);
         Ok(())
     }
 
@@ -108,8 +107,8 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use cosmwasm::errors::{contract_err, NotFound};
-    use cosmwasm::mock::MockStorage;
+    use cosmwasm_std::testing::MockStorage;
+    use cosmwasm_std::{contract_err, NotFound};
     use serde::{Deserialize, Serialize};
     use snafu::OptionExt;
 


### PR DESCRIPTION
This will allow us to iterate faster and also use cw-storage in example contracts.

Done:
- [x] Import cw-storage
- [x] Ensure it passes CI
- [x] Upgrade to master cosmwasm-std with no iterator support

Future PR:
- Add iterator support