### PR TITLE
Add iterator support to cosmwasm-storage

### DIFF
--- a/packages/storage/Cargo.toml
+++ b/packages/storage/Cargo.toml
@@ -14,7 +14,8 @@ circle-ci = { repository = "CosmWasm/cosmwasm", branch = "master" }
 maintenance = { status = "actively-developed" }
 
 [features]
-iterator = []
+# This enables iterator functionality, as exposed in cosmwasm-std/iterator
+iterator = ["cosmwasm-std/iterator"]
 
 [dependencies]
 cosmwasm-std = { path = "../std" }

--- a/packages/storage/src/bucket.rs
+++ b/packages/storage/src/bucket.rs
@@ -357,5 +357,4 @@ mod test {
         assert_eq!(data[0], (b"jose".to_vec(), jose));
         assert_eq!(data[1], (b"maria".to_vec(), maria));
     }
-
 }

--- a/packages/storage/src/namespace_helpers.rs
+++ b/packages/storage/src/namespace_helpers.rs
@@ -296,9 +296,12 @@ mod test {
         assert_eq!(namespace_upper_bound(b"bob"), b"boc".to_vec());
         assert_eq!(namespace_upper_bound(b"fo\xfe"), b"fo\xff".to_vec());
         assert_eq!(namespace_upper_bound(b"fo\xff"), b"fp\x00".to_vec());
+        // multiple \xff roll over
         assert_eq!(
             namespace_upper_bound(b"fo\xff\xff\xff"),
             b"fp\x00\x00\x00".to_vec()
         );
+        // \xff not at the end are ignored
+        assert_eq!(namespace_upper_bound(b"\xffabc"), b"\xffabd".to_vec());
     }
 }

--- a/packages/storage/src/namespace_helpers.rs
+++ b/packages/storage/src/namespace_helpers.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "iterator")]
-use cosmwasm_std::{contract_err, Order, Result, KV};
-use cosmwasm_std::{ReadonlyStorage, Storage};
+use cosmwasm_std::{contract_err, Order, KV};
+use cosmwasm_std::{ReadonlyStorage, Result, Storage};
 
 pub(crate) fn get_with_prefix<S: ReadonlyStorage>(
     storage: &S,
@@ -212,11 +212,11 @@ mod test {
         let other_prefix = key_prefix(b"food");
 
         // set some values in this range
-        set_with_prefix(&mut storage, &prefix, b"bar", b"none");
-        set_with_prefix(&mut storage, &prefix, b"snowy", b"day");
+        set_with_prefix(&mut storage, &prefix, b"bar", b"none").unwrap();
+        set_with_prefix(&mut storage, &prefix, b"snowy", b"day").unwrap();
 
         // set some values outside this range
-        set_with_prefix(&mut storage, &other_prefix, b"moon", b"buggy");
+        set_with_prefix(&mut storage, &other_prefix, b"moon", b"buggy").unwrap();
 
         // ensure we get proper result from prefixed_range iterator
         let mut iter = range_with_prefix(&storage, &prefix, None, None, Order::Descending);
@@ -246,11 +246,11 @@ mod test {
         let other_prefix = key_prefix(b"f\xff\x44");
 
         // set some values in this range
-        set_with_prefix(&mut storage, &prefix, b"bar", b"none");
-        set_with_prefix(&mut storage, &prefix, b"snowy", b"day");
+        set_with_prefix(&mut storage, &prefix, b"bar", b"none").unwrap();
+        set_with_prefix(&mut storage, &prefix, b"snowy", b"day").unwrap();
 
         // set some values outside this range
-        set_with_prefix(&mut storage, &other_prefix, b"moon", b"buggy");
+        set_with_prefix(&mut storage, &other_prefix, b"moon", b"buggy").unwrap();
 
         // ensure we get proper result from prefixed_range iterator
         let mut iter = range_with_prefix(&storage, &prefix, None, None, Order::Descending);
@@ -270,11 +270,11 @@ mod test {
         let other_prefix = key_prefix(b"f\xff\x44");
 
         // set some values in this range
-        set_with_prefix(&mut storage, &prefix, b"bar", b"none");
-        set_with_prefix(&mut storage, &prefix, b"snowy", b"day");
+        set_with_prefix(&mut storage, &prefix, b"bar", b"none").unwrap();
+        set_with_prefix(&mut storage, &prefix, b"snowy", b"day").unwrap();
 
         // set some values outside this range
-        set_with_prefix(&mut storage, &other_prefix, b"moon", b"buggy");
+        set_with_prefix(&mut storage, &other_prefix, b"moon", b"buggy").unwrap();
 
         // make sure start and end are applied properly
         let res: Vec<KV> =

--- a/packages/storage/src/namespace_helpers.rs
+++ b/packages/storage/src/namespace_helpers.rs
@@ -1,6 +1,6 @@
+use cosmwasm_std::{contract_err, ReadonlyStorage, Result, Storage};
 #[cfg(feature = "iterator")]
 use cosmwasm_std::{Order, KV};
-use cosmwasm_std::{ReadonlyStorage, Result, Storage};
 
 pub(crate) fn get_with_prefix<S: ReadonlyStorage>(
     storage: &S,
@@ -34,6 +34,17 @@ fn concat(namespace: &[u8], key: &[u8]) -> Vec<u8> {
     k
 }
 
+fn trim(namespace: &[u8], key: &[u8]) -> Result<Vec<u8>> {
+    let name_len = namespace.len();
+    if key.len() < name_len {
+        return contract_err("key shorter than namespace");
+    }
+    if &key[..name_len] != namespace {
+        return contract_err("key doesn't begin with namespace");
+    }
+    Ok(key[name_len..].to_vec())
+}
+
 #[cfg(feature = "iterator")]
 pub(crate) fn range_with_prefix<'a, S: ReadonlyStorage>(
     storage: &'a S,
@@ -45,7 +56,6 @@ pub(crate) fn range_with_prefix<'a, S: ReadonlyStorage>(
     // prepare start, end with prefix
     let start = match start {
         Some(s) => concat(namespace, s),
-        // FIXME: performance improvement - without a clone on None??
         None => namespace.to_vec(),
     };
     let end = match end {
@@ -64,8 +74,16 @@ pub(crate) fn range_with_prefix<'a, S: ReadonlyStorage>(
     // get iterator from storage
     let base_iterator = storage.range(Some(&start), Some(&end), order);
 
-    // TODO: map to trim key
-    base_iterator
+    // make a copy for the closure to handle lifetimes safely
+    let prefix = namespace.to_vec();
+    let mapped = base_iterator.map(move |(k, v)| {
+        match trim(&prefix, &k) {
+            Ok(trimmed) => (trimmed, v),
+            // TODO: return result when API updates
+            Err(e) => panic!("{}", e),
+        }
+    });
+    Box::new(mapped)
 }
 
 // Calculates the raw key prefix for a given namespace
@@ -165,7 +183,6 @@ mod test {
         let mut storage = MockStorage::new();
         let prefix = key_prefix(b"foo");
 
-        // we use a block scope here to release the &mut before we use it in the next storage
         set_with_prefix(&mut storage, &prefix, b"bar", b"gotcha").unwrap();
         let rfoo = get_with_prefix(&storage, &prefix, b"bar").unwrap();
         assert_eq!(Some(b"gotcha".to_vec()), rfoo);
@@ -175,4 +192,39 @@ mod test {
         let collision = get_with_prefix(&storage, &other_prefix, b"obar").unwrap();
         assert_eq!(None, collision);
     }
+
+    #[test]
+    #[cfg(feature = "iterator")]
+    fn test_range() {
+        let mut storage = MockStorage::new();
+        let prefix = key_prefix(b"foo");
+        let other_prefix = key_prefix(b"food");
+
+        // set some values in this range
+        set_with_prefix(&mut storage, &prefix, b"bar", b"none");
+        set_with_prefix(&mut storage, &prefix, b"snowy", b"day");
+
+        // set some values outside this range
+        set_with_prefix(&mut storage, &other_prefix, b"moon", b"buggy");
+
+        // ensure we get proper result from prefixed_range iterator
+        let mut iter = range_with_prefix(&storage, &prefix, None, None, Order::Descending);
+        let first = iter.next().unwrap();
+        assert_eq!(first, (b"snowy".to_vec(), b"day".to_vec()));
+        let second = iter.next().unwrap();
+        assert_eq!(second, (b"bar".to_vec(), b"none".to_vec()));
+        assert_eq!(iter.next(), None);
+
+        // ensure we get raw result from base range
+        let iter = storage.range(None, None, Order::Ascending);
+        assert_eq!(3, iter.count());
+
+        // foo comes first
+        let mut iter = storage.range(None, None, Order::Ascending);
+        let first = iter.next().unwrap();
+        let expected_key = concat(&prefix, b"bar");
+        assert_eq!(first, (expected_key, b"none".to_vec()));
+    }
+
+    // TODO: test range with multiple (start, end) pairs
 }

--- a/packages/storage/src/namespace_helpers.rs
+++ b/packages/storage/src/namespace_helpers.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "iterator")]
-use cosmwasm_std::{contract_err, Order, KV};
+use cosmwasm_std::{Order, KV};
 use cosmwasm_std::{ReadonlyStorage, Result, Storage};
 
 pub(crate) fn get_with_prefix<S: ReadonlyStorage>(
@@ -47,27 +47,18 @@ pub(crate) fn range_with_prefix<'a, S: ReadonlyStorage>(
         Some(s) => concat(namespace, s),
         None => namespace.to_vec(),
     };
-    let end_vec = match end {
-        Some(e) => Some(concat(namespace, e)),
+    let end = match end {
+        Some(e) => concat(namespace, e),
         // end is updating last byte by one
         None => namespace_upper_bound(namespace),
     };
 
     // get iterator from storage
-    let base_iterator = match end_vec {
-        Some(v) => storage.range(Some(&start), Some(v.as_slice()), order),
-        None => storage.range(Some(&start), None, order),
-    };
+    let base_iterator = storage.range(Some(&start), Some(&end), order);
 
     // make a copy for the closure to handle lifetimes safely
     let prefix = namespace.to_vec();
-    let mapped = base_iterator.map(move |(k, v)| {
-        match trim(&prefix, &k) {
-            Ok(trimmed) => (trimmed, v),
-            // TODO: return result when API updates
-            Err(e) => panic!("{}", e),
-        }
-    });
+    let mapped = base_iterator.map(move |(k, v)| (trim(&prefix, &k), v));
     Box::new(mapped)
 }
 
@@ -111,39 +102,27 @@ fn key_len(prefix: &[u8]) -> [u8; 2] {
 }
 
 #[cfg(feature = "iterator")]
-fn trim(namespace: &[u8], key: &[u8]) -> Result<Vec<u8>> {
-    let name_len = namespace.len();
-    if key.len() < name_len {
-        return contract_err("key shorter than namespace");
-    }
-    if &key[..name_len] != namespace {
-        return contract_err("key doesn't begin with namespace");
-    }
-    Ok(key[name_len..].to_vec())
+#[inline]
+fn trim(namespace: &[u8], key: &[u8]) -> Vec<u8> {
+    key[namespace.len()..].to_vec()
 }
 
 /// Returns a new vec of same length and last byte incremented by one
 /// If last bytes are 255, we handle overflow up the chain.
-/// If all bytes are 255, then return None
+/// If all bytes are 255, this returns wrong data - but that is never possible as a namespace
 #[cfg(feature = "iterator")]
-fn namespace_upper_bound(input: &[u8]) -> Option<Vec<u8>> {
-    if input.len() == 0 {
-        return None;
-    }
+fn namespace_upper_bound(input: &[u8]) -> Vec<u8> {
     let mut copy = input.to_vec();
     // zero out all trailing 255, increment first that is not such
     for i in (0..input.len()).rev() {
         if copy[i] == 255 {
-            if i == 0 {
-                return None;
-            }
             copy[i] = 0;
         } else {
             copy[i] = copy[i] + 1;
             break;
         }
     }
-    Some(copy)
+    copy
 }
 
 #[cfg(test)]
@@ -314,13 +293,12 @@ mod test {
     #[test]
     #[cfg(feature = "iterator")]
     fn test_namespace_upper_bound() {
-        assert_eq!(namespace_upper_bound(b"bob"), Some(b"boc".to_vec()));
-        assert_eq!(namespace_upper_bound(b"fo\xfe"), Some(b"fo\xff".to_vec()));
-        assert_eq!(namespace_upper_bound(b"fo\xff"), Some(b"fp\x00".to_vec()));
-
-        // make sure wrap over works
-        assert_eq!(namespace_upper_bound(b"\xff"), None);
-        assert_eq!(namespace_upper_bound(b"\xff\xff\xff"), None);
-        assert_eq!(namespace_upper_bound(b""), None);
+        assert_eq!(namespace_upper_bound(b"bob"), b"boc".to_vec());
+        assert_eq!(namespace_upper_bound(b"fo\xfe"), b"fo\xff".to_vec());
+        assert_eq!(namespace_upper_bound(b"fo\xff"), b"fp\x00".to_vec());
+        assert_eq!(
+            namespace_upper_bound(b"fo\xff\xff\xff"),
+            b"fp\x00\x00\x00".to_vec()
+        );
     }
 }

--- a/packages/storage/src/namespace_helpers.rs
+++ b/packages/storage/src/namespace_helpers.rs
@@ -5,9 +5,7 @@ pub(crate) fn get_with_prefix<S: ReadonlyStorage>(
     namespace: &[u8],
     key: &[u8],
 ) -> Result<Option<Vec<u8>>> {
-    let mut k = namespace.to_vec();
-    k.extend_from_slice(key);
-    storage.get(&k)
+    storage.get(&concat(namespace, key))
 }
 
 pub(crate) fn set_with_prefix<S: Storage>(
@@ -16,9 +14,7 @@ pub(crate) fn set_with_prefix<S: Storage>(
     key: &[u8],
     value: &[u8],
 ) -> Result<()> {
-    let mut k = namespace.to_vec();
-    k.extend_from_slice(key);
-    storage.set(&k, value)
+    storage.set(&concat(namespace, key), value)
 }
 
 pub(crate) fn remove_with_prefix<S: Storage>(
@@ -26,9 +22,14 @@ pub(crate) fn remove_with_prefix<S: Storage>(
     namespace: &[u8],
     key: &[u8],
 ) -> Result<()> {
+    storage.remove(&concat(namespace, key))
+}
+
+#[inline]
+pub(crate) fn concat(namespace: &[u8], key: &[u8]) -> Vec<u8> {
     let mut k = namespace.to_vec();
     k.extend_from_slice(key);
-    storage.remove(&k)
+    k
 }
 
 // Calculates the raw key prefix for a given namespace

--- a/packages/storage/src/prefix.rs
+++ b/packages/storage/src/prefix.rs
@@ -1,5 +1,9 @@
+#[cfg(feature = "iterator")]
+use cosmwasm_std::{Order, KV};
 use cosmwasm_std::{ReadonlyStorage, Result, Storage};
 
+#[cfg(feature = "iterator")]
+use crate::namespace_helpers::range_with_prefix;
 use crate::namespace_helpers::{
     get_with_prefix, key_prefix, key_prefix_nested, remove_with_prefix, set_with_prefix,
 };
@@ -44,6 +48,18 @@ impl<'a, T: ReadonlyStorage> ReadonlyStorage for ReadonlyPrefixedStorage<'a, T> 
     fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
         get_with_prefix(self.storage, &self.prefix, key)
     }
+
+    #[cfg(feature = "iterator")]
+    /// range allows iteration over a set of keys, either forwards or backwards
+    /// uses standard rust range notation, and eg db.range(b"foo"..b"bar") also works reverse
+    fn range<'b>(
+        &'b self,
+        start: Option<&[u8]>,
+        end: Option<&[u8]>,
+        order: Order,
+    ) -> Box<dyn Iterator<Item = KV> + 'b> {
+        range_with_prefix(self.storage, &self.prefix, start, end, order)
+    }
 }
 
 pub struct PrefixedStorage<'a, T: Storage> {
@@ -72,6 +88,18 @@ impl<'a, T: Storage> PrefixedStorage<'a, T> {
 impl<'a, T: Storage> ReadonlyStorage for PrefixedStorage<'a, T> {
     fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
         get_with_prefix(self.storage, &self.prefix, key)
+    }
+
+    #[cfg(feature = "iterator")]
+    /// range allows iteration over a set of keys, either forwards or backwards
+    /// uses standard rust range notation, and eg db.range(b"foo"..b"bar") also works reverse
+    fn range<'b>(
+        &'b self,
+        start: Option<&[u8]>,
+        end: Option<&[u8]>,
+        order: Order,
+    ) -> Box<dyn Iterator<Item = KV> + 'b> {
+        range_with_prefix(self.storage, &self.prefix, start, end, order)
     }
 }
 

--- a/packages/storage/src/prefix.rs
+++ b/packages/storage/src/prefix.rs
@@ -51,7 +51,6 @@ impl<'a, T: ReadonlyStorage> ReadonlyStorage for ReadonlyPrefixedStorage<'a, T> 
 
     #[cfg(feature = "iterator")]
     /// range allows iteration over a set of keys, either forwards or backwards
-    /// uses standard rust range notation, and eg db.range(b"foo"..b"bar") also works reverse
     fn range<'b>(
         &'b self,
         start: Option<&[u8]>,

--- a/packages/storage/src/type_helpers.rs
+++ b/packages/storage/src/type_helpers.rs
@@ -1,6 +1,8 @@
 use serde::de::DeserializeOwned;
 use std::any::type_name;
 
+#[cfg(feature = "iterator")]
+use cosmwasm_std::KV;
 use cosmwasm_std::{from_slice, NotFound, Result};
 
 /// may_deserialize parses json bytes from storage (Option), returning Ok(None) if no data present
@@ -23,6 +25,13 @@ pub(crate) fn must_deserialize<T: DeserializeOwned>(value: &Option<Vec<u8>>) -> 
         }
         .fail(),
     }
+}
+
+#[cfg(feature = "iterator")]
+pub(crate) fn deserialize_kv<T: DeserializeOwned>(kv: KV) -> Result<KV<T>> {
+    let (k, v) = kv;
+    let t = from_slice::<T>(&v)?;
+    Ok((k, t))
 }
 
 #[cfg(test)]

--- a/packages/storage/src/typed.rs
+++ b/packages/storage/src/typed.rs
@@ -312,6 +312,7 @@ mod test {
         assert_eq!(data[0], (b"jose".to_vec(), jose.clone()));
         assert_eq!(data[1], (b"maria".to_vec(), maria.clone()));
 
+        // also works for readonly
         let read_bucket = typed_read::<_, Data>(&store);
         let res_data: Result<Vec<KV<Data>>> =
             read_bucket.range(None, None, Order::Ascending).collect();


### PR DESCRIPTION
Builds on #249 
This enables a fully-functional cosmwasm-storage.

Done:
- [x] Update with new returns from #246 
- [x] Add `range` to (`Readonly`)`PrefixedStorage` 
- [x] Test prefix range, including edge cases
- [x] Add typed `range` to (`Readonly`)`TypedStorage` 
- [x] Add typed `range` to (`Readonly`)`Bucket` 