### PR TITLE
Sort compatibility module

### DIFF
--- a/packages/vm/src/compatability.rs
+++ b/packages/vm/src/compatability.rs
@@ -189,8 +189,19 @@ mod test {
         }
     }
 
-    // Note: we don't have test data that includes correct exports but has
-    // additional unsupported required imports. However, Wasmer will check this as well.
+    #[test]
+    fn test_check_wasm_imports_of_old_contract() {
+        let module = deserialize_buffer(CONTRACT_0_7).unwrap();
+        match check_wasm_imports(&module) {
+            Err(Error::ValidationErr { msg, .. }) => {
+                assert!(
+                    msg.starts_with("Wasm contract requires unsupported import: \"env.read_db\"")
+                );
+            }
+            Err(e) => panic!("Unexpected error {:?}", e),
+            Ok(_) => panic!("Didn't reject wasm with invalid api"),
+        }
+    }
 
     #[test]
     fn test_find_missing_export() {

--- a/packages/vm/src/compatability.rs
+++ b/packages/vm/src/compatability.rs
@@ -41,17 +41,22 @@ pub fn check_wasm(wasm_code: &[u8]) -> Result<()> {
             ));
         }
     };
-    check_api_compatibility(&module)
+    check_wasm_exports(&module)?;
+    check_wasm_imports(&module)?;
+    Ok(())
 }
 
-/// This is called as part of check_wasm
-fn check_api_compatibility(module: &Module) -> Result<()> {
+fn check_wasm_exports(module: &Module) -> Result<()> {
     if let Some(missing) = find_missing_export(module, REQUIRED_EXPORTS) {
         return make_validation_err(format!(
                 "Wasm contract doesn't have required export: \"{}\". Exports required by VM: {:?}. Contract version too old for this VM?",
                 missing, REQUIRED_EXPORTS
             ));
     }
+    Ok(())
+}
+
+fn check_wasm_imports(module: &Module) -> Result<()> {
     if let Some(missing) = find_missing_import(module, SUPPORTED_IMPORTS) {
         return make_validation_err(format!(
                 "Wasm contract requires unsupported import: \"{}\". Imports supported by VM: {:?}. Contract version too new for this VM?",

--- a/packages/vm/src/compatability.rs
+++ b/packages/vm/src/compatability.rs
@@ -161,10 +161,10 @@ mod test {
                 i32.const 1
                 i32.add))
         "#;
-
         let wasm_missing_exports = wat2wasm(WAT_MISSING_EXPORTS).unwrap();
 
-        match check_wasm(&wasm_missing_exports) {
+        let module = deserialize_buffer(&wasm_missing_exports).unwrap();
+        match check_wasm_exports(&module) {
             Err(Error::ValidationErr { msg, .. }) => {
                 assert!(msg.starts_with(
                     "Wasm contract doesn't have required export: \"cosmwasm_vm_version_1\""
@@ -177,7 +177,8 @@ mod test {
 
     #[test]
     fn test_check_wasm_exports_of_old_contract() {
-        match check_wasm(CONTRACT_0_7) {
+        let module = deserialize_buffer(CONTRACT_0_7).unwrap();
+        match check_wasm_exports(&module) {
             Err(Error::ValidationErr { msg, .. }) => {
                 assert!(msg.starts_with(
                     "Wasm contract doesn't have required export: \"cosmwasm_vm_version_1\""

--- a/packages/vm/src/compatability.rs
+++ b/packages/vm/src/compatability.rs
@@ -1,4 +1,4 @@
-use parity_wasm::elements::{Deserialize, Module};
+use parity_wasm::elements::{deserialize_buffer, Module};
 
 use crate::errors::{make_validation_err, Result};
 
@@ -31,8 +31,7 @@ static REQUIRED_EXPORTS: &[&str] = &[
 
 /// Checks if the data is valid wasm and compatibility with the CosmWasm API (imports and exports)
 pub fn check_wasm(wasm_code: &[u8]) -> Result<()> {
-    let mut reader = std::io::Cursor::new(wasm_code);
-    let module = match Module::deserialize(&mut reader) {
+    let module = match deserialize_buffer(&wasm_code) {
         Ok(deserialized) => deserialized,
         Err(err) => {
             return make_validation_err(format!(
@@ -194,8 +193,7 @@ mod test {
 
     #[test]
     fn test_find_missing_export() {
-        let mut reader = std::io::Cursor::new(CONTRACT_0_6);
-        let module = Module::deserialize(&mut reader).unwrap();
+        let module = deserialize_buffer(CONTRACT_0_6).unwrap();
 
         // subset okay
         let exports_good = find_missing_export(&module, &["init", "handle", "allocate"]);
@@ -222,8 +220,7 @@ mod test {
 
     #[test]
     fn test_find_missing_import() {
-        let mut reader = std::io::Cursor::new(CONTRACT_0_6);
-        let module = Module::deserialize(&mut reader).unwrap();
+        let module = deserialize_buffer(CONTRACT_0_6).unwrap();
 
         // if contract has more than we provide, bad
         let imports_good = find_missing_import(&module, &["env.c_read", "env.c_write"]);

--- a/packages/vm/src/compatability.rs
+++ b/packages/vm/src/compatability.rs
@@ -115,6 +115,25 @@ mod test {
     }
 
     #[test]
+    fn test_check_wasm_old_contract() {
+        match check_wasm(CONTRACT_0_7) {
+            Err(Error::ValidationErr { msg, .. }) => assert!(msg.starts_with(
+                "Wasm contract doesn't have required export: \"cosmwasm_vm_version_1\""
+            )),
+            Err(e) => panic!("Unexpected error {:?}", e),
+            Ok(_) => panic!("This must not succeeed"),
+        };
+
+        match check_wasm(CONTRACT_0_6) {
+            Err(Error::ValidationErr { msg, .. }) => assert!(msg.starts_with(
+                "Wasm contract doesn't have required export: \"cosmwasm_vm_version_1\""
+            )),
+            Err(e) => panic!("Unexpected error {:?}", e),
+            Ok(_) => panic!("This must not succeeed"),
+        };
+    }
+
+    #[test]
     fn test_check_wasm_corrupted_data() {
         match check_wasm(CORRUPTED) {
             Err(Error::ValidationErr { msg, .. }) => {

--- a/packages/vm/src/errors.rs
+++ b/packages/vm/src/errors.rs
@@ -93,6 +93,10 @@ pub fn make_runtime_err<T>(msg: &'static str) -> Result<T> {
     RuntimeErr { msg }.fail()
 }
 
+pub fn make_validation_err<T>(msg: String) -> Result<T> {
+    ValidationErr { msg }.fail()
+}
+
 pub type Result<T, E = Error> = core::result::Result<T, E>;
 
 pub trait CacheExt<T: Debug> {


### PR DESCRIPTION
With the new layout

```rust
    check_wasm_exports(&module)?;
    check_wasm_imports(&module)?;
    Ok(())
```

we're able to test `check_wasm_exports` and `check_wasm_imports` independently. Before we could not test missing imports because the code always failed at missing exports.

This makes the list of checks easily extensible, required for #81.

This also ensures the order of functions is the same in implementation and tests.