### PR TITLE
Wasm memory validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,8 @@
   standard `Result` types now, eg. `Result<HandleResponse, ApiError>`.
 - Add length limit when reading memory from the instance to protect against
   malicious contracts creating overly large `Region`s.
+- Add `Instance.get_memory_size`, giving you the peak memory consumption of an
+  instance.
 
 ## 0.7.2 (2020-03-23)
 

--- a/contracts/hackatom/schema/handle_msg.json
+++ b/contracts/hackatom/schema/handle_msg.json
@@ -48,6 +48,18 @@
       }
     },
     {
+      "description": "Allocate large amounts of memory without consuming much gas",
+      "type": "object",
+      "required": [
+        "allocate_large_memory"
+      ],
+      "properties": {
+        "allocate_large_memory": {
+          "type": "object"
+        }
+      }
+    },
+    {
       "type": "object",
       "required": [
         "panic"

--- a/contracts/hackatom/schema/handle_msg.json
+++ b/contracts/hackatom/schema/handle_msg.json
@@ -36,6 +36,18 @@
       }
     },
     {
+      "description": "Infinite loop reading and writing memory",
+      "type": "object",
+      "required": [
+        "memory_loop"
+      ],
+      "properties": {
+        "memory_loop": {
+          "type": "object"
+        }
+      }
+    },
+    {
       "type": "object",
       "required": [
         "panic"

--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -140,14 +140,8 @@ fn do_storage_loop<S: Storage, A: Api, Q: Querier>(
 fn do_memory_loop() -> Result<HandleResponse> {
     let mut data = vec![1usize];
     loop {
-        // increase by one element
-        data.push(*data.last().expect("must not be empty"));
-
-        // Override all entries
-        let value = data.len();
-        let _overrides = data.iter_mut().map(|x| *x = value).count();
-
-        println!("{:?}", data);
+        // add one element
+        data.push((*data.last().expect("must not be empty")) + 1);
     }
 }
 

--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -32,6 +32,8 @@ pub enum HandleMsg {
     CpuLoop {},
     // Infinite loop making storage calls (to test when their limit hits)
     StorageLoop {},
+    /// Infinite loop reading and writing memory
+    MemoryLoop {},
     // Trigger a panic to ensure framework handles gracefully
     Panic {},
 }
@@ -78,6 +80,7 @@ pub fn handle<S: Storage, A: Api, Q: Querier>(
         HandleMsg::Release {} => do_release(deps, env),
         HandleMsg::CpuLoop {} => do_cpu_loop(),
         HandleMsg::StorageLoop {} => do_storage_loop(deps),
+        HandleMsg::MemoryLoop {} => do_memory_loop(),
         HandleMsg::Panic {} => do_panic(),
     }
 }
@@ -131,6 +134,20 @@ fn do_storage_loop<S: Storage, A: Api, Q: Querier>(
         deps.storage
             .set(b"test.key", test_case.to_string().as_bytes())?;
         test_case += 1;
+    }
+}
+
+fn do_memory_loop() -> Result<HandleResponse> {
+    let mut data = vec![1usize];
+    loop {
+        // increase by one element
+        data.push(*data.last().expect("must not be empty"));
+
+        // Override all entries
+        let value = data.len();
+        let _overrides = data.iter_mut().map(|x| *x = value).count();
+
+        println!("{:?}", data);
     }
 }
 

--- a/contracts/hackatom/tests/integration.rs
+++ b/contracts/hackatom/tests/integration.rs
@@ -241,7 +241,6 @@ mod singlepass_tests {
 
     use cosmwasm_std::to_vec;
     use cosmwasm_vm::call_handle;
-    use cosmwasm_vm::testing::mock_instance_with_gas_limit;
 
     fn make_init_msg() -> (InitMsg, HumanAddr) {
         let verifier = HumanAddr::from("verifies");
@@ -278,8 +277,7 @@ mod singlepass_tests {
 
     #[test]
     fn handle_cpu_loop() {
-        // Gas must be set so we die early on infinite loop
-        let mut deps = mock_instance_with_gas_limit(WASM, &[], 1_000_000);
+        let mut deps = mock_instance(WASM);
 
         let (init_msg, creator) = make_init_msg();
         let init_env = mock_env(&deps.api, creator.as_str(), &[], &[]);
@@ -299,8 +297,7 @@ mod singlepass_tests {
 
     #[test]
     fn handle_storage_loop() {
-        // Gas must be set so we die early on infinite loop
-        let mut deps = mock_instance_with_gas_limit(WASM, &[], 1_000_000);
+        let mut deps = mock_instance(WASM);
 
         let (init_msg, creator) = make_init_msg();
         let init_env = mock_env(&deps.api, creator.as_str(), &[], &[]);
@@ -320,8 +317,7 @@ mod singlepass_tests {
 
     #[test]
     fn handle_memory_loop() {
-        // Gas must be set so we die early on infinite loop
-        let mut deps = mock_instance_with_gas_limit(WASM, &[], 1_000_000);
+        let mut deps = mock_instance(WASM);
 
         let (init_msg, creator) = make_init_msg();
         let init_env = mock_env(&deps.api, creator.as_str(), &[], &[]);

--- a/contracts/hackatom/tests/integration.rs
+++ b/contracts/hackatom/tests/integration.rs
@@ -361,7 +361,10 @@ mod singlepass_tests {
         assert_eq!(handle_res.is_err(), false);
 
         // Gas consumtion is relatively small
-        assert_eq!(gas_used, 28880);
+        // Note: the exact gas usage depends on the Rust version used to compile WASM,
+        // which we only fix when using cosmwasm-opt, not integration tests.
+        assert!(gas_used > 28000);
+        assert!(gas_used < 32000);
 
         // Used between 100 and 102 MiB of memory
         assert!(deps.get_memory_size() > 100 * 1024 * 1024);

--- a/contracts/hackatom/tests/integration.rs
+++ b/contracts/hackatom/tests/integration.rs
@@ -243,29 +243,29 @@ mod singlepass_tests {
     use cosmwasm_vm::call_handle;
     use cosmwasm_vm::testing::mock_instance_with_gas_limit;
 
+    fn make_init_msg() -> (InitMsg, HumanAddr) {
+        let verifier = HumanAddr::from("verifies");
+        let beneficiary = HumanAddr::from("benefits");
+        let creator = HumanAddr::from("creator");
+        (
+            InitMsg {
+                verifier: verifier.clone(),
+                beneficiary: beneficiary.clone(),
+            },
+            creator,
+        )
+    }
+
     #[test]
     fn handle_panic() {
         let mut deps = mock_instance(WASM);
 
-        // initialize the store
-        let verifier = HumanAddr(String::from("verifies"));
-        let beneficiary = HumanAddr(String::from("benefits"));
-        let creator = HumanAddr(String::from("creator"));
-
-        let init_msg = InitMsg {
-            verifier: verifier.clone(),
-            beneficiary: beneficiary.clone(),
-        };
-        let init_env = mock_env(
-            &deps.api,
-            creator.as_str(),
-            &coins(1000, "earth"),
-            &coins(1000, "earth"),
-        );
+        let (init_msg, creator) = make_init_msg();
+        let init_env = mock_env(&deps.api, creator.as_str(), &[], &[]);
         let init_res = init(&mut deps, init_env, init_msg).unwrap();
         assert_eq!(0, init_res.messages.len());
 
-        let handle_env = mock_env(&deps.api, beneficiary.as_str(), &[], &coins(1000, "earth"));
+        let handle_env = mock_env(&deps.api, creator.as_str(), &[], &[]);
         // panic inside contract should not panic out here
         // Note: we need to use the production-call, not the testing call (which unwraps any vm error)
         let handle_res = call_handle(
@@ -281,25 +281,12 @@ mod singlepass_tests {
         // Gas must be set so we die early on infinite loop
         let mut deps = mock_instance_with_gas_limit(WASM, &[], 1_000_000);
 
-        // initialize the store
-        let verifier = HumanAddr(String::from("verifies"));
-        let beneficiary = HumanAddr(String::from("benefits"));
-        let creator = HumanAddr(String::from("creator"));
-
-        let init_msg = InitMsg {
-            verifier: verifier.clone(),
-            beneficiary: beneficiary.clone(),
-        };
-        let init_env = mock_env(
-            &deps.api,
-            creator.as_str(),
-            &coins(1000, "earth"),
-            &coins(1000, "earth"),
-        );
+        let (init_msg, creator) = make_init_msg();
+        let init_env = mock_env(&deps.api, creator.as_str(), &[], &[]);
         let init_res = init(&mut deps, init_env, init_msg).unwrap();
         assert_eq!(0, init_res.messages.len());
 
-        let handle_env = mock_env(&deps.api, beneficiary.as_str(), &[], &coins(1000, "earth"));
+        let handle_env = mock_env(&deps.api, creator.as_str(), &[], &[]);
         // Note: we need to use the production-call, not the testing call (which unwraps any vm error)
         let handle_res = call_handle(
             &mut deps,
@@ -315,25 +302,12 @@ mod singlepass_tests {
         // Gas must be set so we die early on infinite loop
         let mut deps = mock_instance_with_gas_limit(WASM, &[], 1_000_000);
 
-        // initialize the store
-        let verifier = HumanAddr(String::from("verifies"));
-        let beneficiary = HumanAddr(String::from("benefits"));
-        let creator = HumanAddr(String::from("creator"));
-
-        let init_msg = InitMsg {
-            verifier: verifier.clone(),
-            beneficiary: beneficiary.clone(),
-        };
-        let init_env = mock_env(
-            &deps.api,
-            creator.as_str(),
-            &coins(1000, "earth"),
-            &coins(1000, "earth"),
-        );
+        let (init_msg, creator) = make_init_msg();
+        let init_env = mock_env(&deps.api, creator.as_str(), &[], &[]);
         let init_res = init(&mut deps, init_env, init_msg).unwrap();
         assert_eq!(0, init_res.messages.len());
 
-        let handle_env = mock_env(&deps.api, beneficiary.as_str(), &[], &coins(1000, "earth"));
+        let handle_env = mock_env(&deps.api, creator.as_str(), &[], &[]);
         // Note: we need to use the production-call, not the testing call (which unwraps any vm error)
         let handle_res = call_handle(
             &mut deps,

--- a/contracts/hackatom/tests/integration.rs
+++ b/contracts/hackatom/tests/integration.rs
@@ -333,5 +333,8 @@ mod singlepass_tests {
         );
         assert!(handle_res.is_err());
         assert_eq!(deps.get_gas(), 0);
+
+        // Ran out of gas before consuming a significant amount of memory
+        assert!(deps.get_memory_size() < 2 * 1024 * 1024);
     }
 }

--- a/contracts/hackatom/tests/integration.rs
+++ b/contracts/hackatom/tests/integration.rs
@@ -361,7 +361,7 @@ mod singlepass_tests {
         assert_eq!(handle_res.is_err(), false);
 
         // Gas consumtion is relatively small
-        assert_eq!(gas_used, 28866);
+        assert_eq!(gas_used, 28880);
 
         // Used between 100 and 102 MiB of memory
         assert!(deps.get_memory_size() > 100 * 1024 * 1024);

--- a/packages/vm/src/compatability.rs
+++ b/packages/vm/src/compatability.rs
@@ -220,6 +220,27 @@ mod test {
     }
 
     #[test]
+    fn test_check_wasm_memories_zero_memories() {
+        // Generated manually because wat2wasm would not create an empty memory section
+        let wasm = hex::decode(concat!(
+            "0061736d", // magic bytes
+            "01000000", // binary version (uint32)
+            "05",       // section type (memory)
+            "01",       // section length
+            "00",       // number of memories
+        ))
+        .unwrap();
+
+        match check_wasm_memories(&deserialize_buffer(&wasm).unwrap()) {
+            Err(Error::ValidationErr { msg, .. }) => {
+                assert!(msg.starts_with("Wasm contract must contain exactly one memory"));
+            }
+            Err(e) => panic!("Unexpected error {:?}", e),
+            Ok(_) => panic!("Didn't reject wasm with invalid api"),
+        }
+    }
+
+    #[test]
     fn test_check_wasm_memories_initial_size() {
         let wasm_ok = wat2wasm("(module (memory 512))").unwrap();
         check_wasm_memories(&deserialize_buffer(&wasm_ok).unwrap()).unwrap();

--- a/packages/vm/src/compatability.rs
+++ b/packages/vm/src/compatability.rs
@@ -61,23 +61,22 @@ fn check_wasm_memories(module: &Module) -> Result<()> {
         return make_validation_err("Wasm contract must contain exactly one memory".to_string());
     }
 
-    for memory in memories {
-        // println!("Memory: {:?}", memory);
-        let limits = memory.limits();
+    let memory = memories[0];
+    // println!("Memory: {:?}", memory);
+    let limits = memory.limits();
 
-        if limits.initial() > MEMORY_LIMIT {
-            return make_validation_err(format!(
-                "Wasm contract memory's minimum must not exceed {} pages.",
-                MEMORY_LIMIT
-            ));
-        }
+    if limits.initial() > MEMORY_LIMIT {
+        return make_validation_err(format!(
+            "Wasm contract memory's minimum must not exceed {} pages.",
+            MEMORY_LIMIT
+        ));
+    }
 
-        if limits.maximum() != None {
-            return make_validation_err(
-                "Wasm contract memory's maximum must be unset. The host will set it for you."
-                    .to_string(),
-            );
-        }
+    if limits.maximum() != None {
+        return make_validation_err(
+            "Wasm contract memory's maximum must be unset. The host will set it for you."
+                .to_string(),
+        );
     }
     Ok(())
 }

--- a/packages/vm/src/memory.rs
+++ b/packages/vm/src/memory.rs
@@ -26,6 +26,38 @@ struct Region {
 
 unsafe impl ValueType for Region {}
 
+/// A Wasm memory descriptor
+#[derive(Debug, Clone)]
+pub struct MemoryDescriptor {
+    /// The minimum number of allowed pages
+    pub minimum: u32,
+    /// The maximum number of allowed pages
+    pub maximum: Option<u32>,
+    /// This memory can be shared between Wasm threads
+    pub shared: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct MemoryInfo {
+    pub descriptor: MemoryDescriptor,
+    /// Current memory size in pages
+    pub size: u32,
+}
+
+/// Get information about the default memory `memory(0)`
+pub fn get_memory_info(ctx: &Ctx) -> MemoryInfo {
+    let memory = ctx.memory(0);
+    let descriptor = memory.descriptor();
+    MemoryInfo {
+        descriptor: MemoryDescriptor {
+            minimum: descriptor.minimum.0,
+            maximum: descriptor.maximum.map(|pages| pages.0),
+            shared: descriptor.shared,
+        },
+        size: memory.size().0,
+    }
+}
+
 /// Expects a (fixed size) Region struct at ptr, which is read. This links to the
 /// memory region, which is copied in the second step.
 /// Errors if the length of the region exceeds `max_length`.


### PR DESCRIPTION
First step of #81

Based on ~#261~ ~#264~

This adds inital checks on the Wasm memory section, to prove that we have access to all the relevant inforrmation.

- [x] Add memory checks to incoming Wasm
- [x] Test `check_wasm_memories`
- [ ] Override `memory(0).maximum` in VM
- [x] Add OOM crash test to hackatom