### PR TITLE
Add wallet type

### DIFF
--- a/packages/std/schema/handle_result.json
+++ b/packages/std/schema/handle_result.json
@@ -165,6 +165,44 @@
         {
           "type": "object",
           "required": [
+            "Unauthorized"
+          ],
+          "properties": {
+            "Unauthorized": {
+              "type": "object"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "Underflow"
+          ],
+          "properties": {
+            "Underflow": {
+              "type": "object",
+              "required": [
+                "minuend",
+                "subtrahend"
+              ],
+              "properties": {
+                "minuend": {
+                  "type": "integer",
+                  "format": "uint128",
+                  "minimum": 0.0
+                },
+                "subtrahend": {
+                  "type": "integer",
+                  "format": "uint128",
+                  "minimum": 0.0
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
             "Utf8Err"
           ],
           "properties": {
@@ -197,17 +235,6 @@
                   "type": "string"
                 }
               }
-            }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
-            "Unauthorized"
-          ],
-          "properties": {
-            "Unauthorized": {
-              "type": "object"
             }
           }
         },

--- a/packages/std/schema/init_result.json
+++ b/packages/std/schema/init_result.json
@@ -165,6 +165,44 @@
         {
           "type": "object",
           "required": [
+            "Unauthorized"
+          ],
+          "properties": {
+            "Unauthorized": {
+              "type": "object"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "Underflow"
+          ],
+          "properties": {
+            "Underflow": {
+              "type": "object",
+              "required": [
+                "minuend",
+                "subtrahend"
+              ],
+              "properties": {
+                "minuend": {
+                  "type": "integer",
+                  "format": "uint128",
+                  "minimum": 0.0
+                },
+                "subtrahend": {
+                  "type": "integer",
+                  "format": "uint128",
+                  "minimum": 0.0
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
             "Utf8Err"
           ],
           "properties": {
@@ -197,17 +235,6 @@
                   "type": "string"
                 }
               }
-            }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
-            "Unauthorized"
-          ],
-          "properties": {
-            "Unauthorized": {
-              "type": "object"
             }
           }
         },

--- a/packages/std/schema/query_result.json
+++ b/packages/std/schema/query_result.json
@@ -165,6 +165,44 @@
         {
           "type": "object",
           "required": [
+            "Unauthorized"
+          ],
+          "properties": {
+            "Unauthorized": {
+              "type": "object"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "Underflow"
+          ],
+          "properties": {
+            "Underflow": {
+              "type": "object",
+              "required": [
+                "minuend",
+                "subtrahend"
+              ],
+              "properties": {
+                "minuend": {
+                  "type": "integer",
+                  "format": "uint128",
+                  "minimum": 0.0
+                },
+                "subtrahend": {
+                  "type": "integer",
+                  "format": "uint128",
+                  "minimum": 0.0
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
             "Utf8Err"
           ],
           "properties": {
@@ -197,17 +235,6 @@
                   "type": "string"
                 }
               }
-            }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
-            "Unauthorized"
-          ],
-          "properties": {
-            "Unauthorized": {
-              "type": "object"
             }
           }
         },

--- a/packages/std/src/api.rs
+++ b/packages/std/src/api.rs
@@ -50,11 +50,12 @@ pub enum ApiError {
     NullPointer {},
     ParseErr { kind: String, source: String },
     SerializeErr { kind: String, source: String },
+    Unauthorized {},
+    Underflow { minuend: u128, subtrahend: u128 },
     // This is used for std::str::from_utf8, which we may well deprecate
     Utf8Err { source: String },
     // This is used for String::from_utf8, which does zero-copy from Vec<u8>, moving towards this
     Utf8StringErr { source: String },
-    Unauthorized {},
     ValidationErr { field: String, msg: String },
 }
 
@@ -72,9 +73,13 @@ impl std::fmt::Display for ApiError {
             ApiError::SerializeErr { kind, source } => {
                 write!(f, "Error serializing {}: {}", kind, source)
             }
+            ApiError::Unauthorized {} => write!(f, "Unauthorized"),
+            ApiError::Underflow {
+                minuend,
+                subtrahend,
+            } => write!(f, "Cannot subtract {} from {}", subtrahend, minuend),
             ApiError::Utf8Err { source } => write!(f, "UTF8 encoding error: {}", source),
             ApiError::Utf8StringErr { source } => write!(f, "UTF8 encoding error: {}", source),
-            ApiError::Unauthorized {} => write!(f, "Unauthorized"),
             ApiError::ValidationErr { field, msg } => write!(f, "Invalid {}: {}", field, msg),
         }
     }
@@ -102,13 +107,21 @@ impl From<Error> for ApiError {
                 kind: kind.to_string(),
                 source: format!("{}", source),
             },
+            Error::Unauthorized { .. } => ApiError::Unauthorized {},
+            Error::Underflow {
+                minuend,
+                subtrahend,
+                ..
+            } => ApiError::Underflow {
+                minuend,
+                subtrahend,
+            },
             Error::Utf8Err { source, .. } => ApiError::Utf8Err {
                 source: format!("{}", source),
             },
             Error::Utf8StringErr { source, .. } => ApiError::Utf8StringErr {
                 source: format!("{}", source),
             },
-            Error::Unauthorized { .. } => ApiError::Unauthorized {},
             Error::ValidationErr { field, msg, .. } => ApiError::ValidationErr {
                 field: field.to_string(),
                 msg: msg.to_string(),

--- a/packages/std/src/coins.rs
+++ b/packages/std/src/coins.rs
@@ -32,11 +32,7 @@ pub fn coin(amount: u128, denom: &str) -> Coin {
 
 // Wallet wraps Vec<Coin> and provides some nice helpers. It mutates the Vec and can be
 // unwrapped when done.
-//
-// This is meant to be used for calculations and not serialized.
-// (Note: we can add derives if we want to include this in serialization
-// but then we have to think about normalization a bit more)
-#[derive(Clone, Default, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq, JsonSchema)]
 pub struct Wallet(pub Vec<Coin>);
 
 impl Wallet {
@@ -243,13 +239,13 @@ impl<'de> Deserialize<'de> for Uint128 {
     where
         D: Deserializer<'de>,
     {
-        deserializer.deserialize_str(BigIntVisitor)
+        deserializer.deserialize_str(Uint128Visitor)
     }
 }
 
-struct BigIntVisitor;
+struct Uint128Visitor;
 
-impl<'de> de::Visitor<'de> for BigIntVisitor {
+impl<'de> de::Visitor<'de> for Uint128Visitor {
     type Value = Uint128;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/packages/std/src/coins.rs
+++ b/packages/std/src/coins.rs
@@ -53,15 +53,12 @@ impl Wallet {
     }
 
     /// normalize Wallet (sorted by denom, no 0 elements, no duplicate denoms)
-    pub fn normalize(self) -> Self {
-        let mut cleaned: Vec<Coin> = self
-            .0
-            .into_iter()
-            .filter(|c| c.amount.u128() != 0)
-            .collect();
-        cleaned.sort_unstable_by(|a, b| a.denom.cmp(&b.denom));
-        // TODO: join together multiple of same denom
-        Wallet(cleaned)
+    pub fn normalize(&mut self) {
+        // drop 0's
+        self.0.retain(|c| c.amount.u128() != 0);
+        // sort
+        self.0.sort_unstable_by(|a, b| a.denom.cmp(&b.denom));
+        // merge duplicates (now neighbors)
     }
 
     fn find(&self, denom: &str) -> Option<(usize, &Coin)> {
@@ -289,8 +286,9 @@ mod test {
 
     #[test]
     fn normalize_wallet() {
-        let sorted = Wallet(vec![coin(123, "ETH"), coin(0, "BTC"), coin(8990, "ATOM")]).normalize();
-        assert_eq!(sorted, Wallet(vec![coin(8990, "ATOM"), coin(123, "ETH")]));
+        let mut wallet = Wallet(vec![coin(123, "ETH"), coin(0, "BTC"), coin(8990, "ATOM")]);
+        wallet.normalize();
+        assert_eq!(wallet, Wallet(vec![coin(8990, "ATOM"), coin(123, "ETH")]));
 
         // TODO: handle duplicate entries of same denom
     }

--- a/packages/std/src/errors.rs
+++ b/packages/std/src/errors.rs
@@ -40,6 +40,14 @@ pub enum Error {
         source: serde_json_wasm::ser::Error,
         backtrace: snafu::Backtrace,
     },
+    #[snafu(display("Unauthorized"))]
+    Unauthorized { backtrace: snafu::Backtrace },
+    #[snafu(display("Cannot subtract {} from {}", subtrahend, minuend))]
+    Underflow {
+        minuend: u128,
+        subtrahend: u128,
+        backtrace: snafu::Backtrace,
+    },
     // This is used for std::str::from_utf8, which we may well deprecate
     #[snafu(display("UTF8 encoding error: {}", source))]
     Utf8Err {
@@ -52,8 +60,6 @@ pub enum Error {
         source: std::string::FromUtf8Error,
         backtrace: snafu::Backtrace,
     },
-    #[snafu(display("Unauthorized"))]
-    Unauthorized { backtrace: snafu::Backtrace },
     #[snafu(display("Invalid {}: {}", field, msg))]
     ValidationErr {
         field: &'static str,
@@ -103,6 +109,14 @@ pub fn dyn_contract_err<T>(msg: String) -> Result<T> {
 
 pub fn unauthorized<T>() -> Result<T> {
     Unauthorized {}.fail()
+}
+
+pub fn underflow<T>(minuend: u128, subtrahend: u128) -> Result<T> {
+    Underflow {
+        minuend,
+        subtrahend,
+    }
+    .fail()
 }
 
 #[cfg(test)]

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -16,8 +16,8 @@ pub use crate::api::{ApiError, ApiResult, ApiSystemError};
 pub use crate::coins::{coin, coins, Coin, Uint128, Wallet};
 pub use crate::encoding::Binary;
 pub use crate::errors::{
-    contract_err, dyn_contract_err, invalid, unauthorized, Error, InvalidRequest, NotFound,
-    NullPointer, ParseErr, Result, SerializeErr,
+    contract_err, dyn_contract_err, invalid, unauthorized, underflow, Error, InvalidRequest,
+    NotFound, NullPointer, ParseErr, Result, SerializeErr,
 };
 pub use crate::init_handle::{
     log, CosmosMsg, HandleResponse, HandleResult, InitResponse, InitResult, LogAttribute,

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -13,7 +13,7 @@ mod transactions;
 mod types;
 
 pub use crate::api::{ApiError, ApiResult, ApiSystemError};
-pub use crate::coins::{coin, coins, has_coins, Coin, Uint128};
+pub use crate::coins::{coin, coins, Coin, Uint128, Wallet};
 pub use crate::encoding::Binary;
 pub use crate::errors::{
     contract_err, dyn_contract_err, invalid, unauthorized, Error, InvalidRequest, NotFound,


### PR DESCRIPTION
Follow-up functionality after #260 

Adds a `Wallet` newtype wrapper around `Vec<Coin>` that exposes some helpful methods to add and remove tokens from a wallet, and compare amounts. This also updates `Uint128.sub()` to return an error result on underflow (with decent message) rather than relying on compiler-enforced panic.
