### PR TITLE
Range improvements; let range return Result

### DIFF
--- a/contracts/queue/src/contract.rs
+++ b/contracts/queue/src/contract.rs
@@ -82,7 +82,7 @@ fn enqueue<S: Storage, A: Api, Q: Querier>(
     // find the last element in the queue and extract key
     let last_key = deps
         .storage
-        .range(None, None, Order::Descending)
+        .range(None, None, Order::Descending)?
         .next()
         .map(|(k, _)| k);
 
@@ -102,7 +102,7 @@ fn dequeue<S: Storage, A: Api, Q: Querier>(
     _env: Env,
 ) -> Result<HandleResponse> {
     // find the first element in the queue and extract value
-    let first = deps.storage.range(None, None, Order::Ascending).next();
+    let first = deps.storage.range(None, None, Order::Ascending)?.next();
 
     let mut res = HandleResponse::default();
     if let Some((k, v)) = first {
@@ -127,14 +127,14 @@ pub fn query<S: Storage, A: Api, Q: Querier>(
 }
 
 fn query_count<S: Storage, A: Api, Q: Querier>(deps: &Extern<S, A, Q>) -> Result<QueryResponse> {
-    let count = deps.storage.range(None, None, Order::Ascending).count() as u32;
+    let count = deps.storage.range(None, None, Order::Ascending)?.count() as u32;
     Ok(Binary(to_vec(&CountResponse { count })?))
 }
 
 fn query_sum<S: Storage, A: Api, Q: Querier>(deps: &Extern<S, A, Q>) -> Result<QueryResponse> {
     let values: Result<Vec<Item>> = deps
         .storage
-        .range(None, None, Order::Ascending)
+        .range(None, None, Order::Ascending)?
         .map(|(_, v)| from_slice(&v))
         .collect();
     let sum = values?.iter().fold(0, |s, v| s + v.value);
@@ -146,7 +146,7 @@ fn query_reducer<S: Storage, A: Api, Q: Querier>(deps: &Extern<S, A, Q>) -> Resu
     // val: Result<Item>
     for val in deps
         .storage
-        .range(None, None, Order::Ascending)
+        .range(None, None, Order::Ascending)?
         .map(|(_, v)| from_slice::<Item>(&v))
     {
         // this returns error on parse error
@@ -154,7 +154,7 @@ fn query_reducer<S: Storage, A: Api, Q: Querier>(deps: &Extern<S, A, Q>) -> Resu
         // now, let's do second iterator
         let sum: i32 = deps
             .storage
-            .range(None, None, Order::Ascending)
+            .range(None, None, Order::Ascending)?
             // get value. ignore parse errors, just count as 0
             .map(|(_, v)| from_slice::<Item>(&v).map(|v| v.value).unwrap_or(0))
             .filter(|v| *v > my_val)

--- a/packages/std/src/imports.rs
+++ b/packages/std/src/imports.rs
@@ -91,7 +91,7 @@ impl ReadonlyStorage for ExternalStorage {
         start: Option<&[u8]>,
         end: Option<&[u8]>,
         order: Order,
-    ) -> Box<dyn Iterator<Item = KV>> {
+    ) -> Result<Box<dyn Iterator<Item = KV>>> {
         // start and end (Regions) must remain in scope as long as the start_ptr / end_ptr do
         // thus they are not inside a block
         let start = start.map(|s| build_region(s));
@@ -106,14 +106,17 @@ impl ReadonlyStorage for ExternalStorage {
         };
         let order = order as i32;
 
-        let iterator_id = unsafe { db_scan(start_ptr, end_ptr, order) };
-        if iterator_id < 0 {
-            panic!(format!("Error creating iterator: {}", iterator_id));
+        let scan_result = unsafe { db_scan(start_ptr, end_ptr, order) };
+        if scan_result < 0 {
+            return dyn_contract_err(format!(
+                "Error creating iterator (via db_scan). Error code: {}",
+                scan_result
+            ));
         }
         let iter = ExternalIterator {
-            iterator_id: iterator_id as u32, // Cast is safe since we tested for negative values above
+            iterator_id: scan_result as u32, // Cast is safe since we tested for negative values above
         };
-        Box::new(iter)
+        Ok(Box::new(iter))
     }
 }
 

--- a/packages/std/src/storage.rs
+++ b/packages/std/src/storage.rs
@@ -107,6 +107,12 @@ mod test {
             let mut iter = store.range(None, None, Order::Ascending);
             let first = iter.next().unwrap();
             assert_eq!((b"ant".to_vec(), b"hill".to_vec()), first);
+        }
+
+        // open ended range (descending)
+        {
+            let iter = store.range(None, None, Order::Descending);
+            assert_eq!(3, iter.count());
             let mut iter = store.range(None, None, Order::Descending);
             let last = iter.next().unwrap();
             assert_eq!((b"ze".to_vec(), b"bra".to_vec()), last);
@@ -121,7 +127,7 @@ mod test {
             assert_eq!((b"foo".to_vec(), b"bar".to_vec()), first);
         }
 
-        // closed range reverse
+        // closed range (descending)
         {
             let iter = store.range(Some(b"air"), Some(b"loop"), Order::Descending);
             assert_eq!(2, iter.count());
@@ -141,7 +147,7 @@ mod test {
             assert_eq!((b"foo".to_vec(), b"bar".to_vec()), first);
         }
 
-        // end open iterator reverse
+        // end open iterator (descending)
         {
             let iter = store.range(Some(b"f"), None, Order::Descending);
             assert_eq!(2, iter.count());
@@ -159,7 +165,7 @@ mod test {
             assert_eq!((b"ant".to_vec(), b"hill".to_vec()), first);
         }
 
-        // start open iterator
+        // start open iterator (descending)
         {
             let iter = store.range(None, Some(b"no"), Order::Descending);
             assert_eq!(2, iter.count());

--- a/packages/std/src/storage.rs
+++ b/packages/std/src/storage.rs
@@ -33,25 +33,25 @@ impl ReadonlyStorage for MemoryStorage {
         start: Option<&[u8]>,
         end: Option<&[u8]>,
         order: Order,
-    ) -> Box<dyn Iterator<Item = KV> + 'a> {
+    ) -> Result<Box<dyn Iterator<Item = KV> + 'a>> {
         let bounds = range_bounds(start, end);
 
         // BTreeMap.range panics if range is start > end.
         // However, this cases represent just empty range and we treat it as such.
         match (bounds.start_bound(), bounds.end_bound()) {
             (Bound::Included(start), Bound::Excluded(end)) if start > end => {
-                return Box::new(IterVec {
+                return Ok(Box::new(IterVec {
                     iter: iter::empty(),
-                });
+                }));
             }
             _ => {}
         }
 
         let iter = self.data.range(bounds);
-        match order {
+        Ok(match order {
             Order::Ascending => Box::new(IterVec { iter }),
             Order::Descending => Box::new(IterVec { iter: iter.rev() }),
-        }
+        })
     }
 }
 
@@ -104,7 +104,10 @@ mod test {
     fn iterator_test_suite<S: Storage>(store: &mut S) {
         // ensure we had previously set "foo" = "bar"
         assert_eq!(store.get(b"foo").unwrap(), Some(b"bar".to_vec()));
-        assert_eq!(store.range(None, None, Order::Ascending).count(), 1);
+        assert_eq!(
+            store.range(None, None, Order::Ascending).unwrap().count(),
+            1
+        );
 
         // setup - add some data, and delete part of it as well
         store.set(b"ant", b"hill").expect("error setting value");
@@ -116,7 +119,7 @@ mod test {
 
         // unbounded
         {
-            let iter = store.range(None, None, Order::Ascending);
+            let iter = store.range(None, None, Order::Ascending).unwrap();
             let elements: Vec<KV> = iter.collect();
             assert_eq!(
                 elements,
@@ -130,7 +133,7 @@ mod test {
 
         // unbounded (descending)
         {
-            let iter = store.range(None, None, Order::Descending);
+            let iter = store.range(None, None, Order::Descending).unwrap();
             let elements: Vec<KV> = iter.collect();
             assert_eq!(
                 elements,
@@ -144,14 +147,18 @@ mod test {
 
         // bounded
         {
-            let iter = store.range(Some(b"f"), Some(b"n"), Order::Ascending);
+            let iter = store
+                .range(Some(b"f"), Some(b"n"), Order::Ascending)
+                .unwrap();
             let elements: Vec<KV> = iter.collect();
             assert_eq!(elements, vec![(b"foo".to_vec(), b"bar".to_vec())]);
         }
 
         // bounded (descending)
         {
-            let iter = store.range(Some(b"air"), Some(b"loop"), Order::Descending);
+            let iter = store
+                .range(Some(b"air"), Some(b"loop"), Order::Descending)
+                .unwrap();
             let elements: Vec<KV> = iter.collect();
             assert_eq!(
                 elements,
@@ -164,35 +171,43 @@ mod test {
 
         // bounded empty [a, a)
         {
-            let iter = store.range(Some(b"foo"), Some(b"foo"), Order::Ascending);
+            let iter = store
+                .range(Some(b"foo"), Some(b"foo"), Order::Ascending)
+                .unwrap();
             let elements: Vec<KV> = iter.collect();
             assert_eq!(elements, vec![]);
         }
 
         // bounded empty [a, a) (descending)
         {
-            let iter = store.range(Some(b"foo"), Some(b"foo"), Order::Descending);
+            let iter = store
+                .range(Some(b"foo"), Some(b"foo"), Order::Descending)
+                .unwrap();
             let elements: Vec<KV> = iter.collect();
             assert_eq!(elements, vec![]);
         }
 
         // bounded empty [a, b) with b < a
         {
-            let iter = store.range(Some(b"z"), Some(b"a"), Order::Ascending);
+            let iter = store
+                .range(Some(b"z"), Some(b"a"), Order::Ascending)
+                .unwrap();
             let elements: Vec<KV> = iter.collect();
             assert_eq!(elements, vec![]);
         }
 
         // bounded empty [a, b) with b < a (descending)
         {
-            let iter = store.range(Some(b"z"), Some(b"a"), Order::Descending);
+            let iter = store
+                .range(Some(b"z"), Some(b"a"), Order::Descending)
+                .unwrap();
             let elements: Vec<KV> = iter.collect();
             assert_eq!(elements, vec![]);
         }
 
         // right unbounded
         {
-            let iter = store.range(Some(b"f"), None, Order::Ascending);
+            let iter = store.range(Some(b"f"), None, Order::Ascending).unwrap();
             let elements: Vec<KV> = iter.collect();
             assert_eq!(
                 elements,
@@ -205,7 +220,7 @@ mod test {
 
         // right unbounded (descending)
         {
-            let iter = store.range(Some(b"f"), None, Order::Descending);
+            let iter = store.range(Some(b"f"), None, Order::Descending).unwrap();
             let elements: Vec<KV> = iter.collect();
             assert_eq!(
                 elements,
@@ -218,14 +233,14 @@ mod test {
 
         // left unbounded
         {
-            let iter = store.range(None, Some(b"f"), Order::Ascending);
+            let iter = store.range(None, Some(b"f"), Order::Ascending).unwrap();
             let elements: Vec<KV> = iter.collect();
             assert_eq!(elements, vec![(b"ant".to_vec(), b"hill".to_vec()),]);
         }
 
         // left unbounded (descending)
         {
-            let iter = store.range(None, Some(b"no"), Order::Descending);
+            let iter = store.range(None, Some(b"no"), Order::Descending).unwrap();
             let elements: Vec<KV> = iter.collect();
             assert_eq!(
                 elements,

--- a/packages/std/src/storage.rs
+++ b/packages/std/src/storage.rs
@@ -100,7 +100,7 @@ mod test {
         store.set(b"bye", b"bye").expect("error setting value");
         store.remove(b"bye").expect("error removing key");
 
-        // open ended range
+        // unbounded
         {
             let iter = store.range(None, None, Order::Ascending);
             let elements: Vec<KV> = iter.collect();
@@ -114,7 +114,7 @@ mod test {
             );
         }
 
-        // open ended range (descending)
+        // unbounded (descending)
         {
             let iter = store.range(None, None, Order::Descending);
             let elements: Vec<KV> = iter.collect();
@@ -128,14 +128,14 @@ mod test {
             );
         }
 
-        // closed range
+        // bounded
         {
             let iter = store.range(Some(b"f"), Some(b"n"), Order::Ascending);
             let elements: Vec<KV> = iter.collect();
             assert_eq!(elements, vec![(b"foo".to_vec(), b"bar".to_vec())]);
         }
 
-        // closed range (descending)
+        // bounded (descending)
         {
             let iter = store.range(Some(b"air"), Some(b"loop"), Order::Descending);
             let elements: Vec<KV> = iter.collect();
@@ -148,7 +148,7 @@ mod test {
             );
         }
 
-        // end open iterator
+        // right unbounded
         {
             let iter = store.range(Some(b"f"), None, Order::Ascending);
             let elements: Vec<KV> = iter.collect();
@@ -161,7 +161,7 @@ mod test {
             );
         }
 
-        // end open iterator (descending)
+        // right unbounded (descending)
         {
             let iter = store.range(Some(b"f"), None, Order::Descending);
             let elements: Vec<KV> = iter.collect();
@@ -174,14 +174,14 @@ mod test {
             );
         }
 
-        // start open iterator
+        // left unbounded
         {
             let iter = store.range(None, Some(b"f"), Order::Ascending);
             let elements: Vec<KV> = iter.collect();
             assert_eq!(elements, vec![(b"ant".to_vec(), b"hill".to_vec()),]);
         }
 
-        // start open iterator (descending)
+        // left unbounded (descending)
         {
             let iter = store.range(None, Some(b"no"), Order::Descending);
             let elements: Vec<KV> = iter.collect();

--- a/packages/std/src/storage.rs
+++ b/packages/std/src/storage.rs
@@ -103,75 +103,95 @@ mod test {
         // open ended range
         {
             let iter = store.range(None, None, Order::Ascending);
-            assert_eq!(3, iter.count());
-            let mut iter = store.range(None, None, Order::Ascending);
-            let first = iter.next().unwrap();
-            assert_eq!((b"ant".to_vec(), b"hill".to_vec()), first);
+            let elements: Vec<KV> = iter.collect();
+            assert_eq!(
+                elements,
+                vec![
+                    (b"ant".to_vec(), b"hill".to_vec()),
+                    (b"foo".to_vec(), b"bar".to_vec()),
+                    (b"ze".to_vec(), b"bra".to_vec()),
+                ]
+            );
         }
 
         // open ended range (descending)
         {
             let iter = store.range(None, None, Order::Descending);
-            assert_eq!(3, iter.count());
-            let mut iter = store.range(None, None, Order::Descending);
-            let last = iter.next().unwrap();
-            assert_eq!((b"ze".to_vec(), b"bra".to_vec()), last);
+            let elements: Vec<KV> = iter.collect();
+            assert_eq!(
+                elements,
+                vec![
+                    (b"ze".to_vec(), b"bra".to_vec()),
+                    (b"foo".to_vec(), b"bar".to_vec()),
+                    (b"ant".to_vec(), b"hill".to_vec()),
+                ]
+            );
         }
 
         // closed range
         {
             let iter = store.range(Some(b"f"), Some(b"n"), Order::Ascending);
-            assert_eq!(1, iter.count());
-            let mut iter = store.range(Some(b"f"), Some(b"n"), Order::Ascending);
-            let first = iter.next().unwrap();
-            assert_eq!((b"foo".to_vec(), b"bar".to_vec()), first);
+            let elements: Vec<KV> = iter.collect();
+            assert_eq!(elements, vec![(b"foo".to_vec(), b"bar".to_vec())]);
         }
 
         // closed range (descending)
         {
             let iter = store.range(Some(b"air"), Some(b"loop"), Order::Descending);
-            assert_eq!(2, iter.count());
-            let mut iter = store.range(Some(b"air"), Some(b"loop"), Order::Descending);
-            let first = iter.next().unwrap();
-            assert_eq!((b"foo".to_vec(), b"bar".to_vec()), first);
-            let second = iter.next().unwrap();
-            assert_eq!((b"ant".to_vec(), b"hill".to_vec()), second);
+            let elements: Vec<KV> = iter.collect();
+            assert_eq!(
+                elements,
+                vec![
+                    (b"foo".to_vec(), b"bar".to_vec()),
+                    (b"ant".to_vec(), b"hill".to_vec()),
+                ]
+            );
         }
 
         // end open iterator
         {
             let iter = store.range(Some(b"f"), None, Order::Ascending);
-            assert_eq!(2, iter.count());
-            let mut iter = store.range(Some(b"f"), None, Order::Ascending);
-            let first = iter.next().unwrap();
-            assert_eq!((b"foo".to_vec(), b"bar".to_vec()), first);
+            let elements: Vec<KV> = iter.collect();
+            assert_eq!(
+                elements,
+                vec![
+                    (b"foo".to_vec(), b"bar".to_vec()),
+                    (b"ze".to_vec(), b"bra".to_vec()),
+                ]
+            );
         }
 
         // end open iterator (descending)
         {
             let iter = store.range(Some(b"f"), None, Order::Descending);
-            assert_eq!(2, iter.count());
-            let mut iter = store.range(Some(b"f"), None, Order::Descending);
-            let first = iter.next().unwrap();
-            assert_eq!((b"ze".to_vec(), b"bra".to_vec()), first);
+            let elements: Vec<KV> = iter.collect();
+            assert_eq!(
+                elements,
+                vec![
+                    (b"ze".to_vec(), b"bra".to_vec()),
+                    (b"foo".to_vec(), b"bar".to_vec()),
+                ]
+            );
         }
 
         // start open iterator
         {
             let iter = store.range(None, Some(b"f"), Order::Ascending);
-            assert_eq!(1, iter.count());
-            let mut iter = store.range(None, Some(b"f"), Order::Ascending);
-            let first = iter.next().unwrap();
-            assert_eq!((b"ant".to_vec(), b"hill".to_vec()), first);
+            let elements: Vec<KV> = iter.collect();
+            assert_eq!(elements, vec![(b"ant".to_vec(), b"hill".to_vec()),]);
         }
 
         // start open iterator (descending)
         {
             let iter = store.range(None, Some(b"no"), Order::Descending);
-            assert_eq!(2, iter.count());
-            let mut iter = store.range(None, Some(b"no"), Order::Descending);
-            let first = iter.next().unwrap();
-            assert_eq!((b"foo".to_vec(), b"bar".to_vec()), first);
+            let elements: Vec<KV> = iter.collect();
+            assert_eq!(
+                elements,
+                vec![
+                    (b"foo".to_vec(), b"bar".to_vec()),
+                    (b"ant".to_vec(), b"hill".to_vec()),
+                ]
+            );
         }
     }
 

--- a/packages/std/src/traits.rs
+++ b/packages/std/src/traits.rs
@@ -40,7 +40,7 @@ pub trait ReadonlyStorage {
         start: Option<&[u8]>,
         end: Option<&[u8]>,
         order: Order,
-    ) -> Box<dyn Iterator<Item = KV> + 'a>;
+    ) -> Result<Box<dyn Iterator<Item = KV> + 'a>>;
 }
 
 // Storage extends ReadonlyStorage to give mutable access

--- a/packages/std/src/traits.rs
+++ b/packages/std/src/traits.rs
@@ -30,9 +30,11 @@ pub trait ReadonlyStorage {
     fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>>;
 
     #[cfg(feature = "iterator")]
-    /// range allows iteration over a set of keys, either forwards or backwards
-    /// start is inclusive and end is exclusive
-    /// start must be lexicographically before end
+    /// Allows iteration over a set of key/value pairs, either forwards or backwards.
+    ///
+    /// The bound `start` is inclusive and `end` is exclusive.
+    ///
+    /// If `start` is lexicographically greater than or equal to `end`, an empty range is described, mo matter of the order.
     fn range<'a>(
         &'a self,
         start: Option<&[u8]>,

--- a/packages/storage/src/bucket.rs
+++ b/packages/storage/src/bucket.rs
@@ -83,10 +83,10 @@ where
         start: Option<&[u8]>,
         end: Option<&[u8]>,
         order: Order,
-    ) -> Box<dyn Iterator<Item = Result<KV<T>>> + 'b> {
-        let mapped = range_with_prefix(self.storage, &self.prefix, start, end, order)
+    ) -> Result<Box<dyn Iterator<Item = Result<KV<T>>> + 'b>> {
+        let mapped = range_with_prefix(self.storage, &self.prefix, start, end, order)?
             .map(deserialize_kv::<T>);
-        Box::new(mapped)
+        Ok(Box::new(mapped))
     }
 
     /// update will load the data, perform the specified action, and store the result
@@ -152,10 +152,10 @@ where
         start: Option<&[u8]>,
         end: Option<&[u8]>,
         order: Order,
-    ) -> Box<dyn Iterator<Item = Result<KV<T>>> + 'b> {
-        let mapped = range_with_prefix(self.storage, &self.prefix, start, end, order)
+    ) -> Result<Box<dyn Iterator<Item = Result<KV<T>>> + 'b>> {
+        let mapped = range_with_prefix(self.storage, &self.prefix, start, end, order)?
             .map(deserialize_kv::<T>);
-        Box::new(mapped)
+        Ok(Box::new(mapped))
     }
 }
 
@@ -342,7 +342,10 @@ mod test {
         bucket.save(b"maria", &maria).unwrap();
         bucket.save(b"jose", &jose).unwrap();
 
-        let res_data: Result<Vec<KV<Data>>> = bucket.range(None, None, Order::Ascending).collect();
+        let res_data: Result<Vec<KV<Data>>> = bucket
+            .range(None, None, Order::Ascending)
+            .unwrap()
+            .collect();
         let data = res_data.unwrap();
         assert_eq!(data.len(), 2);
         assert_eq!(data[0], (b"jose".to_vec(), jose.clone()));
@@ -350,8 +353,10 @@ mod test {
 
         // also works for readonly
         let read_bucket = bucket_read::<_, Data>(b"data", &store);
-        let res_data: Result<Vec<KV<Data>>> =
-            read_bucket.range(None, None, Order::Ascending).collect();
+        let res_data: Result<Vec<KV<Data>>> = read_bucket
+            .range(None, None, Order::Ascending)
+            .unwrap()
+            .collect();
         let data = res_data.unwrap();
         assert_eq!(data.len(), 2);
         assert_eq!(data[0], (b"jose".to_vec(), jose));

--- a/packages/storage/src/prefix.rs
+++ b/packages/storage/src/prefix.rs
@@ -56,7 +56,7 @@ impl<'a, T: ReadonlyStorage> ReadonlyStorage for ReadonlyPrefixedStorage<'a, T> 
         start: Option<&[u8]>,
         end: Option<&[u8]>,
         order: Order,
-    ) -> Box<dyn Iterator<Item = KV> + 'b> {
+    ) -> Result<Box<dyn Iterator<Item = KV> + 'b>> {
         range_with_prefix(self.storage, &self.prefix, start, end, order)
     }
 }
@@ -97,7 +97,7 @@ impl<'a, T: Storage> ReadonlyStorage for PrefixedStorage<'a, T> {
         start: Option<&[u8]>,
         end: Option<&[u8]>,
         order: Order,
-    ) -> Box<dyn Iterator<Item = KV> + 'b> {
+    ) -> Result<Box<dyn Iterator<Item = KV> + 'b>> {
         range_with_prefix(self.storage, &self.prefix, start, end, order)
     }
 }

--- a/packages/storage/src/transactions.rs
+++ b/packages/storage/src/transactions.rs
@@ -292,75 +292,95 @@ mod test {
         // open ended range
         {
             let iter = store.range(None, None, Order::Ascending);
-            assert_eq!(3, iter.count());
-            let mut iter = store.range(None, None, Order::Ascending);
-            let first = iter.next().unwrap();
-            assert_eq!((b"ant".to_vec(), b"hill".to_vec()), first);
+            let elements: Vec<KV> = iter.collect();
+            assert_eq!(
+                elements,
+                vec![
+                    (b"ant".to_vec(), b"hill".to_vec()),
+                    (b"foo".to_vec(), b"bar".to_vec()),
+                    (b"ze".to_vec(), b"bra".to_vec()),
+                ]
+            );
         }
 
         // open ended range (descending)
         {
             let iter = store.range(None, None, Order::Descending);
-            assert_eq!(3, iter.count());
-            let mut iter = store.range(None, None, Order::Descending);
-            let last = iter.next().unwrap();
-            assert_eq!((b"ze".to_vec(), b"bra".to_vec()), last);
+            let elements: Vec<KV> = iter.collect();
+            assert_eq!(
+                elements,
+                vec![
+                    (b"ze".to_vec(), b"bra".to_vec()),
+                    (b"foo".to_vec(), b"bar".to_vec()),
+                    (b"ant".to_vec(), b"hill".to_vec()),
+                ]
+            );
         }
 
         // closed range
         {
             let iter = store.range(Some(b"f"), Some(b"n"), Order::Ascending);
-            assert_eq!(1, iter.count());
-            let mut iter = store.range(Some(b"f"), Some(b"n"), Order::Ascending);
-            let first = iter.next().unwrap();
-            assert_eq!((b"foo".to_vec(), b"bar".to_vec()), first);
+            let elements: Vec<KV> = iter.collect();
+            assert_eq!(elements, vec![(b"foo".to_vec(), b"bar".to_vec())]);
         }
 
         // closed range (descending)
         {
             let iter = store.range(Some(b"air"), Some(b"loop"), Order::Descending);
-            assert_eq!(2, iter.count());
-            let mut iter = store.range(Some(b"air"), Some(b"loop"), Order::Descending);
-            let first = iter.next().unwrap();
-            assert_eq!((b"foo".to_vec(), b"bar".to_vec()), first);
-            let second = iter.next().unwrap();
-            assert_eq!((b"ant".to_vec(), b"hill".to_vec()), second);
+            let elements: Vec<KV> = iter.collect();
+            assert_eq!(
+                elements,
+                vec![
+                    (b"foo".to_vec(), b"bar".to_vec()),
+                    (b"ant".to_vec(), b"hill".to_vec()),
+                ]
+            );
         }
 
         // end open iterator
         {
             let iter = store.range(Some(b"f"), None, Order::Ascending);
-            assert_eq!(2, iter.count());
-            let mut iter = store.range(Some(b"f"), None, Order::Ascending);
-            let first = iter.next().unwrap();
-            assert_eq!((b"foo".to_vec(), b"bar".to_vec()), first);
+            let elements: Vec<KV> = iter.collect();
+            assert_eq!(
+                elements,
+                vec![
+                    (b"foo".to_vec(), b"bar".to_vec()),
+                    (b"ze".to_vec(), b"bra".to_vec()),
+                ]
+            );
         }
 
         // end open iterator (descending)
         {
             let iter = store.range(Some(b"f"), None, Order::Descending);
-            assert_eq!(2, iter.count());
-            let mut iter = store.range(Some(b"f"), None, Order::Descending);
-            let first = iter.next().unwrap();
-            assert_eq!((b"ze".to_vec(), b"bra".to_vec()), first);
+            let elements: Vec<KV> = iter.collect();
+            assert_eq!(
+                elements,
+                vec![
+                    (b"ze".to_vec(), b"bra".to_vec()),
+                    (b"foo".to_vec(), b"bar".to_vec()),
+                ]
+            );
         }
 
         // start open iterator
         {
             let iter = store.range(None, Some(b"f"), Order::Ascending);
-            assert_eq!(1, iter.count());
-            let mut iter = store.range(None, Some(b"f"), Order::Ascending);
-            let first = iter.next().unwrap();
-            assert_eq!((b"ant".to_vec(), b"hill".to_vec()), first);
+            let elements: Vec<KV> = iter.collect();
+            assert_eq!(elements, vec![(b"ant".to_vec(), b"hill".to_vec()),]);
         }
 
         // start open iterator (descending)
         {
             let iter = store.range(None, Some(b"no"), Order::Descending);
-            assert_eq!(2, iter.count());
-            let mut iter = store.range(None, Some(b"no"), Order::Descending);
-            let first = iter.next().unwrap();
-            assert_eq!((b"foo".to_vec(), b"bar".to_vec()), first);
+            let elements: Vec<KV> = iter.collect();
+            assert_eq!(
+                elements,
+                vec![
+                    (b"foo".to_vec(), b"bar".to_vec()),
+                    (b"ant".to_vec(), b"hill".to_vec()),
+                ]
+            );
         }
     }
 

--- a/packages/storage/src/transactions.rs
+++ b/packages/storage/src/transactions.rs
@@ -289,7 +289,7 @@ mod test {
         store.set(b"bye", b"bye").expect("error setting value");
         store.remove(b"bye").expect("error removing key");
 
-        // open ended range
+        // unbounded
         {
             let iter = store.range(None, None, Order::Ascending);
             let elements: Vec<KV> = iter.collect();
@@ -303,7 +303,7 @@ mod test {
             );
         }
 
-        // open ended range (descending)
+        // unbounded (descending)
         {
             let iter = store.range(None, None, Order::Descending);
             let elements: Vec<KV> = iter.collect();
@@ -317,14 +317,14 @@ mod test {
             );
         }
 
-        // closed range
+        // bounded
         {
             let iter = store.range(Some(b"f"), Some(b"n"), Order::Ascending);
             let elements: Vec<KV> = iter.collect();
             assert_eq!(elements, vec![(b"foo".to_vec(), b"bar".to_vec())]);
         }
 
-        // closed range (descending)
+        // bounded (descending)
         {
             let iter = store.range(Some(b"air"), Some(b"loop"), Order::Descending);
             let elements: Vec<KV> = iter.collect();
@@ -337,7 +337,7 @@ mod test {
             );
         }
 
-        // end open iterator
+        // right unbounded
         {
             let iter = store.range(Some(b"f"), None, Order::Ascending);
             let elements: Vec<KV> = iter.collect();
@@ -350,7 +350,7 @@ mod test {
             );
         }
 
-        // end open iterator (descending)
+        // right unbounded (descending)
         {
             let iter = store.range(Some(b"f"), None, Order::Descending);
             let elements: Vec<KV> = iter.collect();
@@ -363,14 +363,14 @@ mod test {
             );
         }
 
-        // start open iterator
+        // left unbounded
         {
             let iter = store.range(None, Some(b"f"), Order::Ascending);
             let elements: Vec<KV> = iter.collect();
             assert_eq!(elements, vec![(b"ant".to_vec(), b"hill".to_vec()),]);
         }
 
-        // start open iterator (descending)
+        // left unbounded (descending)
         {
             let iter = store.range(None, Some(b"no"), Order::Descending);
             let elements: Vec<KV> = iter.collect();

--- a/packages/storage/src/transactions.rs
+++ b/packages/storage/src/transactions.rs
@@ -296,6 +296,12 @@ mod test {
             let mut iter = store.range(None, None, Order::Ascending);
             let first = iter.next().unwrap();
             assert_eq!((b"ant".to_vec(), b"hill".to_vec()), first);
+        }
+
+        // open ended range (descending)
+        {
+            let iter = store.range(None, None, Order::Descending);
+            assert_eq!(3, iter.count());
             let mut iter = store.range(None, None, Order::Descending);
             let last = iter.next().unwrap();
             assert_eq!((b"ze".to_vec(), b"bra".to_vec()), last);
@@ -310,7 +316,7 @@ mod test {
             assert_eq!((b"foo".to_vec(), b"bar".to_vec()), first);
         }
 
-        // closed range reverse
+        // closed range (descending)
         {
             let iter = store.range(Some(b"air"), Some(b"loop"), Order::Descending);
             assert_eq!(2, iter.count());
@@ -330,7 +336,7 @@ mod test {
             assert_eq!((b"foo".to_vec(), b"bar".to_vec()), first);
         }
 
-        // end open iterator reverse
+        // end open iterator (descending)
         {
             let iter = store.range(Some(b"f"), None, Order::Descending);
             assert_eq!(2, iter.count());
@@ -348,7 +354,7 @@ mod test {
             assert_eq!((b"ant".to_vec(), b"hill".to_vec()), first);
         }
 
-        // start open iterator
+        // start open iterator (descending)
         {
             let iter = store.range(None, Some(b"no"), Order::Descending);
             assert_eq!(2, iter.count());


### PR DESCRIPTION
First step for #258

No changelog entry since `ReadonlyStorage.range` is newly added in 0.8.0