### PR TITLE
Result not panic on Uint128 underflow

### DIFF
--- a/packages/std/schema/handle_result.json
+++ b/packages/std/schema/handle_result.json
@@ -187,14 +187,10 @@
               ],
               "properties": {
                 "minuend": {
-                  "type": "integer",
-                  "format": "uint128",
-                  "minimum": 0.0
+                  "type": "string"
                 },
                 "subtrahend": {
-                  "type": "integer",
-                  "format": "uint128",
-                  "minimum": 0.0
+                  "type": "string"
                 }
               }
             }

--- a/packages/std/schema/handle_result.json
+++ b/packages/std/schema/handle_result.json
@@ -165,6 +165,44 @@
         {
           "type": "object",
           "required": [
+            "Unauthorized"
+          ],
+          "properties": {
+            "Unauthorized": {
+              "type": "object"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "Underflow"
+          ],
+          "properties": {
+            "Underflow": {
+              "type": "object",
+              "required": [
+                "minuend",
+                "subtrahend"
+              ],
+              "properties": {
+                "minuend": {
+                  "type": "integer",
+                  "format": "uint128",
+                  "minimum": 0.0
+                },
+                "subtrahend": {
+                  "type": "integer",
+                  "format": "uint128",
+                  "minimum": 0.0
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
             "Utf8Err"
           ],
           "properties": {
@@ -197,17 +235,6 @@
                   "type": "string"
                 }
               }
-            }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
-            "Unauthorized"
-          ],
-          "properties": {
-            "Unauthorized": {
-              "type": "object"
             }
           }
         },

--- a/packages/std/schema/init_result.json
+++ b/packages/std/schema/init_result.json
@@ -187,14 +187,10 @@
               ],
               "properties": {
                 "minuend": {
-                  "type": "integer",
-                  "format": "uint128",
-                  "minimum": 0.0
+                  "type": "string"
                 },
                 "subtrahend": {
-                  "type": "integer",
-                  "format": "uint128",
-                  "minimum": 0.0
+                  "type": "string"
                 }
               }
             }

--- a/packages/std/schema/init_result.json
+++ b/packages/std/schema/init_result.json
@@ -165,6 +165,44 @@
         {
           "type": "object",
           "required": [
+            "Unauthorized"
+          ],
+          "properties": {
+            "Unauthorized": {
+              "type": "object"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "Underflow"
+          ],
+          "properties": {
+            "Underflow": {
+              "type": "object",
+              "required": [
+                "minuend",
+                "subtrahend"
+              ],
+              "properties": {
+                "minuend": {
+                  "type": "integer",
+                  "format": "uint128",
+                  "minimum": 0.0
+                },
+                "subtrahend": {
+                  "type": "integer",
+                  "format": "uint128",
+                  "minimum": 0.0
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
             "Utf8Err"
           ],
           "properties": {
@@ -197,17 +235,6 @@
                   "type": "string"
                 }
               }
-            }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
-            "Unauthorized"
-          ],
-          "properties": {
-            "Unauthorized": {
-              "type": "object"
             }
           }
         },

--- a/packages/std/schema/query_result.json
+++ b/packages/std/schema/query_result.json
@@ -187,14 +187,10 @@
               ],
               "properties": {
                 "minuend": {
-                  "type": "integer",
-                  "format": "uint128",
-                  "minimum": 0.0
+                  "type": "string"
                 },
                 "subtrahend": {
-                  "type": "integer",
-                  "format": "uint128",
-                  "minimum": 0.0
+                  "type": "string"
                 }
               }
             }

--- a/packages/std/schema/query_result.json
+++ b/packages/std/schema/query_result.json
@@ -165,6 +165,44 @@
         {
           "type": "object",
           "required": [
+            "Unauthorized"
+          ],
+          "properties": {
+            "Unauthorized": {
+              "type": "object"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "Underflow"
+          ],
+          "properties": {
+            "Underflow": {
+              "type": "object",
+              "required": [
+                "minuend",
+                "subtrahend"
+              ],
+              "properties": {
+                "minuend": {
+                  "type": "integer",
+                  "format": "uint128",
+                  "minimum": 0.0
+                },
+                "subtrahend": {
+                  "type": "integer",
+                  "format": "uint128",
+                  "minimum": 0.0
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
             "Utf8Err"
           ],
           "properties": {
@@ -197,17 +235,6 @@
                   "type": "string"
                 }
               }
-            }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
-            "Unauthorized"
-          ],
-          "properties": {
-            "Unauthorized": {
-              "type": "object"
             }
           }
         },

--- a/packages/std/src/api.rs
+++ b/packages/std/src/api.rs
@@ -51,7 +51,7 @@ pub enum ApiError {
     ParseErr { kind: String, source: String },
     SerializeErr { kind: String, source: String },
     Unauthorized {},
-    Underflow { minuend: u128, subtrahend: u128 },
+    Underflow { minuend: String, subtrahend: String },
     // This is used for std::str::from_utf8, which we may well deprecate
     Utf8Err { source: String },
     // This is used for String::from_utf8, which does zero-copy from Vec<u8>, moving towards this

--- a/packages/std/src/api.rs
+++ b/packages/std/src/api.rs
@@ -50,11 +50,12 @@ pub enum ApiError {
     NullPointer {},
     ParseErr { kind: String, source: String },
     SerializeErr { kind: String, source: String },
+    Unauthorized {},
+    Underflow { minuend: u128, subtrahend: u128 },
     // This is used for std::str::from_utf8, which we may well deprecate
     Utf8Err { source: String },
     // This is used for String::from_utf8, which does zero-copy from Vec<u8>, moving towards this
     Utf8StringErr { source: String },
-    Unauthorized {},
     ValidationErr { field: String, msg: String },
 }
 
@@ -72,9 +73,13 @@ impl std::fmt::Display for ApiError {
             ApiError::SerializeErr { kind, source } => {
                 write!(f, "Error serializing {}: {}", kind, source)
             }
+            ApiError::Unauthorized {} => write!(f, "Unauthorized"),
+            ApiError::Underflow {
+                minuend,
+                subtrahend,
+            } => write!(f, "Cannot subtract {} from {}", subtrahend, minuend),
             ApiError::Utf8Err { source } => write!(f, "UTF8 encoding error: {}", source),
             ApiError::Utf8StringErr { source } => write!(f, "UTF8 encoding error: {}", source),
-            ApiError::Unauthorized {} => write!(f, "Unauthorized"),
             ApiError::ValidationErr { field, msg } => write!(f, "Invalid {}: {}", field, msg),
         }
     }
@@ -102,13 +107,21 @@ impl From<StdError> for ApiError {
                 kind: kind.to_string(),
                 source: format!("{}", source),
             },
+            StdError::Unauthorized { .. } => ApiError::Unauthorized {},
+            StdError::Underflow {
+                minuend,
+                subtrahend,
+                ..
+            } => ApiError::Underflow {
+                minuend,
+                subtrahend,
+            },
             StdError::Utf8Err { source, .. } => ApiError::Utf8Err {
                 source: format!("{}", source),
             },
             StdError::Utf8StringErr { source, .. } => ApiError::Utf8StringErr {
                 source: format!("{}", source),
             },
-            StdError::Unauthorized { .. } => ApiError::Unauthorized {},
             StdError::ValidationErr { field, msg, .. } => ApiError::ValidationErr {
                 field: field.to_string(),
                 msg: msg.to_string(),

--- a/packages/std/src/coins.rs
+++ b/packages/std/src/coins.rs
@@ -214,7 +214,7 @@ mod test {
                 minuend,
                 subtrahend,
                 ..
-            }) => assert_eq!((minuend, subtrahend), (a.u128(), b.u128())),
+            }) => assert_eq!((minuend, subtrahend), (a.to_string(), b.to_string())),
             _ => panic!("expected underflow error"),
         }
     }

--- a/packages/std/src/coins.rs
+++ b/packages/std/src/coins.rs
@@ -203,10 +203,16 @@ mod test {
         let a = Uint128(12345);
         let b = Uint128(23456);
 
+        // test + and - for valid values
         assert_eq!(a + b, Uint128(35801));
         assert_eq!((b - a).unwrap(), Uint128(11111));
 
-        // error result on underflow
+        // test +=
+        let mut c = Uint128(300000);
+        c += b;
+        assert_eq!(c, Uint128(323456));
+
+        // error result on underflow (- would produce negative result)
         let underflow = a - b;
         match underflow {
             Ok(_) => panic!("should error"),

--- a/packages/std/src/errors.rs
+++ b/packages/std/src/errors.rs
@@ -43,6 +43,14 @@ pub enum StdError {
         source: serde_json_wasm::ser::Error,
         backtrace: snafu::Backtrace,
     },
+    #[snafu(display("Unauthorized"))]
+    Unauthorized { backtrace: snafu::Backtrace },
+    #[snafu(display("Cannot subtract {} from {}", subtrahend, minuend))]
+    Underflow {
+        minuend: u128,
+        subtrahend: u128,
+        backtrace: snafu::Backtrace,
+    },
     // This is used for std::str::from_utf8, which we may well deprecate
     #[snafu(display("UTF8 encoding error: {}", source))]
     Utf8Err {
@@ -55,8 +63,6 @@ pub enum StdError {
         source: std::string::FromUtf8Error,
         backtrace: snafu::Backtrace,
     },
-    #[snafu(display("Unauthorized"))]
-    Unauthorized { backtrace: snafu::Backtrace },
     #[snafu(display("Invalid {}: {}", field, msg))]
     ValidationErr {
         field: &'static str,
@@ -105,6 +111,14 @@ pub fn contract_err<T>(msg: &'static str) -> StdResult<T> {
 
 pub fn dyn_contract_err<T>(msg: String) -> StdResult<T> {
     DynContractErr { msg }.fail()
+}
+
+pub fn underflow<T>(minuend: u128, subtrahend: u128) -> StdResult<T> {
+    Underflow {
+        minuend,
+        subtrahend,
+    }
+    .fail()
 }
 
 pub fn unauthorized<T>() -> StdResult<T> {

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -17,8 +17,8 @@ pub use crate::api::{ApiError, ApiResult, ApiSystemError};
 pub use crate::coins::{coin, coins, has_coins, Coin, Uint128};
 pub use crate::encoding::Binary;
 pub use crate::errors::{
-    contract_err, dyn_contract_err, invalid, unauthorized, InvalidRequest, NotFound, NullPointer,
-    ParseErr, SerializeErr, StdError, StdResult,
+    contract_err, dyn_contract_err, invalid, unauthorized, underflow, InvalidRequest, NotFound,
+    NullPointer, ParseErr, SerializeErr, StdError, StdResult,
 };
 pub use crate::init_handle::{
     log, CosmosMsg, HandleResponse, HandleResult, InitResponse, InitResult, LogAttribute,


### PR DESCRIPTION
Some more code that got thrown away with the `add-wallet-type` branch. Improvements in how we handle underflow, returning an explicit Result rather than panic, as an underflow is a normal occurrance (not enough balance to transfer)