### PR TITLE
Create safe get_context_data

### DIFF
--- a/packages/vm/src/context.rs
+++ b/packages/vm/src/context.rs
@@ -379,10 +379,7 @@ unsafe fn get_data<S: Storage, Q: Querier>(ptr: *mut c_void) -> Box<ContextData<
 
 #[cfg(feature = "iterator")]
 fn destroy_iterators<S: Storage, Q: Querier>(context: &mut ContextData<S, Q>) {
-    let keys: Vec<u32> = context.iter.keys().cloned().collect();
-    for key in keys {
-        let _ = context.iter.remove(&key);
-    }
+    context.iter.clear();
 }
 
 #[cfg(not(feature = "iterator"))]


### PR DESCRIPTION
Among a few smaller cleanups, this replaces `get_data` with `get_context_data`, allowing a safe usage of context data. During this refactoring, clippy revealed that we create a mutable reference to `ContextData` from an immutable `Ctx`, which was only possible because of raw pointer usage.