### PR TITLE
Test do_scan, do_read and do_write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,8 @@
 - Rename `Result` to `StdResult` to differentiate between the auto-`use`d
   `core::result::Result`. Fix error argument to `Error`.
 - Rename `Error` to `StdError`.
+- `ExternalStorage.get` now returns an empty vector if a storage entry exists
+  but has an empty value. Before, this was normalized to `None`.
 
 **cosmwasm-vm**
 
@@ -113,6 +115,9 @@
 - Remove `cosmwasm_vm::errors::CacheExt`.
 - Move `cosmwasm_vm::errors::{Error, Result}` to
   `cosmwasm_vm::{VmError, VmResult}` and remove generic error type from result.
+- The import `db_read` now returns an error code if the storage key does not
+  exist. The latest standard library converts this error code back to a `None`
+  value. This allows differentiating non-existent and empty storage entries.
 
 ## 0.7.2 (2020-03-23)
 

--- a/packages/std/src/imports.rs
+++ b/packages/std/src/imports.rs
@@ -67,16 +67,18 @@ impl ExternalStorage {
         let value_ptr = alloc(result_length);
 
         let read = unsafe { db_read(key_ptr, value_ptr) };
-        if read == -1000002 {
+        if read == -1_000_002 {
             return contract_err("Allocated memory too small to hold the database value for the given key. \
                 You can specify custom result buffer lengths by using ExternalStorage.get_with_result_length explicitely.");
+        } else if read == -1_000_502 {
+            // key does not exist in external storage
+            return Ok(None);
         } else if read < 0 {
             return dyn_contract_err(format!("Error reading from database. Error code: {}", read));
         }
 
         let data = unsafe { consume_region(value_ptr) }?;
-        // TODO: how can we know if the key was available or not in the backend?
-        Ok(if data.len() == 0 { None } else { Some(data) })
+        Ok(Some(data))
     }
 }
 

--- a/packages/vm/src/context.rs
+++ b/packages/vm/src/context.rs
@@ -86,6 +86,7 @@ pub(crate) fn move_into_context<S: Storage, Q: Querier>(target: &mut Ctx, storag
 }
 
 /// Add the iterator to the context's data. A new ID is assigned and returned.
+/// IDs are guaranteed to be in the range [0, 2**31-1], i.e. fit in the non-negative part if type i32.
 #[cfg(feature = "iterator")]
 pub fn add_iterator<S: Storage, Q: Querier>(
     ctx: &mut Ctx,
@@ -98,6 +99,10 @@ pub fn add_iterator<S: Storage, Q: Querier>(
         .try_into()
         .expect("Found more iterator IDs than supported");
     let new_id = last_id + 1;
+    static INT32_MAX_VALUE: u32 = 2_147_483_647;
+    if new_id > INT32_MAX_VALUE {
+        panic!("Iterator ID exceeded INT32_MAX_VALUE. This must not happen.");
+    }
     b.iterators.insert(new_id, iter);
     new_id
 }

--- a/packages/vm/src/context.rs
+++ b/packages/vm/src/context.rs
@@ -85,9 +85,9 @@ pub(crate) fn move_into_context<S: Storage, Q: Querier>(target: &mut Ctx, storag
     b.querier = Some(querier);
 }
 
-// set the iterator, overwriting any possible iterator previously
+/// Add the iterator to the context's data. A new ID is assigned and returned.
 #[cfg(feature = "iterator")]
-pub fn set_iterator<S: Storage, Q: Querier>(
+pub fn add_iterator<S: Storage, Q: Querier>(
     ctx: &mut Ctx,
     iter: Box<dyn Iterator<Item = StdResult<KV>>>,
 ) -> u32 {

--- a/packages/vm/src/context.rs
+++ b/packages/vm/src/context.rs
@@ -212,7 +212,7 @@ mod test {
         instance
     }
 
-    fn leave_default_data(instance: &mut Instance) {
+    fn leave_default_data(ctx: &mut Ctx) {
         // create some mock data
         let mut storage = MockStorage::new();
         storage
@@ -220,28 +220,29 @@ mod test {
             .expect("error setting value");
         let querier =
             MockQuerier::new(&[(&HumanAddr::from(INIT_ADDR), &coins(INIT_AMOUNT, INIT_DENOM))]);
-        move_into_context(instance.context_mut(), storage, querier);
+        move_into_context(ctx, storage, querier);
     }
 
     #[test]
     fn leave_and_take_context_data() {
         // this creates an instance
         let mut instance = make_instance();
+        let ctx = instance.context_mut();
 
         // empty data on start
-        let (inits, initq) = move_out_of_context::<S, Q>(instance.context_mut());
+        let (inits, initq) = move_out_of_context::<S, Q>(ctx);
         assert!(inits.is_none());
         assert!(initq.is_none());
 
         // store it on the instance
-        leave_default_data(&mut instance);
-        let (s, q) = move_out_of_context::<S, Q>(instance.context_mut());
+        leave_default_data(ctx);
+        let (s, q) = move_out_of_context::<S, Q>(ctx);
         assert!(s.is_some());
         assert!(q.is_some());
         assert_eq!(s.unwrap().get(INIT_KEY).unwrap(), Some(INIT_VALUE.to_vec()));
 
         // now is empty again
-        let (ends, endq) = move_out_of_context::<S, Q>(instance.context_mut());
+        let (ends, endq) = move_out_of_context::<S, Q>(ctx);
         assert!(ends.is_none());
         assert!(endq.is_none());
     }
@@ -250,8 +251,8 @@ mod test {
     #[cfg(feature = "iterator")]
     fn add_iterator_works() {
         let mut instance = make_instance();
-        leave_default_data(&mut instance);
         let ctx = instance.context_mut();
+        leave_default_data(ctx);
 
         assert_eq!(get_context_data::<S, Q>(ctx).iterators.len(), 0);
         let id1 = add_iterator::<S, Q>(ctx, Box::new(std::iter::empty()));
@@ -266,8 +267,8 @@ mod test {
     #[test]
     fn with_storage_from_context_set_get() {
         let mut instance = make_instance();
-        leave_default_data(&mut instance);
         let ctx = instance.context_mut();
+        leave_default_data(ctx);
 
         let val = with_storage_from_context::<S, Q, _, _>(ctx, |store| {
             Ok(store.get(INIT_KEY).expect("error getting value"))
@@ -296,8 +297,8 @@ mod test {
     #[should_panic(expected = "A panic occurred in the callback.")]
     fn with_storage_from_context_handles_panics() {
         let mut instance = make_instance();
-        leave_default_data(&mut instance);
         let ctx = instance.context_mut();
+        leave_default_data(ctx);
 
         with_storage_from_context::<S, Q, _, ()>(ctx, |_store| {
             panic!("A panic occurred in the callback.")
@@ -308,8 +309,8 @@ mod test {
     #[test]
     fn with_querier_from_context_works() {
         let mut instance = make_instance();
-        leave_default_data(&mut instance);
         let ctx = instance.context_mut();
+        leave_default_data(ctx);
 
         let res = with_querier_from_context::<S, Q, _, _>(ctx, |querier| {
             let req = QueryRequest::AllBalances {
@@ -327,8 +328,8 @@ mod test {
     #[test]
     fn with_querier_from_context_parse_works() {
         let mut instance = make_instance();
-        leave_default_data(&mut instance);
         let ctx = instance.context_mut();
+        leave_default_data(ctx);
         let contract = HumanAddr::from(INIT_ADDR);
 
         let balance = with_querier_from_context::<S, Q, _, _>(ctx, |querier| {
@@ -350,8 +351,8 @@ mod test {
     #[should_panic(expected = "A panic occurred in the callback.")]
     fn with_querier_from_context_handles_panics() {
         let mut instance = make_instance();
-        leave_default_data(&mut instance);
         let ctx = instance.context_mut();
+        leave_default_data(ctx);
 
         with_querier_from_context::<S, Q, _, ()>(ctx, |_querier| {
             panic!("A panic occurred in the callback.")
@@ -363,8 +364,8 @@ mod test {
     #[cfg(feature = "iterator")]
     fn with_iterator_from_context_works() {
         let mut instance = make_instance();
-        leave_default_data(&mut instance);
         let ctx = instance.context_mut();
+        leave_default_data(ctx);
 
         let id = add_iterator::<S, Q>(ctx, Box::new(std::iter::empty()));
         with_iterator_from_context::<S, Q, _, ()>(ctx, id, |iter| {
@@ -378,8 +379,8 @@ mod test {
     #[cfg(feature = "iterator")]
     fn with_iterator_from_context_errors_for_non_existent_iterator_id() {
         let mut instance = make_instance();
-        leave_default_data(&mut instance);
         let ctx = instance.context_mut();
+        leave_default_data(ctx);
 
         let miss = with_iterator_from_context::<S, Q, _, ()>(ctx, 42, |_iter| {
             panic!("this should not be called");

--- a/packages/vm/src/context.rs
+++ b/packages/vm/src/context.rs
@@ -379,10 +379,7 @@ unsafe fn get_data<S: Storage, Q: Querier>(ptr: *mut c_void) -> Box<ContextData<
 
 #[cfg(feature = "iterator")]
 fn destroy_iterators<S: Storage, Q: Querier>(context: &mut ContextData<S, Q>) {
-    let keys: Vec<u32> = context.iter.keys().cloned().collect();
-    for key in keys {
-        let _ = context.iter.remove(&key);
-    }
+    context.iter.clear();
 }
 
 #[cfg(not(feature = "iterator"))]

--- a/packages/vm/src/context.rs
+++ b/packages/vm/src/context.rs
@@ -221,8 +221,6 @@ mod test {
         let querier =
             MockQuerier::new(&[(&HumanAddr::from(INIT_ADDR), &coins(INIT_AMOUNT, INIT_DENOM))]);
         move_into_context(instance.context_mut(), storage, querier);
-        #[cfg(feature = "iterator")]
-        let _ = add_iterator::<S, Q>(instance.context_mut(), Box::new(std::iter::empty()));
     }
 
     #[test]
@@ -246,6 +244,23 @@ mod test {
         let (ends, endq) = move_out_of_context::<S, Q>(instance.context_mut());
         assert!(ends.is_none());
         assert!(endq.is_none());
+    }
+
+    #[test]
+    #[cfg(feature = "iterator")]
+    fn add_iterator_works() {
+        let mut instance = make_instance();
+        leave_default_data(&mut instance);
+        let ctx = instance.context_mut();
+
+        assert_eq!(get_context_data::<S, Q>(ctx).iterators.len(), 0);
+        let id1 = add_iterator::<S, Q>(ctx, Box::new(std::iter::empty()));
+        let id2 = add_iterator::<S, Q>(ctx, Box::new(std::iter::empty()));
+        let id3 = add_iterator::<S, Q>(ctx, Box::new(std::iter::empty()));
+        assert_eq!(get_context_data::<S, Q>(ctx).iterators.len(), 3);
+        assert!(get_context_data::<S, Q>(ctx).iterators.contains_key(&id1));
+        assert!(get_context_data::<S, Q>(ctx).iterators.contains_key(&id2));
+        assert!(get_context_data::<S, Q>(ctx).iterators.contains_key(&id3));
     }
 
     #[test]
@@ -356,7 +371,8 @@ mod test {
         leave_default_data(&mut instance);
         let ctx = instance.context_mut();
 
-        with_iterator_from_context::<S, Q, _, ()>(ctx, 1, |iter| {
+        let id = add_iterator::<S, Q>(ctx, Box::new(std::iter::empty()));
+        with_iterator_from_context::<S, Q, _, ()>(ctx, id, |iter| {
             assert!(iter.next().is_none());
             Ok(())
         })

--- a/packages/vm/src/context.rs
+++ b/packages/vm/src/context.rs
@@ -88,6 +88,7 @@ pub(crate) fn move_into_context<S: Storage, Q: Querier>(target: &mut Ctx, storag
 /// Add the iterator to the context's data. A new ID is assigned and returned.
 /// IDs are guaranteed to be in the range [0, 2**31-1], i.e. fit in the non-negative part if type i32.
 #[cfg(feature = "iterator")]
+#[must_use = "without the returned iterator ID, the iterator cannot be accessed"]
 pub fn add_iterator<S: Storage, Q: Querier>(
     ctx: &mut Ctx,
     iter: Box<dyn Iterator<Item = StdResult<KV>>>,
@@ -221,7 +222,7 @@ mod test {
             MockQuerier::new(&[(&HumanAddr::from(INIT_ADDR), &coins(INIT_AMOUNT, INIT_DENOM))]);
         move_into_context(instance.context_mut(), storage, querier);
         #[cfg(feature = "iterator")]
-        add_iterator::<S, Q>(instance.context_mut(), Box::new(std::iter::empty()));
+        let _ = add_iterator::<S, Q>(instance.context_mut(), Box::new(std::iter::empty()));
     }
 
     #[test]

--- a/packages/vm/src/context.rs
+++ b/packages/vm/src/context.rs
@@ -1,343 +1,17 @@
 //! Internal details to be used by instance.rs only
 #[cfg(feature = "iterator")]
 use std::collections::HashMap;
+#[cfg(feature = "iterator")]
+use std::convert::TryInto;
 use std::ffi::c_void;
 
 use wasmer_runtime_core::vm::Ctx;
 
-use cosmwasm_std::{
-    Api, ApiQuerierResponse, ApiSystemError, Binary, CanonicalAddr, HumanAddr, Querier,
-    QuerierResponse, QueryRequest, Storage,
-};
+use cosmwasm_std::{ApiSystemError, Querier, Storage};
 #[cfg(feature = "iterator")]
 use cosmwasm_std::{StdResult, KV};
 
-#[cfg(feature = "iterator")]
-use crate::conversion::to_i32;
-use crate::errors::{make_runtime_err, UninitializedContextData, VmError, VmResult};
-use crate::memory::{read_region, write_region};
-use crate::serde::{from_slice, to_vec};
-#[cfg(feature = "iterator")]
-pub(crate) use iter_support::{do_next, do_scan};
-
-/// A kibi (kilo binary)
-static KI: usize = 1024;
-/// Max key length for db_write (i.e. when VM reads from Wasm memory). Should match the
-/// value for db_next (see DB_READ_KEY_BUFFER_LENGTH in packages/std/src/imports.rs)
-static MAX_LENGTH_DB_KEY: usize = 64 * KI;
-/// Max key length for db_write (i.e. when VM reads from Wasm memory). Should match the
-/// value for db_read/db_next (see DB_READ_VALUE_BUFFER_LENGTH in packages/std/src/imports.rs)
-static MAX_LENGTH_DB_VALUE: usize = 128 * KI;
-/// Typically 20 (Cosmos SDK, Ethereum) or 32 (Nano, Substrate)
-static MAX_LENGTH_CANONICAL_ADDRESS: usize = 32;
-/// The maximum allowed size for bech32 (https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#bech32)
-static MAX_LENGTH_HUMAN_ADDRESS: usize = 90;
-static MAX_LENGTH_QUERY_CHAIN_REQUEST: usize = 64 * KI;
-
-static SUCCESS: i32 = 0;
-/// An unknown error occurred when writing to region
-static ERROR_REGION_WRITE_UNKNOWN: i32 = -1_000_001;
-/// Could not write to region because it is too small
-static ERROR_REGION_WRITE_TOO_SMALL: i32 = -1_000_002;
-/// An unknown error occurred when reading region
-static ERROR_REGION_READ_UNKNOWN: i32 = -1_000_101;
-/// The contract sent us a Region we're not willing to read because it is too big
-static ERROR_REGION_READ_LENGTH_TOO_BIG: i32 = -1_000_102;
-/// An unknown error when canonicalizing address
-static ERROR_CANONICALIZE_UNKNOWN: i32 = -1_000_201;
-/// The input address (human address) was invalid
-static ERROR_CANONICALIZE_INVALID_INPUT: i32 = -1_000_202;
-/// An unknonw error when humanizing address
-static ERROR_HUMANIZE_UNKNOWN: i32 = -1_000_301;
-/// Cannot serialize query response
-static ERROR_QUERY_CHAIN_CANNOT_SERIALIZE_RESPONSE: i32 = -1_000_402;
-/// Generic error - using context with no Storage attached
-pub static ERROR_NO_CONTEXT_DATA: i32 = -1_000_501;
-/// Generic error - An unknown error accessing the DB
-static ERROR_DB_UNKNOWN: i32 = -1_000_502;
-
-/// Reads a storage entry from the VM's storage into Wasm memory
-pub fn do_read<S: Storage, Q: Querier>(ctx: &mut Ctx, key_ptr: u32, value_ptr: u32) -> i32 {
-    let key = match read_region(ctx, key_ptr, MAX_LENGTH_DB_KEY) {
-        Ok(data) => data,
-        Err(VmError::RegionLengthTooBigErr { .. }) => return ERROR_REGION_READ_LENGTH_TOO_BIG,
-        Err(_) => return ERROR_REGION_READ_UNKNOWN,
-    };
-    let value: Option<Vec<u8>> = match with_storage_from_context::<S, Q, _, _>(ctx, |store| {
-        store
-            .get(&key)
-            .or_else(|_| make_runtime_err("Error reading from backend"))
-    }) {
-        Ok(v) => v,
-        Err(VmError::UninitializedContextData { .. }) => return ERROR_NO_CONTEXT_DATA,
-        Err(_) => return ERROR_DB_UNKNOWN,
-    };
-    match value {
-        Some(buf) => match write_region(ctx, value_ptr, &buf) {
-            Ok(()) => SUCCESS,
-            Err(VmError::RegionTooSmallErr { .. }) => ERROR_REGION_WRITE_TOO_SMALL,
-            Err(_) => ERROR_REGION_WRITE_UNKNOWN,
-        },
-        None => SUCCESS,
-    }
-}
-
-/// Writes a storage entry from Wasm memory into the VM's storage
-pub fn do_write<S: Storage, Q: Querier>(ctx: &mut Ctx, key_ptr: u32, value_ptr: u32) -> i32 {
-    let key = match read_region(ctx, key_ptr, MAX_LENGTH_DB_KEY) {
-        Ok(data) => data,
-        Err(VmError::RegionLengthTooBigErr { .. }) => return ERROR_REGION_READ_LENGTH_TOO_BIG,
-        Err(_) => return ERROR_REGION_READ_UNKNOWN,
-    };
-    let value = match read_region(ctx, value_ptr, MAX_LENGTH_DB_VALUE) {
-        Ok(data) => data,
-        Err(VmError::RegionLengthTooBigErr { .. }) => return ERROR_REGION_READ_LENGTH_TOO_BIG,
-        Err(_) => return ERROR_REGION_READ_UNKNOWN,
-    };
-    match with_storage_from_context::<S, Q, _, ()>(ctx, |store| {
-        store
-            .set(&key, &value)
-            .or_else(|_| make_runtime_err("Error setting database value in backend"))
-    }) {
-        Ok(_) => SUCCESS,
-        Err(VmError::UninitializedContextData { .. }) => ERROR_NO_CONTEXT_DATA,
-        Err(_) => ERROR_DB_UNKNOWN,
-    }
-}
-
-pub fn do_remove<S: Storage, Q: Querier>(ctx: &mut Ctx, key_ptr: u32) -> i32 {
-    let key = match read_region(ctx, key_ptr, MAX_LENGTH_DB_KEY) {
-        Ok(data) => data,
-        Err(VmError::RegionLengthTooBigErr { .. }) => return ERROR_REGION_READ_LENGTH_TOO_BIG,
-        Err(_) => return ERROR_REGION_READ_UNKNOWN,
-    };
-    match with_storage_from_context::<S, Q, _, ()>(ctx, |store| {
-        store
-            .remove(&key)
-            .or_else(|_| make_runtime_err("Error removing database key from backend"))
-    }) {
-        Ok(_) => SUCCESS,
-        Err(VmError::UninitializedContextData { .. }) => ERROR_NO_CONTEXT_DATA,
-        Err(_) => ERROR_DB_UNKNOWN,
-    }
-}
-
-pub fn do_canonicalize_address<A: Api>(
-    api: A,
-    ctx: &mut Ctx,
-    human_ptr: u32,
-    canonical_ptr: u32,
-) -> i32 {
-    let human_data = match read_region(ctx, human_ptr, MAX_LENGTH_HUMAN_ADDRESS) {
-        Ok(data) => data,
-        Err(VmError::RegionLengthTooBigErr { .. }) => return ERROR_REGION_READ_LENGTH_TOO_BIG,
-        Err(_) => return ERROR_REGION_READ_UNKNOWN,
-    };
-    let human = match String::from_utf8(human_data) {
-        Ok(human_str) => HumanAddr(human_str),
-        Err(_) => return ERROR_CANONICALIZE_INVALID_INPUT,
-    };
-    match api.canonical_address(&human) {
-        Ok(canon) => match write_region(ctx, canonical_ptr, canon.as_slice()) {
-            Ok(()) => SUCCESS,
-            Err(VmError::RegionTooSmallErr { .. }) => ERROR_REGION_WRITE_TOO_SMALL,
-            Err(_) => ERROR_REGION_WRITE_UNKNOWN,
-        },
-        Err(_) => ERROR_CANONICALIZE_UNKNOWN,
-    }
-}
-
-pub fn do_humanize_address<A: Api>(
-    api: A,
-    ctx: &mut Ctx,
-    canonical_ptr: u32,
-    human_ptr: u32,
-) -> i32 {
-    let canonical = match read_region(ctx, canonical_ptr, MAX_LENGTH_CANONICAL_ADDRESS) {
-        Ok(data) => Binary(data),
-        Err(VmError::RegionLengthTooBigErr { .. }) => return ERROR_REGION_READ_LENGTH_TOO_BIG,
-        Err(_) => return ERROR_REGION_READ_UNKNOWN,
-    };
-    match api.human_address(&CanonicalAddr(canonical)) {
-        Ok(human) => match write_region(ctx, human_ptr, human.as_str().as_bytes()) {
-            Ok(()) => SUCCESS,
-            Err(VmError::RegionTooSmallErr { .. }) => ERROR_REGION_WRITE_TOO_SMALL,
-            Err(_) => ERROR_REGION_WRITE_UNKNOWN,
-        },
-        Err(_) => ERROR_HUMANIZE_UNKNOWN,
-    }
-}
-
-pub fn do_query_chain<A: Api, S: Storage, Q: Querier>(
-    _api: A,
-    ctx: &mut Ctx,
-    request_ptr: u32,
-    response_ptr: u32,
-) -> i32 {
-    let request = match read_region(ctx, request_ptr, MAX_LENGTH_QUERY_CHAIN_REQUEST) {
-        Ok(data) => data,
-        Err(VmError::RegionLengthTooBigErr { .. }) => return ERROR_REGION_READ_LENGTH_TOO_BIG,
-        Err(_) => return ERROR_REGION_READ_UNKNOWN,
-    };
-
-    let res = match from_slice::<QueryRequest>(&request) {
-        // if we parse, try to execute the query
-        Ok(parsed) => {
-            let qr: QuerierResponse =
-                with_querier_from_context::<S, Q, _, _>(ctx, |querier: &Q| querier.query(&parsed));
-            qr
-        }
-        // otherwise, return the InvalidRequest error as ApiSystemError
-        Err(err) => Err(ApiSystemError::InvalidRequest {
-            error: err.to_string(),
-        }),
-    };
-
-    let api_res: ApiQuerierResponse = res.into();
-
-    match to_vec(&api_res) {
-        Ok(serialized) => match write_region(ctx, response_ptr, &serialized) {
-            Ok(()) => SUCCESS,
-            Err(VmError::RegionTooSmallErr { .. }) => ERROR_REGION_WRITE_TOO_SMALL,
-            Err(_) => ERROR_REGION_WRITE_UNKNOWN,
-        },
-        Err(_) => ERROR_QUERY_CHAIN_CANNOT_SERIALIZE_RESPONSE,
-    }
-}
-
-#[cfg(feature = "iterator")]
-mod iter_support {
-    use super::*;
-    use crate::memory::maybe_read_region;
-    use cosmwasm_std::{Order, KV};
-    use std::convert::TryInto;
-    use std::mem;
-
-    /// Invalid Order enum value passed into scan
-    pub static ERROR_SCAN_INVALID_ORDER: i32 = -2_000_001;
-    /// An unknown error in the db_next implementation
-    pub static ERROR_NEXT_UNKNOWN: i32 = -2_000_101;
-    /// Iterator pointer not registered
-    pub static ERROR_NEXT_INVALID_ITERATOR: i32 = -2_000_102;
-
-    pub fn do_scan<S: Storage + 'static, Q: Querier>(
-        ctx: &mut Ctx,
-        start_ptr: u32,
-        end_ptr: u32,
-        order: i32,
-    ) -> i32 {
-        let start = match maybe_read_region(ctx, start_ptr, MAX_LENGTH_DB_KEY) {
-            Ok(data) => data,
-            Err(VmError::RegionLengthTooBigErr { .. }) => return ERROR_REGION_READ_LENGTH_TOO_BIG,
-            Err(_) => return ERROR_REGION_READ_UNKNOWN,
-        };
-        let end = match maybe_read_region(ctx, end_ptr, MAX_LENGTH_DB_KEY) {
-            Ok(data) => data,
-            Err(VmError::RegionLengthTooBigErr { .. }) => return ERROR_REGION_READ_LENGTH_TOO_BIG,
-            Err(_) => return ERROR_REGION_READ_UNKNOWN,
-        };
-        let order: Order = match order.try_into() {
-            Ok(o) => o,
-            Err(_) => return ERROR_SCAN_INVALID_ORDER,
-        };
-        let range_result = with_storage_from_context::<S, Q, _, _>(ctx, |store| {
-            let iter = match store.range(start.as_deref(), end.as_deref(), order) {
-                Ok(iter) => iter,
-                Err(_) => return make_runtime_err("An error occurred in range call"),
-            };
-
-            // Unsafe: I know the iterator will be deallocated before the storage as I control the lifetime below
-            // But there is no way for the compiler to know. So... let's just lie to the compiler a little bit.
-            let live_forever: Box<dyn Iterator<Item = StdResult<KV>> + 'static> =
-                unsafe { mem::transmute(iter) };
-            Ok(live_forever)
-        });
-
-        match range_result {
-            Ok(iterator) => {
-                let new_id = set_iterator::<S, Q>(ctx, iterator);
-                match to_i32(new_id) {
-                    Ok(new_id_signed) => new_id_signed,
-                    Err(_) => ERROR_DB_UNKNOWN,
-                }
-            }
-            Err(VmError::UninitializedContextData { .. }) => ERROR_NO_CONTEXT_DATA,
-            Err(_) => ERROR_DB_UNKNOWN,
-        }
-    }
-
-    pub fn do_next<S: Storage, Q: Querier>(
-        ctx: &mut Ctx,
-        iterator_id: u32,
-        key_ptr: u32,
-        value_ptr: u32,
-    ) -> i32 {
-        let item = match with_iterator_from_context::<S, Q, _, _>(ctx, iterator_id, |iter| {
-            Ok(iter.next())
-        }) {
-            Ok(i) => i,
-            Err(VmError::UninitializedContextData { .. }) => return ERROR_NO_CONTEXT_DATA,
-            Err(_) => return ERROR_NEXT_INVALID_ITERATOR,
-        };
-
-        // prepare return values
-        let (key, value) = match item {
-            Some(Ok(item)) => item,
-            Some(Err(_)) => return ERROR_NEXT_UNKNOWN,
-            None => return SUCCESS, // Return early without writing key. Empty key will later be treated as _no more element_.
-        };
-
-        match write_region(ctx, key_ptr, &key) {
-            Ok(()) => (),
-            Err(VmError::RegionTooSmallErr { .. }) => return ERROR_REGION_WRITE_TOO_SMALL,
-            Err(_) => return ERROR_REGION_WRITE_UNKNOWN,
-        };
-        match write_region(ctx, value_ptr, &value) {
-            Ok(()) => (),
-            Err(VmError::RegionTooSmallErr { .. }) => return ERROR_REGION_WRITE_TOO_SMALL,
-            Err(_) => return ERROR_REGION_WRITE_UNKNOWN,
-        };
-        SUCCESS
-    }
-
-    pub(crate) fn with_iterator_from_context<S, Q, F, T>(
-        ctx: &mut Ctx,
-        iterator_id: u32,
-        mut func: F,
-    ) -> VmResult<T>
-    where
-        S: Storage,
-        Q: Querier,
-        F: FnMut(&mut dyn Iterator<Item = StdResult<KV>>) -> VmResult<T>,
-    {
-        let b = get_context_data::<S, Q>(ctx);
-        let iter = b.iterators.remove(&iterator_id);
-        match iter {
-            Some(mut data) => {
-                let res = func(&mut data);
-                b.iterators.insert(iterator_id, data);
-                res
-            }
-            None => UninitializedContextData { kind: "iterator" }.fail(),
-        }
-    }
-
-    // set the iterator, overwriting any possible iterator previously set
-    fn set_iterator<S: Storage, Q: Querier>(
-        ctx: &mut Ctx,
-        iter: Box<dyn Iterator<Item = StdResult<KV>>>,
-    ) -> u32 {
-        let b = get_context_data::<S, Q>(ctx);
-        let last_id: u32 = b
-            .iterators
-            .len()
-            .try_into()
-            .expect("Found more iterator IDs than supported");
-        let new_id = last_id + 1;
-        b.iterators.insert(new_id, iter);
-        new_id
-    }
-}
+use crate::errors::{UninitializedContextData, VmResult};
 
 /** context data **/
 
@@ -446,18 +120,55 @@ pub(crate) fn move_into_context<S: Storage, Q: Querier>(target: &mut Ctx, storag
     b.querier = Some(querier);
 }
 
+#[cfg(feature = "iterator")]
+pub(crate) fn with_iterator_from_context<S, Q, F, T>(
+    ctx: &mut Ctx,
+    iterator_id: u32,
+    mut func: F,
+) -> VmResult<T>
+where
+    S: Storage,
+    Q: Querier,
+    F: FnMut(&mut dyn Iterator<Item = StdResult<KV>>) -> VmResult<T>,
+{
+    let b = get_context_data::<S, Q>(ctx);
+    let iter = b.iterators.remove(&iterator_id);
+    match iter {
+        Some(mut data) => {
+            let res = func(&mut data);
+            b.iterators.insert(iterator_id, data);
+            res
+        }
+        None => UninitializedContextData { kind: "iterator" }.fail(),
+    }
+}
+
+// set the iterator, overwriting any possible iterator previously
+#[cfg(feature = "iterator")]
+pub fn set_iterator<S: Storage, Q: Querier>(
+    ctx: &mut Ctx,
+    iter: Box<dyn Iterator<Item = StdResult<KV>>>,
+) -> u32 {
+    let b = get_context_data::<S, Q>(ctx);
+    let last_id: u32 = b
+        .iterators
+        .len()
+        .try_into()
+        .expect("Found more iterator IDs than supported");
+    let new_id = last_id + 1;
+    b.iterators.insert(new_id, iter);
+    new_id
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
     use crate::backends::compile;
     use cosmwasm_std::testing::{MockQuerier, MockStorage};
-    use cosmwasm_std::{coin, coins, from_binary, AllBalanceResponse, ReadonlyStorage};
+    use cosmwasm_std::{
+        coin, coins, from_binary, AllBalanceResponse, HumanAddr, QueryRequest, ReadonlyStorage,
+    };
     use wasmer_runtime_core::{imports, instance::Instance, typed_func::Func};
-
-    #[cfg(feature = "iterator")]
-    use super::iter_support::with_iterator_from_context;
-    #[cfg(feature = "iterator")]
-    use crate::conversion::to_u32;
 
     static CONTRACT: &[u8] = include_bytes!("../testdata/contract.wasm");
 
@@ -555,148 +266,6 @@ mod test {
             Ok(())
         })
         .unwrap();
-    }
-
-    #[test]
-    #[cfg(feature = "iterator")]
-    fn with_iterator_miss_and_hit() {
-        // this creates an instance
-        let mut instance = make_instance();
-        leave_default_data(&mut instance);
-        let ctx = instance.context_mut();
-
-        let miss = with_iterator_from_context::<S, Q, _, ()>(ctx, 1, |_iter| {
-            panic!("this should be empty / not callled");
-        });
-        match miss {
-            Ok(_) => panic!("Expected error"),
-            Err(VmError::UninitializedContextData { .. }) => assert!(true),
-            Err(e) => panic!("Unexpected error: {}", e),
-        }
-
-        // add some more data
-        let (next_key, next_value): (&[u8], &[u8]) = (b"second", b"point");
-        with_storage_from_context::<S, Q, _, ()>(ctx, |store| {
-            store
-                .set(next_key, next_value)
-                .expect("error setting value");
-            Ok(())
-        })
-        .unwrap();
-
-        // set up iterator over all space
-        let id = to_u32(do_scan::<S, Q>(
-            ctx,
-            0,
-            0,
-            cosmwasm_std::Order::Ascending.into(),
-        ))
-        .expect("ID must not negative");
-        assert_eq!(1, id);
-
-        let item =
-            with_iterator_from_context::<S, Q, _, _>(ctx, id, |iter| Ok(iter.next())).unwrap();
-        assert_eq!(
-            item.unwrap().unwrap(),
-            (INIT_KEY.to_vec(), INIT_VALUE.to_vec())
-        );
-
-        let item =
-            with_iterator_from_context::<S, Q, _, _>(ctx, id, |iter| Ok(iter.next())).unwrap();
-        assert_eq!(
-            item.unwrap().unwrap(),
-            (next_key.to_vec(), next_value.to_vec())
-        );
-
-        let item =
-            with_iterator_from_context::<S, Q, _, _>(ctx, id, |iter| Ok(iter.next())).unwrap();
-        assert!(item.is_none());
-
-        // we also miss when using a non-registered counter
-        let miss = with_iterator_from_context::<S, Q, _, ()>(ctx, id + 1, |_iter| {
-            panic!("this should be empty / not callled");
-        });
-        match miss {
-            Ok(_) => panic!("Expected error"),
-            Err(VmError::UninitializedContextData { .. }) => assert!(true),
-            Err(e) => panic!("Unexpected error: {}", e),
-        }
-    }
-
-    #[test]
-    #[cfg(feature = "iterator")]
-    fn multiple_iterators() {
-        // this creates an instance
-        let mut instance = make_instance();
-        leave_default_data(&mut instance);
-        let ctx = instance.context_mut();
-
-        // add some more data
-        let (next_key, next_value): (&[u8], &[u8]) = (b"second", b"point");
-        with_storage_from_context::<S, Q, _, ()>(ctx, |store| {
-            store
-                .set(next_key, next_value)
-                .expect("error setting value");
-            Ok(())
-        })
-        .unwrap();
-
-        // set up iterator over all space
-        let id1 = to_u32(do_scan::<S, Q>(
-            ctx,
-            0,
-            0,
-            cosmwasm_std::Order::Ascending.into(),
-        ))
-        .expect("ID must not negative");
-        assert_eq!(1, id1);
-
-        // first item, first iterator
-        let item =
-            with_iterator_from_context::<S, Q, _, _>(ctx, id1, |iter| Ok(iter.next())).unwrap();
-        assert_eq!(
-            item.unwrap().unwrap(),
-            (INIT_KEY.to_vec(), INIT_VALUE.to_vec())
-        );
-
-        // set up second iterator over all space
-        let id2 = to_u32(do_scan::<S, Q>(
-            ctx,
-            0,
-            0,
-            cosmwasm_std::Order::Ascending.into(),
-        ))
-        .expect("ID must not negative");
-        assert_eq!(2, id2);
-
-        // second item, first iterator
-        let item =
-            with_iterator_from_context::<S, Q, _, _>(ctx, id1, |iter| Ok(iter.next())).unwrap();
-        assert_eq!(
-            item.unwrap().unwrap(),
-            (next_key.to_vec(), next_value.to_vec())
-        );
-
-        // first item, second iterator
-        let item =
-            with_iterator_from_context::<S, Q, _, _>(ctx, id2, |iter| Ok(iter.next())).unwrap();
-        assert_eq!(
-            item.unwrap().unwrap(),
-            (INIT_KEY.to_vec(), INIT_VALUE.to_vec())
-        );
-
-        // end, first iterator
-        let item =
-            with_iterator_from_context::<S, Q, _, _>(ctx, id1, |iter| Ok(iter.next())).unwrap();
-        assert!(item.is_none());
-
-        // second item, second iterator
-        let item =
-            with_iterator_from_context::<S, Q, _, _>(ctx, id2, |iter| Ok(iter.next())).unwrap();
-        assert_eq!(
-            item.unwrap().unwrap(),
-            (next_key.to_vec(), next_value.to_vec())
-        );
     }
 
     #[test]

--- a/packages/vm/src/context.rs
+++ b/packages/vm/src/context.rs
@@ -264,8 +264,7 @@ mod test {
     }
 
     #[test]
-    fn with_storage_set_get() {
-        // this creates an instance
+    fn with_storage_from_context_set_get() {
         let mut instance = make_instance();
         leave_default_data(&mut instance);
         let ctx = instance.context_mut();
@@ -294,8 +293,20 @@ mod test {
     }
 
     #[test]
-    fn with_query_success() {
-        // this creates an instance
+    #[should_panic]
+    fn with_storage_from_context_handles_panics() {
+        let mut instance = make_instance();
+        leave_default_data(&mut instance);
+        let ctx = instance.context_mut();
+
+        with_storage_from_context::<S, Q, _, ()>(ctx, |_store| {
+            panic!("fails, but shouldn't cause segfault")
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn with_querier_from_context_works() {
         let mut instance = make_instance();
         leave_default_data(&mut instance);
         let ctx = instance.context_mut();
@@ -314,8 +325,7 @@ mod test {
     }
 
     #[test]
-    fn with_query_parse_success() {
-        // this creates an instance
+    fn with_querier_from_context_parse_works() {
         let mut instance = make_instance();
         leave_default_data(&mut instance);
         let ctx = instance.context_mut();
@@ -338,22 +348,7 @@ mod test {
 
     #[test]
     #[should_panic]
-    fn with_storage_handles_panics() {
-        // this creates an instance
-        let mut instance = make_instance();
-        leave_default_data(&mut instance);
-        let ctx = instance.context_mut();
-
-        with_storage_from_context::<S, Q, _, ()>(ctx, |_store| {
-            panic!("fails, but shouldn't cause segfault")
-        })
-        .unwrap();
-    }
-
-    #[test]
-    #[should_panic]
-    fn with_query_handles_panics() {
-        // this creates an instance
+    fn with_querier_from_context_handles_panics() {
         let mut instance = make_instance();
         leave_default_data(&mut instance);
         let ctx = instance.context_mut();

--- a/packages/vm/src/context.rs
+++ b/packages/vm/src/context.rs
@@ -293,14 +293,14 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "A panic occurred in the callback.")]
     fn with_storage_from_context_handles_panics() {
         let mut instance = make_instance();
         leave_default_data(&mut instance);
         let ctx = instance.context_mut();
 
         with_storage_from_context::<S, Q, _, ()>(ctx, |_store| {
-            panic!("fails, but shouldn't cause segfault")
+            panic!("A panic occurred in the callback.")
         })
         .unwrap();
     }
@@ -347,14 +347,14 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "A panic occurred in the callback.")]
     fn with_querier_from_context_handles_panics() {
         let mut instance = make_instance();
         leave_default_data(&mut instance);
         let ctx = instance.context_mut();
 
         with_querier_from_context::<S, Q, _, ()>(ctx, |_querier| {
-            panic!("fails, but shouldn't cause segfault")
+            panic!("A panic occurred in the callback.")
         })
         .unwrap();
     }

--- a/packages/vm/src/imports.rs
+++ b/packages/vm/src/imports.rs
@@ -419,6 +419,21 @@ mod test {
     }
 
     #[test]
+    fn do_read_fails_for_large_key() {
+        let mut instance = make_instance();
+
+        let key_ptr = write_data(&mut instance, &vec![7u8; 300 * 1024]);
+        let value_ptr = create_empty(&mut instance, 50);
+
+        let ctx = instance.context_mut();
+        leave_default_data(ctx);
+
+        let result = do_read::<S, Q>(ctx, key_ptr, value_ptr);
+        assert_eq!(result, ERROR_REGION_READ_LENGTH_TOO_BIG);
+        assert!(read_region(ctx, value_ptr, 500).unwrap().is_empty());
+    }
+
+    #[test]
     fn do_read_fails_for_small_result_region() {
         let mut instance = make_instance();
 

--- a/packages/vm/src/imports.rs
+++ b/packages/vm/src/imports.rs
@@ -354,7 +354,7 @@ mod test {
         instance
     }
 
-    fn leave_default_data(instance: &mut Instance) {
+    fn leave_default_data(ctx: &mut Ctx) {
         // create some mock data
         let mut storage = MockStorage::new();
         storage
@@ -362,7 +362,7 @@ mod test {
             .expect("error setting value");
         let querier =
             MockQuerier::new(&[(&HumanAddr::from(INIT_ADDR), &coins(INIT_AMOUNT, INIT_DENOM))]);
-        move_into_context(instance.context_mut(), storage, querier);
+        move_into_context(ctx, storage, querier);
     }
 
     #[test]
@@ -370,8 +370,8 @@ mod test {
     fn do_scan_with_iterator_miss_and_hit() {
         // this creates an instance
         let mut instance = make_instance();
-        leave_default_data(&mut instance);
         let ctx = instance.context_mut();
+        leave_default_data(ctx);
 
         // add some more data
         let (next_key, next_value): (&[u8], &[u8]) = (b"second", b"point");
@@ -412,8 +412,8 @@ mod test {
     fn do_scan_multiple_iterators() {
         // this creates an instance
         let mut instance = make_instance();
-        leave_default_data(&mut instance);
         let ctx = instance.context_mut();
+        leave_default_data(ctx);
 
         // add some more data
         let (next_key, next_value): (&[u8], &[u8]) = (b"second", b"point");

--- a/packages/vm/src/imports.rs
+++ b/packages/vm/src/imports.rs
@@ -16,7 +16,7 @@ use cosmwasm_std::{Order, KV};
 use wasmer_runtime_core::vm::Ctx;
 
 #[cfg(feature = "iterator")]
-use crate::context::{set_iterator, with_iterator_from_context};
+use crate::context::{add_iterator, with_iterator_from_context};
 use crate::context::{with_querier_from_context, with_storage_from_context};
 #[cfg(feature = "iterator")]
 use crate::conversion::to_i32;
@@ -262,7 +262,7 @@ pub fn do_scan<S: Storage + 'static, Q: Querier>(
 
     match range_result {
         Ok(iterator) => {
-            let new_id = set_iterator::<S, Q>(ctx, iterator);
+            let new_id = add_iterator::<S, Q>(ctx, iterator);
             match to_i32(new_id) {
                 Ok(new_id_signed) => new_id_signed,
                 Err(_) => ERROR_SCAN_UNKNOWN,

--- a/packages/vm/src/imports.rs
+++ b/packages/vm/src/imports.rs
@@ -64,9 +64,12 @@ static ERROR_DB_UNKNOWN: i32 = -1_000_502;
 
 // The 2_xxx_xxx namespace is reserved for #[cfg(feature = "iterator")]
 
+/// An unknown error in the db_scan implementation
+#[cfg(feature = "iterator")]
+static ERROR_SCAN_UNKNOWN: i32 = -2_000_001;
 /// Invalid Order enum value passed into scan
 #[cfg(feature = "iterator")]
-static ERROR_SCAN_INVALID_ORDER: i32 = -2_000_001;
+static ERROR_SCAN_INVALID_ORDER: i32 = -2_000_002;
 /// An unknown error in the db_next implementation
 #[cfg(feature = "iterator")]
 static ERROR_NEXT_UNKNOWN: i32 = -2_000_101;
@@ -262,11 +265,11 @@ pub fn do_scan<S: Storage + 'static, Q: Querier>(
             let new_id = set_iterator::<S, Q>(ctx, iterator);
             match to_i32(new_id) {
                 Ok(new_id_signed) => new_id_signed,
-                Err(_) => ERROR_DB_UNKNOWN,
+                Err(_) => ERROR_SCAN_UNKNOWN,
             }
         }
         Err(VmError::UninitializedContextData { .. }) => ERROR_NO_CONTEXT_DATA,
-        Err(_) => ERROR_DB_UNKNOWN,
+        Err(_) => ERROR_SCAN_UNKNOWN,
     }
 }
 

--- a/packages/vm/src/imports.rs
+++ b/packages/vm/src/imports.rs
@@ -373,15 +373,6 @@ mod test {
         leave_default_data(&mut instance);
         let ctx = instance.context_mut();
 
-        let miss = with_iterator_from_context::<S, Q, _, ()>(ctx, 1, |_iter| {
-            panic!("this should be empty / not callled");
-        });
-        match miss {
-            Ok(_) => panic!("Expected error"),
-            Err(VmError::UninitializedContextData { .. }) => assert!(true),
-            Err(e) => panic!("Unexpected error: {}", e),
-        }
-
         // add some more data
         let (next_key, next_value): (&[u8], &[u8]) = (b"second", b"point");
         with_storage_from_context::<S, Q, _, ()>(ctx, |store| {
@@ -414,16 +405,6 @@ mod test {
         let item =
             with_iterator_from_context::<S, Q, _, _>(ctx, id, |iter| Ok(iter.next())).unwrap();
         assert!(item.is_none());
-
-        // we also miss when using a non-registered counter
-        let miss = with_iterator_from_context::<S, Q, _, ()>(ctx, id + 1, |_iter| {
-            panic!("this should be empty / not callled");
-        });
-        match miss {
-            Ok(_) => panic!("Expected error"),
-            Err(VmError::UninitializedContextData { .. }) => assert!(true),
-            Err(e) => panic!("Unexpected error: {}", e),
-        }
     }
 
     #[test]

--- a/packages/vm/src/imports.rs
+++ b/packages/vm/src/imports.rs
@@ -1,0 +1,506 @@
+//! Import implementations
+
+#[cfg(feature = "iterator")]
+use std::convert::TryInto;
+#[cfg(feature = "iterator")]
+use std::mem;
+
+#[cfg(feature = "iterator")]
+use cosmwasm_std::StdResult;
+use cosmwasm_std::{
+    Api, ApiQuerierResponse, ApiSystemError, Binary, CanonicalAddr, HumanAddr, Querier,
+    QuerierResponse, QueryRequest, Storage,
+};
+#[cfg(feature = "iterator")]
+use cosmwasm_std::{Order, KV};
+use wasmer_runtime_core::vm::Ctx;
+
+#[cfg(feature = "iterator")]
+use crate::context::{set_iterator, with_iterator_from_context};
+use crate::context::{with_querier_from_context, with_storage_from_context};
+#[cfg(feature = "iterator")]
+use crate::conversion::to_i32;
+use crate::errors::{make_runtime_err, VmError};
+#[cfg(feature = "iterator")]
+use crate::memory::maybe_read_region;
+use crate::memory::{read_region, write_region};
+use crate::serde::{from_slice, to_vec};
+
+/// A kibi (kilo binary)
+static KI: usize = 1024;
+/// Max key length for db_write (i.e. when VM reads from Wasm memory). Should match the
+/// value for db_next (see DB_READ_KEY_BUFFER_LENGTH in packages/std/src/imports.rs)
+static MAX_LENGTH_DB_KEY: usize = 64 * KI;
+/// Max key length for db_write (i.e. when VM reads from Wasm memory). Should match the
+/// value for db_read/db_next (see DB_READ_VALUE_BUFFER_LENGTH in packages/std/src/imports.rs)
+static MAX_LENGTH_DB_VALUE: usize = 128 * KI;
+/// Typically 20 (Cosmos SDK, Ethereum) or 32 (Nano, Substrate)
+static MAX_LENGTH_CANONICAL_ADDRESS: usize = 32;
+/// The maximum allowed size for bech32 (https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#bech32)
+static MAX_LENGTH_HUMAN_ADDRESS: usize = 90;
+static MAX_LENGTH_QUERY_CHAIN_REQUEST: usize = 64 * KI;
+
+static SUCCESS: i32 = 0;
+/// An unknown error occurred when writing to region
+static ERROR_REGION_WRITE_UNKNOWN: i32 = -1_000_001;
+/// Could not write to region because it is too small
+static ERROR_REGION_WRITE_TOO_SMALL: i32 = -1_000_002;
+/// An unknown error occurred when reading region
+static ERROR_REGION_READ_UNKNOWN: i32 = -1_000_101;
+/// The contract sent us a Region we're not willing to read because it is too big
+static ERROR_REGION_READ_LENGTH_TOO_BIG: i32 = -1_000_102;
+/// An unknown error when canonicalizing address
+static ERROR_CANONICALIZE_UNKNOWN: i32 = -1_000_201;
+/// The input address (human address) was invalid
+static ERROR_CANONICALIZE_INVALID_INPUT: i32 = -1_000_202;
+/// An unknonw error when humanizing address
+static ERROR_HUMANIZE_UNKNOWN: i32 = -1_000_301;
+/// Cannot serialize query response
+static ERROR_QUERY_CHAIN_CANNOT_SERIALIZE_RESPONSE: i32 = -1_000_402;
+/// Generic error - using context with no Storage attached
+static ERROR_NO_CONTEXT_DATA: i32 = -1_000_501;
+/// Generic error - An unknown error accessing the DB
+static ERROR_DB_UNKNOWN: i32 = -1_000_502;
+
+// The 2_xxx_xxx namespace is reserved for #[cfg(feature = "iterator")]
+
+/// Invalid Order enum value passed into scan
+#[cfg(feature = "iterator")]
+static ERROR_SCAN_INVALID_ORDER: i32 = -2_000_001;
+/// An unknown error in the db_next implementation
+#[cfg(feature = "iterator")]
+static ERROR_NEXT_UNKNOWN: i32 = -2_000_101;
+/// Iterator pointer not registered
+#[cfg(feature = "iterator")]
+static ERROR_NEXT_INVALID_ITERATOR: i32 = -2_000_102;
+
+/// Reads a storage entry from the VM's storage into Wasm memory
+pub fn do_read<S: Storage, Q: Querier>(ctx: &mut Ctx, key_ptr: u32, value_ptr: u32) -> i32 {
+    let key = match read_region(ctx, key_ptr, MAX_LENGTH_DB_KEY) {
+        Ok(data) => data,
+        Err(VmError::RegionLengthTooBigErr { .. }) => return ERROR_REGION_READ_LENGTH_TOO_BIG,
+        Err(_) => return ERROR_REGION_READ_UNKNOWN,
+    };
+    let value: Option<Vec<u8>> = match with_storage_from_context::<S, Q, _, _>(ctx, |store| {
+        store
+            .get(&key)
+            .or_else(|_| make_runtime_err("Error reading from backend"))
+    }) {
+        Ok(v) => v,
+        Err(VmError::UninitializedContextData { .. }) => return ERROR_NO_CONTEXT_DATA,
+        Err(_) => return ERROR_DB_UNKNOWN,
+    };
+    match value {
+        Some(buf) => match write_region(ctx, value_ptr, &buf) {
+            Ok(()) => SUCCESS,
+            Err(VmError::RegionTooSmallErr { .. }) => ERROR_REGION_WRITE_TOO_SMALL,
+            Err(_) => ERROR_REGION_WRITE_UNKNOWN,
+        },
+        None => SUCCESS,
+    }
+}
+
+/// Writes a storage entry from Wasm memory into the VM's storage
+pub fn do_write<S: Storage, Q: Querier>(ctx: &mut Ctx, key_ptr: u32, value_ptr: u32) -> i32 {
+    let key = match read_region(ctx, key_ptr, MAX_LENGTH_DB_KEY) {
+        Ok(data) => data,
+        Err(VmError::RegionLengthTooBigErr { .. }) => return ERROR_REGION_READ_LENGTH_TOO_BIG,
+        Err(_) => return ERROR_REGION_READ_UNKNOWN,
+    };
+    let value = match read_region(ctx, value_ptr, MAX_LENGTH_DB_VALUE) {
+        Ok(data) => data,
+        Err(VmError::RegionLengthTooBigErr { .. }) => return ERROR_REGION_READ_LENGTH_TOO_BIG,
+        Err(_) => return ERROR_REGION_READ_UNKNOWN,
+    };
+    match with_storage_from_context::<S, Q, _, ()>(ctx, |store| {
+        store
+            .set(&key, &value)
+            .or_else(|_| make_runtime_err("Error setting database value in backend"))
+    }) {
+        Ok(_) => SUCCESS,
+        Err(VmError::UninitializedContextData { .. }) => ERROR_NO_CONTEXT_DATA,
+        Err(_) => ERROR_DB_UNKNOWN,
+    }
+}
+
+pub fn do_remove<S: Storage, Q: Querier>(ctx: &mut Ctx, key_ptr: u32) -> i32 {
+    let key = match read_region(ctx, key_ptr, MAX_LENGTH_DB_KEY) {
+        Ok(data) => data,
+        Err(VmError::RegionLengthTooBigErr { .. }) => return ERROR_REGION_READ_LENGTH_TOO_BIG,
+        Err(_) => return ERROR_REGION_READ_UNKNOWN,
+    };
+    match with_storage_from_context::<S, Q, _, ()>(ctx, |store| {
+        store
+            .remove(&key)
+            .or_else(|_| make_runtime_err("Error removing database key from backend"))
+    }) {
+        Ok(_) => SUCCESS,
+        Err(VmError::UninitializedContextData { .. }) => ERROR_NO_CONTEXT_DATA,
+        Err(_) => ERROR_DB_UNKNOWN,
+    }
+}
+
+pub fn do_canonicalize_address<A: Api>(
+    api: A,
+    ctx: &mut Ctx,
+    human_ptr: u32,
+    canonical_ptr: u32,
+) -> i32 {
+    let human_data = match read_region(ctx, human_ptr, MAX_LENGTH_HUMAN_ADDRESS) {
+        Ok(data) => data,
+        Err(VmError::RegionLengthTooBigErr { .. }) => return ERROR_REGION_READ_LENGTH_TOO_BIG,
+        Err(_) => return ERROR_REGION_READ_UNKNOWN,
+    };
+    let human = match String::from_utf8(human_data) {
+        Ok(human_str) => HumanAddr(human_str),
+        Err(_) => return ERROR_CANONICALIZE_INVALID_INPUT,
+    };
+    match api.canonical_address(&human) {
+        Ok(canon) => match write_region(ctx, canonical_ptr, canon.as_slice()) {
+            Ok(()) => SUCCESS,
+            Err(VmError::RegionTooSmallErr { .. }) => ERROR_REGION_WRITE_TOO_SMALL,
+            Err(_) => ERROR_REGION_WRITE_UNKNOWN,
+        },
+        Err(_) => ERROR_CANONICALIZE_UNKNOWN,
+    }
+}
+
+pub fn do_humanize_address<A: Api>(
+    api: A,
+    ctx: &mut Ctx,
+    canonical_ptr: u32,
+    human_ptr: u32,
+) -> i32 {
+    let canonical = match read_region(ctx, canonical_ptr, MAX_LENGTH_CANONICAL_ADDRESS) {
+        Ok(data) => Binary(data),
+        Err(VmError::RegionLengthTooBigErr { .. }) => return ERROR_REGION_READ_LENGTH_TOO_BIG,
+        Err(_) => return ERROR_REGION_READ_UNKNOWN,
+    };
+    match api.human_address(&CanonicalAddr(canonical)) {
+        Ok(human) => match write_region(ctx, human_ptr, human.as_str().as_bytes()) {
+            Ok(()) => SUCCESS,
+            Err(VmError::RegionTooSmallErr { .. }) => ERROR_REGION_WRITE_TOO_SMALL,
+            Err(_) => ERROR_REGION_WRITE_UNKNOWN,
+        },
+        Err(_) => ERROR_HUMANIZE_UNKNOWN,
+    }
+}
+
+pub fn do_query_chain<A: Api, S: Storage, Q: Querier>(
+    _api: A,
+    ctx: &mut Ctx,
+    request_ptr: u32,
+    response_ptr: u32,
+) -> i32 {
+    let request = match read_region(ctx, request_ptr, MAX_LENGTH_QUERY_CHAIN_REQUEST) {
+        Ok(data) => data,
+        Err(VmError::RegionLengthTooBigErr { .. }) => return ERROR_REGION_READ_LENGTH_TOO_BIG,
+        Err(_) => return ERROR_REGION_READ_UNKNOWN,
+    };
+
+    let res = match from_slice::<QueryRequest>(&request) {
+        // if we parse, try to execute the query
+        Ok(parsed) => {
+            let qr: QuerierResponse =
+                with_querier_from_context::<S, Q, _, _>(ctx, |querier: &Q| querier.query(&parsed));
+            qr
+        }
+        // otherwise, return the InvalidRequest error as ApiSystemError
+        Err(err) => Err(ApiSystemError::InvalidRequest {
+            error: err.to_string(),
+        }),
+    };
+
+    let api_res: ApiQuerierResponse = res.into();
+
+    match to_vec(&api_res) {
+        Ok(serialized) => match write_region(ctx, response_ptr, &serialized) {
+            Ok(()) => SUCCESS,
+            Err(VmError::RegionTooSmallErr { .. }) => ERROR_REGION_WRITE_TOO_SMALL,
+            Err(_) => ERROR_REGION_WRITE_UNKNOWN,
+        },
+        Err(_) => ERROR_QUERY_CHAIN_CANNOT_SERIALIZE_RESPONSE,
+    }
+}
+
+#[cfg(feature = "iterator")]
+pub fn do_scan<S: Storage + 'static, Q: Querier>(
+    ctx: &mut Ctx,
+    start_ptr: u32,
+    end_ptr: u32,
+    order: i32,
+) -> i32 {
+    let start = match maybe_read_region(ctx, start_ptr, MAX_LENGTH_DB_KEY) {
+        Ok(data) => data,
+        Err(VmError::RegionLengthTooBigErr { .. }) => return ERROR_REGION_READ_LENGTH_TOO_BIG,
+        Err(_) => return ERROR_REGION_READ_UNKNOWN,
+    };
+    let end = match maybe_read_region(ctx, end_ptr, MAX_LENGTH_DB_KEY) {
+        Ok(data) => data,
+        Err(VmError::RegionLengthTooBigErr { .. }) => return ERROR_REGION_READ_LENGTH_TOO_BIG,
+        Err(_) => return ERROR_REGION_READ_UNKNOWN,
+    };
+    let order: Order = match order.try_into() {
+        Ok(o) => o,
+        Err(_) => return ERROR_SCAN_INVALID_ORDER,
+    };
+    let range_result = with_storage_from_context::<S, Q, _, _>(ctx, |store| {
+        let iter = match store.range(start.as_deref(), end.as_deref(), order) {
+            Ok(iter) => iter,
+            Err(_) => return make_runtime_err("An error occurred in range call"),
+        };
+
+        // Unsafe: I know the iterator will be deallocated before the storage as I control the lifetime below
+        // But there is no way for the compiler to know. So... let's just lie to the compiler a little bit.
+        let live_forever: Box<dyn Iterator<Item = StdResult<KV>> + 'static> =
+            unsafe { mem::transmute(iter) };
+        Ok(live_forever)
+    });
+
+    match range_result {
+        Ok(iterator) => {
+            let new_id = set_iterator::<S, Q>(ctx, iterator);
+            match to_i32(new_id) {
+                Ok(new_id_signed) => new_id_signed,
+                Err(_) => ERROR_DB_UNKNOWN,
+            }
+        }
+        Err(VmError::UninitializedContextData { .. }) => ERROR_NO_CONTEXT_DATA,
+        Err(_) => ERROR_DB_UNKNOWN,
+    }
+}
+
+#[cfg(feature = "iterator")]
+pub fn do_next<S: Storage, Q: Querier>(
+    ctx: &mut Ctx,
+    iterator_id: u32,
+    key_ptr: u32,
+    value_ptr: u32,
+) -> i32 {
+    let item =
+        match with_iterator_from_context::<S, Q, _, _>(ctx, iterator_id, |iter| Ok(iter.next())) {
+            Ok(i) => i,
+            Err(VmError::UninitializedContextData { .. }) => return ERROR_NO_CONTEXT_DATA,
+            Err(_) => return ERROR_NEXT_INVALID_ITERATOR,
+        };
+
+    // prepare return values
+    let (key, value) = match item {
+        Some(Ok(item)) => item,
+        Some(Err(_)) => return ERROR_NEXT_UNKNOWN,
+        None => return SUCCESS, // Return early without writing key. Empty key will later be treated as _no more element_.
+    };
+
+    match write_region(ctx, key_ptr, &key) {
+        Ok(()) => (),
+        Err(VmError::RegionTooSmallErr { .. }) => return ERROR_REGION_WRITE_TOO_SMALL,
+        Err(_) => return ERROR_REGION_WRITE_UNKNOWN,
+    };
+    match write_region(ctx, value_ptr, &value) {
+        Ok(()) => (),
+        Err(VmError::RegionTooSmallErr { .. }) => return ERROR_REGION_WRITE_TOO_SMALL,
+        Err(_) => return ERROR_REGION_WRITE_UNKNOWN,
+    };
+    SUCCESS
+}
+
+#[cfg(test)]
+#[cfg(feature = "iterator")]
+mod test {
+    use super::*;
+    use cosmwasm_std::testing::{MockQuerier, MockStorage};
+    use cosmwasm_std::{coins, HumanAddr};
+    use wasmer_runtime_core::{imports, instance::Instance, typed_func::Func};
+
+    use crate::backends::compile;
+    use crate::context::{move_into_context, setup_context};
+    #[cfg(feature = "iterator")]
+    use crate::conversion::to_u32;
+
+    static CONTRACT: &[u8] = include_bytes!("../testdata/contract.wasm");
+
+    // shorthand for function generics below
+    type S = MockStorage;
+    type Q = MockQuerier;
+
+    // prepared data
+    static INIT_KEY: &[u8] = b"foo";
+    static INIT_VALUE: &[u8] = b"bar";
+    // this account has some coins
+    static INIT_ADDR: &str = "someone";
+    static INIT_AMOUNT: u128 = 500;
+    static INIT_DENOM: &str = "TOKEN";
+
+    fn make_instance() -> Instance {
+        let module = compile(&CONTRACT).unwrap();
+        // we need stubs for all required imports
+        let import_obj = imports! {
+            || { setup_context::<MockStorage, MockQuerier>() },
+            "env" => {
+                "db_read" => Func::new(|_a: i32, _b: i32| -> i32 { 0 }),
+                "db_write" => Func::new(|_a: i32, _b: i32| -> i32 { 0 }),
+                "db_remove" => Func::new(|_a: i32| -> i32 { 0 }),
+                "db_scan" => Func::new(|_a: i32, _b: i32, _c: i32| -> i32 { 0 }),
+                "db_next" => Func::new(|_a: u32, _b: i32, _c: i32| -> i32 { 0 }),
+                "query_chain" => Func::new(|_a: i32, _b: i32| -> i32 { 0 }),
+                "canonicalize_address" => Func::new(|_a: i32, _b: i32| -> i32 { 0 }),
+                "humanize_address" => Func::new(|_a: i32, _b: i32| -> i32 { 0 }),
+            },
+        };
+        let instance = module.instantiate(&import_obj).unwrap();
+        instance
+    }
+
+    fn leave_default_data(instance: &mut Instance) {
+        // create some mock data
+        let mut storage = MockStorage::new();
+        storage
+            .set(INIT_KEY, INIT_VALUE)
+            .expect("error setting value");
+        let querier =
+            MockQuerier::new(&[(&HumanAddr::from(INIT_ADDR), &coins(INIT_AMOUNT, INIT_DENOM))]);
+        move_into_context(instance.context_mut(), storage, querier);
+    }
+
+    #[test]
+    #[cfg(feature = "iterator")]
+    fn do_scan_with_iterator_miss_and_hit() {
+        // this creates an instance
+        let mut instance = make_instance();
+        leave_default_data(&mut instance);
+        let ctx = instance.context_mut();
+
+        let miss = with_iterator_from_context::<S, Q, _, ()>(ctx, 1, |_iter| {
+            panic!("this should be empty / not callled");
+        });
+        match miss {
+            Ok(_) => panic!("Expected error"),
+            Err(VmError::UninitializedContextData { .. }) => assert!(true),
+            Err(e) => panic!("Unexpected error: {}", e),
+        }
+
+        // add some more data
+        let (next_key, next_value): (&[u8], &[u8]) = (b"second", b"point");
+        with_storage_from_context::<S, Q, _, ()>(ctx, |store| {
+            store
+                .set(next_key, next_value)
+                .expect("error setting value");
+            Ok(())
+        })
+        .unwrap();
+
+        // set up iterator over all space
+        let id = to_u32(do_scan::<S, Q>(
+            ctx,
+            0,
+            0,
+            cosmwasm_std::Order::Ascending.into(),
+        ))
+        .expect("ID must not negative");
+        assert_eq!(1, id);
+
+        let item =
+            with_iterator_from_context::<S, Q, _, _>(ctx, id, |iter| Ok(iter.next())).unwrap();
+        assert_eq!(
+            item.unwrap().unwrap(),
+            (INIT_KEY.to_vec(), INIT_VALUE.to_vec())
+        );
+
+        let item =
+            with_iterator_from_context::<S, Q, _, _>(ctx, id, |iter| Ok(iter.next())).unwrap();
+        assert_eq!(
+            item.unwrap().unwrap(),
+            (next_key.to_vec(), next_value.to_vec())
+        );
+
+        let item =
+            with_iterator_from_context::<S, Q, _, _>(ctx, id, |iter| Ok(iter.next())).unwrap();
+        assert!(item.is_none());
+
+        // we also miss when using a non-registered counter
+        let miss = with_iterator_from_context::<S, Q, _, ()>(ctx, id + 1, |_iter| {
+            panic!("this should be empty / not callled");
+        });
+        match miss {
+            Ok(_) => panic!("Expected error"),
+            Err(VmError::UninitializedContextData { .. }) => assert!(true),
+            Err(e) => panic!("Unexpected error: {}", e),
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "iterator")]
+    fn do_scan_multiple_iterators() {
+        // this creates an instance
+        let mut instance = make_instance();
+        leave_default_data(&mut instance);
+        let ctx = instance.context_mut();
+
+        // add some more data
+        let (next_key, next_value): (&[u8], &[u8]) = (b"second", b"point");
+        with_storage_from_context::<S, Q, _, ()>(ctx, |store| {
+            store
+                .set(next_key, next_value)
+                .expect("error setting value");
+            Ok(())
+        })
+        .unwrap();
+
+        // set up iterator over all space
+        let id1 = to_u32(do_scan::<S, Q>(
+            ctx,
+            0,
+            0,
+            cosmwasm_std::Order::Ascending.into(),
+        ))
+        .expect("ID must not negative");
+        assert_eq!(1, id1);
+
+        // first item, first iterator
+        let item =
+            with_iterator_from_context::<S, Q, _, _>(ctx, id1, |iter| Ok(iter.next())).unwrap();
+        assert_eq!(
+            item.unwrap().unwrap(),
+            (INIT_KEY.to_vec(), INIT_VALUE.to_vec())
+        );
+
+        // set up second iterator over all space
+        let id2 = to_u32(do_scan::<S, Q>(
+            ctx,
+            0,
+            0,
+            cosmwasm_std::Order::Ascending.into(),
+        ))
+        .expect("ID must not negative");
+        assert_eq!(2, id2);
+
+        // second item, first iterator
+        let item =
+            with_iterator_from_context::<S, Q, _, _>(ctx, id1, |iter| Ok(iter.next())).unwrap();
+        assert_eq!(
+            item.unwrap().unwrap(),
+            (next_key.to_vec(), next_value.to_vec())
+        );
+
+        // first item, second iterator
+        let item =
+            with_iterator_from_context::<S, Q, _, _>(ctx, id2, |iter| Ok(iter.next())).unwrap();
+        assert_eq!(
+            item.unwrap().unwrap(),
+            (INIT_KEY.to_vec(), INIT_VALUE.to_vec())
+        );
+
+        // end, first iterator
+        let item =
+            with_iterator_from_context::<S, Q, _, _>(ctx, id1, |iter| Ok(iter.next())).unwrap();
+        assert!(item.is_none());
+
+        // second item, second iterator
+        let item =
+            with_iterator_from_context::<S, Q, _, _>(ctx, id2, |iter| Ok(iter.next())).unwrap();
+        assert_eq!(
+            item.unwrap().unwrap(),
+            (next_key.to_vec(), next_value.to_vec())
+        );
+    }
+}

--- a/packages/vm/src/imports.rs
+++ b/packages/vm/src/imports.rs
@@ -57,6 +57,8 @@ static ERROR_CANONICALIZE_INVALID_INPUT: i32 = -1_000_202;
 static ERROR_HUMANIZE_UNKNOWN: i32 = -1_000_301;
 /// Cannot serialize query response
 static ERROR_QUERY_CHAIN_CANNOT_SERIALIZE_RESPONSE: i32 = -1_000_402;
+/// The given key does not exist in storage
+static ERROR_DB_READ_KEY_DOES_NOT_EXIST: i32 = -1_000_502;
 /// Generic error - using context with no Storage attached
 static ERROR_NO_CONTEXT_DATA: i32 = -1_000_501;
 /// Generic error - An unknown error accessing the DB
@@ -99,7 +101,7 @@ pub fn do_read<S: Storage, Q: Querier>(ctx: &mut Ctx, key_ptr: u32, value_ptr: u
             Err(VmError::RegionTooSmallErr { .. }) => ERROR_REGION_WRITE_TOO_SMALL,
             Err(_) => ERROR_REGION_WRITE_UNKNOWN,
         },
-        None => SUCCESS,
+        None => ERROR_DB_READ_KEY_DOES_NOT_EXIST,
     }
 }
 
@@ -412,8 +414,7 @@ mod test {
         leave_default_data(ctx);
 
         let result = do_read::<S, Q>(ctx, key_ptr, value_ptr);
-        // TODO: What if we had an error code for this?
-        assert_eq!(result, SUCCESS);
+        assert_eq!(result, ERROR_DB_READ_KEY_DOES_NOT_EXIST);
         assert!(read_region(ctx, value_ptr, 500).unwrap().is_empty());
     }
 

--- a/packages/vm/src/imports.rs
+++ b/packages/vm/src/imports.rs
@@ -390,13 +390,8 @@ mod test {
         .unwrap();
 
         // set up iterator over all space
-        let id = to_u32(do_scan::<S, Q>(
-            ctx,
-            0,
-            0,
-            cosmwasm_std::Order::Ascending.into(),
-        ))
-        .expect("ID must not negative");
+        let id = to_u32(do_scan::<S, Q>(ctx, 0, 0, Order::Ascending.into()))
+            .expect("ID must not be negative");
         assert_eq!(1, id);
 
         let item =
@@ -447,13 +442,8 @@ mod test {
         .unwrap();
 
         // set up iterator over all space
-        let id1 = to_u32(do_scan::<S, Q>(
-            ctx,
-            0,
-            0,
-            cosmwasm_std::Order::Ascending.into(),
-        ))
-        .expect("ID must not negative");
+        let id1 = to_u32(do_scan::<S, Q>(ctx, 0, 0, Order::Ascending.into()))
+            .expect("ID must not be negative");
         assert_eq!(1, id1);
 
         // first item, first iterator
@@ -465,13 +455,8 @@ mod test {
         );
 
         // set up second iterator over all space
-        let id2 = to_u32(do_scan::<S, Q>(
-            ctx,
-            0,
-            0,
-            cosmwasm_std::Order::Ascending.into(),
-        ))
-        .expect("ID must not negative");
+        let id2 = to_u32(do_scan::<S, Q>(ctx, 0, 0, Order::Ascending.into()))
+            .expect("ID must not be negative");
         assert_eq!(2, id2);
 
         // second item, first iterator

--- a/packages/vm/src/imports.rs
+++ b/packages/vm/src/imports.rs
@@ -314,7 +314,7 @@ pub fn do_next<S: Storage, Q: Querier>(
 mod test {
     use super::*;
     use cosmwasm_std::testing::{MockQuerier, MockStorage};
-    use cosmwasm_std::{coins, HumanAddr};
+    use cosmwasm_std::{coins, HumanAddr, ReadonlyStorage};
     use wasmer_runtime_core::{imports, instance::Instance, typed_func::Func};
 
     use crate::backends::compile;
@@ -446,6 +446,94 @@ mod test {
         let result = do_read::<S, Q>(ctx, key_ptr, value_ptr);
         assert_eq!(result, ERROR_REGION_WRITE_TOO_SMALL);
         assert!(read_region(ctx, value_ptr, 500).unwrap().is_empty());
+    }
+
+    #[test]
+    fn do_write_works() {
+        let mut instance = make_instance();
+
+        let key_ptr = write_data(&mut instance, b"new storage key");
+        let value_ptr = write_data(&mut instance, b"new value");
+
+        let ctx = instance.context_mut();
+        leave_default_data(ctx);
+
+        let result = do_write::<S, Q>(ctx, key_ptr, value_ptr);
+        assert_eq!(result, SUCCESS);
+
+        let val = with_storage_from_context::<S, Q, _, _>(ctx, |store| {
+            Ok(store.get(b"new storage key").expect("error getting value"))
+        })
+        .unwrap();
+        assert_eq!(val, Some(b"new value".to_vec()));
+    }
+
+    #[test]
+    fn do_write_works_for_empty_value() {
+        let mut instance = make_instance();
+
+        let key_ptr = write_data(&mut instance, b"new storage key");
+        let value_ptr = write_data(&mut instance, b"");
+
+        let ctx = instance.context_mut();
+        leave_default_data(ctx);
+
+        let result = do_write::<S, Q>(ctx, key_ptr, value_ptr);
+        assert_eq!(result, SUCCESS);
+
+        let val = with_storage_from_context::<S, Q, _, _>(ctx, |store| {
+            Ok(store.get(b"new storage key").expect("error getting value"))
+        })
+        .unwrap();
+        assert_eq!(val, Some(b"".to_vec()));
+    }
+
+    #[test]
+    fn do_write_fails_for_large_key() {
+        let mut instance = make_instance();
+
+        let key_ptr = write_data(&mut instance, &vec![4u8; 300 * 1024]);
+        let value_ptr = write_data(&mut instance, b"new value");
+
+        let ctx = instance.context_mut();
+        leave_default_data(ctx);
+
+        let result = do_write::<S, Q>(ctx, key_ptr, value_ptr);
+        assert_eq!(result, ERROR_REGION_READ_LENGTH_TOO_BIG);
+    }
+
+    #[test]
+    fn do_write_fails_for_large_value() {
+        let mut instance = make_instance();
+
+        let key_ptr = write_data(&mut instance, b"new storage key");
+        let value_ptr = write_data(&mut instance, &vec![5u8; 300 * 1024]);
+
+        let ctx = instance.context_mut();
+        leave_default_data(ctx);
+
+        let result = do_write::<S, Q>(ctx, key_ptr, value_ptr);
+        assert_eq!(result, ERROR_REGION_READ_LENGTH_TOO_BIG);
+    }
+
+    #[test]
+    fn do_write_can_override() {
+        let mut instance = make_instance();
+
+        let key_ptr = write_data(&mut instance, KEY1);
+        let value_ptr = write_data(&mut instance, VALUE2);
+
+        let ctx = instance.context_mut();
+        leave_default_data(ctx);
+
+        let result = do_write::<S, Q>(ctx, key_ptr, value_ptr);
+        assert_eq!(result, SUCCESS);
+
+        let val = with_storage_from_context::<S, Q, _, _>(ctx, |store| {
+            Ok(store.get(KEY1).expect("error getting value"))
+        })
+        .unwrap();
+        assert_eq!(val, Some(VALUE2.to_vec()));
     }
 
     #[test]

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -55,7 +55,8 @@ where
                 // Reads the database entry at the given key into the the value.
                 // A prepared and sufficiently large memory Region is expected at value_ptr that points to pre-allocated memory.
                 // Returns 0 on success. Returns negative value on error. An incomplete list of error codes is:
-                //   value region too small: -1000002
+                //   value region too small: -1_000_002
+                //   key does not exist: -1_000_502
                 // Ownership of both input and output pointer is not transferred to the host.
                 "db_read" => Func::new(move |ctx: &mut Ctx, key_ptr: u32, value_ptr: u32| -> i32 {
                     do_read::<S, Q>(ctx, key_ptr, value_ptr)

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -13,13 +13,15 @@ use cosmwasm_std::{Api, Extern, Querier, Storage};
 
 use crate::backends::{compile, get_gas, set_gas};
 use crate::context::{
-    do_canonicalize_address, do_humanize_address, do_query_chain, do_read, do_remove, do_write,
     move_into_context, move_out_of_context, setup_context, with_storage_from_context,
 };
-#[cfg(feature = "iterator")]
-use crate::context::{do_next, do_scan};
 use crate::conversion::to_u32;
 use crate::errors::{ResolveErr, VmResult, WasmerErr, WasmerRuntimeErr};
+use crate::imports::{
+    do_canonicalize_address, do_humanize_address, do_query_chain, do_read, do_remove, do_write,
+};
+#[cfg(feature = "iterator")]
+use crate::imports::{do_next, do_scan};
 use crate::memory::{get_memory_info, read_region, write_region};
 
 static WASM_PAGE_SIZE: u64 = 64 * 1024;

--- a/packages/vm/src/lib.rs
+++ b/packages/vm/src/lib.rs
@@ -5,6 +5,7 @@ mod compatability;
 mod context;
 mod conversion;
 mod errors;
+mod imports;
 mod instance;
 mod memory;
 mod middleware;


### PR DESCRIPTION
Based on #285

This fixes the first ~two~ 3 items from #237 

In order to provide clarity and keep the files managable, the import implementations were moved out of `context.rs` into `imports.rs`.