### PR TITLE
Organize error codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,8 +273,8 @@ nightly toolchain installed as well.
 
 ```sh
 cargo fmt \
-  && (cd packages/std && cargo wasm-debug --features iterator && cargo test --features iterator && cargo clippy -- -D warnings) \
-  && (cd packages/storage && cargo build && cargo test --features iterator && cargo clippy -- -D warnings) \
+  && (cd packages/std && cargo wasm-debug --features iterator && cargo test --features iterator && cargo clippy --features iterator -- -D warnings) \
+  && (cd packages/storage && cargo build && cargo test --features iterator && cargo clippy --features iterator -- -D warnings) \
   && (cd packages/schema && cargo build && cargo test && cargo clippy -- -D warnings) \
   && (cd packages/vm && cargo +nightly build --features iterator && cargo +nightly test --features iterator && cargo +nightly clippy --features iterator -- -D warnings)
 ```

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ cargo fmt \
   && (cd packages/std && cargo wasm-debug --features iterator && cargo test --features iterator && cargo clippy -- -D warnings) \
   && (cd packages/storage && cargo build && cargo test --features iterator && cargo clippy -- -D warnings) \
   && (cd packages/schema && cargo build && cargo test && cargo clippy -- -D warnings) \
-  && (cd packages/vm && cargo +nightly build --features iterator && cargo +nightly test --features iterator)
+  && (cd packages/vm && cargo +nightly build --features iterator && cargo +nightly test --features iterator && cargo +nightly clippy --features iterator -- -D warnings)
 ```
 
 **Contracts**

--- a/packages/std/src/imports.rs
+++ b/packages/std/src/imports.rs
@@ -67,10 +67,10 @@ impl ExternalStorage {
         let value_ptr = alloc(result_length);
 
         let read = unsafe { db_read(key_ptr, value_ptr) };
-        if read == -1_000_002 {
+        if read == -1_000_001 {
             return contract_err("Allocated memory too small to hold the database value for the given key. \
                 You can specify custom result buffer lengths by using ExternalStorage.get_with_result_length explicitely.");
-        } else if read == -1_000_502 {
+        } else if read == -1_001_001 {
             // key does not exist in external storage
             return Ok(None);
         } else if read < 0 {

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -55,8 +55,8 @@ where
                 // Reads the database entry at the given key into the the value.
                 // A prepared and sufficiently large memory Region is expected at value_ptr that points to pre-allocated memory.
                 // Returns 0 on success. Returns negative value on error. An incomplete list of error codes is:
-                //   value region too small: -1_000_002
-                //   key does not exist: -1_000_502
+                //   value region too small: -1_000_001
+                //   key does not exist: -1_001_001
                 // Ownership of both input and output pointer is not transferred to the host.
                 "db_read" => Func::new(move |ctx: &mut Ctx, key_ptr: u32, value_ptr: u32| -> i32 {
                     do_read::<S, Q>(ctx, key_ptr, value_ptr)


### PR DESCRIPTION
Resolves a error code collision introduced in https://github.com/CosmWasm/cosmwasm/pull/286/commits/443eeab8570af7bcd843cb11753e59ae1e2c0c98 and organized error codes in a way the is more maintainable