### PR TITLE
Add new Staking messages and queries under feature flag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,15 +60,15 @@ jobs:
       - run:
           name: Build library for native target
           working_directory: ~/project/packages/std
-          command: cargo build --locked
+          command: cargo build --locked --no-default-features
       - run:
           name: Build library for wasm target
           working_directory: ~/project/packages/std
-          command: cargo wasm --locked
+          command: cargo wasm --locked --no-default-features
       - run:
           name: Run unit tests
           working_directory: ~/project/packages/std
-          command: cargo test --locked
+          command: cargo test --locked --no-default-features
       - run:
           name: Build library for native target (with iterator support)
           working_directory: ~/project/packages/std
@@ -80,7 +80,7 @@ jobs:
       - run:
           name: Run unit tests (with iterator and staking support)
           working_directory: ~/project/packages/std
-          command: cargo test --locked --features iterator,staking
+          command: cargo test --locked --features iterator
       - run:
           name: Build and run schema generator
           working_directory: ~/project/packages/std

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,9 +78,9 @@ jobs:
           working_directory: ~/project/packages/std
           command: cargo wasm --locked --features iterator
       - run:
-          name: Run unit tests (with iterator support)
+          name: Run unit tests (with iterator and staking support)
           working_directory: ~/project/packages/std
-          command: cargo test --locked --features iterator
+          command: cargo test --locked --features iterator,staking
       - run:
           name: Build and run schema generator
           working_directory: ~/project/packages/std

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,29 +58,29 @@ jobs:
           name: Add wasm32 target
           command: rustup target add wasm32-unknown-unknown && rustup target list --installed
       - run:
-          name: Build library for native target
+          name: Build library for native target (no features)
           working_directory: ~/project/packages/std
           command: cargo build --locked --no-default-features
       - run:
-          name: Build library for wasm target
+          name: Build library for wasm target (no features)
           working_directory: ~/project/packages/std
           command: cargo wasm --locked --no-default-features
       - run:
-          name: Run unit tests
+          name: Run unit tests (no features)
           working_directory: ~/project/packages/std
           command: cargo test --locked --no-default-features
       - run:
-          name: Build library for native target (with iterator support)
+          name: Build library for native target (all features)
           working_directory: ~/project/packages/std
-          command: cargo build --locked --features iterator
+          command: cargo build --locked --all-features
       - run:
-          name: Build library for wasm target (with iterator support)
+          name: Build library for wasm target (all features)
           working_directory: ~/project/packages/std
-          command: cargo wasm --locked --features iterator
+          command: cargo wasm --locked --all-features
       - run:
-          name: Run unit tests (with iterator and staking support)
+          name: Run unit tests (all features)
           working_directory: ~/project/packages/std
-          command: cargo test --locked --features iterator
+          command: cargo test --locked --all-features
       - run:
           name: Build and run schema generator
           working_directory: ~/project/packages/std

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,12 +92,13 @@
 - `ExternalStorage.get` now returns an empty vector if a storage entry exists
   but has an empty value. Before, this was normalized to `None`.
 - Reorganize `CosmosMsg` enum types. They are now split by modules:
-  `CosmosMsg::Bank(BankMsg)`, `CosmosMsg::Custom(T)`,
-  `CosmosMsg::Wasm(WasmMsg)`
+  `CosmosMsg::Bank(BankMsg)`, `CosmosMsg::Custom(T)`, `CosmosMsg::Wasm(WasmMsg)`
 - CosmosMsg is now generic over the content of `Custom` variant. This allows
   blockchains to support custom native calls in their Cosmos-SDK apps and
   developers to make use of them in CosmWasm apps without forking the
   `cosmwasm-vm` and `go-cosmwasm` runtime.
+- Add `staking` feature flag to expose new `StakingMsg` types under `CosmosMsg`
+  and new `StakingRequest` types under `QueryRequest`.
 
 **cosmwasm-vm**
 

--- a/contracts/hackatom/schema/balance_response.json
+++ b/contracts/hackatom/schema/balance_response.json
@@ -7,7 +7,12 @@
   ],
   "properties": {
     "amount": {
-      "$ref": "#/definitions/Coin"
+      "description": "Always returns a Coin with the requested denom. This may be of 0 amount if no such funds.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Coin"
+        }
+      ]
     }
   },
   "definitions": {

--- a/contracts/reflect/schema/handle_msg.json
+++ b/contracts/reflect/schema/handle_msg.json
@@ -237,6 +237,7 @@
               ],
               "properties": {
                 "recipient": {
+                  "description": "this is the \"withdraw address\", the one that should receive the rewards if None, then use delegator address",
                   "anyOf": [
                     {
                       "$ref": "#/definitions/HumanAddr"
@@ -288,6 +289,7 @@
     "WasmMsg": {
       "anyOf": [
         {
+          "description": "this dispatches a call to another contract at a known address (with known ABI)",
           "type": "object",
           "required": [
             "execute"
@@ -304,7 +306,12 @@
                   "$ref": "#/definitions/HumanAddr"
                 },
                 "msg": {
-                  "$ref": "#/definitions/Binary"
+                  "description": "msg is the json-encoded HandleMsg struct (as raw Binary)",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  ]
                 },
                 "send": {
                   "type": [
@@ -320,6 +327,7 @@
           }
         },
         {
+          "description": "this instantiates a new contracts from previously uploaded wasm code",
           "type": "object",
           "required": [
             "instantiate"
@@ -338,7 +346,12 @@
                   "minimum": 0.0
                 },
                 "msg": {
-                  "$ref": "#/definitions/Binary"
+                  "description": "msg is the json-encoded InitMsg struct (as raw Binary)",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  ]
                 },
                 "send": {
                   "type": [

--- a/contracts/reflect/schema/handle_msg.json
+++ b/contracts/reflect/schema/handle_msg.json
@@ -125,6 +125,17 @@
         {
           "type": "object",
           "required": [
+            "staking"
+          ],
+          "properties": {
+            "staking": {
+              "$ref": "#/definitions/StakingMsg"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
             "wasm"
           ],
           "properties": {
@@ -164,6 +175,112 @@
     },
     "HumanAddr": {
       "type": "string"
+    },
+    "StakingMsg": {
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "delegate"
+          ],
+          "properties": {
+            "delegate": {
+              "type": "object",
+              "required": [
+                "amount",
+                "validator"
+              ],
+              "properties": {
+                "amount": {
+                  "$ref": "#/definitions/Coin"
+                },
+                "validator": {
+                  "$ref": "#/definitions/HumanAddr"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "undelegate"
+          ],
+          "properties": {
+            "undelegate": {
+              "type": "object",
+              "required": [
+                "amount",
+                "validator"
+              ],
+              "properties": {
+                "amount": {
+                  "$ref": "#/definitions/Coin"
+                },
+                "validator": {
+                  "$ref": "#/definitions/HumanAddr"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "withdraw"
+          ],
+          "properties": {
+            "withdraw": {
+              "type": "object",
+              "required": [
+                "validator"
+              ],
+              "properties": {
+                "recipient": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/HumanAddr"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "validator": {
+                  "$ref": "#/definitions/HumanAddr"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "redelegate"
+          ],
+          "properties": {
+            "redelegate": {
+              "type": "object",
+              "required": [
+                "amount",
+                "dst_validator",
+                "src_validator"
+              ],
+              "properties": {
+                "amount": {
+                  "$ref": "#/definitions/Coin"
+                },
+                "dst_validator": {
+                  "$ref": "#/definitions/HumanAddr"
+                },
+                "src_validator": {
+                  "$ref": "#/definitions/HumanAddr"
+                }
+              }
+            }
+          }
+        }
+      ]
     },
     "Uint128": {
       "type": "string"

--- a/contracts/reflect/schema/handle_response_for__custom_msg.json
+++ b/contracts/reflect/schema/handle_response_for__custom_msg.json
@@ -111,6 +111,17 @@
         {
           "type": "object",
           "required": [
+            "staking"
+          ],
+          "properties": {
+            "staking": {
+              "$ref": "#/definitions/StakingMsg"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
             "wasm"
           ],
           "properties": {
@@ -165,6 +176,112 @@
           "type": "string"
         }
       }
+    },
+    "StakingMsg": {
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "delegate"
+          ],
+          "properties": {
+            "delegate": {
+              "type": "object",
+              "required": [
+                "amount",
+                "validator"
+              ],
+              "properties": {
+                "amount": {
+                  "$ref": "#/definitions/Coin"
+                },
+                "validator": {
+                  "$ref": "#/definitions/HumanAddr"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "undelegate"
+          ],
+          "properties": {
+            "undelegate": {
+              "type": "object",
+              "required": [
+                "amount",
+                "validator"
+              ],
+              "properties": {
+                "amount": {
+                  "$ref": "#/definitions/Coin"
+                },
+                "validator": {
+                  "$ref": "#/definitions/HumanAddr"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "withdraw"
+          ],
+          "properties": {
+            "withdraw": {
+              "type": "object",
+              "required": [
+                "validator"
+              ],
+              "properties": {
+                "recipient": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/HumanAddr"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "validator": {
+                  "$ref": "#/definitions/HumanAddr"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "redelegate"
+          ],
+          "properties": {
+            "redelegate": {
+              "type": "object",
+              "required": [
+                "amount",
+                "dst_validator",
+                "src_validator"
+              ],
+              "properties": {
+                "amount": {
+                  "$ref": "#/definitions/Coin"
+                },
+                "dst_validator": {
+                  "$ref": "#/definitions/HumanAddr"
+                },
+                "src_validator": {
+                  "$ref": "#/definitions/HumanAddr"
+                }
+              }
+            }
+          }
+        }
+      ]
     },
     "Uint128": {
       "type": "string"

--- a/contracts/reflect/schema/handle_response_for__custom_msg.json
+++ b/contracts/reflect/schema/handle_response_for__custom_msg.json
@@ -238,6 +238,7 @@
               ],
               "properties": {
                 "recipient": {
+                  "description": "this is the \"withdraw address\", the one that should receive the rewards if None, then use delegator address",
                   "anyOf": [
                     {
                       "$ref": "#/definitions/HumanAddr"
@@ -289,6 +290,7 @@
     "WasmMsg": {
       "anyOf": [
         {
+          "description": "this dispatches a call to another contract at a known address (with known ABI)",
           "type": "object",
           "required": [
             "execute"
@@ -305,7 +307,12 @@
                   "$ref": "#/definitions/HumanAddr"
                 },
                 "msg": {
-                  "$ref": "#/definitions/Binary"
+                  "description": "msg is the json-encoded HandleMsg struct (as raw Binary)",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  ]
                 },
                 "send": {
                   "type": [
@@ -321,6 +328,7 @@
           }
         },
         {
+          "description": "this instantiates a new contracts from previously uploaded wasm code",
           "type": "object",
           "required": [
             "instantiate"
@@ -339,7 +347,12 @@
                   "minimum": 0.0
                 },
                 "msg": {
-                  "$ref": "#/definitions/Binary"
+                  "description": "msg is the json-encoded InitMsg struct (as raw Binary)",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  ]
                 },
                 "send": {
                   "type": [

--- a/contracts/reflect/src/contract.rs
+++ b/contracts/reflect/src/contract.rs
@@ -92,7 +92,7 @@ fn query_owner<S: Storage, A: Api, Q: Querier>(deps: &Extern<S, A, Q>) -> StdRes
 mod tests {
     use super::*;
     use cosmwasm_std::testing::{mock_dependencies, mock_env};
-    use cosmwasm_std::{coins, from_binary, BankMsg, Binary, StdError};
+    use cosmwasm_std::{coin, coins, from_binary, BankMsg, Binary, StakingMsg, StdError};
 
     #[test]
     fn proper_initialization() {
@@ -203,6 +203,11 @@ mod tests {
             // make sure we can pass through custom native messages
             CustomMsg::Raw(Binary(b"{\"foo\":123}".to_vec())).into(),
             CustomMsg::Debug("Hi, Dad!".to_string()).into(),
+            StakingMsg::Delegate {
+                validator: HumanAddr::from("validator"),
+                amount: coin(100, "stake"),
+            }
+            .into(),
         ];
 
         let msg = HandleMsg::ReflectMsg {

--- a/contracts/reflect/tests/integration.rs
+++ b/contracts/reflect/tests/integration.rs
@@ -1,7 +1,7 @@
 use cosmwasm_std::testing::mock_env;
 use cosmwasm_std::{
-    coins, from_binary, Api, ApiError, BankMsg, Binary, HandleResponse, HandleResult, HumanAddr,
-    InitResponse,
+    coin, coins, from_binary, Api, ApiError, BankMsg, Binary, HandleResponse, HandleResult,
+    HumanAddr, InitResponse, StakingMsg,
 };
 
 use cosmwasm_vm::testing::{handle, init, mock_instance, query};
@@ -86,6 +86,11 @@ fn reflect() {
         // make sure we can pass through custom native messages
         CustomMsg::Raw(Binary(b"{\"foo\":123}".to_vec())).into(),
         CustomMsg::Debug("Hi, Dad!".to_string()).into(),
+        StakingMsg::Delegate {
+            validator: HumanAddr::from("validator"),
+            amount: coin(100, "stake"),
+        }
+        .into(),
     ];
     let msg = HandleMsg::ReflectMsg {
         msgs: payload.clone(),

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -13,6 +13,7 @@ circle-ci = { repository = "CosmWasm/cosmwasm", branch = "master" }
 maintenance = { status = "actively-developed" }
 
 [features]
+default = ["staking"]
 # iterator allows us to iterate over all DB items in a given range
 # optional as some merkle stores (like tries) don't support this
 # given Ethereum 1.0, 2.0, Substrate, and other major projects use Tries

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -18,6 +18,10 @@ maintenance = { status = "actively-developed" }
 # given Ethereum 1.0, 2.0, Substrate, and other major projects use Tries
 # we keep this optional, to allow possible future integration (or different Cosmos Backends)
 iterator = []
+# staking exposes bindings to a required staking moudle in the runtime, via new
+# CosmosMsg types, and new QueryRequest types. This should only be enabled on contracts
+# that require these types, so other contracts can be used on systems with eg. PoA consensus
+staking = []
 # backtraces provides much better context at runtime errors (in non-wasm code)
 # at the cost of a bit of code size and performance.
 backtraces = ["snafu/backtraces"]

--- a/packages/std/schema/cosmos_msg_for__no_msg.json
+++ b/packages/std/schema/cosmos_msg_for__no_msg.json
@@ -27,6 +27,17 @@
     {
       "type": "object",
       "required": [
+        "staking"
+      ],
+      "properties": {
+        "staking": {
+          "$ref": "#/definitions/StakingMsg"
+        }
+      }
+    },
+    {
+      "type": "object",
+      "required": [
         "wasm"
       ],
       "properties": {
@@ -96,6 +107,112 @@
     "NoMsg": {
       "description": "NoMsg can never be instantiated and is a no-op placeholder for those contracts that don't explicitly set a custom message.",
       "enum": []
+    },
+    "StakingMsg": {
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "delegate"
+          ],
+          "properties": {
+            "delegate": {
+              "type": "object",
+              "required": [
+                "amount",
+                "validator"
+              ],
+              "properties": {
+                "amount": {
+                  "$ref": "#/definitions/Coin"
+                },
+                "validator": {
+                  "$ref": "#/definitions/HumanAddr"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "undelegate"
+          ],
+          "properties": {
+            "undelegate": {
+              "type": "object",
+              "required": [
+                "amount",
+                "validator"
+              ],
+              "properties": {
+                "amount": {
+                  "$ref": "#/definitions/Coin"
+                },
+                "validator": {
+                  "$ref": "#/definitions/HumanAddr"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "withdraw"
+          ],
+          "properties": {
+            "withdraw": {
+              "type": "object",
+              "required": [
+                "validator"
+              ],
+              "properties": {
+                "recipient": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/HumanAddr"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "validator": {
+                  "$ref": "#/definitions/HumanAddr"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "redelegate"
+          ],
+          "properties": {
+            "redelegate": {
+              "type": "object",
+              "required": [
+                "amount",
+                "dst_validator",
+                "src_validator"
+              ],
+              "properties": {
+                "amount": {
+                  "$ref": "#/definitions/Coin"
+                },
+                "dst_validator": {
+                  "$ref": "#/definitions/HumanAddr"
+                },
+                "src_validator": {
+                  "$ref": "#/definitions/HumanAddr"
+                }
+              }
+            }
+          }
+        }
+      ]
     },
     "Uint128": {
       "type": "string"

--- a/packages/std/schema/cosmos_msg_for__no_msg.json
+++ b/packages/std/schema/cosmos_msg_for__no_msg.json
@@ -169,6 +169,7 @@
               ],
               "properties": {
                 "recipient": {
+                  "description": "this is the \"withdraw address\", the one that should receive the rewards if None, then use delegator address",
                   "anyOf": [
                     {
                       "$ref": "#/definitions/HumanAddr"
@@ -220,6 +221,7 @@
     "WasmMsg": {
       "anyOf": [
         {
+          "description": "this dispatches a call to another contract at a known address (with known ABI)",
           "type": "object",
           "required": [
             "execute"
@@ -236,7 +238,12 @@
                   "$ref": "#/definitions/HumanAddr"
                 },
                 "msg": {
-                  "$ref": "#/definitions/Binary"
+                  "description": "msg is the json-encoded HandleMsg struct (as raw Binary)",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  ]
                 },
                 "send": {
                   "type": [
@@ -252,6 +259,7 @@
           }
         },
         {
+          "description": "this instantiates a new contracts from previously uploaded wasm code",
           "type": "object",
           "required": [
             "instantiate"
@@ -270,7 +278,12 @@
                   "minimum": 0.0
                 },
                 "msg": {
-                  "$ref": "#/definitions/Binary"
+                  "description": "msg is the json-encoded InitMsg struct (as raw Binary)",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  ]
                 },
                 "send": {
                   "type": [

--- a/packages/std/schema/handle_result.json
+++ b/packages/std/schema/handle_result.json
@@ -339,6 +339,17 @@
         {
           "type": "object",
           "required": [
+            "staking"
+          ],
+          "properties": {
+            "staking": {
+              "$ref": "#/definitions/StakingMsg"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
             "wasm"
           ],
           "properties": {
@@ -401,6 +412,112 @@
     "NoMsg": {
       "description": "NoMsg can never be instantiated and is a no-op placeholder for those contracts that don't explicitly set a custom message.",
       "enum": []
+    },
+    "StakingMsg": {
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "delegate"
+          ],
+          "properties": {
+            "delegate": {
+              "type": "object",
+              "required": [
+                "amount",
+                "validator"
+              ],
+              "properties": {
+                "amount": {
+                  "$ref": "#/definitions/Coin"
+                },
+                "validator": {
+                  "$ref": "#/definitions/HumanAddr"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "undelegate"
+          ],
+          "properties": {
+            "undelegate": {
+              "type": "object",
+              "required": [
+                "amount",
+                "validator"
+              ],
+              "properties": {
+                "amount": {
+                  "$ref": "#/definitions/Coin"
+                },
+                "validator": {
+                  "$ref": "#/definitions/HumanAddr"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "withdraw"
+          ],
+          "properties": {
+            "withdraw": {
+              "type": "object",
+              "required": [
+                "validator"
+              ],
+              "properties": {
+                "recipient": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/HumanAddr"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "validator": {
+                  "$ref": "#/definitions/HumanAddr"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "redelegate"
+          ],
+          "properties": {
+            "redelegate": {
+              "type": "object",
+              "required": [
+                "amount",
+                "dst_validator",
+                "src_validator"
+              ],
+              "properties": {
+                "amount": {
+                  "$ref": "#/definitions/Coin"
+                },
+                "dst_validator": {
+                  "$ref": "#/definitions/HumanAddr"
+                },
+                "src_validator": {
+                  "$ref": "#/definitions/HumanAddr"
+                }
+              }
+            }
+          }
+        }
+      ]
     },
     "Uint128": {
       "type": "string"

--- a/packages/std/schema/handle_result.json
+++ b/packages/std/schema/handle_result.json
@@ -474,6 +474,7 @@
               ],
               "properties": {
                 "recipient": {
+                  "description": "this is the \"withdraw address\", the one that should receive the rewards if None, then use delegator address",
                   "anyOf": [
                     {
                       "$ref": "#/definitions/HumanAddr"
@@ -525,6 +526,7 @@
     "WasmMsg": {
       "anyOf": [
         {
+          "description": "this dispatches a call to another contract at a known address (with known ABI)",
           "type": "object",
           "required": [
             "execute"
@@ -541,7 +543,12 @@
                   "$ref": "#/definitions/HumanAddr"
                 },
                 "msg": {
-                  "$ref": "#/definitions/Binary"
+                  "description": "msg is the json-encoded HandleMsg struct (as raw Binary)",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  ]
                 },
                 "send": {
                   "type": [
@@ -557,6 +564,7 @@
           }
         },
         {
+          "description": "this instantiates a new contracts from previously uploaded wasm code",
           "type": "object",
           "required": [
             "instantiate"
@@ -575,7 +583,12 @@
                   "minimum": 0.0
                 },
                 "msg": {
-                  "$ref": "#/definitions/Binary"
+                  "description": "msg is the json-encoded InitMsg struct (as raw Binary)",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  ]
                 },
                 "send": {
                   "type": [

--- a/packages/std/schema/init_result.json
+++ b/packages/std/schema/init_result.json
@@ -339,6 +339,17 @@
         {
           "type": "object",
           "required": [
+            "staking"
+          ],
+          "properties": {
+            "staking": {
+              "$ref": "#/definitions/StakingMsg"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
             "wasm"
           ],
           "properties": {
@@ -401,6 +412,112 @@
     "NoMsg": {
       "description": "NoMsg can never be instantiated and is a no-op placeholder for those contracts that don't explicitly set a custom message.",
       "enum": []
+    },
+    "StakingMsg": {
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "delegate"
+          ],
+          "properties": {
+            "delegate": {
+              "type": "object",
+              "required": [
+                "amount",
+                "validator"
+              ],
+              "properties": {
+                "amount": {
+                  "$ref": "#/definitions/Coin"
+                },
+                "validator": {
+                  "$ref": "#/definitions/HumanAddr"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "undelegate"
+          ],
+          "properties": {
+            "undelegate": {
+              "type": "object",
+              "required": [
+                "amount",
+                "validator"
+              ],
+              "properties": {
+                "amount": {
+                  "$ref": "#/definitions/Coin"
+                },
+                "validator": {
+                  "$ref": "#/definitions/HumanAddr"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "withdraw"
+          ],
+          "properties": {
+            "withdraw": {
+              "type": "object",
+              "required": [
+                "validator"
+              ],
+              "properties": {
+                "recipient": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/HumanAddr"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "validator": {
+                  "$ref": "#/definitions/HumanAddr"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "redelegate"
+          ],
+          "properties": {
+            "redelegate": {
+              "type": "object",
+              "required": [
+                "amount",
+                "dst_validator",
+                "src_validator"
+              ],
+              "properties": {
+                "amount": {
+                  "$ref": "#/definitions/Coin"
+                },
+                "dst_validator": {
+                  "$ref": "#/definitions/HumanAddr"
+                },
+                "src_validator": {
+                  "$ref": "#/definitions/HumanAddr"
+                }
+              }
+            }
+          }
+        }
+      ]
     },
     "Uint128": {
       "type": "string"

--- a/packages/std/schema/init_result.json
+++ b/packages/std/schema/init_result.json
@@ -474,6 +474,7 @@
               ],
               "properties": {
                 "recipient": {
+                  "description": "this is the \"withdraw address\", the one that should receive the rewards if None, then use delegator address",
                   "anyOf": [
                     {
                       "$ref": "#/definitions/HumanAddr"
@@ -525,6 +526,7 @@
     "WasmMsg": {
       "anyOf": [
         {
+          "description": "this dispatches a call to another contract at a known address (with known ABI)",
           "type": "object",
           "required": [
             "execute"
@@ -541,7 +543,12 @@
                   "$ref": "#/definitions/HumanAddr"
                 },
                 "msg": {
-                  "$ref": "#/definitions/Binary"
+                  "description": "msg is the json-encoded HandleMsg struct (as raw Binary)",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  ]
                 },
                 "send": {
                   "type": [
@@ -557,6 +564,7 @@
           }
         },
         {
+          "description": "this instantiates a new contracts from previously uploaded wasm code",
           "type": "object",
           "required": [
             "instantiate"
@@ -575,7 +583,12 @@
                   "minimum": 0.0
                 },
                 "msg": {
-                  "$ref": "#/definitions/Binary"
+                  "description": "msg is the json-encoded InitMsg struct (as raw Binary)",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  ]
                 },
                 "send": {
                   "type": [

--- a/packages/std/src/init_handle.rs
+++ b/packages/std/src/init_handle.rs
@@ -20,6 +20,8 @@ where
     // by default we use RawMsg, but a contract can override that
     // to call into more app-specific code (whatever they define)
     Custom(T),
+    #[cfg(feature = "staking")]
+    Staking(StakingMsg),
     Wasm(WasmMsg),
 }
 
@@ -38,6 +40,35 @@ pub enum BankMsg {
 /// NoMsg can never be instantiated and is a no-op placeholder for
 /// those contracts that don't explicitly set a custom message.
 pub enum NoMsg {}
+
+#[cfg(feature = "staking")]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum StakingMsg {
+    Delegate {
+        // delegator is automatically set to address of the calling contract
+        validator: HumanAddr,
+        amount: Coin,
+    },
+    Undelegate {
+        // delegator is automatically set to address of the calling contract
+        validator: HumanAddr,
+        amount: Coin,
+    },
+    Withdraw {
+        // delegator is automatically set to address of the calling contract
+        validator: HumanAddr,
+        // this is the "withdraw address", the one that should receive the rewards
+        // if None, then use delegator address
+        recipient: Option<HumanAddr>,
+    },
+    Redelegate {
+        // delegator is automatically set to address of the calling contract
+        src_validator: HumanAddr,
+        dst_validator: HumanAddr,
+        amount: Coin,
+    },
+}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]

--- a/packages/std/src/init_handle.rs
+++ b/packages/std/src/init_handle.rs
@@ -93,6 +93,13 @@ impl<T: Clone + fmt::Debug + PartialEq + JsonSchema> From<BankMsg> for CosmosMsg
     }
 }
 
+#[cfg(feature = "staking")]
+impl<T: Clone + fmt::Debug + PartialEq + JsonSchema> From<StakingMsg> for CosmosMsg<T> {
+    fn from(msg: StakingMsg) -> Self {
+        CosmosMsg::Staking(msg)
+    }
+}
+
 impl<T: Clone + fmt::Debug + PartialEq + JsonSchema> From<WasmMsg> for CosmosMsg<T> {
     fn from(msg: WasmMsg) -> Self {
         CosmosMsg::Wasm(msg)

--- a/packages/std/src/init_handle.rs
+++ b/packages/std/src/init_handle.rs
@@ -36,9 +36,9 @@ pub enum BankMsg {
     },
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 /// NoMsg can never be instantiated and is a no-op placeholder for
 /// those contracts that don't explicitly set a custom message.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub enum NoMsg {}
 
 #[cfg(feature = "staking")]
@@ -58,8 +58,8 @@ pub enum StakingMsg {
     Withdraw {
         // delegator is automatically set to address of the calling contract
         validator: HumanAddr,
-        // this is the "withdraw address", the one that should receive the rewards
-        // if None, then use delegator address
+        /// this is the "withdraw address", the one that should receive the rewards
+        /// if None, then use delegator address
         recipient: Option<HumanAddr>,
     },
     Redelegate {
@@ -73,16 +73,18 @@ pub enum StakingMsg {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum WasmMsg {
-    // this dispatches a call to another contract at a known address (with known ABI)
-    // msg is the json-encoded HandleMsg struct
+    /// this dispatches a call to another contract at a known address (with known ABI)
     Execute {
         contract_addr: HumanAddr,
-        msg: Binary, // we pass this in as Vec<u8> to the contract, so allow any binary encoding (later, limit to rawjson?)
+        /// msg is the json-encoded HandleMsg struct (as raw Binary)
+        msg: Binary,
         send: Option<Vec<Coin>>,
     },
+    /// this instantiates a new contracts from previously uploaded wasm code
     Instantiate {
         code_id: u64,
-        msg: Binary, // we pass this in as Vec<u8> to the contract, so allow any binary encoding (later, limit to rawjson?)
+        /// msg is the json-encoded InitMsg struct (as raw Binary)
+        msg: Binary,
         send: Option<Vec<Coin>>,
     },
 }

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -22,13 +22,13 @@ pub use crate::errors::{
 };
 pub use crate::init_handle::{
     log, BankMsg, CosmosMsg, HandleResponse, HandleResult, InitResponse, InitResult, LogAttribute,
-    NoMsg, WasmMsg,
+    NoMsg, StakingMsg, WasmMsg,
 };
 #[cfg(feature = "iterator")]
 pub use crate::iterator::{Order, KV};
 pub use crate::query::{
     AllBalanceResponse, BalanceResponse, BankQuery, QueryRequest, QueryResponse, QueryResult,
-    WasmQuery,
+    StakingQuery, WasmQuery,
 };
 pub use crate::serde::{from_binary, from_slice, to_binary, to_vec};
 pub use crate::storage::MemoryStorage;

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -22,18 +22,25 @@ pub use crate::errors::{
 };
 pub use crate::init_handle::{
     log, BankMsg, CosmosMsg, HandleResponse, HandleResult, InitResponse, InitResult, LogAttribute,
-    NoMsg, StakingMsg, WasmMsg,
+    NoMsg, WasmMsg,
 };
 #[cfg(feature = "iterator")]
 pub use crate::iterator::{Order, KV};
 pub use crate::query::{
     AllBalanceResponse, BalanceResponse, BankQuery, QueryRequest, QueryResponse, QueryResult,
-    StakingQuery, WasmQuery,
+    WasmQuery,
 };
 pub use crate::serde::{from_binary, from_slice, to_binary, to_vec};
 pub use crate::storage::MemoryStorage;
 pub use crate::traits::{Api, Extern, Querier, QuerierResult, ReadonlyStorage, Storage};
 pub use crate::types::{CanonicalAddr, Env, HumanAddr};
+
+#[cfg(feature = "staking")]
+pub use crate::init_handle::StakingMsg;
+#[cfg(feature = "staking")]
+pub use crate::query::{
+    Delegation, DelegationsResponse, StakingQuery, Validator, ValidatorsResponse,
+};
 
 // Exposed in wasm build only
 

--- a/packages/std/src/mock.rs
+++ b/packages/std/src/mock.rs
@@ -166,6 +166,10 @@ impl Querier for MockQuerier {
                 let api_res = to_vec(&bank_res).map(Binary).map_err(|e| e.into());
                 Ok(api_res)
             }
+            #[cfg(feature = "staking")]
+            QueryRequest::Staking(_) => Err(ApiSystemError::InvalidRequest {
+                error: "staking not yet implemented".to_string(),
+            }),
             QueryRequest::Wasm(msg) => {
                 let addr = match msg {
                     WasmQuery::Smart { contract_addr, .. } => contract_addr,

--- a/packages/std/src/mock.rs
+++ b/packages/std/src/mock.rs
@@ -201,12 +201,11 @@ impl BankQuerier {
 
 #[cfg(feature = "staking")]
 mod staking {
-    use crate::api::{ApiError, ApiSystemError};
-    use crate::encoding::Binary;
     use crate::query::{
         Delegation, DelegationsResponse, StakingQuery, Validator, ValidatorsResponse,
     };
-    use crate::to_binary;
+    use crate::serde::to_binary;
+    use crate::traits::QuerierResult;
 
     #[derive(Clone)]
     pub struct StakingQuerier {
@@ -222,10 +221,7 @@ mod staking {
             }
         }
 
-        pub fn query(
-            &self,
-            request: &StakingQuery,
-        ) -> Result<Result<Binary, ApiError>, ApiSystemError> {
+        pub fn query(&self, request: &StakingQuery) -> QuerierResult {
             match request {
                 StakingQuery::Validators {} => {
                     let val_res = ValidatorsResponse {

--- a/packages/std/src/mock.rs
+++ b/packages/std/src/mock.rs
@@ -21,7 +21,7 @@ pub fn mock_dependencies(
 ) -> Extern<MockStorage, MockApi, MockQuerier> {
     let contract_addr = HumanAddr::from(CONTRACT_ADDR);
     Extern {
-        storage: MockStorage::new(),
+        storage: MockStorage::default(),
         api: MockApi::new(canonical_length),
         querier: MockQuerier::new(&[(&contract_addr, contract_balance)]),
     }
@@ -34,7 +34,7 @@ pub fn mock_dependencies_with_balances(
     balances: &[(&HumanAddr, &[Coin])],
 ) -> Extern<MockStorage, MockApi, MockQuerier> {
     Extern {
-        storage: MockStorage::new(),
+        storage: MockStorage::default(),
         api: MockApi::new(canonical_length),
         querier: MockQuerier::new(balances),
     }
@@ -124,7 +124,7 @@ pub fn mock_env<T: Api, U: Into<HumanAddr>>(api: &T, sender: U, sent: &[Coin]) -
 
 /// MockQuerier holds an immutable table of bank balances
 /// TODO: also allow querying contracts
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct MockQuerier {
     bank: BankQuerier,
     #[cfg(feature = "staking")]
@@ -143,7 +143,7 @@ impl MockQuerier {
     pub fn new(balances: &[(&HumanAddr, &[Coin])]) -> Self {
         MockQuerier {
             bank: BankQuerier::new(balances),
-            staking: staking::StakingQuerier::new(&[], &[]),
+            staking: staking::StakingQuerier::default(),
         }
     }
 
@@ -175,7 +175,7 @@ impl Querier for MockQuerier {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 struct BankQuerier {
     balances: HashMap<HumanAddr, Vec<Coin>>,
 }
@@ -225,7 +225,7 @@ mod staking {
     use crate::serde::to_binary;
     use crate::traits::QuerierResult;
 
-    #[derive(Clone)]
+    #[derive(Clone, Default)]
     pub struct StakingQuerier {
         validators: Vec<Validator>,
         delegations: Vec<Delegation>,

--- a/packages/std/src/query.rs
+++ b/packages/std/src/query.rs
@@ -22,45 +22,46 @@ pub enum QueryRequest {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum BankQuery {
-    // This calls into the native bank module for one denomination
-    // Return value is BalanceResponse
+    /// This calls into the native bank module for one denomination
+    /// Return value is BalanceResponse
     Balance { address: HumanAddr, denom: String },
-    // This calls into the native bank module for all denominations.
-    // Note that this may be much more expensive than Balance and should be avoided if possible.
-    // Return value is AllBalanceResponse.
+    /// This calls into the native bank module for all denominations.
+    /// Note that this may be much more expensive than Balance and should be avoided if possible.
+    /// Return value is AllBalanceResponse.
     AllBalances { address: HumanAddr },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum WasmQuery {
-    // this queries the public API of another contract at a known address (with known ABI)
-    // msg is the json-encoded QueryMsg struct
-    // return value is whatever the contract returns (caller should know)
+    /// this queries the public API of another contract at a known address (with known ABI)
+    /// return value is whatever the contract returns (caller should know)
     Smart {
         contract_addr: HumanAddr,
-        msg: Binary, // we pass this in as Vec<u8> to the contract, so allow any binary encoding (later, limit to rawjson?)
+        /// msg is the json-encoded QueryMsg struct
+        msg: Binary,
     },
-    // this queries the raw kv-store of the contract.
-    // returns the raw, unparsed data stored at that key (or `Ok(Err(ApiError:NotFound{}))` if missing)
+    /// this queries the raw kv-store of the contract.
+    /// returns the raw, unparsed data stored at that key (or `Ok(Err(ApiError:NotFound{}))` if missing)
     Raw {
         contract_addr: HumanAddr,
-        key: Binary, // we pass this in as Vec<u8> to the contract, so allow any binary encoding (later, limit to rawjson?)
+        /// Key is the raw key used in the contracts Storage
+        key: Binary,
     },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct BalanceResponse {
-    // Always returns a Coin with the requested denom.
-    // This may be of 0 amount if no such funds.
+    /// Always returns a Coin with the requested denom.
+    /// This may be of 0 amount if no such funds.
     pub amount: Coin,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct AllBalanceResponse {
-    // Returns all non-zero coins held by this account.
+    /// Returns all non-zero coins held by this account.
     pub amount: Vec<Coin>,
 }
 
@@ -78,18 +79,19 @@ mod staking {
     #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
     #[serde(rename_all = "snake_case")]
     pub enum StakingQuery {
+        /// Returns all registered Validators on the system
         Validators {},
-        // Delegations will return all delegations by the delegator,
-        // or just those to the given validator (if set)
+        /// Delegations will return all delegations by the delegator,
+        /// or just those to the given validator (if set)
         Delegations {
             delegator: HumanAddr,
             validator: Option<HumanAddr>,
         },
     }
 
+    /// ValidatorsResponse is data format returned from StakingRequest::Validators query
     #[cfg(feature = "staking")]
     #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-    /// ValidatorsResponse is data format returned from StakingRequest::Validators query
     pub struct ValidatorsResponse {
         pub validators: Vec<Validator>,
     }
@@ -98,18 +100,18 @@ mod staking {
     #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
     pub struct Validator {
         pub address: HumanAddr,
-        // rates are denominated in 10^-6 - 1_000_000 (max) = 100%, 10_000 = 1%
-        // TODO: capture this in some Dec type?
+        /// rates are denominated in 10^-6 - 1_000_000 (max) = 100%, 10_000 = 1%
+        /// TODO: capture this in some Dec type?
         pub commission: u64,
         pub max_commission: u64,
-        // what units are these (in terms of time)?
+        /// TODO: what units are these (in terms of time)?
         pub max_change_rate: u64,
     }
 
+    /// DelegationsResponse is data format returned from StakingRequest::Delegations query
     #[cfg(feature = "staking")]
     #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
     #[serde(rename_all = "snake_case")]
-    /// DelegationsResponse is data format returned from StakingRequest::Delegations query
     pub struct DelegationsResponse {
         pub delegations: Vec<Delegation>,
     }
@@ -119,9 +121,11 @@ mod staking {
     pub struct Delegation {
         pub delegator: HumanAddr,
         pub validator: HumanAddr,
+        /// How much we have locked in the delegation
         pub amount: Coin,
+        /// If true, then a Redelegate command will work now, otherwise you may have to wait more
         pub can_redelegate: bool,
-        // Review this: this is how much we can withdraw
+        /// How much we can currently withdraw
         pub accumulated_rewards: Coin,
         // TODO: do we want to expose more info?
     }

--- a/packages/std/src/query.rs
+++ b/packages/std/src/query.rs
@@ -15,7 +15,7 @@ pub type QueryResult = ApiResult<QueryResponse>;
 pub enum QueryRequest {
     Bank(BankQuery),
     #[cfg(feature = "staking")]
-    Staking(StakingRequest),
+    Staking(StakingQuery),
     Wasm(WasmQuery),
 }
 
@@ -65,7 +65,7 @@ pub struct AllBalanceResponse {
 }
 
 #[cfg(feature = "staking")]
-pub use staking::{Delegation, DelegationsResponse, StakingRequest, Validator, ValidatorsResponse};
+pub use staking::{Delegation, DelegationsResponse, StakingQuery, Validator, ValidatorsResponse};
 
 #[cfg(feature = "staking")]
 mod staking {
@@ -77,7 +77,7 @@ mod staking {
 
     #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
     #[serde(rename_all = "snake_case")]
-    pub enum StakingRequest {
+    pub enum StakingQuery {
         Validators {},
         // Delegations will return all delegations by the delegator,
         // or just those to the given validator (if set)


### PR DESCRIPTION
Replaces #211 

Closes #174 

I think everything is now implemented except for the test cases. Happy for a review and feedback,

- [x] Add new types
- [x] Update CHANGELOG
- [x] Generate proper schemas
- [x] Add mock Querier support
- [x] Test `MockQuerier`, especially `StakingQuerier`

For another PR:

- Demo usage in a contract

Note: I like the feature flag approach, as it allows us to downgrade and support non-PoS chains easily (eg. if someone wants to run cosmwasm in a PoA environment or other novel consensus mechanism.). However, I realize that the schemas generated for `cosmwasm_std` are now incomplete.... We can either generate them with or without staking info. 

My idea (which I tentatively did in https://github.com/CosmWasm/cosmwasm/pull/300/commits/a15b22b874dbf754eb388bf97465859e3fea7307) is to make staking on by default and use `--no-default-features` to disable it, as it will be the case in almost all cosmwasm chains in the near future. And the other chains can just ignore some entries in the schema (rather than having missing specs). Open for more ideas.