### PR TITLE
Make QueryRequest Extensible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,8 +77,11 @@
   from `Error` into serializable `ApiError` (dropping runtime info), and back
   and forth between `Result` and `ApiResult` (with the same serializable error
   types).
-- Add `Querier` trait and `QueryRequest` for future query callbacks from the
-  contract, along with `SystemError` type for the runtime rejecting messages.
+- Add `Querier` trait and `QueryRequest` for query callbacks from the contract,
+  along with `SystemError` type for the runtime rejecting messages.
+- `QueryRequest` takes a generic `Custom(T)` type that is passed opaquely to the
+  end consumer (`wasmd` or integration test stubs), allowing custom queries to
+  native code.
 - `{Init,Handle,Query}Result` are now just aliases for a concrete `ApiResult`
   type.
 - Support results up to 128 KiB in `ExternalStorage.get`.
@@ -99,6 +102,7 @@
   `cosmwasm-vm` and `go-cosmwasm` runtime.
 - Add `staking` feature flag to expose new `StakingMsg` types under `CosmosMsg`
   and new `StakingRequest` types under `QueryRequest`.
+- Add support for mocking-out staking queries via `MockQuerier.with_staking`
 
 **cosmwasm-vm**
 

--- a/contracts/hackatom/tests/integration.rs
+++ b/contracts/hackatom/tests/integration.rs
@@ -226,7 +226,7 @@ fn passes_io_tests() {
 mod singlepass_tests {
     use super::*;
 
-    use cosmwasm_std::{to_vec, NoMsg};
+    use cosmwasm_std::{to_vec, Never};
     use cosmwasm_vm::call_handle;
 
     fn make_init_msg() -> (InitMsg, HumanAddr) {
@@ -254,7 +254,7 @@ mod singlepass_tests {
         let handle_env = mock_env(&deps.api, creator.as_str(), &[]);
         // panic inside contract should not panic out here
         // Note: we need to use the production-call, not the testing call (which unwraps any vm error)
-        let handle_res = call_handle::<_, _, _, NoMsg>(
+        let handle_res = call_handle::<_, _, _, Never>(
             &mut deps,
             &handle_env,
             &to_vec(&HandleMsg::Panic {}).unwrap(),
@@ -273,7 +273,7 @@ mod singlepass_tests {
 
         let handle_env = mock_env(&deps.api, creator.as_str(), &[]);
         // Note: we need to use the production-call, not the testing call (which unwraps any vm error)
-        let handle_res = call_handle::<_, _, _, NoMsg>(
+        let handle_res = call_handle::<_, _, _, Never>(
             &mut deps,
             &handle_env,
             &to_vec(&HandleMsg::CpuLoop {}).unwrap(),
@@ -293,7 +293,7 @@ mod singlepass_tests {
 
         let handle_env = mock_env(&deps.api, creator.as_str(), &[]);
         // Note: we need to use the production-call, not the testing call (which unwraps any vm error)
-        let handle_res = call_handle::<_, _, _, NoMsg>(
+        let handle_res = call_handle::<_, _, _, Never>(
             &mut deps,
             &handle_env,
             &to_vec(&HandleMsg::StorageLoop {}).unwrap(),
@@ -313,7 +313,7 @@ mod singlepass_tests {
 
         let handle_env = mock_env(&deps.api, creator.as_str(), &[]);
         // Note: we need to use the production-call, not the testing call (which unwraps any vm error)
-        let handle_res = call_handle::<_, _, _, NoMsg>(
+        let handle_res = call_handle::<_, _, _, Never>(
             &mut deps,
             &handle_env,
             &to_vec(&HandleMsg::MemoryLoop {}).unwrap(),
@@ -337,7 +337,7 @@ mod singlepass_tests {
         let handle_env = mock_env(&deps.api, creator.as_str(), &[]);
         let gas_before = deps.get_gas();
         // Note: we need to use the production-call, not the testing call (which unwraps any vm error)
-        let handle_res = call_handle::<_, _, _, NoMsg>(
+        let handle_res = call_handle::<_, _, _, Never>(
             &mut deps,
             &handle_env,
             &to_vec(&HandleMsg::AllocateLargeMemory {}).unwrap(),

--- a/contracts/reflect/schema/handle_msg.json
+++ b/contracts/reflect/schema/handle_msg.json
@@ -5,10 +5,10 @@
     {
       "type": "object",
       "required": [
-        "reflectmsg"
+        "reflect_msg"
       ],
       "properties": {
-        "reflectmsg": {
+        "reflect_msg": {
           "type": "object",
           "required": [
             "msgs"
@@ -27,10 +27,10 @@
     {
       "type": "object",
       "required": [
-        "changeowner"
+        "change_owner"
       ],
       "properties": {
-        "changeowner": {
+        "change_owner": {
           "type": "object",
           "required": [
             "owner"

--- a/contracts/reflect/schema/query_msg.json
+++ b/contracts/reflect/schema/query_msg.json
@@ -12,6 +12,25 @@
           "type": "object"
         }
       }
+    },
+    {
+      "type": "object",
+      "required": [
+        "reflect_custom"
+      ],
+      "properties": {
+        "reflect_custom": {
+          "type": "object",
+          "required": [
+            "text"
+          ],
+          "properties": {
+            "text": {
+              "type": "string"
+            }
+          }
+        }
+      }
     }
   ]
 }

--- a/contracts/reflect/src/contract.rs
+++ b/contracts/reflect/src/contract.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{
     contract_err, log, to_binary, unauthorized, Api, Binary, CosmosMsg, Env, Extern,
-    HandleResponse, HumanAddr, InitResponse, Querier, QueryRequest, StdResult, Storage,
+    HandleResponse, HumanAddr, InitResponse, Querier, StdResult, Storage,
 };
 
 use crate::msg::{CustomMsg, HandleMsg, InitMsg, OwnerResponse, QueryMsg};
@@ -94,8 +94,8 @@ fn query_reflect<S: Storage, A: Api, Q: Querier>(
     deps: &Extern<S, A, Q>,
     text: String,
 ) -> StdResult<Binary> {
-    let req: QueryRequest<_> = CustomQuery::Capital { text }.into();
-    let resp: CustomResponse = deps.querier.parse_query(&req)?;
+    let req = CustomQuery::Capital { text }.into();
+    let resp: CustomResponse = deps.querier.custom_query(&req)?;
     to_binary(&resp)
 }
 

--- a/contracts/reflect/src/contract.rs
+++ b/contracts/reflect/src/contract.rs
@@ -103,8 +103,8 @@ fn query_reflect<S: Storage, A: Api, Q: Querier>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::testing::CustomQuerier;
-    use cosmwasm_std::testing::{mock_dependencies, mock_env};
+    use crate::testing::mock_dependencies;
+    use cosmwasm_std::testing::mock_env;
     use cosmwasm_std::{coin, coins, from_binary, BankMsg, Binary, StakingMsg, StdError};
 
     #[test]
@@ -275,7 +275,7 @@ mod tests {
 
     #[test]
     fn dispatch_custom_query() {
-        let deps = mock_dependencies(20, &[]).with_querier(CustomQuerier {});
+        let deps = mock_dependencies(20, &[]);
 
         // we don't even initialize, just trigger a query
         let res = query(

--- a/contracts/reflect/src/contract.rs
+++ b/contracts/reflect/src/contract.rs
@@ -3,8 +3,9 @@ use cosmwasm_std::{
     HandleResponse, HumanAddr, InitResponse, Querier, StdResult, Storage,
 };
 
-use crate::msg::{CustomMsg, HandleMsg, InitMsg, OwnerResponse, QueryMsg};
-use crate::query::{CustomQuery, CustomResponse};
+use crate::msg::{
+    CustomMsg, CustomQuery, CustomResponse, HandleMsg, InitMsg, OwnerResponse, QueryMsg,
+};
 use crate::state::{config, config_read, State};
 
 pub fn init<S: Storage, A: Api, Q: Querier>(
@@ -102,7 +103,7 @@ fn query_reflect<S: Storage, A: Api, Q: Querier>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::query::CustomQuerier;
+    use crate::testing::CustomQuerier;
     use cosmwasm_std::testing::{mock_dependencies, mock_env};
     use cosmwasm_std::{coin, coins, from_binary, BankMsg, Binary, StakingMsg, StdError};
 

--- a/contracts/reflect/src/contract.rs
+++ b/contracts/reflect/src/contract.rs
@@ -275,13 +275,7 @@ mod tests {
 
     #[test]
     fn dispatch_custom_query() {
-        // stub gives us defaults. Consume it and override...
-        let stub = mock_dependencies(20, &[]);
-        let deps = Extern {
-            api: stub.api,
-            storage: stub.storage,
-            querier: CustomQuerier {},
-        };
+        let deps = mock_dependencies(20, &[]).with_querier(CustomQuerier {});
 
         // we don't even initialize, just trigger a query
         let res = query(

--- a/contracts/reflect/src/lib.rs
+++ b/contracts/reflect/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod contract;
 pub mod msg;
+pub mod query;
 pub mod state;
 
 #[cfg(target_arch = "wasm32")]

--- a/contracts/reflect/src/lib.rs
+++ b/contracts/reflect/src/lib.rs
@@ -1,7 +1,9 @@
 pub mod contract;
 pub mod msg;
-pub mod query;
 pub mod state;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub mod testing;
 
 #[cfg(target_arch = "wasm32")]
 mod wasm {

--- a/contracts/reflect/src/msg.rs
+++ b/contracts/reflect/src/msg.rs
@@ -7,16 +7,18 @@ use cosmwasm_std::{Binary, CosmosMsg, HumanAddr};
 pub struct InitMsg {}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum HandleMsg {
     ReflectMsg { msgs: Vec<CosmosMsg<CustomMsg>> },
     ChangeOwner { owner: HumanAddr },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
     Owner {},
+    // this will call out to CustomQuery::Capitalize
+    ReflectCustom { text: String },
 }
 
 // We define a custom struct for each query response

--- a/contracts/reflect/src/msg.rs
+++ b/contracts/reflect/src/msg.rs
@@ -1,7 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use cosmwasm_std::{Binary, CosmosMsg, HumanAddr};
+use cosmwasm_std::{Binary, CosmosMsg, HumanAddr, QueryRequest};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct InitMsg {}
@@ -39,4 +39,26 @@ impl Into<CosmosMsg<CustomMsg>> for CustomMsg {
     fn into(self) -> CosmosMsg<CustomMsg> {
         CosmosMsg::Custom(self)
     }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+/// CustomQuery is an override of QueryRequest::Custom to show this works and can be extended in the contract
+pub enum CustomQuery {
+    Ping {},
+    Capital { text: String },
+}
+
+// TODO: do we want to standardize this somehow for all?
+impl Into<QueryRequest<CustomQuery>> for CustomQuery {
+    fn into(self) -> QueryRequest<CustomQuery> {
+        QueryRequest::Custom(self)
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+// All return values of CustomQuery are CustomResponse
+pub struct CustomResponse {
+    pub msg: String,
 }

--- a/contracts/reflect/src/query.rs
+++ b/contracts/reflect/src/query.rs
@@ -24,7 +24,7 @@ impl Into<QueryRequest<CustomQuery>> for CustomQuery {
 #[serde(rename_all = "snake_case")]
 // All return values of CustomQuery are CustomResponse
 pub struct CustomResponse {
-    msg: String,
+    pub msg: String,
 }
 
 impl CustomQuery {

--- a/contracts/reflect/src/query.rs
+++ b/contracts/reflect/src/query.rs
@@ -1,0 +1,96 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use cosmwasm_std::{
+    from_slice, to_binary, Binary, Querier, QuerierResult, QueryRequest, StdResult, SystemError,
+};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+/// CustomQuery is an override of QueryRequest::Custom to show this works and can be extended in the contract
+pub enum CustomQuery {
+    Ping {},
+    Capital { text: String },
+}
+
+// TODO: do we want to standardize this somehow for all?
+impl Into<QueryRequest<CustomQuery>> for CustomQuery {
+    fn into(self) -> QueryRequest<CustomQuery> {
+        QueryRequest::Custom(self)
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+// All return values of CustomQuery are CustomResponse
+pub struct CustomResponse {
+    msg: String,
+}
+
+impl CustomQuery {
+    fn execute(&self) -> StdResult<Binary> {
+        let msg = match self {
+            CustomQuery::Ping {} => "pong".to_string(),
+            CustomQuery::Capital { text } => text.to_uppercase(),
+        };
+        to_binary(&CustomResponse { msg })
+    }
+}
+
+#[derive(Clone)]
+pub struct CustomQuerier {}
+
+impl Querier for CustomQuerier {
+    fn raw_query(&self, bin_request: &[u8]) -> QuerierResult {
+        // parse into our custom query class
+        let request: QueryRequest<CustomQuery> = match from_slice(bin_request) {
+            Ok(v) => v,
+            Err(e) => {
+                return Err(SystemError::InvalidRequest {
+                    error: format!("Parsing QueryRequest: {}", e),
+                })
+            }
+        };
+        match &request {
+            QueryRequest::Custom(custom_query) => Ok(custom_query.execute().map_err(|e| e.into())),
+            _ => Err(SystemError::InvalidRequest {
+                error: "Mock only supports custom queries".to_string(),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use cosmwasm_std::from_binary;
+
+    #[test]
+    fn custom_query_ping() {
+        let res = CustomQuery::Ping {}.execute().unwrap();
+        let msg: CustomResponse = from_binary(&res).unwrap();
+        assert_eq!(msg.msg, "pong".to_string());
+    }
+
+    #[test]
+    fn custom_query_capitalize() {
+        let res = CustomQuery::Capital {
+            text: "fOObaR".to_string(),
+        }
+        .execute()
+        .unwrap();
+        let msg: CustomResponse = from_binary(&res).unwrap();
+        assert_eq!(msg.msg, "FOOBAR".to_string());
+    }
+
+    #[test]
+    fn custom_querier() {
+        let querier = CustomQuerier {};
+        let req: QueryRequest<_> = CustomQuery::Capital {
+            text: "food".to_string(),
+        }
+        .into();
+        let res: CustomResponse = querier.parse_query(&req).unwrap();
+        assert_eq!(res.msg, "FOOD".to_string());
+    }
+}

--- a/contracts/reflect/src/query.rs
+++ b/contracts/reflect/src/query.rs
@@ -90,7 +90,7 @@ mod test {
             text: "food".to_string(),
         }
         .into();
-        let res: CustomResponse = querier.parse_query(&req).unwrap();
+        let res: CustomResponse = querier.custom_query(&req).unwrap();
         assert_eq!(res.msg, "FOOD".to_string());
     }
 }

--- a/contracts/reflect/src/query.rs
+++ b/contracts/reflect/src/query.rs
@@ -53,8 +53,8 @@ impl Querier for CustomQuerier {
         };
         match &request {
             QueryRequest::Custom(custom_query) => Ok(custom_query.execute().map_err(|e| e.into())),
-            _ => Err(SystemError::InvalidRequest {
-                error: "Mock only supports custom queries".to_string(),
+            _ => Err(SystemError::UnsupportedRequest {
+                kind: "non-custom".to_string(),
             }),
         }
     }

--- a/contracts/reflect/tests/integration.rs
+++ b/contracts/reflect/tests/integration.rs
@@ -176,12 +176,7 @@ fn transfer_requires_owner() {
 #[test]
 fn dispatch_custom_query() {
     // stub gives us defaults. Consume it and override...
-    let stub = mock_dependencies(20, &[]);
-    let custom = Extern {
-        api: stub.api,
-        storage: stub.storage,
-        querier: CustomQuerier {},
-    };
+    let custom = mock_dependencies(20, &[]).with_querier(CustomQuerier {});
     // we cannot use mock_instance, so we just copy and modify code from cosmwasm_vm::testing
     let mut deps = Instance::from_code(WASM, custom, 500_000).unwrap();
 

--- a/contracts/reflect/tests/integration.rs
+++ b/contracts/reflect/tests/integration.rs
@@ -1,6 +1,6 @@
-use cosmwasm_std::testing::{mock_dependencies, mock_env};
+use cosmwasm_std::testing::mock_env;
 use cosmwasm_std::{
-    coin, coins, from_binary, Api, ApiError, BankMsg, Binary, Extern, HandleResponse, HandleResult,
+    coin, coins, from_binary, Api, ApiError, BankMsg, Binary, HandleResponse, HandleResult,
     HumanAddr, InitResponse, StakingMsg,
 };
 
@@ -8,7 +8,7 @@ use cosmwasm_vm::testing::{handle, init, mock_instance, query};
 use cosmwasm_vm::Instance;
 
 use reflect::msg::{CustomMsg, CustomResponse, HandleMsg, InitMsg, OwnerResponse, QueryMsg};
-use reflect::testing::CustomQuerier;
+use reflect::testing::mock_dependencies;
 
 /**
 This integration test tries to run and call the generated wasm.
@@ -176,7 +176,7 @@ fn transfer_requires_owner() {
 #[test]
 fn dispatch_custom_query() {
     // stub gives us defaults. Consume it and override...
-    let custom = mock_dependencies(20, &[]).with_querier(CustomQuerier {});
+    let custom = mock_dependencies(20, &[]);
     // we cannot use mock_instance, so we just copy and modify code from cosmwasm_vm::testing
     let mut deps = Instance::from_code(WASM, custom, 500_000).unwrap();
 

--- a/contracts/reflect/tests/integration.rs
+++ b/contracts/reflect/tests/integration.rs
@@ -7,8 +7,8 @@ use cosmwasm_std::{
 use cosmwasm_vm::testing::{handle, init, mock_instance, query};
 use cosmwasm_vm::Instance;
 
-use reflect::msg::{CustomMsg, HandleMsg, InitMsg, OwnerResponse, QueryMsg};
-use reflect::query::{CustomQuerier, CustomResponse};
+use reflect::msg::{CustomMsg, CustomResponse, HandleMsg, InitMsg, OwnerResponse, QueryMsg};
+use reflect::testing::CustomQuerier;
 
 /**
 This integration test tries to run and call the generated wasm.

--- a/packages/std/schema/cosmos_msg_for__never.json
+++ b/packages/std/schema/cosmos_msg_for__never.json
@@ -1,0 +1,304 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "CosmosMsg_for_Never",
+  "anyOf": [
+    {
+      "type": "object",
+      "required": [
+        "bank"
+      ],
+      "properties": {
+        "bank": {
+          "$ref": "#/definitions/BankMsg"
+        }
+      }
+    },
+    {
+      "type": "object",
+      "required": [
+        "custom"
+      ],
+      "properties": {
+        "custom": {
+          "$ref": "#/definitions/Never"
+        }
+      }
+    },
+    {
+      "type": "object",
+      "required": [
+        "staking"
+      ],
+      "properties": {
+        "staking": {
+          "$ref": "#/definitions/StakingMsg"
+        }
+      }
+    },
+    {
+      "type": "object",
+      "required": [
+        "wasm"
+      ],
+      "properties": {
+        "wasm": {
+          "$ref": "#/definitions/WasmMsg"
+        }
+      }
+    }
+  ],
+  "definitions": {
+    "BankMsg": {
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "send"
+          ],
+          "properties": {
+            "send": {
+              "type": "object",
+              "required": [
+                "amount",
+                "from_address",
+                "to_address"
+              ],
+              "properties": {
+                "amount": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Coin"
+                  }
+                },
+                "from_address": {
+                  "$ref": "#/definitions/HumanAddr"
+                },
+                "to_address": {
+                  "$ref": "#/definitions/HumanAddr"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "Binary": {
+      "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>",
+      "type": "string"
+    },
+    "Coin": {
+      "type": "object",
+      "required": [
+        "amount",
+        "denom"
+      ],
+      "properties": {
+        "amount": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "denom": {
+          "type": "string"
+        }
+      }
+    },
+    "HumanAddr": {
+      "type": "string"
+    },
+    "Never": {
+      "description": "Never can never be instantiated and is a no-op placeholder for unsupported enums, such as contracts that don't set a custom message.",
+      "enum": []
+    },
+    "StakingMsg": {
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "delegate"
+          ],
+          "properties": {
+            "delegate": {
+              "type": "object",
+              "required": [
+                "amount",
+                "validator"
+              ],
+              "properties": {
+                "amount": {
+                  "$ref": "#/definitions/Coin"
+                },
+                "validator": {
+                  "$ref": "#/definitions/HumanAddr"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "undelegate"
+          ],
+          "properties": {
+            "undelegate": {
+              "type": "object",
+              "required": [
+                "amount",
+                "validator"
+              ],
+              "properties": {
+                "amount": {
+                  "$ref": "#/definitions/Coin"
+                },
+                "validator": {
+                  "$ref": "#/definitions/HumanAddr"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "withdraw"
+          ],
+          "properties": {
+            "withdraw": {
+              "type": "object",
+              "required": [
+                "validator"
+              ],
+              "properties": {
+                "recipient": {
+                  "description": "this is the \"withdraw address\", the one that should receive the rewards if None, then use delegator address",
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/HumanAddr"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "validator": {
+                  "$ref": "#/definitions/HumanAddr"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "redelegate"
+          ],
+          "properties": {
+            "redelegate": {
+              "type": "object",
+              "required": [
+                "amount",
+                "dst_validator",
+                "src_validator"
+              ],
+              "properties": {
+                "amount": {
+                  "$ref": "#/definitions/Coin"
+                },
+                "dst_validator": {
+                  "$ref": "#/definitions/HumanAddr"
+                },
+                "src_validator": {
+                  "$ref": "#/definitions/HumanAddr"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "Uint128": {
+      "type": "string"
+    },
+    "WasmMsg": {
+      "anyOf": [
+        {
+          "description": "this dispatches a call to another contract at a known address (with known ABI)",
+          "type": "object",
+          "required": [
+            "execute"
+          ],
+          "properties": {
+            "execute": {
+              "type": "object",
+              "required": [
+                "contract_addr",
+                "msg"
+              ],
+              "properties": {
+                "contract_addr": {
+                  "$ref": "#/definitions/HumanAddr"
+                },
+                "msg": {
+                  "description": "msg is the json-encoded HandleMsg struct (as raw Binary)",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  ]
+                },
+                "send": {
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "$ref": "#/definitions/Coin"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "this instantiates a new contracts from previously uploaded wasm code",
+          "type": "object",
+          "required": [
+            "instantiate"
+          ],
+          "properties": {
+            "instantiate": {
+              "type": "object",
+              "required": [
+                "code_id",
+                "msg"
+              ],
+              "properties": {
+                "code_id": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                },
+                "msg": {
+                  "description": "msg is the json-encoded InitMsg struct (as raw Binary)",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  ]
+                },
+                "send": {
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "$ref": "#/definitions/Coin"
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/packages/std/schema/env.json
+++ b/packages/std/schema/env.json
@@ -83,7 +83,7 @@
       ],
       "properties": {
         "sender": {
-          "description": "The `sender` field from the wasm/store-code, wasm/instantiate or wasm/execute message. You can think of this as the address that initiated the action (i.e. the message). What that means exactly heavily depends on the application.\n\nThe x/wasm module ensures that the sender address signed the transaction. Additional signers of the transaction that are either needed for other messages or contain unnecessary signatures are not propagated into the contract.\n\nThere is a disussion to open up this field to multiple initiators, which you're welcome to join if you have a specific need for that feature: https://github.com/CosmWasm/cosmwasm/issues/293",
+          "description": "The `sender` field from the wasm/store-code, wasm/instantiate or wasm/execute message. You can think of this as the address that initiated the action (i.e. the message). What that means exactly heavily depends on the application.\n\nThe x/wasm module ensures that the sender address signed the transaction. Additional signers of the transaction that are either needed for other messages or contain unnecessary signatures are not propagated into the contract.\n\nThere is a discussion to open up this field to multiple initiators, which you're welcome to join if you have a specific need for that feature: https://github.com/CosmWasm/cosmwasm/issues/293",
           "allOf": [
             {
               "$ref": "#/definitions/CanonicalAddr"

--- a/packages/std/schema/handle_result.json
+++ b/packages/std/schema/handle_result.json
@@ -9,7 +9,7 @@
       ],
       "properties": {
         "Ok": {
-          "$ref": "#/definitions/HandleResponse_for_NoMsg"
+          "$ref": "#/definitions/HandleResponse_for_Never"
         }
       }
     },
@@ -312,7 +312,7 @@
         }
       }
     },
-    "CosmosMsg_for_NoMsg": {
+    "CosmosMsg_for_Never": {
       "anyOf": [
         {
           "type": "object",
@@ -332,7 +332,7 @@
           ],
           "properties": {
             "custom": {
-              "$ref": "#/definitions/NoMsg"
+              "$ref": "#/definitions/Never"
             }
           }
         },
@@ -360,7 +360,7 @@
         }
       ]
     },
-    "HandleResponse_for_NoMsg": {
+    "HandleResponse_for_Never": {
       "type": "object",
       "required": [
         "log",
@@ -386,7 +386,7 @@
         "messages": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/CosmosMsg_for_NoMsg"
+            "$ref": "#/definitions/CosmosMsg_for_Never"
           }
         }
       }
@@ -409,8 +409,8 @@
         }
       }
     },
-    "NoMsg": {
-      "description": "NoMsg can never be instantiated and is a no-op placeholder for those contracts that don't explicitly set a custom message.",
+    "Never": {
+      "description": "Never can never be instantiated and is a no-op placeholder for unsupported enums, such as contracts that don't set a custom message.",
       "enum": []
     },
     "StakingMsg": {

--- a/packages/std/schema/init_result.json
+++ b/packages/std/schema/init_result.json
@@ -9,7 +9,7 @@
       ],
       "properties": {
         "Ok": {
-          "$ref": "#/definitions/InitResponse_for_NoMsg"
+          "$ref": "#/definitions/InitResponse_for_Never"
         }
       }
     },
@@ -312,7 +312,7 @@
         }
       }
     },
-    "CosmosMsg_for_NoMsg": {
+    "CosmosMsg_for_Never": {
       "anyOf": [
         {
           "type": "object",
@@ -332,7 +332,7 @@
           ],
           "properties": {
             "custom": {
-              "$ref": "#/definitions/NoMsg"
+              "$ref": "#/definitions/Never"
             }
           }
         },
@@ -363,7 +363,7 @@
     "HumanAddr": {
       "type": "string"
     },
-    "InitResponse_for_NoMsg": {
+    "InitResponse_for_Never": {
       "type": "object",
       "required": [
         "log",
@@ -389,7 +389,7 @@
         "messages": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/CosmosMsg_for_NoMsg"
+            "$ref": "#/definitions/CosmosMsg_for_Never"
           }
         }
       }
@@ -409,8 +409,8 @@
         }
       }
     },
-    "NoMsg": {
-      "description": "NoMsg can never be instantiated and is a no-op placeholder for those contracts that don't explicitly set a custom message.",
+    "Never": {
+      "description": "Never can never be instantiated and is a no-op placeholder for unsupported enums, such as contracts that don't set a custom message.",
       "enum": []
     },
     "StakingMsg": {

--- a/packages/std/src/api.rs
+++ b/packages/std/src/api.rs
@@ -128,6 +128,7 @@ pub enum SystemError {
     InvalidRequest { error: String },
     NoSuchContract { addr: HumanAddr },
     Unknown {},
+    UnsupportedRequest { kind: String },
 }
 
 impl std::error::Error for SystemError {}
@@ -138,6 +139,7 @@ impl std::fmt::Display for SystemError {
             SystemError::InvalidRequest { error } => write!(f, "Cannot parse request: {}", error),
             SystemError::NoSuchContract { addr } => write!(f, "No such contract: {}", addr),
             SystemError::Unknown {} => write!(f, "Unknown system error"),
+            SystemError::UnsupportedRequest { kind } => write!(f, "Unsupport query type: {}", kind),
         }
     }
 }

--- a/packages/std/src/imports.rs
+++ b/packages/std/src/imports.rs
@@ -11,6 +11,7 @@ use crate::query::QueryRequest;
 use crate::serde::{from_slice, to_vec};
 use crate::traits::{Api, Querier, QuerierResult, ReadonlyStorage, Storage};
 use crate::types::{CanonicalAddr, HumanAddr};
+use serde::Serialize;
 
 /// A kibi (kilo binary)
 static KI: usize = 1024;
@@ -242,7 +243,7 @@ impl ExternalQuerier {
 }
 
 impl Querier for ExternalQuerier {
-    fn query(&self, request: &QueryRequest) -> QuerierResult {
+    fn query<T: Serialize>(&self, request: &QueryRequest<T>) -> QuerierResult {
         let bin_request = to_vec(request).or(Err(SystemError::Unknown {}))?;
         let req = build_region(&bin_request);
         let request_ptr = &*req as *const Region as *const c_void;

--- a/packages/std/src/imports.rs
+++ b/packages/std/src/imports.rs
@@ -7,11 +7,9 @@ use crate::errors::{contract_err, dyn_contract_err, ContractErr, StdResult};
 #[cfg(feature = "iterator")]
 use crate::iterator::{Order, KV};
 use crate::memory::{alloc, build_region, consume_region, Region};
-use crate::query::QueryRequest;
-use crate::serde::{from_slice, to_vec};
+use crate::serde::from_slice;
 use crate::traits::{Api, Querier, QuerierResult, ReadonlyStorage, Storage};
 use crate::types::{CanonicalAddr, HumanAddr};
-use serde::Serialize;
 
 /// A kibi (kilo binary)
 static KI: usize = 1024;
@@ -243,9 +241,8 @@ impl ExternalQuerier {
 }
 
 impl Querier for ExternalQuerier {
-    fn query<T: Serialize>(&self, request: &QueryRequest<T>) -> QuerierResult {
-        let bin_request = to_vec(request).or(Err(SystemError::Unknown {}))?;
-        let req = build_region(&bin_request);
+    fn raw_query(&self, bin_request: &[u8]) -> QuerierResult {
+        let req = build_region(bin_request);
         let request_ptr = &*req as *const Region as *const c_void;
         let response_ptr = alloc(QUERY_RESULT_BUFFER_LENGTH);
 

--- a/packages/std/src/init_handle.rs
+++ b/packages/std/src/init_handle.rs
@@ -7,7 +7,7 @@ use std::fmt;
 use crate::api::ApiResult;
 use crate::coins::Coin;
 use crate::encoding::Binary;
-use crate::types::HumanAddr;
+use crate::types::{HumanAddr, NoMsg};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
@@ -35,11 +35,6 @@ pub enum BankMsg {
         amount: Vec<Coin>,
     },
 }
-
-/// NoMsg can never be instantiated and is a no-op placeholder for
-/// those contracts that don't explicitly set a custom message.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub enum NoMsg {}
 
 #[cfg(feature = "staking")]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/packages/std/src/init_handle.rs
+++ b/packages/std/src/init_handle.rs
@@ -7,12 +7,12 @@ use std::fmt;
 use crate::api::ApiResult;
 use crate::coins::Coin;
 use crate::encoding::Binary;
-use crate::types::{HumanAddr, NoMsg};
+use crate::types::{HumanAddr, Never};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 // See https://github.com/serde-rs/serde/issues/1296 why we cannot add De-Serialize trait bounds to T
-pub enum CosmosMsg<T = NoMsg>
+pub enum CosmosMsg<T = Never>
 where
     T: Clone + fmt::Debug + PartialEq + JsonSchema,
 {
@@ -118,7 +118,7 @@ pub fn log(key: &str, value: &str) -> LogAttribute {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct InitResponse<T = NoMsg>
+pub struct InitResponse<T = Never>
 where
     T: Clone + fmt::Debug + PartialEq + JsonSchema,
 {
@@ -128,7 +128,7 @@ where
     pub data: Option<Binary>,   // abci defines this as bytes
 }
 
-pub type InitResult<U = NoMsg> = ApiResult<InitResponse<U>>;
+pub type InitResult<U = Never> = ApiResult<InitResponse<U>>;
 
 impl<T> Default for InitResponse<T>
 where
@@ -144,7 +144,7 @@ where
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct HandleResponse<T = NoMsg>
+pub struct HandleResponse<T = Never>
 where
     T: Clone + fmt::Debug + PartialEq + JsonSchema,
 {
@@ -154,7 +154,7 @@ where
     pub data: Option<Binary>,   // abci defines this as bytes
 }
 
-pub type HandleResult<U = NoMsg> = ApiResult<HandleResponse<U>>;
+pub type HandleResult<U = Never> = ApiResult<HandleResponse<U>>;
 
 impl<T> Default for HandleResponse<T>
 where

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -22,7 +22,7 @@ pub use crate::errors::{
 };
 pub use crate::init_handle::{
     log, BankMsg, CosmosMsg, HandleResponse, HandleResult, InitResponse, InitResult, LogAttribute,
-    NoMsg, WasmMsg,
+    WasmMsg,
 };
 #[cfg(feature = "iterator")]
 pub use crate::iterator::{Order, KV};
@@ -33,7 +33,7 @@ pub use crate::query::{
 pub use crate::serde::{from_binary, from_slice, to_binary, to_vec};
 pub use crate::storage::MemoryStorage;
 pub use crate::traits::{Api, Extern, Querier, QuerierResult, ReadonlyStorage, Storage};
-pub use crate::types::{CanonicalAddr, Env, HumanAddr};
+pub use crate::types::{CanonicalAddr, Env, HumanAddr, NoMsg};
 
 #[cfg(feature = "staking")]
 pub use crate::init_handle::StakingMsg;

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -33,7 +33,7 @@ pub use crate::query::{
 pub use crate::serde::{from_binary, from_slice, to_binary, to_vec};
 pub use crate::storage::MemoryStorage;
 pub use crate::traits::{Api, Extern, Querier, QuerierResult, ReadonlyStorage, Storage};
-pub use crate::types::{CanonicalAddr, Env, HumanAddr, NoMsg};
+pub use crate::types::{CanonicalAddr, Env, HumanAddr, Never};
 
 #[cfg(feature = "staking")]
 pub use crate::init_handle::StakingMsg;

--- a/packages/std/src/mock.rs
+++ b/packages/std/src/mock.rs
@@ -170,8 +170,8 @@ impl Querier for MockQuerier {
         };
         match &request {
             QueryRequest::Bank(bank_query) => self.bank.query(bank_query),
-            QueryRequest::Custom(_) => Err(SystemError::InvalidRequest {
-                error: "Mock doesn't support custom queries".to_string(),
+            QueryRequest::Custom(_) => Err(SystemError::UnsupportedRequest {
+                kind: "custom".to_string(),
             }),
             #[cfg(feature = "staking")]
             QueryRequest::Staking(staking_query) => self.staking.query(staking_query),

--- a/packages/std/src/mock.rs
+++ b/packages/std/src/mock.rs
@@ -9,7 +9,7 @@ use crate::query::{AllBalanceResponse, BalanceResponse, BankQuery, QueryRequest,
 use crate::serde::{from_slice, to_binary};
 use crate::storage::MemoryStorage;
 use crate::traits::{Api, Extern, Querier, QuerierResult};
-use crate::types::{BlockInfo, CanonicalAddr, ContractInfo, Env, HumanAddr, MessageInfo, NoMsg};
+use crate::types::{BlockInfo, CanonicalAddr, ContractInfo, Env, HumanAddr, MessageInfo, Never};
 
 static CONTRACT_ADDR: &str = "cosmos2contract";
 
@@ -160,7 +160,7 @@ impl MockQuerier {
 impl Querier for MockQuerier {
     fn raw_query(&self, bin_request: &[u8]) -> QuerierResult {
         // MockQuerier doesn't support Custom, so we ignore it completely here
-        let request: QueryRequest<NoMsg> = match from_slice(bin_request) {
+        let request: QueryRequest<Never> = match from_slice(bin_request) {
             Ok(v) => v,
             Err(e) => {
                 return Err(SystemError::InvalidRequest {

--- a/packages/std/src/mock.rs
+++ b/packages/std/src/mock.rs
@@ -161,6 +161,7 @@ impl Querier for MockQuerier {
     fn query(&self, request: &QueryRequest) -> QuerierResult {
         match request {
             QueryRequest::Bank(bank_query) => self.bank.query(bank_query),
+            QueryRequest::Custom(_) => Err(SystemError::InvalidRequest { error: "Mock doesn't support custom queries".to_string()}),
             #[cfg(feature = "staking")]
             QueryRequest::Staking(staking_query) => self.staking.query(staking_query),
             QueryRequest::Wasm(msg) => {

--- a/packages/std/src/mock.rs
+++ b/packages/std/src/mock.rs
@@ -158,10 +158,12 @@ impl MockQuerier {
 }
 
 impl Querier for MockQuerier {
-    fn query(&self, request: &QueryRequest) -> QuerierResult {
+    fn query<T>(&self, request: &QueryRequest<T>) -> QuerierResult {
         match request {
             QueryRequest::Bank(bank_query) => self.bank.query(bank_query),
-            QueryRequest::Custom(_) => Err(SystemError::InvalidRequest { error: "Mock doesn't support custom queries".to_string()}),
+            QueryRequest::Custom(_) => Err(SystemError::InvalidRequest {
+                error: "Mock doesn't support custom queries".to_string(),
+            }),
             #[cfg(feature = "staking")]
             QueryRequest::Staking(staking_query) => self.staking.query(staking_query),
             QueryRequest::Wasm(msg) => {

--- a/packages/std/src/query.rs
+++ b/packages/std/src/query.rs
@@ -1,5 +1,6 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::fmt;
 
 use crate::api::ApiResult;
 use crate::coins::Coin;
@@ -49,6 +50,25 @@ pub enum WasmQuery {
         /// Key is the raw key used in the contracts Storage
         key: Binary,
     },
+}
+
+impl<T: Clone + fmt::Debug + PartialEq + JsonSchema> From<BankQuery> for QueryRequest<T> {
+    fn from(msg: BankQuery) -> Self {
+        QueryRequest::Bank(msg)
+    }
+}
+
+#[cfg(feature = "staking")]
+impl<T: Clone + fmt::Debug + PartialEq + JsonSchema> From<StakingQuery> for QueryRequest<T> {
+    fn from(msg: StakingQuery) -> Self {
+        QueryRequest::Staking(msg)
+    }
+}
+
+impl<T: Clone + fmt::Debug + PartialEq + JsonSchema> From<WasmQuery> for QueryRequest<T> {
+    fn from(msg: WasmQuery) -> Self {
+        QueryRequest::Wasm(msg)
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/packages/std/src/query.rs
+++ b/packages/std/src/query.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use crate::api::ApiResult;
 use crate::coins::Coin;
 use crate::encoding::Binary;
-use crate::types::{HumanAddr, NoMsg};
+use crate::types::HumanAddr;
 
 pub type QueryResponse = Binary;
 
@@ -12,7 +12,7 @@ pub type QueryResult = ApiResult<QueryResponse>;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
-pub enum QueryRequest<T = NoMsg> {
+pub enum QueryRequest<T> {
     Bank(BankQuery),
     Custom(T),
     #[cfg(feature = "staking")]

--- a/packages/std/src/query.rs
+++ b/packages/std/src/query.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use crate::api::ApiResult;
 use crate::coins::Coin;
 use crate::encoding::Binary;
-use crate::types::HumanAddr;
+use crate::types::{HumanAddr, NoMsg};
 
 pub type QueryResponse = Binary;
 
@@ -12,8 +12,9 @@ pub type QueryResult = ApiResult<QueryResponse>;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
-pub enum QueryRequest {
+pub enum QueryRequest<T = NoMsg> {
     Bank(BankQuery),
+    Custom(T),
     #[cfg(feature = "staking")]
     Staking(StakingQuery),
     Wasm(WasmQuery),

--- a/packages/std/src/traits.rs
+++ b/packages/std/src/traits.rs
@@ -21,6 +21,19 @@ pub struct Extern<S: Storage, A: Api, Q: Querier> {
     pub querier: Q,
 }
 
+impl<S: Storage, A: Api, Q: Querier> Extern<S, A, Q> {
+    /// with_querier is a helper mainly for test code when swapping out the Querier
+    /// from the auto-generated one from mock_dependencies. This changes the type of
+    /// Extern so replaces requires some boilerplate.
+    pub fn with_querier<T: Querier>(self, querier: T) -> Extern<S, A, T> {
+        Extern {
+            storage: self.storage,
+            api: self.api,
+            querier,
+        }
+    }
+}
+
 /// ReadonlyStorage is access to the contracts persistent data store
 pub trait ReadonlyStorage {
     /// Returns Err on error.

--- a/packages/std/src/traits.rs
+++ b/packages/std/src/traits.rs
@@ -79,6 +79,7 @@ pub trait Querier: Clone + Send {
     fn query<T: Serialize>(&self, request: &QueryRequest<T>) -> QuerierResult {
         match to_vec(request) {
             Ok(raw) => self.raw_query(&raw),
+            // TODO: maybe I want to make this a SystemError::InvalidRequest ?
             Err(e) => Ok(Err(e.into())),
         }
     }

--- a/packages/std/src/traits.rs
+++ b/packages/std/src/traits.rs
@@ -8,7 +8,7 @@ use crate::iterator::{Order, KV};
 use crate::query::{AllBalanceResponse, BalanceResponse, BankQuery, QueryRequest};
 use crate::serde::from_binary;
 use crate::to_vec;
-use crate::types::{CanonicalAddr, HumanAddr, NoMsg};
+use crate::types::{CanonicalAddr, HumanAddr, Never};
 use serde::Serialize;
 
 /// Holds all external dependencies of the contract.
@@ -111,13 +111,13 @@ pub trait Querier: Clone + Send {
             address: address.into(),
             denom: denom.to_string(),
         });
-        self.parse_query::<NoMsg, _>(&request)
+        self.parse_query::<Never, _>(&request)
     }
 
     fn query_all_balances<U: Into<HumanAddr>>(&self, address: U) -> StdResult<AllBalanceResponse> {
         let request = QueryRequest::Bank(BankQuery::AllBalances {
             address: address.into(),
         });
-        self.parse_query::<NoMsg, _>(&request)
+        self.parse_query::<Never, _>(&request)
     }
 }

--- a/packages/std/src/traits.rs
+++ b/packages/std/src/traits.rs
@@ -22,14 +22,14 @@ pub struct Extern<S: Storage, A: Api, Q: Querier> {
 }
 
 impl<S: Storage, A: Api, Q: Querier> Extern<S, A, Q> {
-    /// with_querier is a helper mainly for test code when swapping out the Querier
+    /// change_querier is a helper mainly for test code when swapping out the Querier
     /// from the auto-generated one from mock_dependencies. This changes the type of
     /// Extern so replaces requires some boilerplate.
-    pub fn with_querier<T: Querier>(self, querier: T) -> Extern<S, A, T> {
+    pub fn change_querier<T: Querier, F: Fn(Q) -> T>(self, transform: F) -> Extern<S, A, T> {
         Extern {
             storage: self.storage,
             api: self.api,
-            querier,
+            querier: transform(self.querier),
         }
     }
 }

--- a/packages/std/src/traits.rs
+++ b/packages/std/src/traits.rs
@@ -100,7 +100,7 @@ pub trait Querier: Clone + Send {
         let raw = match to_vec(request) {
             Ok(raw) => raw,
             // TODO: maybe I want to make this a SystemError::InvalidRequest ?
-            Err(e) => return Err(e.into()),
+            Err(e) => return Err(e),
         };
         match self.raw_query(&raw) {
             Err(sys_err) => dyn_contract_err(format!("Querier system error: {}", sys_err)),
@@ -117,17 +117,19 @@ pub trait Querier: Clone + Send {
         address: U,
         denom: &str,
     ) -> StdResult<BalanceResponse> {
-        let request = QueryRequest::Bank(BankQuery::Balance {
+        let request = BankQuery::Balance {
             address: address.into(),
             denom: denom.to_string(),
-        });
+        }
+        .into();
         self.query(&request)
     }
 
     fn query_all_balances<U: Into<HumanAddr>>(&self, address: U) -> StdResult<AllBalanceResponse> {
-        let request = QueryRequest::Bank(BankQuery::AllBalances {
+        let request = BankQuery::AllBalances {
             address: address.into(),
-        });
+        }
+        .into();
         self.query(&request)
     }
 }

--- a/packages/std/src/traits.rs
+++ b/packages/std/src/traits.rs
@@ -8,6 +8,7 @@ use crate::iterator::{Order, KV};
 use crate::query::{AllBalanceResponse, BalanceResponse, BankQuery, QueryRequest};
 use crate::serde::from_binary;
 use crate::types::{CanonicalAddr, HumanAddr, NoMsg};
+use serde::Serialize;
 
 /// Holds all external dependencies of the contract.
 /// Designed to allow easy dependency injection at runtime.
@@ -76,7 +77,7 @@ pub trait Querier: Clone + Send {
     //
     // ApiResult is a format that can capture this info in a serialized form. We parse it into
     // a typical Result for the implementing object
-    fn query<T>(&self, request: &QueryRequest<T>) -> QuerierResult;
+    fn query<T: Serialize>(&self, request: &QueryRequest<T>) -> QuerierResult;
 
     /// Makes the query and parses the response.
     /// Any error (System Error, Error or called contract, or Parse Error) are flattened into
@@ -84,7 +85,10 @@ pub trait Querier: Clone + Send {
     ///
     /// eg. When querying another contract, you will often want some way to detect/handle if there
     /// is no contract there.
-    fn parse_query<T, U: DeserializeOwned>(&self, request: &QueryRequest<T>) -> StdResult<U> {
+    fn parse_query<T: Serialize, U: DeserializeOwned>(
+        &self,
+        request: &QueryRequest<T>,
+    ) -> StdResult<U> {
         match self.query(&request) {
             Err(sys_err) => dyn_contract_err(format!("Querier system error: {}", sys_err)),
             Ok(Err(err)) => dyn_contract_err(format!("Querier contract error: {}", err)),

--- a/packages/std/src/types.rs
+++ b/packages/std/src/types.rs
@@ -92,7 +92,7 @@ pub struct MessageInfo {
     /// Additional signers of the transaction that are either needed for other messages or contain unnecessary
     /// signatures are not propagated into the contract.
     ///
-    /// There is a disussion to open up this field to multiple initiators, which you're welcome to join
+    /// There is a discussion to open up this field to multiple initiators, which you're welcome to join
     /// if you have a specific need for that feature: https://github.com/CosmWasm/cosmwasm/issues/293
     pub sender: CanonicalAddr,
     pub sent_funds: Vec<Coin>,

--- a/packages/std/src/types.rs
+++ b/packages/std/src/types.rs
@@ -103,7 +103,7 @@ pub struct ContractInfo {
     pub address: CanonicalAddr,
 }
 
-/// NoMsg can never be instantiated and is a no-op placeholder for
-/// those contracts that don't explicitly set a custom message.
+/// Never can never be instantiated and is a no-op placeholder for
+/// unsupported enums, such as contracts that don't set a custom message.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub enum NoMsg {}
+pub enum Never {}

--- a/packages/std/src/types.rs
+++ b/packages/std/src/types.rs
@@ -102,3 +102,8 @@ pub struct MessageInfo {
 pub struct ContractInfo {
     pub address: CanonicalAddr,
 }
+
+/// NoMsg can never be instantiated and is a no-op placeholder for
+/// those contracts that don't explicitly set a custom message.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub enum NoMsg {}

--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -142,7 +142,7 @@ mod test {
     use crate::calls::{call_handle, call_init};
     use crate::errors::VmError;
     use cosmwasm_std::testing::{mock_dependencies, mock_env, MockApi, MockQuerier, MockStorage};
-    use cosmwasm_std::{coins, NoMsg};
+    use cosmwasm_std::{coins, Never};
     use tempfile::TempDir;
 
     static TESTING_GAS_LIMIT: u64 = 400_000;
@@ -237,7 +237,7 @@ mod test {
         let msg = r#"{"verifier": "verifies", "beneficiary": "benefits"}"#.as_bytes();
 
         // call and check
-        let res = call_init::<_, _, _, NoMsg>(&mut instance, &env, msg).unwrap();
+        let res = call_init::<_, _, _, Never>(&mut instance, &env, msg).unwrap();
         let msgs = res.unwrap().messages;
         assert_eq!(msgs.len(), 0);
     }
@@ -254,14 +254,14 @@ mod test {
         // init contract
         let env = mock_env(&instance.api, "creator", &coins(1000, "earth"));
         let msg = r#"{"verifier": "verifies", "beneficiary": "benefits"}"#.as_bytes();
-        let res = call_init::<_, _, _, NoMsg>(&mut instance, &env, msg).unwrap();
+        let res = call_init::<_, _, _, Never>(&mut instance, &env, msg).unwrap();
         let msgs = res.unwrap().messages;
         assert_eq!(msgs.len(), 0);
 
         // run contract - just sanity check - results validate in contract unit tests
         let env = mock_env(&instance.api, "verifies", &coins(15, "earth"));
         let msg = br#"{"release":{}}"#;
-        let res = call_handle::<_, _, _, NoMsg>(&mut instance, &env, msg).unwrap();
+        let res = call_handle::<_, _, _, Never>(&mut instance, &env, msg).unwrap();
         let msgs = res.unwrap().messages;
         assert_eq!(1, msgs.len());
     }
@@ -280,7 +280,7 @@ mod test {
         let mut instance = cache.get_instance(&id, deps1, TESTING_GAS_LIMIT).unwrap();
         let env = mock_env(&instance.api, "owner1", &coins(1000, "earth"));
         let msg = r#"{"verifier": "sue", "beneficiary": "mary"}"#.as_bytes();
-        let res = call_init::<_, _, _, NoMsg>(&mut instance, &env, msg).unwrap();
+        let res = call_init::<_, _, _, Never>(&mut instance, &env, msg).unwrap();
         let msgs = res.unwrap().messages;
         assert_eq!(msgs.len(), 0);
         let deps1 = cache.store_instance(&id, instance).unwrap();
@@ -289,7 +289,7 @@ mod test {
         let mut instance = cache.get_instance(&id, deps2, TESTING_GAS_LIMIT).unwrap();
         let env = mock_env(&instance.api, "owner2", &coins(500, "earth"));
         let msg = r#"{"verifier": "bob", "beneficiary": "john"}"#.as_bytes();
-        let res = call_init::<_, _, _, NoMsg>(&mut instance, &env, msg).unwrap();
+        let res = call_init::<_, _, _, Never>(&mut instance, &env, msg).unwrap();
         let msgs = res.unwrap().messages;
         assert_eq!(msgs.len(), 0);
         let deps2 = cache.store_instance(&id, instance).unwrap();
@@ -298,7 +298,7 @@ mod test {
         let mut instance = cache.get_instance(&id, deps2, TESTING_GAS_LIMIT).unwrap();
         let env = mock_env(&instance.api, "bob", &coins(15, "earth"));
         let msg = br#"{"release":{}}"#;
-        let res = call_handle::<_, _, _, NoMsg>(&mut instance, &env, msg).unwrap();
+        let res = call_handle::<_, _, _, Never>(&mut instance, &env, msg).unwrap();
         let msgs = res.unwrap().messages;
         assert_eq!(1, msgs.len());
         let _ = cache.store_instance(&id, instance).unwrap();
@@ -307,7 +307,7 @@ mod test {
         let mut instance = cache.get_instance(&id, deps1, TESTING_GAS_LIMIT).unwrap();
         let env = mock_env(&instance.api, "sue", &coins(15, "earth"));
         let msg = br#"{"release":{}}"#;
-        let res = call_handle::<_, _, _, NoMsg>(&mut instance, &env, msg).unwrap();
+        let res = call_handle::<_, _, _, Never>(&mut instance, &env, msg).unwrap();
         let msgs = res.unwrap().messages;
         assert_eq!(1, msgs.len());
         let _ = cache.store_instance(&id, instance);
@@ -333,7 +333,7 @@ mod test {
         // Consume some gas
         let env = mock_env(&instance1.api, "owner1", &coins(1000, "earth"));
         let msg = r#"{"verifier": "sue", "beneficiary": "mary"}"#.as_bytes();
-        call_init::<_, _, _, NoMsg>(&mut instance1, &env, msg)
+        call_init::<_, _, _, Never>(&mut instance1, &env, msg)
             .unwrap()
             .unwrap();
         assert!(instance1.get_gas() < original_gas);
@@ -366,7 +366,7 @@ mod test {
         // Consume some gas. This fails
         let env1 = mock_env(&instance1.api, "owner1", &coins(1000, "earth"));
         let msg1 = r#"{"verifier": "sue", "beneficiary": "mary"}"#.as_bytes();
-        match call_init::<_, _, _, NoMsg>(&mut instance1, &env1, msg1) {
+        match call_init::<_, _, _, Never>(&mut instance1, &env1, msg1) {
             Err(VmError::WasmerRuntimeErr { .. }) => (), // all good, continue
             Err(e) => panic!("unexpected error, {:?}", e),
             Ok(_) => panic!("call_init must run out of gas"),
@@ -384,7 +384,7 @@ mod test {
         // Now it works
         let env2 = mock_env(&instance2.api, "owner2", &coins(500, "earth"));
         let msg2 = r#"{"verifier": "bob", "beneficiary": "john"}"#.as_bytes();
-        call_init::<_, _, _, NoMsg>(&mut instance2, &env2, msg2)
+        call_init::<_, _, _, Never>(&mut instance2, &env2, msg2)
             .unwrap()
             .unwrap();
     }

--- a/packages/vm/src/context.rs
+++ b/packages/vm/src/context.rs
@@ -173,7 +173,7 @@ mod test {
     use crate::errors::VmError;
     use cosmwasm_std::testing::{MockQuerier, MockStorage};
     use cosmwasm_std::{
-        coin, coins, from_binary, AllBalanceResponse, BankQuery, HumanAddr, NoMsg, QueryRequest,
+        coin, coins, from_binary, AllBalanceResponse, BankQuery, HumanAddr, Never, QueryRequest,
         ReadonlyStorage,
     };
     use wasmer_runtime_core::{imports, instance::Instance, typed_func::Func};
@@ -313,7 +313,7 @@ mod test {
         leave_default_data(ctx);
 
         let res = with_querier_from_context::<S, Q, _, _>(ctx, |querier| {
-            let req: QueryRequest<NoMsg> = QueryRequest::Bank(BankQuery::AllBalances {
+            let req: QueryRequest<Never> = QueryRequest::Bank(BankQuery::AllBalances {
                 address: HumanAddr::from(INIT_ADDR),
             });
             querier.query(&req)

--- a/packages/vm/src/context.rs
+++ b/packages/vm/src/context.rs
@@ -173,7 +173,7 @@ mod test {
     use crate::errors::VmError;
     use cosmwasm_std::testing::{MockQuerier, MockStorage};
     use cosmwasm_std::{
-        coin, coins, from_binary, AllBalanceResponse, BankQuery, HumanAddr, QueryRequest,
+        coin, coins, from_binary, AllBalanceResponse, BankQuery, HumanAddr, NoMsg, QueryRequest,
         ReadonlyStorage,
     };
     use wasmer_runtime_core::{imports, instance::Instance, typed_func::Func};
@@ -313,7 +313,7 @@ mod test {
         leave_default_data(ctx);
 
         let res = with_querier_from_context::<S, Q, _, _>(ctx, |querier| {
-            let req = QueryRequest::Bank(BankQuery::AllBalances {
+            let req: QueryRequest<NoMsg> = QueryRequest::Bank(BankQuery::AllBalances {
                 address: HumanAddr::from(INIT_ADDR),
             });
             querier.query(&req)

--- a/packages/vm/src/context.rs
+++ b/packages/vm/src/context.rs
@@ -173,8 +173,8 @@ mod test {
     use crate::errors::VmError;
     use cosmwasm_std::testing::{MockQuerier, MockStorage};
     use cosmwasm_std::{
-        coin, coins, from_binary, AllBalanceResponse, BankQuery, HumanAddr, Never, QueryRequest,
-        ReadonlyStorage,
+        coin, coins, from_binary, to_vec, AllBalanceResponse, BankQuery, HumanAddr, Never,
+        QueryRequest, ReadonlyStorage,
     };
     use wasmer_runtime_core::{imports, instance::Instance, typed_func::Func};
 
@@ -316,7 +316,7 @@ mod test {
             let req: QueryRequest<Never> = QueryRequest::Bank(BankQuery::AllBalances {
                 address: HumanAddr::from(INIT_ADDR),
             });
-            querier.query(&req)
+            querier.raw_query(&to_vec(&req).unwrap())
         })
         .unwrap()
         .unwrap();

--- a/packages/vm/src/imports.rs
+++ b/packages/vm/src/imports.rs
@@ -341,7 +341,7 @@ mod test {
     use super::*;
     use cosmwasm_std::testing::{MockApi, MockQuerier, MockStorage};
     use cosmwasm_std::{
-        coins, from_binary, AllBalanceResponse, BankQuery, HumanAddr, NoMsg, QueryRequest,
+        coins, from_binary, AllBalanceResponse, BankQuery, HumanAddr, Never, QueryRequest,
         ReadonlyStorage, SystemError, WasmQuery,
     };
     use wasmer_runtime_core::{imports, instance::Instance, typed_func::Func};
@@ -760,7 +760,7 @@ mod test {
     fn do_query_chain_works() {
         let mut instance = make_instance();
 
-        let request: QueryRequest<NoMsg> = QueryRequest::Bank(BankQuery::AllBalances {
+        let request: QueryRequest<Never> = QueryRequest::Bank(BankQuery::AllBalances {
             address: HumanAddr::from(INIT_ADDR),
         });
         let request_data = cosmwasm_std::to_vec(&request).unwrap();
@@ -809,7 +809,7 @@ mod test {
     fn do_query_chain_fails_for_missing_contract() {
         let mut instance = make_instance();
 
-        let request: QueryRequest<NoMsg> = QueryRequest::Wasm(WasmQuery::Smart {
+        let request: QueryRequest<Never> = QueryRequest::Wasm(WasmQuery::Smart {
             contract_addr: HumanAddr::from("non-existent"),
             msg: Binary::from(b"{}" as &[u8]),
         });

--- a/packages/vm/src/imports.rs
+++ b/packages/vm/src/imports.rs
@@ -7,10 +7,7 @@ use std::mem;
 
 #[cfg(feature = "iterator")]
 use cosmwasm_std::StdResult;
-use cosmwasm_std::{
-    Api, Binary, CanonicalAddr, HumanAddr, Querier, QuerierResult, QueryRequest, Storage,
-    SystemError,
-};
+use cosmwasm_std::{Api, Binary, CanonicalAddr, HumanAddr, Querier, QuerierResult, Storage};
 #[cfg(feature = "iterator")]
 use cosmwasm_std::{Order, KV};
 use wasmer_runtime_core::vm::Ctx;
@@ -24,7 +21,7 @@ use crate::errors::{make_runtime_err, VmError};
 #[cfg(feature = "iterator")]
 use crate::memory::maybe_read_region;
 use crate::memory::{read_region, write_region};
-use crate::serde::{from_slice, to_vec};
+use crate::serde::to_vec;
 
 /// A kibi (kilo binary)
 static KI: usize = 1024;
@@ -237,18 +234,8 @@ pub fn do_query_chain<S: Storage, Q: Querier>(
         Err(_) => return errors::REGION_READ_UNKNOWN,
     };
 
-    let res = match from_slice::<QueryRequest>(&request) {
-        // if we parse, try to execute the query
-        Ok(parsed) => {
-            let qr: QuerierResult =
-                with_querier_from_context::<S, Q, _, _>(ctx, |querier: &Q| querier.query(&parsed));
-            qr
-        }
-        // otherwise, return the InvalidRequest error as SystemError
-        Err(err) => Err(SystemError::InvalidRequest {
-            error: err.to_string(),
-        }),
-    };
+    let res: QuerierResult =
+        with_querier_from_context::<S, Q, _, _>(ctx, |querier: &Q| querier.raw_query(&request));
 
     match to_vec(&res) {
         Ok(serialized) => match write_region(ctx, response_ptr, &serialized) {
@@ -354,7 +341,8 @@ mod test {
     use super::*;
     use cosmwasm_std::testing::{MockApi, MockQuerier, MockStorage};
     use cosmwasm_std::{
-        coins, from_binary, AllBalanceResponse, BankQuery, HumanAddr, ReadonlyStorage, WasmQuery,
+        coins, from_binary, AllBalanceResponse, BankQuery, HumanAddr, NoMsg, QueryRequest,
+        ReadonlyStorage, SystemError, WasmQuery,
     };
     use wasmer_runtime_core::{imports, instance::Instance, typed_func::Func};
 
@@ -772,7 +760,7 @@ mod test {
     fn do_query_chain_works() {
         let mut instance = make_instance();
 
-        let request = QueryRequest::Bank(BankQuery::AllBalances {
+        let request: QueryRequest<NoMsg> = QueryRequest::Bank(BankQuery::AllBalances {
             address: HumanAddr::from(INIT_ADDR),
         });
         let request_data = cosmwasm_std::to_vec(&request).unwrap();
@@ -810,7 +798,9 @@ mod test {
         let query_result: QuerierResult = cosmwasm_std::from_slice(&response).unwrap();
         match query_result {
             Ok(_) => panic!("This must not succeed"),
-            Err(SystemError::InvalidRequest { error }) => assert!(error.starts_with("Parse error")),
+            Err(SystemError::InvalidRequest { error }) => {
+                assert!(error.starts_with("Parsing QueryRequest"), error)
+            }
             Err(error) => panic!("Unexpeted error: {:?}", error),
         }
     }
@@ -819,7 +809,7 @@ mod test {
     fn do_query_chain_fails_for_missing_contract() {
         let mut instance = make_instance();
 
-        let request = QueryRequest::Wasm(WasmQuery::Smart {
+        let request: QueryRequest<NoMsg> = QueryRequest::Wasm(WasmQuery::Smart {
             contract_addr: HumanAddr::from("non-existent"),
             msg: Binary::from(b"{}" as &[u8]),
         });

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -365,7 +365,7 @@ mod test {
 #[cfg(feature = "default-singlepass")]
 mod singlepass_test {
     use cosmwasm_std::testing::mock_env;
-    use cosmwasm_std::{coins, NoMsg};
+    use cosmwasm_std::{coins, Never};
 
     use crate::calls::{call_handle, call_init, call_query};
     use crate::testing::{mock_instance, mock_instance_with_gas_limit};
@@ -387,7 +387,7 @@ mod singlepass_test {
         // init contract
         let env = mock_env(&instance.api, "creator", &coins(1000, "earth"));
         let msg = r#"{"verifier": "verifies", "beneficiary": "benefits"}"#.as_bytes();
-        call_init::<_, _, _, NoMsg>(&mut instance, &env, msg)
+        call_init::<_, _, _, Never>(&mut instance, &env, msg)
             .unwrap()
             .unwrap();
 
@@ -403,7 +403,7 @@ mod singlepass_test {
         // init contract
         let env = mock_env(&instance.api, "creator", &coins(1000, "earth"));
         let msg = r#"{"verifier": "verifies", "beneficiary": "benefits"}"#.as_bytes();
-        call_init::<_, _, _, NoMsg>(&mut instance, &env, msg)
+        call_init::<_, _, _, Never>(&mut instance, &env, msg)
             .unwrap()
             .unwrap();
 
@@ -411,7 +411,7 @@ mod singlepass_test {
         let gas_before_handle = instance.get_gas();
         let env = mock_env(&instance.api, "verifies", &coins(15, "earth"));
         let msg = br#"{"release":{}}"#;
-        call_handle::<_, _, _, NoMsg>(&mut instance, &env, msg)
+        call_handle::<_, _, _, Never>(&mut instance, &env, msg)
             .unwrap()
             .unwrap();
 
@@ -427,7 +427,7 @@ mod singlepass_test {
         // init contract
         let env = mock_env(&instance.api, "creator", &coins(1000, "earth"));
         let msg = r#"{"verifier": "verifies", "beneficiary": "benefits"}"#.as_bytes();
-        let res = call_init::<_, _, _, NoMsg>(&mut instance, &env, msg);
+        let res = call_init::<_, _, _, Never>(&mut instance, &env, msg);
         assert!(res.is_err());
     }
 
@@ -438,7 +438,7 @@ mod singlepass_test {
         // init contract
         let env = mock_env(&instance.api, "creator", &coins(1000, "earth"));
         let msg = r#"{"verifier": "verifies", "beneficiary": "benefits"}"#.as_bytes();
-        let _res = call_init::<_, _, _, NoMsg>(&mut instance, &env, msg)
+        let _res = call_init::<_, _, _, Never>(&mut instance, &env, msg)
             .unwrap()
             .unwrap();
 


### PR DESCRIPTION
Closes #298

Based on #300 (merge that first) only last few commits are from this PR.

This works fine in "std", but fails as soon as we hit the "vm". This line is the catch: https://github.com/cosmwasm/cosmwasm/blob/a9aee732c6013446967a93293e9f10368b87bfff/packages/vm/src/imports.rs#L240 (in the `do_query_chain`)

I modified `Querier` trait to require a `raw_query` implementation that takes and returns `Vec<u8>` and needs no parser. Where `query` takes a `T` for `QueryRequest<T>` and the two ends (contract and final querier) are the only ones that need to agree on the encoding, not all layers in between.

- [x] Add `Custom(T)` variant to QueryRequest
- [x] Update `Querier` trait
- [x] Tests pass std
- [x] Test pass through vm
- [x] Test using Custom query request in contract - unit and integration
- [x] Cleanup (esp. Querier trait naming)
- [ ] CHANGELOG and MIGRATING