### PR TITLE
boxed the wasmer_instance field of Instance to make it safe to reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The imports provided to give the contract access to the environment are:
 // TODO: use feature switches to enable precompile dependencies in the future,
 // so contracts that need less
 extern "C" {
-    fn db_read(key: *const c_void, value: *mut c_void) -> i32;
+    fn db_read(key: *const c_void) -> i32;
     fn db_write(key: *const c_void, value: *mut c_void) -> i32;
     fn db_remove(key: *const c_void) -> i32;
     fn canonicalize_address(human: *const c_void, canonical: *mut c_void) -> i32;

--- a/packages/std/src/imports.rs
+++ b/packages/std/src/imports.rs
@@ -12,9 +12,6 @@ use crate::traits::{Api, Querier, QuerierResponse, ReadonlyStorage, Storage};
 use crate::traits::{Order, KV};
 use crate::types::{CanonicalAddr, HumanAddr};
 
-// this is the buffer we pre-allocate in get - we should configure this somehow later
-static MAX_READ: usize = 2000;
-
 // this is the maximum allowed size for bech32
 // https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#bech32
 static ADDR_BUFFER: usize = 90;
@@ -26,7 +23,7 @@ static QUERY_BUFFER: usize = 4000;
 // A complete documentation those functions is available in the VM that provides them:
 // https://github.com/confio/cosmwasm/blob/0.7/lib/vm/src/instance.rs#L43
 extern "C" {
-    fn db_read(key: *const c_void, value: *mut c_void) -> i32;
+    fn db_read(key: *const c_void) -> i32;
     fn db_write(key: *const c_void, value: *mut c_void) -> i32;
     fn db_remove(key: *const c_void) -> i32;
 
@@ -58,24 +55,17 @@ impl ReadonlyStorage for ExternalStorage {
     fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
         let key = build_region(key);
         let key_ptr = &*key as *const Region as *const c_void;
-        let value = alloc(MAX_READ);
 
-        let read = unsafe { db_read(key_ptr, value) };
-        if read == -1000002 {
-            panic!("Allocated memory too small to hold the database value for the given key. \
-                If this is causing trouble for you, have a look at https://github.com/confio/cosmwasm/issues/126");
-        } else if read < 0 {
-            panic!("An unknown error occurred in the db_read call.")
+        let read = unsafe { db_read(key_ptr) };
+        if read < 0 {
+            panic!("An unknown error occurred in the db_read call");
+        } else if read == 0 {
+            return None;
         }
 
-        match unsafe { consume_region(value) } {
-            Ok(data) => {
-                if data.len() == 0 {
-                    None
-                } else {
-                    Some(data)
-                }
-            }
+        let value_ptr = read as u32;
+        match unsafe { consume_region(value_ptr as *mut c_void) } {
+            Ok(data) => Some(data),
             // TODO: do we really want to convert errors to None?
             Err(_) => None,
         }

--- a/packages/vm/src/context.rs
+++ b/packages/vm/src/context.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 use std::ffi::c_void;
 use std::mem;
+use std::ptr::null_mut;
 
 use wasmer_runtime_core::vm::Ctx;
 
@@ -318,6 +319,7 @@ mod iter_support {
 struct ContextData<S: Storage, Q: Querier> {
     storage: Option<S>,
     querier: Option<Q>,
+    wasmer_instance: *mut wasmer_runtime_core::instance::Instance,
     #[cfg(feature = "iterator")]
     iter: HashMap<u32, Box<dyn Iterator<Item = KV>>>,
 }
@@ -333,6 +335,7 @@ fn create_unmanaged_context_data<S: Storage, Q: Querier>() -> *mut c_void {
     let data = ContextData::<S, Q> {
         storage: None,
         querier: None,
+        wasmer_instance: null_mut(),
         #[cfg(feature = "iterator")]
         iter: HashMap::new(),
     };
@@ -345,6 +348,17 @@ fn destroy_unmanaged_context_data<S: Storage, Q: Querier>(ptr: *mut c_void) {
         let mut dead = unsafe { get_data::<S, Q>(ptr) };
         // ensure the iterator (if any) is dropped before the storage
         free_iterator(&mut dead);
+    }
+}
+
+/// Creates a back reference from a contact to its partent instance
+pub fn set_wasmer_instance<S: Storage, Q: Querier>(
+    ctx: &Ctx,
+    wasmer_instance: *mut wasmer_runtime_core::instance::Instance,
+) {
+    let context_data = ctx.data as *mut ContextData<S, Q>;
+    unsafe {
+        (*context_data).wasmer_instance = wasmer_instance;
     }
 }
 

--- a/packages/vm/src/context.rs
+++ b/packages/vm/src/context.rs
@@ -18,7 +18,6 @@ use cosmwasm_std::{
     QuerierResponse, QueryRequest, Storage,
 };
 
-#[cfg(feature = "iterator")]
 use crate::conversion::{to_i32, to_u32};
 use crate::errors::{Error, Result, UninitializedContextData, WasmerRuntimeErr};
 use crate::memory::{read_region, write_region};

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -1,4 +1,5 @@
 use std::marker::PhantomData;
+use std::ptr::NonNull;
 
 use snafu::ResultExt;
 pub use wasmer_runtime_core::typed_func::Func;
@@ -54,8 +55,8 @@ where
                 // Returns 0 on success. Returns negative value on error. An incomplete list of error codes is:
                 //   value region too small: -1000002
                 // Ownership of both input and output pointer is not transferred to the host.
-                "db_read" => Func::new(move |ctx: &mut Ctx, key_ptr: u32, value_ptr: u32| -> i32 {
-                    do_read::<S, Q>(ctx, key_ptr, value_ptr)
+                "db_read" => Func::new(move |ctx: &mut Ctx, key_ptr: u32| -> i32 {
+                    do_read::<S, Q>(ctx, key_ptr)
                 }),
                 // Writes the given value into the database entry at the given key.
                 // Ownership of both input and output pointer is not transferred to the host.
@@ -120,7 +121,7 @@ where
         gas_limit: u64,
     ) -> Self {
         set_gas(&mut wasmer_instance, gas_limit);
-        let instance_ptr = &mut wasmer_instance as *mut wasmer_runtime_core::instance::Instance;
+        let instance_ptr = NonNull::from(&mut wasmer_instance);
         set_wasmer_instance::<S, Q>(wasmer_instance.context(), instance_ptr);
         move_from_context(wasmer_instance.context(), deps.storage, deps.querier);
         Instance {

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -14,7 +14,8 @@ use cosmwasm_std::{Api, Extern, Querier, Storage};
 use crate::backends::{compile, get_gas, set_gas};
 use crate::context::{
     do_canonicalize_address, do_humanize_address, do_query_chain, do_read, do_remove, do_write,
-    move_from_context, move_into_context, setup_context, with_storage_from_context,
+    move_from_context, move_into_context, set_wasmer_instance, setup_context,
+    with_storage_from_context,
 };
 #[cfg(feature = "iterator")]
 use crate::context::{do_next, do_scan};
@@ -119,6 +120,8 @@ where
         gas_limit: u64,
     ) -> Self {
         set_gas(&mut wasmer_instance, gas_limit);
+        let instance_ptr = &mut wasmer_instance as *mut wasmer_runtime_core::instance::Instance;
+        set_wasmer_instance::<S, Q>(wasmer_instance.context(), instance_ptr);
         move_from_context(wasmer_instance.context(), deps.storage, deps.querier);
         Instance {
             wasmer_instance,


### PR DESCRIPTION
This PR modifies the original draft PR to add boxing of the wasmer instance. This makes creating a pointer to it valid, as long as it is not shared between thread (Which isn't possible for the `Instance` anyways).

For now I opened this just as a demonstration. A lot of APIs have changed and i'm too tired to fix up all the conflicts with master at the moment.