### PR TITLE
Simplify staking feature

### DIFF
--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -2,9 +2,9 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use cosmwasm_std::{
-    from_slice, generic_err, log, not_found, to_binary, to_vec, unauthorized, Api, BankMsg, Binary,
-    CanonicalAddr, Env, Extern, HandleResponse, HumanAddr, InitResponse, Querier, QueryResponse,
-    StdResult, Storage,
+    from_slice, generic_err, log, not_found, to_binary, to_vec, unauthorized, AllBalanceResponse,
+    Api, BankMsg, Binary, CanonicalAddr, Env, Extern, HandleResponse, HumanAddr, InitResponse,
+    Querier, QueryResponse, StdResult, Storage,
 };
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -110,7 +110,7 @@ fn do_release<S: Storage, A: Api, Q: Querier>(
             messages: vec![BankMsg::Send {
                 from_address: from_addr,
                 to_address: to_addr,
-                amount: balance.amount,
+                amount: balance,
             }
             .into()],
             data: None,
@@ -200,8 +200,8 @@ fn query_other_balance<S: Storage, A: Api, Q: Querier>(
     deps: &Extern<S, A, Q>,
     address: HumanAddr,
 ) -> StdResult<QueryResponse> {
-    let res = deps.querier.query_all_balances(address)?;
-    to_binary(&res)
+    let amount = deps.querier.query_all_balances(address)?;
+    to_binary(&AllBalanceResponse { amount })
 }
 
 #[cfg(test)]

--- a/contracts/reflect/Cargo.toml
+++ b/contracts/reflect/Cargo.toml
@@ -43,7 +43,7 @@ debug-assertions = false
 opt-level = 1
 
 [dependencies]
-cosmwasm-std = { path = "../../packages/std" }
+cosmwasm-std = { path = "../../packages/std", features = ["staking"] }
 cosmwasm-storage = { path = "../../packages/storage" }
 schemars = "0.7"
 serde = { version = "=1.0.103", default-features = false, features = ["derive"] }

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -13,7 +13,7 @@ circle-ci = { repository = "CosmWasm/cosmwasm", branch = "master" }
 maintenance = { status = "actively-developed" }
 
 [features]
-default = ["staking"]
+default = []
 # iterator allows us to iterate over all DB items in a given range
 # optional as some merkle stores (like tries) don't support this
 # given Ethereum 1.0, 2.0, Substrate, and other major projects use Tries

--- a/packages/std/src/init_handle.rs
+++ b/packages/std/src/init_handle.rs
@@ -20,7 +20,6 @@ where
     // by default we use RawMsg, but a contract can override that
     // to call into more app-specific code (whatever they define)
     Custom(T),
-    #[cfg(feature = "staking")]
     Staking(StakingMsg),
     Wasm(WasmMsg),
 }
@@ -36,7 +35,6 @@ pub enum BankMsg {
     },
 }
 
-#[cfg(feature = "staking")]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum StakingMsg {

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -20,25 +20,19 @@ pub use crate::errors::{
 };
 pub use crate::init_handle::{
     log, BankMsg, CosmosMsg, HandleResponse, HandleResult, InitResponse, InitResult, LogAttribute,
-    WasmMsg,
+    StakingMsg, WasmMsg,
 };
 #[cfg(feature = "iterator")]
 pub use crate::iterator::{Order, KV};
 pub use crate::query::{
-    AllBalanceResponse, BalanceResponse, BankQuery, QueryRequest, QueryResponse, QueryResult,
+    AllBalanceResponse, BalanceResponse, BankQuery, Billionth, Delegation, DelegationsResponse,
+    QueryRequest, QueryResponse, QueryResult, StakingQuery, Validator, ValidatorsResponse,
     WasmQuery,
 };
 pub use crate::serde::{from_binary, from_slice, to_binary, to_vec};
 pub use crate::storage::MemoryStorage;
 pub use crate::traits::{Api, Extern, Querier, QuerierResult, ReadonlyStorage, Storage};
 pub use crate::types::{CanonicalAddr, Env, HumanAddr, Never};
-
-#[cfg(feature = "staking")]
-pub use crate::init_handle::StakingMsg;
-#[cfg(feature = "staking")]
-pub use crate::query::{
-    Billionth, Delegation, DelegationsResponse, StakingQuery, Validator, ValidatorsResponse,
-};
 
 // Exposed in wasm build only
 
@@ -62,7 +56,7 @@ mod mock;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod testing {
     pub use crate::mock::{
-        mock_dependencies, mock_dependencies_with_balances, mock_env, MockApi, MockQuerier,
-        MockStorage,
+        mock_dependencies, mock_dependencies_with_balances, mock_env, BankQuerier, MockApi,
+        MockQuerier, MockStorage, StakingQuerier,
     };
 }

--- a/packages/std/src/query.rs
+++ b/packages/std/src/query.rs
@@ -16,7 +16,6 @@ pub type QueryResult = StdResult<QueryResponse>;
 pub enum QueryRequest<T> {
     Bank(BankQuery),
     Custom(T),
-    #[cfg(feature = "staking")]
     Staking(StakingQuery),
     Wasm(WasmQuery),
 }
@@ -86,89 +85,71 @@ pub struct AllBalanceResponse {
     pub amount: Vec<Coin>,
 }
 
-#[cfg(feature = "staking")]
-pub use staking::{
-    Billionth, Delegation, DelegationsResponse, StakingQuery, Validator, ValidatorsResponse,
-};
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum StakingQuery {
+    /// Returns all registered Validators on the system
+    Validators {},
+    /// Delegations will return all delegations by the delegator,
+    /// or just those to the given validator (if set)
+    Delegations {
+        delegator: HumanAddr,
+        validator: Option<HumanAddr>,
+    },
+}
 
-#[cfg(feature = "staking")]
-mod staking {
-    use schemars::JsonSchema;
-    use serde::{Deserialize, Serialize};
+/// ValidatorsResponse is data format returned from StakingRequest::Validators query
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct ValidatorsResponse {
+    pub validators: Vec<Validator>,
+}
 
-    use crate::coins::Coin;
-    use crate::types::HumanAddr;
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct Validator {
+    pub address: HumanAddr,
+    pub commission: Billionth,
+    pub max_commission: Billionth,
+    /// TODO: what units are these (in terms of time)?
+    pub max_change_rate: Billionth,
+}
 
-    #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-    #[serde(rename_all = "snake_case")]
-    pub enum StakingQuery {
-        /// Returns all registered Validators on the system
-        Validators {},
-        /// Delegations will return all delegations by the delegator,
-        /// or just those to the given validator (if set)
-        Delegations {
-            delegator: HumanAddr,
-            validator: Option<HumanAddr>,
-        },
+/// DelegationsResponse is data format returned from StakingRequest::Delegations query
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct DelegationsResponse {
+    pub delegations: Vec<Delegation>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct Delegation {
+    pub delegator: HumanAddr,
+    pub validator: HumanAddr,
+    /// How much we have locked in the delegation
+    pub amount: Coin,
+    /// If true, then a Redelegate command will work now, otherwise you may have to wait more
+    pub can_redelegate: bool,
+    /// How much we can currently withdraw
+    pub accumulated_rewards: Coin,
+    // TODO: do we want to expose more info?
+}
+
+/// Billionth represents a fixed-point decimal value with 9 fractional digits.
+/// That is Billionth(1_000_000_000) == 1
+#[derive(Serialize, Deserialize, Copy, Clone, Debug, PartialEq, JsonSchema)]
+pub struct Billionth(u64);
+
+impl Billionth {
+    pub fn one() -> Billionth {
+        Billionth(1_000_000_000)
     }
 
-    /// ValidatorsResponse is data format returned from StakingRequest::Validators query
-    #[cfg(feature = "staking")]
-    #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-    pub struct ValidatorsResponse {
-        pub validators: Vec<Validator>,
+    // convert integer % into Billionth units
+    pub fn percent(percent: u64) -> Billionth {
+        Billionth(percent * 10_000_000)
     }
 
-    #[cfg(feature = "staking")]
-    #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-    pub struct Validator {
-        pub address: HumanAddr,
-        pub commission: Billionth,
-        pub max_commission: Billionth,
-        /// TODO: what units are these (in terms of time)?
-        pub max_change_rate: Billionth,
-    }
-
-    /// DelegationsResponse is data format returned from StakingRequest::Delegations query
-    #[cfg(feature = "staking")]
-    #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-    #[serde(rename_all = "snake_case")]
-    pub struct DelegationsResponse {
-        pub delegations: Vec<Delegation>,
-    }
-
-    #[cfg(feature = "staking")]
-    #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-    pub struct Delegation {
-        pub delegator: HumanAddr,
-        pub validator: HumanAddr,
-        /// How much we have locked in the delegation
-        pub amount: Coin,
-        /// If true, then a Redelegate command will work now, otherwise you may have to wait more
-        pub can_redelegate: bool,
-        /// How much we can currently withdraw
-        pub accumulated_rewards: Coin,
-        // TODO: do we want to expose more info?
-    }
-
-    /// Billionth represents a fixed-point decimal value with 9 fractional digits.
-    /// That is Billionth(1_000_000_000) == 1
-    #[derive(Serialize, Deserialize, Copy, Clone, Debug, PartialEq, JsonSchema)]
-    pub struct Billionth(u64);
-
-    impl Billionth {
-        pub fn one() -> Billionth {
-            Billionth(1_000_000_000)
-        }
-
-        // convert integer % into Billionth units
-        pub fn percent(percent: u64) -> Billionth {
-            Billionth(percent * 10_000_000)
-        }
-
-        // convert permille (1/1000) into Billionth units
-        pub fn permille(permille: u64) -> Billionth {
-            Billionth(permille * 1_000_000)
-        }
+    // convert permille (1/1000) into Billionth units
+    pub fn permille(permille: u64) -> Billionth {
+        Billionth(permille * 1_000_000)
     }
 }

--- a/packages/std/src/traits.rs
+++ b/packages/std/src/traits.rs
@@ -1,13 +1,17 @@
 use serde::de::DeserializeOwned;
 
+use crate::coins::Coin;
 use crate::encoding::Binary;
 use crate::errors::{generic_err, StdResult, SystemResult};
 #[cfg(feature = "iterator")]
 use crate::iterator::{Order, KV};
-use crate::query::{AllBalanceResponse, BalanceResponse, BankQuery, QueryRequest};
-use crate::serde::from_binary;
-use crate::to_vec;
+use crate::query::{
+    AllBalanceResponse, BalanceResponse, BankQuery, QueryRequest, StakingQuery, Validator,
+    ValidatorsResponse,
+};
+use crate::serde::{from_binary, to_vec};
 use crate::types::{CanonicalAddr, HumanAddr, Never};
+use crate::{Delegation, DelegationsResponse};
 use serde::Serialize;
 
 /// Holds all external dependencies of the contract.
@@ -111,18 +115,15 @@ pub trait Querier: Clone + Send {
     ) -> StdResult<U> {
         let raw = match to_vec(request) {
             Ok(raw) => raw,
-            // TODO: maybe I want to make this a SystemError::InvalidRequest ?
-            Err(e) => return Err(e),
+            Err(e) => return Err(generic_err(format!("Serializing QueryRequest: {}", e))),
         };
         match self.raw_query(&raw) {
             Err(sys) => Err(generic_err(format!("Querier system error: {}", sys))),
-            Ok(Err(err)) => Err(generic_err(format!("Querier contract error: {}", err))),
+            Ok(Err(err)) => Err(err),
             // in theory we would process the response, but here it is the same type, so just pass through
             Ok(Ok(res)) => from_binary(&res),
         }
     }
-
-    // TODO: a non-flattened version?
 
     fn query_balance<U: Into<HumanAddr>>(
         &self,
@@ -137,11 +138,48 @@ pub trait Querier: Clone + Send {
         self.query(&request)
     }
 
-    fn query_all_balances<U: Into<HumanAddr>>(&self, address: U) -> StdResult<AllBalanceResponse> {
+    fn query_all_balances<U: Into<HumanAddr>>(&self, address: U) -> StdResult<Vec<Coin>> {
         let request = BankQuery::AllBalances {
             address: address.into(),
         }
         .into();
-        self.query(&request)
+        let res: AllBalanceResponse = self.query(&request)?;
+        Ok(res.amount)
+    }
+
+    #[cfg(feature = "staking")]
+    fn query_validators(&self) -> StdResult<Vec<Validator>> {
+        let request = StakingQuery::Validators {}.into();
+        let res: ValidatorsResponse = self.query(&request)?;
+        Ok(res.validators)
+    }
+
+    #[cfg(feature = "staking")]
+    fn query_all_delegations<U: Into<HumanAddr>>(
+        &self,
+        delegator: U,
+    ) -> StdResult<Vec<Delegation>> {
+        let request = StakingQuery::Delegations {
+            delegator: delegator.into(),
+            validator: None,
+        }
+        .into();
+        let res: DelegationsResponse = self.query(&request)?;
+        Ok(res.delegations)
+    }
+
+    #[cfg(feature = "staking")]
+    fn query_delegation<U: Into<HumanAddr>>(
+        &self,
+        delegator: U,
+        validator: U,
+    ) -> StdResult<Vec<Delegation>> {
+        let request = StakingQuery::Delegations {
+            delegator: delegator.into(),
+            validator: Some(validator.into()),
+        }
+        .into();
+        let res: DelegationsResponse = self.query(&request)?;
+        Ok(res.delegations)
     }
 }

--- a/packages/std/src/traits.rs
+++ b/packages/std/src/traits.rs
@@ -1,18 +1,15 @@
-use serde::de::DeserializeOwned;
+use serde::{de::DeserializeOwned, Serialize};
 
 use crate::coins::Coin;
 use crate::encoding::Binary;
 use crate::errors::{generic_err, StdResult, SystemResult};
 #[cfg(feature = "iterator")]
 use crate::iterator::{Order, KV};
-use crate::query::{
-    AllBalanceResponse, BalanceResponse, BankQuery, QueryRequest, StakingQuery, Validator,
-    ValidatorsResponse,
-};
+use crate::query::{AllBalanceResponse, BalanceResponse, BankQuery, QueryRequest};
+#[cfg(feature = "staking")]
+use crate::query::{Delegation, DelegationsResponse, StakingQuery, Validator, ValidatorsResponse};
 use crate::serde::{from_binary, to_vec};
 use crate::types::{CanonicalAddr, HumanAddr, Never};
-use crate::{Delegation, DelegationsResponse};
-use serde::Serialize;
 
 /// Holds all external dependencies of the contract.
 /// Designed to allow easy dependency injection at runtime.


### PR DESCRIPTION
Based on #321 (please merge that first)

This is a follow-up from the new way we handle feature flags after #318 

We don't need to feature-gate all the staking-related data structures, which greatly simplifies our code, and helps for more reliable de/serialization. Simply by feature gating some higher-level helpers, this is pretty much auto-enforcing. I used `StakingMsg::Delegate{ .. }.into()` in some test code in `reflect` and it failed to compile until I added the feature flag.

The staking feature flag remains, but is much more optional than before and only needs to be enabled by those contracts actually using these features (using the `extern "C"` which is also feature-gated)