### PR TITLE
Avoid using Wasmer type WasmHash in our cache

### DIFF
--- a/packages/vm/src/checksum.rs
+++ b/packages/vm/src/checksum.rs
@@ -1,4 +1,3 @@
-use crate::modules::WasmHash;
 use sha2::{Digest, Sha256};
 
 /// A SHA-256 checksum of a Wasm blob, used to identify a Wasm code.
@@ -20,13 +19,6 @@ impl Checksum {
 
     pub fn to_hex(&self) -> String {
         hex::encode(self.0)
-    }
-
-    /// This generates a module hash in the data type required by Wasmer.
-    /// The existence of this method is a bit hacky, since WasmHash::generate expects
-    /// the Wasm blob as an input. Here we derive Wasm -> Checksum -> WasmHash.
-    pub(crate) fn derive_module_hash(&self) -> WasmHash {
-        WasmHash::generate(&self.0)
     }
 }
 

--- a/packages/vm/src/modules.rs
+++ b/packages/vm/src/modules.rs
@@ -8,11 +8,8 @@ use std::{
     path::PathBuf,
 };
 
-use wasmer_runtime_core::module::Module;
-pub use wasmer_runtime_core::{
-    backend::Compiler,
-    cache::{Artifact, WasmHash},
-};
+pub use wasmer_runtime_core::cache::WasmHash;
+use wasmer_runtime_core::{cache::Artifact, module::Module};
 
 use crate::backends::{backend, compiler_for_backend};
 use crate::errors::{make_cache_err, VmResult};


### PR DESCRIPTION
Before, WasmHash was used inconsistently. Usually WasmHash was derived from checksum. But in one test it was generated directly from the Wasm bytecode.

Since we use a clone of the cache from Wasmer, we can use our own key type.