### PR TITLE
Cleanup Bucket.update -> update_mut

### DIFF
--- a/contracts/reflect/src/contract.rs
+++ b/contracts/reflect/src/contract.rs
@@ -59,7 +59,7 @@ pub fn try_change_owner<S: Storage, A: Api, Q: Querier>(
     owner: HumanAddr,
 ) -> StdResult<HandleResponse<CustomMsg>> {
     let api = deps.api;
-    config(&mut deps.storage).update(&mut |mut state| {
+    config(&mut deps.storage).update(&|mut state| {
         if env.message.sender != state.owner {
             return Err(unauthorized());
         }

--- a/contracts/staking/src/contract.rs
+++ b/contracts/staking/src/contract.rs
@@ -78,10 +78,10 @@ pub fn transfer<S: Storage, A: Api, Q: Querier>(
     let sender_raw = env.message.sender;
 
     let mut accounts = balances(&mut deps.storage);
-    accounts.update(sender_raw.as_slice(), &mut |balance: Option<Uint128>| {
+    accounts.update(sender_raw.as_slice(), &|balance: Option<Uint128>| {
         balance.unwrap_or_default() - send
     })?;
-    accounts.update(rcpt_raw.as_slice(), &mut |balance: Option<Uint128>| {
+    accounts.update(rcpt_raw.as_slice(), &|balance: Option<Uint128>| {
         Ok(balance.unwrap_or_default() + send)
     })?;
 
@@ -116,7 +116,7 @@ pub fn bond<S: Storage, A: Api, Q: Querier>(
 
     // update total supply
     let mut to_mint = Uint128(0);
-    let _ = total_supply(&mut deps.storage).update(&mut |mut supply| {
+    let _ = total_supply(&mut deps.storage).update_mut(&mut |mut supply| {
         to_mint = if supply.issued.is_zero() || supply.bonded.is_zero() {
             FALLBACK_RATIO * payment.amount
         } else {
@@ -128,7 +128,7 @@ pub fn bond<S: Storage, A: Api, Q: Querier>(
     })?;
 
     // update the balance of the sender
-    balances(&mut deps.storage).update(sender_raw.as_slice(), &mut |balance| {
+    balances(&mut deps.storage).update(sender_raw.as_slice(), &|balance| {
         Ok(balance.unwrap_or_default() + to_mint)
     })?;
 
@@ -170,12 +170,12 @@ pub fn unbond<S: Storage, A: Api, Q: Querier>(
 
     // deduct all from the account
     let mut accounts = balances(&mut deps.storage);
-    accounts.update(sender_raw.as_slice(), &mut |balance| {
+    accounts.update(sender_raw.as_slice(), &|balance| {
         balance.unwrap_or_default() - amount
     })?;
     if tax > Uint128(0) {
         // add tax to the owner
-        accounts.update(invest.owner.as_slice(), &mut |balance: Option<Uint128>| {
+        accounts.update(invest.owner.as_slice(), &|balance: Option<Uint128>| {
             Ok(balance.unwrap_or_default() + tax)
         })?;
     }
@@ -183,7 +183,7 @@ pub fn unbond<S: Storage, A: Api, Q: Querier>(
     // calculate how many native tokens this is worth and update supply
     let remainder = (amount - tax)?;
     let mut unbond = Uint128(0);
-    total_supply(&mut deps.storage).update(&mut |mut supply| {
+    total_supply(&mut deps.storage).update_mut(&mut |mut supply| {
         unbond = remainder.multiply_ratio(supply.bonded, supply.issued);
         supply.bonded = (supply.bonded - unbond)?;
         supply.issued = (supply.issued - remainder)?;
@@ -192,7 +192,7 @@ pub fn unbond<S: Storage, A: Api, Q: Querier>(
     })?;
 
     // add a claim to this user to get their tokens after the unbonding period
-    claims(&mut deps.storage).update(sender_raw.as_slice(), &mut |claim| {
+    claims(&mut deps.storage).update(sender_raw.as_slice(), &|claim| {
         Ok(claim.unwrap_or_default() + unbond)
     })?;
 
@@ -233,14 +233,14 @@ pub fn claim<S: Storage, A: Api, Q: Querier>(
     // check how much to send - min(balance, claims[sender]), and reduce the claim
     let sender_raw = env.message.sender;
     let mut to_send = balance.amount;
-    claims(&mut deps.storage).update(sender_raw.as_slice(), &mut |claim| {
+    claims(&mut deps.storage).update_mut(sender_raw.as_slice(), &mut |claim| {
         let claim = claim.ok_or_else(|| generic_err("no claim for this address"))?;
         to_send = to_send.min(claim);
         claim - to_send
     })?;
 
     // update total supply (lower claim)
-    total_supply(&mut deps.storage).update(&mut |mut supply| {
+    total_supply(&mut deps.storage).update(&|mut supply| {
         supply.claims = (supply.claims - to_send)?;
         Ok(supply)
     })?;
@@ -315,7 +315,7 @@ pub fn _bond_all_tokens<S: Storage, A: Api, Q: Querier>(
 
     // we deduct pending claims from our account balance before reinvesting.
     // if there is not enough funds, we just return a no-op
-    match total_supply(&mut deps.storage).update(&mut |mut supply| {
+    match total_supply(&mut deps.storage).update_mut(&mut |mut supply| {
         balance.amount = (balance.amount - supply.claims)?;
         // this just triggers the "no op" case if we don't have min_withdrawl left to reinvest
         (balance.amount - invest.min_withdrawl)?;

--- a/packages/storage/src/singleton.rs
+++ b/packages/storage/src/singleton.rs
@@ -73,7 +73,16 @@ where
     /// in the database. This is shorthand for some common sequences, which may be useful
     ///
     /// This is the least stable of the APIs, and definitely needs some usage
-    pub fn update(&mut self, action: &mut dyn FnMut(T) -> StdResult<T>) -> StdResult<T> {
+    pub fn update(&mut self, action: &dyn Fn(T) -> StdResult<T>) -> StdResult<T> {
+        let input = self.load()?;
+        let output = action(input)?;
+        self.save(&output)?;
+        Ok(output)
+    }
+
+    /// update_mut is like update but takes FnMut allowing you to pass in a closure that modifies some
+    /// shared variable
+    pub fn update_mut(&mut self, action: &mut dyn FnMut(T) -> StdResult<T>) -> StdResult<T> {
         let input = self.load()?;
         let output = action(input)?;
         self.save(&output)?;
@@ -179,7 +188,7 @@ mod test {
         };
         writer.save(&cfg).unwrap();
 
-        let output = writer.update(&mut |mut c| {
+        let output = writer.update(&|mut c| {
             c.max_tokens *= 2;
             Ok(c)
         });
@@ -203,7 +212,7 @@ mod test {
         writer.save(&cfg).unwrap();
 
         let mut old_tokens = 0i32;
-        let output = writer.update(&mut |mut c| {
+        let output = writer.update_mut(&mut |mut c| {
             old_tokens = c.max_tokens;
             c.max_tokens *= 2;
             Ok(c)
@@ -228,7 +237,7 @@ mod test {
         };
         writer.save(&cfg).unwrap();
 
-        let output = writer.update(&mut |_c| Err(unauthorized()));
+        let output = writer.update(&|_c| Err(unauthorized()));
         match output {
             Err(StdError::Unauthorized { .. }) => {}
             _ => panic!("Unexpected output: {:?}", output),


### PR DESCRIPTION
I converted `update` to take `&mut FnMut` instead of `&Fn` to support more closures, which helps in a few cases, but is needless in many. I fixed this to two calls: `update` is how it worked before. `update_mut` takes the new `&mut FnMut` which allows us to mutate variables outside the closue.