### PR TITLE
Unleash the power of FnOnce

### DIFF
--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -298,7 +298,7 @@ mod tests {
         };
 
         // let's see if we can checkpoint on a contract
-        let res = transactional_deps(&mut deps, &|deps| {
+        let res = transactional_deps(&mut deps, |deps| {
             let msg = InitMsg {
                 verifier: verifier.clone(),
                 beneficiary: beneficiary.clone(),

--- a/contracts/reflect/src/contract.rs
+++ b/contracts/reflect/src/contract.rs
@@ -59,7 +59,7 @@ pub fn try_change_owner<S: Storage, A: Api, Q: Querier>(
     owner: HumanAddr,
 ) -> StdResult<HandleResponse<CustomMsg>> {
     let api = deps.api;
-    config(&mut deps.storage).update(&|mut state| {
+    config(&mut deps.storage).update(|mut state| {
         if env.message.sender != state.owner {
             return Err(unauthorized());
         }

--- a/contracts/staking/src/contract.rs
+++ b/contracts/staking/src/contract.rs
@@ -116,7 +116,7 @@ pub fn bond<S: Storage, A: Api, Q: Querier>(
 
     // update total supply
     let mut to_mint = Uint128(0);
-    let _ = total_supply(&mut deps.storage).update_mut(&mut |mut supply| {
+    let _ = total_supply(&mut deps.storage).update_mut(|mut supply| {
         to_mint = if supply.issued.is_zero() || supply.bonded.is_zero() {
             FALLBACK_RATIO * payment.amount
         } else {
@@ -183,7 +183,7 @@ pub fn unbond<S: Storage, A: Api, Q: Querier>(
     // calculate how many native tokens this is worth and update supply
     let remainder = (amount - tax)?;
     let mut unbond = Uint128(0);
-    total_supply(&mut deps.storage).update_mut(&mut |mut supply| {
+    total_supply(&mut deps.storage).update_mut(|mut supply| {
         unbond = remainder.multiply_ratio(supply.bonded, supply.issued);
         supply.bonded = (supply.bonded - unbond)?;
         supply.issued = (supply.issued - remainder)?;
@@ -233,7 +233,7 @@ pub fn claim<S: Storage, A: Api, Q: Querier>(
     // check how much to send - min(balance, claims[sender]), and reduce the claim
     let sender_raw = env.message.sender;
     let mut to_send = balance.amount;
-    claims(&mut deps.storage).update_mut(sender_raw.as_slice(), &mut |claim| {
+    claims(&mut deps.storage).update_mut(sender_raw.as_slice(), |claim| {
         let claim = claim.ok_or_else(|| generic_err("no claim for this address"))?;
         to_send = to_send.min(claim);
         claim - to_send
@@ -315,7 +315,7 @@ pub fn _bond_all_tokens<S: Storage, A: Api, Q: Querier>(
 
     // we deduct pending claims from our account balance before reinvesting.
     // if there is not enough funds, we just return a no-op
-    match total_supply(&mut deps.storage).update_mut(&mut |mut supply| {
+    match total_supply(&mut deps.storage).update_mut(|mut supply| {
         balance.amount = (balance.amount - supply.claims)?;
         // this just triggers the "no op" case if we don't have min_withdrawl left to reinvest
         (balance.amount - invest.min_withdrawl)?;

--- a/contracts/staking/src/contract.rs
+++ b/contracts/staking/src/contract.rs
@@ -78,10 +78,10 @@ pub fn transfer<S: Storage, A: Api, Q: Querier>(
     let sender_raw = env.message.sender;
 
     let mut accounts = balances(&mut deps.storage);
-    accounts.update(sender_raw.as_slice(), &|balance: Option<Uint128>| {
+    accounts.update(sender_raw.as_slice(), |balance: Option<Uint128>| {
         balance.unwrap_or_default() - send
     })?;
-    accounts.update(rcpt_raw.as_slice(), &|balance: Option<Uint128>| {
+    accounts.update(rcpt_raw.as_slice(), |balance: Option<Uint128>| {
         Ok(balance.unwrap_or_default() + send)
     })?;
 
@@ -116,7 +116,7 @@ pub fn bond<S: Storage, A: Api, Q: Querier>(
 
     // update total supply
     let mut to_mint = Uint128(0);
-    let _ = total_supply(&mut deps.storage).update_mut(|mut supply| {
+    let _ = total_supply(&mut deps.storage).update(|mut supply| {
         to_mint = if supply.issued.is_zero() || supply.bonded.is_zero() {
             FALLBACK_RATIO * payment.amount
         } else {
@@ -128,7 +128,7 @@ pub fn bond<S: Storage, A: Api, Q: Querier>(
     })?;
 
     // update the balance of the sender
-    balances(&mut deps.storage).update(sender_raw.as_slice(), &|balance| {
+    balances(&mut deps.storage).update(sender_raw.as_slice(), |balance| {
         Ok(balance.unwrap_or_default() + to_mint)
     })?;
 
@@ -170,12 +170,12 @@ pub fn unbond<S: Storage, A: Api, Q: Querier>(
 
     // deduct all from the account
     let mut accounts = balances(&mut deps.storage);
-    accounts.update(sender_raw.as_slice(), &|balance| {
+    accounts.update(sender_raw.as_slice(), |balance| {
         balance.unwrap_or_default() - amount
     })?;
     if tax > Uint128(0) {
         // add tax to the owner
-        accounts.update(invest.owner.as_slice(), &|balance: Option<Uint128>| {
+        accounts.update(invest.owner.as_slice(), |balance: Option<Uint128>| {
             Ok(balance.unwrap_or_default() + tax)
         })?;
     }
@@ -183,7 +183,7 @@ pub fn unbond<S: Storage, A: Api, Q: Querier>(
     // calculate how many native tokens this is worth and update supply
     let remainder = (amount - tax)?;
     let mut unbond = Uint128(0);
-    total_supply(&mut deps.storage).update_mut(|mut supply| {
+    total_supply(&mut deps.storage).update(|mut supply| {
         unbond = remainder.multiply_ratio(supply.bonded, supply.issued);
         supply.bonded = (supply.bonded - unbond)?;
         supply.issued = (supply.issued - remainder)?;
@@ -192,7 +192,7 @@ pub fn unbond<S: Storage, A: Api, Q: Querier>(
     })?;
 
     // add a claim to this user to get their tokens after the unbonding period
-    claims(&mut deps.storage).update(sender_raw.as_slice(), &|claim| {
+    claims(&mut deps.storage).update(sender_raw.as_slice(), |claim| {
         Ok(claim.unwrap_or_default() + unbond)
     })?;
 
@@ -233,14 +233,14 @@ pub fn claim<S: Storage, A: Api, Q: Querier>(
     // check how much to send - min(balance, claims[sender]), and reduce the claim
     let sender_raw = env.message.sender;
     let mut to_send = balance.amount;
-    claims(&mut deps.storage).update_mut(sender_raw.as_slice(), |claim| {
+    claims(&mut deps.storage).update(sender_raw.as_slice(), |claim| {
         let claim = claim.ok_or_else(|| generic_err("no claim for this address"))?;
         to_send = to_send.min(claim);
         claim - to_send
     })?;
 
     // update total supply (lower claim)
-    total_supply(&mut deps.storage).update(&|mut supply| {
+    total_supply(&mut deps.storage).update(|mut supply| {
         supply.claims = (supply.claims - to_send)?;
         Ok(supply)
     })?;
@@ -315,7 +315,7 @@ pub fn _bond_all_tokens<S: Storage, A: Api, Q: Querier>(
 
     // we deduct pending claims from our account balance before reinvesting.
     // if there is not enough funds, we just return a no-op
-    match total_supply(&mut deps.storage).update_mut(|mut supply| {
+    match total_supply(&mut deps.storage).update(|mut supply| {
         balance.amount = (balance.amount - supply.claims)?;
         // this just triggers the "no op" case if we don't have min_withdrawl left to reinvest
         (balance.amount - invest.min_withdrawl)?;

--- a/packages/storage/src/bucket.rs
+++ b/packages/storage/src/bucket.rs
@@ -108,11 +108,10 @@ where
 
     /// update_mut is like update but takes FnMut allowing you to pass in a closure that modifies some
     /// shared variable
-    pub fn update_mut(
-        &mut self,
-        key: &[u8],
-        action: &mut dyn FnMut(Option<T>) -> StdResult<T>,
-    ) -> StdResult<T> {
+    pub fn update_mut<A>(&mut self, key: &[u8], action: A) -> StdResult<T>
+    where
+        A: FnOnce(Option<T>) -> StdResult<T>,
+    {
         let input = self.may_load(key)?;
         let output = action(input)?;
         self.save(key, &output)?;

--- a/packages/storage/src/bucket.rs
+++ b/packages/storage/src/bucket.rs
@@ -95,20 +95,7 @@ where
     /// non-existent values, please use `may_update`
     ///
     /// This is the least stable of the APIs, and definitely needs some usage
-    pub fn update(
-        &mut self,
-        key: &[u8],
-        action: &dyn Fn(Option<T>) -> StdResult<T>,
-    ) -> StdResult<T> {
-        let input = self.may_load(key)?;
-        let output = action(input)?;
-        self.save(key, &output)?;
-        Ok(output)
-    }
-
-    /// update_mut is like update but takes FnMut allowing you to pass in a closure that modifies some
-    /// shared variable
-    pub fn update_mut<A>(&mut self, key: &[u8], action: A) -> StdResult<T>
+    pub fn update<A>(&mut self, key: &[u8], action: A) -> StdResult<T>
     where
         A: FnOnce(Option<T>) -> StdResult<T>,
     {
@@ -295,11 +282,9 @@ mod test {
     }
 
     #[test]
-    fn update_mut_success() {
+    fn update_can_change_variable_from_outer_scope() {
         let mut store = MockStorage::new();
         let mut bucket = bucket::<_, Data>(b"data", &mut store);
-
-        // initial data
         let init = Data {
             name: "Maria".to_string(),
             age: 42,
@@ -308,19 +293,14 @@ mod test {
 
         // show we can capture data from the closure
         let mut old_age = 0i32;
-        let mut birthday = |mayd: Option<Data>| -> StdResult<Data> {
-            let mut d = mayd.ok_or(not_found("Data"))?;
-            old_age = d.age;
-            d.age += 1;
-            Ok(d)
-        };
-        let output = bucket.update_mut(b"maria", &mut birthday).unwrap();
-        let expected = Data {
-            name: "Maria".to_string(),
-            age: 43,
-        };
-        assert_eq!(output, expected);
-        //
+        bucket
+            .update(b"maria", |mayd: Option<Data>| {
+                let mut d = mayd.ok_or(not_found("Data"))?;
+                old_age = d.age;
+                d.age += 1;
+                Ok(d)
+            })
+            .unwrap();
         assert_eq!(old_age, 42);
     }
 
@@ -337,7 +317,7 @@ mod test {
         bucket.save(b"maria", &init).unwrap();
 
         // it's my birthday
-        let output = bucket.update(b"maria", &|_d| Err(generic_err("cuz i feel like it")));
+        let output = bucket.update(b"maria", |_d| Err(generic_err("cuz i feel like it")));
         assert!(output.is_err());
 
         // load it properly
@@ -357,7 +337,7 @@ mod test {
 
         // it's my birthday
         let output = bucket
-            .update(b"maria", &|d| match d {
+            .update(b"maria", |d| match d {
                 Some(_) => Err(generic_err("Ensure this was empty")),
                 None => Ok(init_value.clone()),
             })

--- a/packages/storage/src/singleton.rs
+++ b/packages/storage/src/singleton.rs
@@ -82,7 +82,10 @@ where
 
     /// update_mut is like update but takes FnMut allowing you to pass in a closure that modifies some
     /// shared variable
-    pub fn update_mut(&mut self, action: &mut dyn FnMut(T) -> StdResult<T>) -> StdResult<T> {
+    pub fn update_mut<A>(&mut self, action: A) -> StdResult<T>
+    where
+        A: FnOnce(T) -> StdResult<T>,
+    {
         let input = self.load()?;
         let output = action(input)?;
         self.save(&output)?;
@@ -212,7 +215,7 @@ mod test {
         writer.save(&cfg).unwrap();
 
         let mut old_tokens = 0i32;
-        let output = writer.update_mut(&mut |mut c| {
+        let output = writer.update_mut(|mut c| {
             old_tokens = c.max_tokens;
             c.max_tokens *= 2;
             Ok(c)


### PR DESCRIPTION
[FnOnce](https://doc.rust-lang.org/std/ops/trait.FnOnce.html) is called no more than once. It is the perfect type for callbacks. Turns out this allows us to only have one update implementation.