### PR TITLE
Expose querier in Instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,7 @@
 - Split `VmError::RuntimeErr` in `VmError::BackendErr` and
   `VmError::GenericErr`; rename `VmError::WasmerRuntimeErr` to
   `VmError::RuntimeErr`.
+- Add `Instance.with_querier` analogue to `Instance.with_storage`.
 
 ## 0.7.2 (2020-03-23)
 

--- a/contracts/hackatom/schema/handle_msg.json
+++ b/contracts/hackatom/schema/handle_msg.json
@@ -3,6 +3,7 @@
   "title": "HandleMsg",
   "anyOf": [
     {
+      "description": "Releasing all funds in the contract to the beneficiary. This is the only \"proper\" action of this demo contract.",
       "type": "object",
       "required": [
         "release"

--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -343,7 +343,7 @@ mod tests {
         deps.querier.update_balance(&contract_addr, init_amount);
 
         // beneficiary can release it
-        let handle_env = mock_env(&deps.api, verifier.as_str(), &coins(15, "earth"));
+        let handle_env = mock_env(&deps.api, verifier.as_str(), &[]);
         let handle_res = handle(&mut deps, handle_env, HandleMsg::Release {}).unwrap();
         assert_eq!(handle_res.messages.len(), 1);
         let msg = handle_res.messages.get(0).expect("no message");

--- a/contracts/hackatom/tests/integration.rs
+++ b/contracts/hackatom/tests/integration.rs
@@ -152,7 +152,7 @@ fn handle_release_works() {
     .unwrap();
 
     // beneficiary can release it
-    let handle_env = mock_env(&deps.api, verifier.as_str(), &coins(15, "earth"));
+    let handle_env = mock_env(&deps.api, verifier.as_str(), &[]);
     let handle_res: HandleResponse = handle(&mut deps, handle_env, HandleMsg::Release {}).unwrap();
     assert_eq!(handle_res.messages.len(), 1);
     let msg = handle_res.messages.get(0).expect("no message");

--- a/packages/vm/src/context.rs
+++ b/packages/vm/src/context.rs
@@ -162,10 +162,10 @@ pub(crate) fn with_querier_from_context<'a, 'b, S, Q, F, T>(
 where
     S: Storage,
     Q: Querier,
-    F: FnOnce(&'b Q) -> VmResult<T>,
+    F: FnOnce(&'b mut Q) -> VmResult<T>,
 {
     let b = get_context_data::<S, Q>(ctx);
-    match b.querier.as_ref() {
+    match b.querier.as_mut() {
         Some(q) => func(q),
         None => Err(make_uninitialized_context_data("querier")),
     }

--- a/packages/vm/src/imports.rs
+++ b/packages/vm/src/imports.rs
@@ -220,9 +220,8 @@ pub fn do_query_chain<S: Storage, Q: Querier>(
 ) -> VmResult<i32> {
     let request = read_region!(ctx, request_ptr, MAX_LENGTH_QUERY_CHAIN_REQUEST);
 
-    let res = with_querier_from_context::<S, Q, _, _>(ctx, |querier: &Q| {
-        Ok(querier.raw_query(&request)?)
-    })?;
+    let res =
+        with_querier_from_context::<S, Q, _, _>(ctx, |querier| Ok(querier.raw_query(&request)?))?;
 
     Ok(match to_vec(&res) {
         Ok(serialized) => write_region!(ctx, response_ptr, &serialized),

--- a/packages/vm/src/mock/mod.rs
+++ b/packages/vm/src/mock/mod.rs
@@ -148,6 +148,15 @@ impl MockQuerier {
         }
     }
 
+    // set a new balance for the given address and return the old balance
+    pub fn update_balance<U: Into<HumanAddr>>(
+        &mut self,
+        addr: U,
+        balance: Vec<Coin>,
+    ) -> Option<Vec<Coin>> {
+        self.bank.balances.insert(addr.into(), balance)
+    }
+
     pub fn with_staking(
         &mut self,
         denom: &str,


### PR DESCRIPTION
We can now do

```rust
    // balance changed in init
    deps.with_querier(|querier| {
        querier.update_balance(&contract_addr, init_amount);
        Ok(())
    })
    .unwrap();
```

to update the contract's balance in an integration test