### PR TITLE
Use cosmwasm_vm::testing module

### DIFF
--- a/contracts/hackatom/tests/integration.rs
+++ b/contracts/hackatom/tests/integration.rs
@@ -23,8 +23,7 @@ use cosmwasm_std::{
 };
 use cosmwasm_vm::{
     from_slice,
-    mock::mock_env,
-    testing::{handle, init, mock_instance, mock_instance_with_balances, query, test_io},
+    testing::{handle, init, mock_env, mock_instance, mock_instance_with_balances, query, test_io},
     Api, ReadonlyStorage,
 };
 

--- a/contracts/queue/tests/integration.rs
+++ b/contracts/queue/tests/integration.rs
@@ -19,8 +19,7 @@
 
 use cosmwasm_std::{from_binary, from_slice, Env, HandleResponse, HumanAddr, InitResponse};
 use cosmwasm_vm::{
-    mock::{mock_env, MockApi, MockQuerier, MockStorage},
-    testing::{handle, init, mock_instance, query},
+    testing::{handle, init, mock_env, mock_instance, query, MockApi, MockQuerier, MockStorage},
     Instance,
 };
 

--- a/contracts/reflect/tests/integration.rs
+++ b/contracts/reflect/tests/integration.rs
@@ -22,8 +22,7 @@ use cosmwasm_std::{
     InitResponse, StakingMsg, StdError,
 };
 use cosmwasm_vm::{
-    mock::mock_env,
-    testing::{handle, init, mock_instance, query},
+    testing::{handle, init, mock_env, mock_instance, query},
     Api, Instance,
 };
 
@@ -41,7 +40,9 @@ mod mock {
     use cosmwasm_std::{from_slice, to_binary, Binary, Coin, QueryRequest, StdResult};
     use cosmwasm_vm::{
         make_ffi_other,
-        mock::{MockApi, MockQuerier, MockStorage},
+        testing::{
+            mock_dependencies as original_mock_dependencies, MockApi, MockQuerier, MockStorage,
+        },
         Extern, Querier, QuerierResult,
     };
 
@@ -79,7 +80,7 @@ mod mock {
         canonical_length: usize,
         contract_balance: &[Coin],
     ) -> Extern<MockStorage, MockApi, CustomQuerier> {
-        let base = cosmwasm_vm::mock::mock_dependencies(canonical_length, contract_balance);
+        let base = original_mock_dependencies(canonical_length, contract_balance);
         base.change_querier(CustomQuerier::new)
     }
 

--- a/contracts/staking/tests/integration.rs
+++ b/contracts/staking/tests/integration.rs
@@ -20,8 +20,7 @@
 use cosmwasm_std::{
     coin, from_binary, Decimal, HumanAddr, InitResponse, StdError, StdResult, Uint128, Validator,
 };
-use cosmwasm_vm::mock::{mock_dependencies, mock_env};
-use cosmwasm_vm::testing::{init, query};
+use cosmwasm_vm::testing::{init, mock_dependencies, mock_env, query};
 use cosmwasm_vm::Instance;
 
 use staking::msg::{

--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -191,7 +191,7 @@ mod test {
     use super::*;
     use crate::calls::{call_handle, call_init};
     use crate::errors::VmError;
-    use crate::mock::{mock_dependencies, mock_env, MockApi, MockQuerier, MockStorage};
+    use crate::testing::{mock_dependencies, mock_env, MockApi, MockQuerier, MockStorage};
     use cosmwasm_std::{coins, Never};
     use std::fs::OpenOptions;
     use std::io::Write;

--- a/packages/vm/src/context.rs
+++ b/packages/vm/src/context.rs
@@ -195,8 +195,8 @@ mod test {
     use crate::backends::compile;
     #[cfg(feature = "iterator")]
     use crate::errors::VmError;
-    use crate::mock::{MockQuerier, MockStorage};
-    use crate::ReadonlyStorage;
+    use crate::testing::{MockQuerier, MockStorage};
+    use crate::traits::ReadonlyStorage;
     use cosmwasm_std::{
         coins, from_binary, to_vec, AllBalanceResponse, BankQuery, HumanAddr, Never, QueryRequest,
     };

--- a/packages/vm/src/imports.rs
+++ b/packages/vm/src/imports.rs
@@ -287,7 +287,6 @@ pub fn do_next<S: Storage, Q: Querier>(
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::mock::{MockApi, MockQuerier, MockStorage};
     use cosmwasm_std::{
         coins, from_binary, AllBalanceResponse, BankQuery, HumanAddr, Never, QueryRequest,
         SystemError, WasmQuery,
@@ -298,6 +297,7 @@ mod test {
     use crate::context::{move_into_context, setup_context};
     #[cfg(feature = "iterator")]
     use crate::conversion::to_u32;
+    use crate::testing::{MockApi, MockQuerier, MockStorage};
     use crate::traits::ReadonlyStorage;
     use crate::FfiError;
 

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -229,8 +229,7 @@ where
 mod test {
     use super::*;
     use crate::errors::VmError;
-    use crate::mock::mock_dependencies;
-    use crate::testing::{mock_instance, mock_instance_with_balances};
+    use crate::testing::{mock_dependencies, mock_instance, mock_instance_with_balances};
     use crate::traits::ReadonlyStorage;
     use cosmwasm_std::{
         coin, from_binary, AllBalanceResponse, BalanceResponse, BankQuery, HumanAddr, Never,
@@ -558,11 +557,10 @@ mod test {
 #[cfg(test)]
 #[cfg(feature = "default-singlepass")]
 mod singlepass_test {
-    use crate::mock::mock_env;
     use cosmwasm_std::{coins, Never};
 
     use crate::calls::{call_handle, call_init, call_query};
-    use crate::testing::{mock_instance, mock_instance_with_gas_limit};
+    use crate::testing::{mock_env, mock_instance, mock_instance_with_gas_limit};
 
     static CONTRACT: &[u8] = include_bytes!("../testdata/contract.wasm");
 

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -229,7 +229,9 @@ where
 mod test {
     use super::*;
     use crate::errors::VmError;
-    use crate::testing::{mock_dependencies, mock_instance, mock_instance_with_balances};
+    use crate::testing::{
+        mock_dependencies, mock_instance, mock_instance_with_balances, mock_instance_with_gas_limit,
+    };
     use crate::traits::ReadonlyStorage;
     use cosmwasm_std::{
         coin, from_binary, AllBalanceResponse, BalanceResponse, BankQuery, HumanAddr, Never,
@@ -415,10 +417,18 @@ mod test {
 
     #[test]
     #[cfg(feature = "default-cranelift")]
-    fn set_get_and_gas_cranelift_noop() {
-        let instance = crate::testing::mock_instance_with_gas_limit(&CONTRACT, &[], 123321);
+    fn set_get_and_gas_cranelift() {
+        let instance = mock_instance_with_gas_limit(&CONTRACT, &[], 123321);
         let orig_gas = instance.get_gas();
-        assert_eq!(orig_gas, 1_000_000);
+        assert_eq!(orig_gas, 1_000_000); // We expect a dummy value for cranelift
+    }
+
+    #[test]
+    #[cfg(feature = "default-singlepass")]
+    fn set_get_and_gas_singlepass() {
+        let instance = mock_instance_with_gas_limit(&CONTRACT, &[], 123321);
+        let orig_gas = instance.get_gas();
+        assert_eq!(orig_gas, 123321);
     }
 
     #[test]
@@ -563,13 +573,6 @@ mod singlepass_test {
     use crate::testing::{mock_env, mock_instance, mock_instance_with_gas_limit};
 
     static CONTRACT: &[u8] = include_bytes!("../testdata/contract.wasm");
-
-    #[test]
-    fn set_get_and_gas_singlepass_works() {
-        let instance = mock_instance_with_gas_limit(&CONTRACT, &[], 123321);
-        let orig_gas = instance.get_gas();
-        assert_eq!(orig_gas, 123321);
-    }
 
     #[test]
     fn contract_deducts_gas_init() {

--- a/packages/vm/src/lib.rs
+++ b/packages/vm/src/lib.rs
@@ -11,7 +11,6 @@ mod imports;
 mod instance;
 mod memory;
 mod middleware;
-pub mod mock;
 mod modules;
 mod serde;
 pub mod testing;

--- a/packages/vm/src/testing/calls.rs
+++ b/packages/vm/src/testing/calls.rs
@@ -1,0 +1,64 @@
+//! This file has some helpers for integration tests.
+//! They should be imported via full path to ensure there is no confusion
+//! use cosmwasm_vm::testing::X
+use schemars::JsonSchema;
+use serde::{de::DeserializeOwned, Serialize};
+use std::fmt;
+
+use cosmwasm_std::{to_vec, Env, HandleResult, InitResult, QueryResponse, StdResult};
+
+use crate::calls::{call_handle, call_init, call_query};
+use crate::instance::Instance;
+use crate::{Api, Querier, Storage};
+
+// init mimicks the call signature of the smart contracts.
+// thus it moves env and msg rather than take them as reference.
+// this is inefficient here, but only used in test code
+pub fn init<
+    S: Storage + 'static,
+    A: Api + 'static,
+    Q: Querier + 'static,
+    T: Serialize + JsonSchema,
+    U: DeserializeOwned + Clone + PartialEq + JsonSchema + fmt::Debug,
+>(
+    instance: &mut Instance<S, A, Q>,
+    env: Env,
+    msg: T,
+) -> InitResult<U> {
+    let serialized_msg = to_vec(&msg)?;
+    call_init(instance, &env, &serialized_msg).expect("VM error")
+}
+
+// handle mimicks the call signature of the smart contracts.
+// thus it moves env and msg rather than take them as reference.
+// this is inefficient here, but only used in test code
+pub fn handle<
+    S: Storage + 'static,
+    A: Api + 'static,
+    Q: Querier + 'static,
+    T: Serialize + JsonSchema,
+    U: DeserializeOwned + Clone + PartialEq + JsonSchema + fmt::Debug,
+>(
+    instance: &mut Instance<S, A, Q>,
+    env: Env,
+    msg: T,
+) -> HandleResult<U> {
+    let serialized_msg = to_vec(&msg)?;
+    call_handle(instance, &env, &serialized_msg).expect("VM error")
+}
+
+// query mimicks the call signature of the smart contracts.
+// thus it moves env and msg rather than take them as reference.
+// this is inefficient here, but only used in test code
+pub fn query<
+    S: Storage + 'static,
+    A: Api + 'static,
+    Q: Querier + 'static,
+    T: Serialize + JsonSchema,
+>(
+    instance: &mut Instance<S, A, Q>,
+    msg: T,
+) -> StdResult<QueryResponse> {
+    let serialized_msg = to_vec(&msg)?;
+    call_query(instance, &serialized_msg).expect("VM error")
+}

--- a/packages/vm/src/testing/instance.rs
+++ b/packages/vm/src/testing/instance.rs
@@ -1,26 +1,19 @@
 //! This file has some helpers for integration tests.
 //! They should be imported via full path to ensure there is no confusion
 //! use cosmwasm_vm::testing::X
-use schemars::JsonSchema;
-use serde::{de::DeserializeOwned, Serialize};
+use cosmwasm_std::{Coin, HumanAddr};
 use std::collections::HashSet;
-use std::fmt;
 use std::iter::FromIterator;
 
-use crate::mock::{
-    mock_dependencies, mock_dependencies_with_balances, MockApi, MockQuerier, MockStorage,
-};
-use crate::{Api, Querier, Storage};
-use cosmwasm_std::{
-    to_vec, Coin, Env, HandleResult, HumanAddr, InitResult, QueryResponse, StdResult,
-};
-
-use crate::calls::{call_handle, call_init, call_query};
 use crate::compatability::check_wasm;
 use crate::instance::Instance;
+use crate::{Api, Querier, Storage};
+
+use super::mock::{mock_dependencies, mock_dependencies_with_balances, MockApi, MockQuerier};
+use super::storage::MockStorage;
 
 /// Gas limit for testing
-static DEFAULT_GAS_LIMIT: u64 = 500_000;
+const DEFAULT_GAS_LIMIT: u64 = 500_000;
 
 fn default_features() -> HashSet<String> {
     HashSet::from_iter(["staking".to_string()].iter().cloned())
@@ -52,58 +45,6 @@ pub fn mock_instance_with_gas_limit(
     check_wasm(wasm, &default_features()).unwrap();
     let deps = mock_dependencies(20, contract_balance);
     Instance::from_code(wasm, deps, gas_limit).unwrap()
-}
-
-// init mimicks the call signature of the smart contracts.
-// thus it moves env and msg rather than take them as reference.
-// this is inefficient here, but only used in test code
-pub fn init<
-    S: Storage + 'static,
-    A: Api + 'static,
-    Q: Querier + 'static,
-    T: Serialize + JsonSchema,
-    U: DeserializeOwned + Clone + PartialEq + JsonSchema + fmt::Debug,
->(
-    instance: &mut Instance<S, A, Q>,
-    env: Env,
-    msg: T,
-) -> InitResult<U> {
-    let serialized_msg = to_vec(&msg)?;
-    call_init(instance, &env, &serialized_msg).expect("VM error")
-}
-
-// handle mimicks the call signature of the smart contracts.
-// thus it moves env and msg rather than take them as reference.
-// this is inefficient here, but only used in test code
-pub fn handle<
-    S: Storage + 'static,
-    A: Api + 'static,
-    Q: Querier + 'static,
-    T: Serialize + JsonSchema,
-    U: DeserializeOwned + Clone + PartialEq + JsonSchema + fmt::Debug,
->(
-    instance: &mut Instance<S, A, Q>,
-    env: Env,
-    msg: T,
-) -> HandleResult<U> {
-    let serialized_msg = to_vec(&msg)?;
-    call_handle(instance, &env, &serialized_msg).expect("VM error")
-}
-
-// query mimicks the call signature of the smart contracts.
-// thus it moves env and msg rather than take them as reference.
-// this is inefficient here, but only used in test code
-pub fn query<
-    S: Storage + 'static,
-    A: Api + 'static,
-    Q: Querier + 'static,
-    T: Serialize + JsonSchema,
->(
-    instance: &mut Instance<S, A, Q>,
-    msg: T,
-) -> StdResult<QueryResponse> {
-    let serialized_msg = to_vec(&msg)?;
-    call_query(instance, &serialized_msg).expect("VM error")
 }
 
 /// Runs a series of IO tests, hammering especially on allocate and deallocate.

--- a/packages/vm/src/testing/mock.rs
+++ b/packages/vm/src/testing/mock.rs
@@ -1,15 +1,13 @@
-use std::collections::HashMap;
-
-use crate::{Api, Extern, FfiResult, Querier, QuerierResult};
 use cosmwasm_std::{
     from_slice, to_binary, AllBalanceResponse, BalanceResponse, BankQuery, Binary, BlockInfo,
     CanonicalAddr, Coin, ContractInfo, Delegation, Env, HumanAddr, MessageInfo, Never,
     QueryRequest, SystemError, Validator, WasmQuery,
 };
+use std::collections::HashMap;
 
-mod storage;
+use crate::{Api, Extern, FfiResult, Querier, QuerierResult};
 
-use storage::MemoryStorage;
+use super::storage::MockStorage;
 
 static CONTRACT_ADDR: &str = "cosmos2contract";
 
@@ -39,10 +37,6 @@ pub fn mock_dependencies_with_balances(
         querier: MockQuerier::new(balances),
     }
 }
-
-// Use MemoryStorage implementation (which is valid in non-testcode)
-// We can later make simplifications here if needed
-pub type MockStorage = MemoryStorage;
 
 // MockPrecompiles zero pads all human addresses to make them fit the canonical_length
 // it trims off zeros for the reverse operation.

--- a/packages/vm/src/testing/mod.rs
+++ b/packages/vm/src/testing/mod.rs
@@ -1,0 +1,15 @@
+// The external interface is `use cosmwasm_vm::testing::X` for all integration testing symbols, no matter where they live internally.
+
+mod calls;
+mod instance;
+mod mock;
+mod storage;
+
+pub use calls::{handle, init, query};
+pub use instance::{
+    mock_instance, mock_instance_with_balances, mock_instance_with_gas_limit, test_io,
+};
+pub use mock::{
+    mock_dependencies, mock_dependencies_with_balances, mock_env, MockApi, MockQuerier,
+};
+pub use storage::MockStorage;

--- a/packages/vm/src/testing/storage.rs
+++ b/packages/vm/src/testing/storage.rs
@@ -10,17 +10,17 @@ use crate::{FfiResult, ReadonlyStorage, Storage};
 use cosmwasm_std::{Order, KV};
 
 #[derive(Default)]
-pub struct MemoryStorage {
+pub struct MockStorage {
     data: BTreeMap<Vec<u8>, Vec<u8>>,
 }
 
-impl MemoryStorage {
+impl MockStorage {
     pub fn new() -> Self {
-        MemoryStorage::default()
+        MockStorage::default()
     }
 }
 
-impl ReadonlyStorage for MemoryStorage {
+impl ReadonlyStorage for MockStorage {
     fn get(&self, key: &[u8]) -> FfiResult<Option<Vec<u8>>> {
         Ok(self.data.get(key).cloned())
     }
@@ -72,7 +72,7 @@ fn clone_item<T: Clone>(item_ref: BTreeMapPairRef<T>) -> KV<T> {
     (key.clone(), value.clone())
 }
 
-impl Storage for MemoryStorage {
+impl Storage for MockStorage {
     fn set(&mut self, key: &[u8], value: &[u8]) -> FfiResult<()> {
         self.data.insert(key.to_vec(), value.to_vec());
         Ok(())
@@ -245,7 +245,7 @@ mod test {
 
     #[test]
     fn get_and_set() {
-        let mut store = MemoryStorage::new();
+        let mut store = MockStorage::new();
         assert_eq!(None, store.get(b"foo").unwrap());
         store.set(b"foo", b"bar").unwrap();
         assert_eq!(Some(b"bar".to_vec()), store.get(b"foo").unwrap());
@@ -254,7 +254,7 @@ mod test {
 
     #[test]
     fn delete() {
-        let mut store = MemoryStorage::new();
+        let mut store = MockStorage::new();
         store.set(b"foo", b"bar").unwrap();
         store.set(b"food", b"bank").unwrap();
         store.remove(b"foo").unwrap();
@@ -266,7 +266,7 @@ mod test {
     #[test]
     #[cfg(feature = "iterator")]
     fn iterator() {
-        let mut store = MemoryStorage::new();
+        let mut store = MockStorage::new();
         store.set(b"foo", b"bar").expect("error setting value");
         iterator_test_suite(&mut store);
     }


### PR DESCRIPTION
Follow-up of #331

- in `cosmwasm-vm`, rename `MemoryStorage` to `MockStorage` since it is not reused anymore
- in `cosmwasm-vm`, export everything that is related to testing (such as the mock stuff) in the `cosmwasm_vm::testing` module, like we do in `cosmwasm-std`