### PR TITLE
Separate Delegation and AllDelegations in staking query API

### DIFF
--- a/contracts/staking/Cargo.toml
+++ b/contracts/staking/Cargo.toml
@@ -42,5 +42,5 @@ serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 snafu = { version = "0.6.3" }
 
 [dev-dependencies]
-cosmwasm-vm = { path = "../../packages/vm", default-features = false }
+cosmwasm-vm = { path = "../../packages/vm", default-features = false, features = ["staking"] }
 cosmwasm-schema = { path = "../../packages/schema" }

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -28,7 +28,7 @@ pub use crate::iterator::{Order, KV};
 pub use crate::math::{Decimal, Uint128};
 pub use crate::query::{
     AllBalanceResponse, AllDelegationsResponse, BalanceResponse, BankQuery, BondedDenomResponse,
-    Delegation, QueryRequest, QueryResponse, QueryResult, StakingQuery, Validator,
+    Delegation, FullDelegation, QueryRequest, QueryResponse, QueryResult, StakingQuery, Validator,
     ValidatorsResponse, WasmQuery,
 };
 pub use crate::serde::{from_binary, from_slice, to_binary, to_vec};

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -27,8 +27,8 @@ pub use crate::init_handle::{
 pub use crate::iterator::{Order, KV};
 pub use crate::math::{Decimal, Uint128};
 pub use crate::query::{
-    AllBalanceResponse, BalanceResponse, BankQuery, BondedDenomResponse, Delegation,
-    DelegationsResponse, QueryRequest, QueryResponse, QueryResult, StakingQuery, Validator,
+    AllBalanceResponse, AllDelegationsResponse, BalanceResponse, BankQuery, BondedDenomResponse,
+    Delegation, QueryRequest, QueryResponse, QueryResult, StakingQuery, Validator,
     ValidatorsResponse, WasmQuery,
 };
 pub use crate::serde::{from_binary, from_slice, to_binary, to_vec};

--- a/packages/std/src/mock.rs
+++ b/packages/std/src/mock.rs
@@ -159,7 +159,7 @@ impl MockQuerier {
         &mut self,
         denom: &str,
         validators: &[crate::query::Validator],
-        delegations: &[crate::query::Delegation],
+        delegations: &[crate::query::FullDelegation],
     ) {
         self.staking = StakingQuerier::new(denom, validators, delegations);
     }

--- a/packages/std/src/mock.rs
+++ b/packages/std/src/mock.rs
@@ -509,14 +509,14 @@ mod test {
             delegator: user_a.clone(),
             validator: val1.clone(),
             amount: coin(100, "stake"),
-            can_redelegate: true,
+            can_redelegate: coin(100, "stake"),
             accumulated_rewards: coin(5, "stake"),
         };
         let del2a = FullDelegation {
             delegator: user_a.clone(),
             validator: val2.clone(),
             amount: coin(500, "stake"),
-            can_redelegate: true,
+            can_redelegate: coin(500, "stake"),
             accumulated_rewards: coin(20, "stake"),
         };
 
@@ -525,7 +525,7 @@ mod test {
             delegator: user_b.clone(),
             validator: val1.clone(),
             amount: coin(500, "stake"),
-            can_redelegate: false,
+            can_redelegate: coin(0, "stake"),
             accumulated_rewards: coin(0, "stake"),
         };
 
@@ -534,7 +534,7 @@ mod test {
             delegator: user_c.clone(),
             validator: val2.clone(),
             amount: coin(8888, "stake"),
-            can_redelegate: true,
+            can_redelegate: coin(4567, "stake"),
             accumulated_rewards: coin(900, "stake"),
         };
 

--- a/packages/std/src/mock.rs
+++ b/packages/std/src/mock.rs
@@ -4,8 +4,9 @@ use crate::coins::Coin;
 use crate::encoding::Binary;
 use crate::errors::{generic_err, invalid_utf8, StdResult, SystemError};
 use crate::query::{
-    AllBalanceResponse, BalanceResponse, BankQuery, BondedDenomResponse, Delegation,
-    DelegationsResponse, QueryRequest, StakingQuery, Validator, ValidatorsResponse, WasmQuery,
+    AllBalanceResponse, AllDelegationsResponse, BalanceResponse, BankQuery, BondedDenomResponse,
+    DelegationResponse, FullDelegation, QueryRequest, StakingQuery, Validator, ValidatorsResponse,
+    WasmQuery,
 };
 use crate::serde::{from_slice, to_binary};
 use crate::storage::MemoryStorage;
@@ -255,11 +256,11 @@ impl BankQuerier {
 pub struct StakingQuerier {
     denom: String,
     validators: Vec<Validator>,
-    delegations: Vec<Delegation>,
+    delegations: Vec<FullDelegation>,
 }
 
 impl StakingQuerier {
-    pub fn new(denom: &str, validators: &[Validator], delegations: &[Delegation]) -> Self {
+    pub fn new(denom: &str, validators: &[Validator], delegations: &[FullDelegation]) -> Self {
         StakingQuerier {
             denom: denom.to_string(),
             validators: validators.to_vec(),
@@ -281,21 +282,28 @@ impl StakingQuerier {
                 };
                 Ok(to_binary(&res))
             }
-            StakingQuery::Delegations {
+            StakingQuery::AllDelegations { delegator } => {
+                let delegations: Vec<_> = self
+                    .delegations
+                    .iter()
+                    .filter(|d| &d.delegator == delegator)
+                    .cloned()
+                    .map(|d| d.into())
+                    .collect();
+                let res = AllDelegationsResponse { delegations };
+                Ok(to_binary(&res))
+            }
+            StakingQuery::Delegation {
                 delegator,
                 validator,
             } => {
-                let matches = |d: &&Delegation| {
-                    if let Some(val) = validator {
-                        if val != &d.validator {
-                            return false;
-                        }
-                    }
-                    &d.delegator == delegator
+                let delegation = self
+                    .delegations
+                    .iter()
+                    .find(|d| &d.delegator == delegator && &d.validator == validator);
+                let res = DelegationResponse {
+                    delegation: delegation.cloned(),
                 };
-                let delegations: Vec<_> =
-                    self.delegations.iter().filter(matches).cloned().collect();
-                let res = DelegationsResponse { delegations };
                 Ok(to_binary(&res))
             }
         }
@@ -305,7 +313,7 @@ impl StakingQuerier {
 #[cfg(test)]
 mod test {
     use super::*;
-
+    use crate::query::Delegation;
     use crate::{coin, coins, from_binary, Decimal, HumanAddr};
 
     #[test]
@@ -461,20 +469,30 @@ mod test {
     }
 
     // gets delegators from query or panic
-    fn get_delegators(
+    fn get_all_delegators(staking: &StakingQuerier, delegator: HumanAddr) -> Vec<Delegation> {
+        let raw = staking
+            .query(&StakingQuery::AllDelegations { delegator })
+            .unwrap()
+            .unwrap();
+        let dels: AllDelegationsResponse = from_binary(&raw).unwrap();
+        dels.delegations
+    }
+
+    // gets full delegators from query or panic
+    fn get_delegator(
         staking: &StakingQuerier,
         delegator: HumanAddr,
-        validator: Option<HumanAddr>,
-    ) -> Vec<Delegation> {
+        validator: HumanAddr,
+    ) -> Option<FullDelegation> {
         let raw = staking
-            .query(&StakingQuery::Delegations {
+            .query(&StakingQuery::Delegation {
                 delegator,
                 validator,
             })
             .unwrap()
             .unwrap();
-        let dels: DelegationsResponse = from_binary(&raw).unwrap();
-        dels.delegations
+        let dels: DelegationResponse = from_binary(&raw).unwrap();
+        dels.delegation
     }
 
     #[test]
@@ -487,14 +505,14 @@ mod test {
         let user_c = HumanAddr::from("hodler");
 
         // we need multiple validators per delegator, so the queries provide different results
-        let del1a = Delegation {
+        let del1a = FullDelegation {
             delegator: user_a.clone(),
             validator: val1.clone(),
             amount: coin(100, "stake"),
             can_redelegate: true,
             accumulated_rewards: coin(5, "stake"),
         };
-        let del2a = Delegation {
+        let del2a = FullDelegation {
             delegator: user_a.clone(),
             validator: val2.clone(),
             amount: coin(500, "stake"),
@@ -502,24 +520,17 @@ mod test {
             accumulated_rewards: coin(20, "stake"),
         };
 
-        // this is multiple times on the same validator
-        let del1b = Delegation {
+        // note we cannot have multiple delegations on one validator, they are collapsed into one
+        let del1b = FullDelegation {
             delegator: user_b.clone(),
             validator: val1.clone(),
             amount: coin(500, "stake"),
             can_redelegate: false,
             accumulated_rewards: coin(0, "stake"),
         };
-        let del1bb = Delegation {
-            delegator: user_b.clone(),
-            validator: val1.clone(),
-            amount: coin(700, "stake"),
-            can_redelegate: true,
-            accumulated_rewards: coin(70, "stake"),
-        };
 
         // and another one on val2
-        let del2c = Delegation {
+        let del2c = FullDelegation {
             delegator: user_c.clone(),
             validator: val2.clone(),
             amount: coin(8888, "stake"),
@@ -530,47 +541,41 @@ mod test {
         let staking = StakingQuerier::new(
             "stake",
             &[],
-            &[
-                del1a.clone(),
-                del1b.clone(),
-                del1bb.clone(),
-                del2a.clone(),
-                del2c.clone(),
-            ],
+            &[del1a.clone(), del1b.clone(), del2a.clone(), del2c.clone()],
         );
 
         // get all for user a
-        let dels = get_delegators(&staking, user_a.clone(), None);
-        assert_eq!(dels, vec![del1a.clone(), del2a.clone()]);
+        let dels = get_all_delegators(&staking, user_a.clone());
+        assert_eq!(dels, vec![del1a.clone().into(), del2a.clone().into()]);
 
         // get all for user b
-        let dels = get_delegators(&staking, user_b.clone(), None);
-        assert_eq!(dels, vec![del1b.clone(), del1bb.clone()]);
+        let dels = get_all_delegators(&staking, user_b.clone());
+        assert_eq!(dels, vec![del1b.clone().into()]);
 
         // get all for user c
-        let dels = get_delegators(&staking, user_c.clone(), None);
-        assert_eq!(dels, vec![del2c.clone()]);
+        let dels = get_all_delegators(&staking, user_c.clone());
+        assert_eq!(dels, vec![del2c.clone().into()]);
 
         // for user with no delegations...
-        let dels = get_delegators(&staking, HumanAddr::from("no one"), None);
+        let dels = get_all_delegators(&staking, HumanAddr::from("no one"));
         assert_eq!(dels, vec![]);
 
         // filter a by validator (1 and 1)
-        let dels = get_delegators(&staking, user_a.clone(), Some(val1.clone()));
-        assert_eq!(dels, vec![del1a.clone()]);
-        let dels = get_delegators(&staking, user_a.clone(), Some(val2.clone()));
-        assert_eq!(dels, vec![del2a.clone()]);
+        let dels = get_delegator(&staking, user_a.clone(), val1.clone());
+        assert_eq!(dels, Some(del1a.clone()));
+        let dels = get_delegator(&staking, user_a.clone(), val2.clone());
+        assert_eq!(dels, Some(del2a.clone()));
 
         // filter b by validator (2 and 0)
-        let dels = get_delegators(&staking, user_b.clone(), Some(val1.clone()));
-        assert_eq!(dels, vec![del1b.clone(), del1bb.clone()]);
-        let dels = get_delegators(&staking, user_b.clone(), Some(val2.clone()));
-        assert_eq!(dels, vec![]);
+        let dels = get_delegator(&staking, user_b.clone(), val1.clone());
+        assert_eq!(dels, Some(del1b.clone()));
+        let dels = get_delegator(&staking, user_b.clone(), val2.clone());
+        assert_eq!(dels, None);
 
         // filter c by validator (0 and 1)
-        let dels = get_delegators(&staking, user_c.clone(), Some(val1.clone()));
-        assert_eq!(dels, vec![]);
-        let dels = get_delegators(&staking, user_c.clone(), Some(val2.clone()));
-        assert_eq!(dels, vec![del2c.clone()]);
+        let dels = get_delegator(&staking, user_c.clone(), val1.clone());
+        assert_eq!(dels, None);
+        let dels = get_delegator(&staking, user_c.clone(), val2.clone());
+        assert_eq!(dels, Some(del2c.clone()));
     }
 }

--- a/packages/std/src/query.rs
+++ b/packages/std/src/query.rs
@@ -151,11 +151,12 @@ pub struct FullDelegation {
     pub validator: HumanAddr,
     /// How much we have locked in the delegation
     pub amount: Coin,
-    /// If true, then a Redelegate command will work now, otherwise you may have to wait more
-    pub can_redelegate: bool,
+    /// can_redelegate captures how much can be immediately redelegated.
+    /// 0 is no redelegation and can_redelegate == amount is redelegate all
+    /// but there are many places between the two
+    pub can_redelegate: Coin,
     /// How much we can currently withdraw
     pub accumulated_rewards: Coin,
-    // TODO: do we want to expose more info?
 }
 
 /// ValidatorsResponse is data format returned from StakingRequest::Validators query

--- a/packages/std/src/traits.rs
+++ b/packages/std/src/traits.rs
@@ -8,8 +8,8 @@ use crate::iterator::{Order, KV};
 use crate::query::{AllBalanceResponse, BalanceResponse, BankQuery, QueryRequest};
 #[cfg(feature = "staking")]
 use crate::query::{
-    AllDelegationsResponse, BondedDenomResponse, Delegation, StakingQuery, Validator,
-    ValidatorsResponse,
+    AllDelegationsResponse, BondedDenomResponse, Delegation, DelegationResponse, FullDelegation,
+    StakingQuery, Validator, ValidatorsResponse,
 };
 use crate::serde::{from_binary, to_vec};
 use crate::types::{CanonicalAddr, HumanAddr, Never};
@@ -163,9 +163,8 @@ pub trait Querier: Clone + Send {
         &self,
         delegator: U,
     ) -> StdResult<Vec<Delegation>> {
-        let request = StakingQuery::Delegations {
+        let request = StakingQuery::AllDelegations {
             delegator: delegator.into(),
-            validator: None,
         }
         .into();
         let res: AllDelegationsResponse = self.query(&request)?;
@@ -177,13 +176,13 @@ pub trait Querier: Clone + Send {
         &self,
         delegator: U,
         validator: U,
-    ) -> StdResult<Vec<Delegation>> {
-        let request = StakingQuery::Delegations {
+    ) -> StdResult<Option<FullDelegation>> {
+        let request = StakingQuery::Delegation {
             delegator: delegator.into(),
-            validator: Some(validator.into()),
+            validator: validator.into(),
         }
         .into();
-        let res: AllDelegationsResponse = self.query(&request)?;
-        Ok(res.delegations)
+        let res: DelegationResponse = self.query(&request)?;
+        Ok(res.delegation)
     }
 }

--- a/packages/std/src/traits.rs
+++ b/packages/std/src/traits.rs
@@ -8,7 +8,7 @@ use crate::iterator::{Order, KV};
 use crate::query::{AllBalanceResponse, BalanceResponse, BankQuery, QueryRequest};
 #[cfg(feature = "staking")]
 use crate::query::{
-    BondedDenomResponse, Delegation, DelegationsResponse, StakingQuery, Validator,
+    AllDelegationsResponse, BondedDenomResponse, Delegation, StakingQuery, Validator,
     ValidatorsResponse,
 };
 use crate::serde::{from_binary, to_vec};
@@ -168,7 +168,7 @@ pub trait Querier: Clone + Send {
             validator: None,
         }
         .into();
-        let res: DelegationsResponse = self.query(&request)?;
+        let res: AllDelegationsResponse = self.query(&request)?;
         Ok(res.delegations)
     }
 
@@ -183,7 +183,7 @@ pub trait Querier: Clone + Send {
             validator: Some(validator.into()),
         }
         .into();
-        let res: DelegationsResponse = self.query(&request)?;
+        let res: AllDelegationsResponse = self.query(&request)?;
         Ok(res.delegations)
     }
 }

--- a/packages/vm/Cargo.toml
+++ b/packages/vm/Cargo.toml
@@ -12,7 +12,7 @@ circle-ci = { repository = "CosmWasm/cosmwasm", branch = "master" }
 maintenance = { status = "actively-developed" }
 
 [features]
-default = ["default-singlepass"]
+default = ["default-singlepass", "staking"]
 # multiple backends may be activated here (available through eg. backends::cranelift::*)
 cranelift = ["wasmer-clif-backend"]
 singlepass = ["wasmer-singlepass-backend"]
@@ -27,6 +27,7 @@ backtraces = ["snafu/backtraces"]
 # given Ethereum 1.0, 2.0, Substrate, and other major projects use Tries
 # we keep this optional, to allow possible future integration (or different Cosmos Backends)
 iterator = ["cosmwasm-std/iterator"]
+staking = ["cosmwasm-std/staking"]
 
 [dependencies]
 # Uses the path when built locally; uses the given version from crates.io when published

--- a/packages/vm/src/testing/mock.rs
+++ b/packages/vm/src/testing/mock.rs
@@ -251,8 +251,8 @@ impl BankQuerier {
 mod staking {
     use crate::traits::QuerierResult;
     use cosmwasm_std::{
-        to_binary, BondedDenomResponse, Delegation, AllDelegationsResponse, StakingQuery, Validator,
-        ValidatorsResponse,
+        to_binary, AllDelegationsResponse, BondedDenomResponse, Delegation, StakingQuery,
+        Validator, ValidatorsResponse,
     };
 
     #[derive(Clone, Default)]

--- a/packages/vm/src/testing/mock.rs
+++ b/packages/vm/src/testing/mock.rs
@@ -1,7 +1,10 @@
 use serde::Serialize;
 
 use cosmwasm_std::testing::MockQuerier as StdMockQuerier;
-use cosmwasm_std::{to_binary, Binary, BlockInfo, CanonicalAddr, Coin, ContractInfo, Env, HumanAddr, MessageInfo, Querier as _, QueryRequest, SystemError};
+use cosmwasm_std::{
+    to_binary, Binary, BlockInfo, CanonicalAddr, Coin, ContractInfo, Env, HumanAddr, MessageInfo,
+    Querier as _, QueryRequest, SystemError,
+};
 
 use super::storage::MockStorage;
 use crate::{Api, Extern, FfiResult, Querier, QuerierResult};

--- a/packages/vm/src/testing/mock.rs
+++ b/packages/vm/src/testing/mock.rs
@@ -1,13 +1,10 @@
-use cosmwasm_std::{
-    from_slice, to_binary, AllBalanceResponse, BalanceResponse, BankQuery, Binary, BlockInfo,
-    CanonicalAddr, Coin, ContractInfo, Delegation, Env, HumanAddr, MessageInfo, Never,
-    QueryRequest, SystemError, Validator, WasmQuery,
-};
-use std::collections::HashMap;
+use serde::Serialize;
 
-use crate::{Api, Extern, FfiResult, Querier, QuerierResult};
+use cosmwasm_std::testing::MockQuerier as StdMockQuerier;
+use cosmwasm_std::{to_binary, Binary, BlockInfo, CanonicalAddr, Coin, ContractInfo, Env, HumanAddr, MessageInfo, Querier as _, QueryRequest, SystemError};
 
 use super::storage::MockStorage;
+use crate::{Api, Extern, FfiResult, Querier, QuerierResult};
 
 static CONTRACT_ADDR: &str = "cosmos2contract";
 
@@ -127,18 +124,13 @@ pub fn mock_env<T: Api, U: Into<HumanAddr>>(api: &T, sender: U, sent: &[Coin]) -
 /// TODO: also allow querying contracts
 #[derive(Clone, Default)]
 pub struct MockQuerier {
-    bank: BankQuerier,
-    staking: staking::StakingQuerier,
-    // placeholder to add support later
-    wasm: NoWasmQuerier,
+    querier: StdMockQuerier,
 }
 
 impl MockQuerier {
     pub fn new(balances: &[(&HumanAddr, &[Coin])]) -> Self {
         MockQuerier {
-            bank: BankQuerier::new(balances),
-            staking: staking::StakingQuerier::default(),
-            wasm: NoWasmQuerier {},
+            querier: StdMockQuerier::new(balances),
         }
     }
 
@@ -148,311 +140,41 @@ impl MockQuerier {
         addr: U,
         balance: Vec<Coin>,
     ) -> Option<Vec<Coin>> {
-        self.bank.balances.insert(addr.into(), balance)
+        self.querier.update_balance(addr, balance)
     }
 
+    #[cfg(feature = "staking")]
     pub fn with_staking(
         &mut self,
         denom: &str,
-        validators: &[Validator],
-        delegations: &[Delegation],
+        validators: &[cosmwasm_std::Validator],
+        delegations: &[cosmwasm_std::FullDelegation],
     ) {
-        self.staking = staking::StakingQuerier::new(denom, validators, delegations);
+        self.querier.with_staking(denom, validators, delegations);
     }
 }
 
 impl Querier for MockQuerier {
     fn raw_query(&self, bin_request: &[u8]) -> QuerierResult {
-        // MockQuerier doesn't support Custom, so we ignore it completely here
-        let request: QueryRequest<Never> = match from_slice(bin_request) {
-            Ok(v) => v,
-            Err(e) => {
-                return Ok(Err(SystemError::InvalidRequest {
-                    error: format!("Parsing query request: {}", e),
-                    request: bin_request.into(),
-                }))
-            }
-        };
-        self.handle_query(&request)
+        let res = self.querier.raw_query(bin_request);
+        // We don't use FFI, so FfiResult is always Ok() regardless of error on other levels
+        Ok(res)
     }
 }
 
 impl MockQuerier {
-    pub fn handle_query<T>(&self, request: &QueryRequest<T>) -> QuerierResult {
-        match &request {
-            QueryRequest::Bank(bank_query) => self.bank.query(bank_query),
-            QueryRequest::Custom(_) => Ok(Err(SystemError::UnsupportedRequest {
-                kind: "custom".to_string(),
-            })),
-            QueryRequest::Staking(staking_query) => self.staking.query(staking_query),
-            QueryRequest::Wasm(msg) => self.wasm.query(msg),
-        }
-    }
-}
-
-#[derive(Clone, Default)]
-struct NoWasmQuerier {
-    // FIXME: actually provide a way to call out
-}
-
-impl NoWasmQuerier {
-    fn query(&self, request: &WasmQuery) -> QuerierResult {
-        let addr = match request {
-            WasmQuery::Smart { contract_addr, .. } => contract_addr,
-            WasmQuery::Raw { contract_addr, .. } => contract_addr,
-        }
-        .clone();
-        Ok(Err(SystemError::NoSuchContract { addr }))
-    }
-}
-
-#[derive(Clone, Default)]
-struct BankQuerier {
-    balances: HashMap<HumanAddr, Vec<Coin>>,
-}
-
-impl BankQuerier {
-    fn new(balances: &[(&HumanAddr, &[Coin])]) -> Self {
-        let mut map = HashMap::new();
-        for (addr, coins) in balances.iter() {
-            map.insert(HumanAddr::from(addr), coins.to_vec());
-        }
-        BankQuerier { balances: map }
-    }
-
-    fn query(&self, request: &BankQuery) -> QuerierResult {
-        match request {
-            BankQuery::Balance { address, denom } => {
-                // proper error on not found, serialize result on found
-                let amount = self
-                    .balances
-                    .get(address)
-                    .and_then(|v| v.iter().find(|c| &c.denom == denom).map(|c| c.amount))
-                    .unwrap_or_default();
-                let bank_res = BalanceResponse {
-                    amount: Coin {
-                        amount,
-                        denom: denom.to_string(),
-                    },
-                };
-                Ok(Ok(to_binary(&bank_res)))
+    pub fn handle_query<T: Serialize>(&self, request: &QueryRequest<T>) -> QuerierResult {
+        // encode the request, then call raw_query
+        let bin = match to_binary(request) {
+            Ok(raw) => raw,
+            Err(e) => {
+                return Ok(Err(SystemError::InvalidRequest {
+                    error: format!("Serializing query request: {}", e),
+                    request: Binary(b"N/A".to_vec()),
+                }));
             }
-            BankQuery::AllBalances { address } => {
-                // proper error on not found, serialize result on found
-                let bank_res = AllBalanceResponse {
-                    amount: self.balances.get(address).cloned().unwrap_or_default(),
-                };
-                Ok(Ok(to_binary(&bank_res)))
-            }
-        }
-    }
-}
-
-mod staking {
-    use crate::traits::QuerierResult;
-    use cosmwasm_std::{
-        to_binary, AllDelegationsResponse, BondedDenomResponse, Delegation, StakingQuery,
-        Validator, ValidatorsResponse,
-    };
-
-    #[derive(Clone, Default)]
-    pub struct StakingQuerier {
-        denom: String,
-        validators: Vec<Validator>,
-        delegations: Vec<Delegation>,
-    }
-
-    impl StakingQuerier {
-        pub fn new(denom: &str, validators: &[Validator], delegations: &[Delegation]) -> Self {
-            StakingQuerier {
-                denom: denom.to_string(),
-                validators: validators.to_vec(),
-                delegations: delegations.to_vec(),
-            }
-        }
-
-        pub fn query(&self, request: &StakingQuery) -> QuerierResult {
-            match request {
-                StakingQuery::BondedDenom {} => {
-                    let res = BondedDenomResponse {
-                        denom: self.denom.clone(),
-                    };
-                    Ok(Ok(to_binary(&res)))
-                }
-                StakingQuery::Validators {} => {
-                    let res = ValidatorsResponse {
-                        validators: self.validators.clone(),
-                    };
-                    Ok(Ok(to_binary(&res)))
-                }
-                StakingQuery::Delegations {
-                    delegator,
-                    validator,
-                } => {
-                    let matches = |d: &&Delegation| {
-                        if let Some(val) = validator {
-                            if val != &d.validator {
-                                return false;
-                            }
-                        }
-                        &d.delegator == delegator
-                    };
-                    let delegations: Vec<_> =
-                        self.delegations.iter().filter(matches).cloned().collect();
-                    let res = AllDelegationsResponse { delegations };
-                    Ok(Ok(to_binary(&res)))
-                }
-            }
-        }
-    }
-
-    #[cfg(test)]
-    mod test {
-        use super::*;
-
-        use cosmwasm_std::{coin, from_binary, Decimal, HumanAddr};
-
-        #[test]
-        fn staking_querier_validators() {
-            let val1 = Validator {
-                address: HumanAddr::from("validator-one"),
-                commission: Decimal::percent(1),
-                max_commission: Decimal::percent(3),
-                max_change_rate: Decimal::percent(1),
-            };
-            let val2 = Validator {
-                address: HumanAddr::from("validator-two"),
-                commission: Decimal::permille(15),
-                max_commission: Decimal::permille(40),
-                max_change_rate: Decimal::permille(5),
-            };
-
-            let staking = StakingQuerier::new("stake", &[val1.clone(), val2.clone()], &[]);
-
-            // one match
-            let raw = staking
-                .query(&StakingQuery::Validators {})
-                .unwrap()
-                .unwrap()
-                .unwrap();
-            let vals: ValidatorsResponse = from_binary(&raw).unwrap();
-            assert_eq!(vals.validators, vec![val1, val2]);
-        }
-
-        // gets delegators from query or panic
-        fn get_delegators(
-            staking: &StakingQuerier,
-            delegator: HumanAddr,
-            validator: Option<HumanAddr>,
-        ) -> Vec<Delegation> {
-            let raw = staking
-                .query(&StakingQuery::Delegations {
-                    delegator,
-                    validator,
-                })
-                .unwrap()
-                .unwrap()
-                .unwrap();
-            let dels: AllDelegationsResponse = from_binary(&raw).unwrap();
-            dels.delegations
-        }
-
-        #[test]
-        fn staking_querier_delegations() {
-            let val1 = HumanAddr::from("validator-one");
-            let val2 = HumanAddr::from("validator-two");
-
-            let user_a = HumanAddr::from("investor");
-            let user_b = HumanAddr::from("speculator");
-            let user_c = HumanAddr::from("hodler");
-
-            // we need multiple validators per delegator, so the queries provide different results
-            let del1a = Delegation {
-                delegator: user_a.clone(),
-                validator: val1.clone(),
-                amount: coin(100, "stake"),
-                can_redelegate: true,
-                accumulated_rewards: coin(5, "stake"),
-            };
-            let del2a = Delegation {
-                delegator: user_a.clone(),
-                validator: val2.clone(),
-                amount: coin(500, "stake"),
-                can_redelegate: true,
-                accumulated_rewards: coin(20, "stake"),
-            };
-
-            // this is multiple times on the same validator
-            let del1b = Delegation {
-                delegator: user_b.clone(),
-                validator: val1.clone(),
-                amount: coin(500, "stake"),
-                can_redelegate: false,
-                accumulated_rewards: coin(0, "stake"),
-            };
-            let del1bb = Delegation {
-                delegator: user_b.clone(),
-                validator: val1.clone(),
-                amount: coin(700, "stake"),
-                can_redelegate: true,
-                accumulated_rewards: coin(70, "stake"),
-            };
-
-            // and another one on val2
-            let del2c = Delegation {
-                delegator: user_c.clone(),
-                validator: val2.clone(),
-                amount: coin(8888, "stake"),
-                can_redelegate: true,
-                accumulated_rewards: coin(900, "stake"),
-            };
-
-            let staking = StakingQuerier::new(
-                "stake",
-                &[],
-                &[
-                    del1a.clone(),
-                    del1b.clone(),
-                    del1bb.clone(),
-                    del2a.clone(),
-                    del2c.clone(),
-                ],
-            );
-
-            // get all for user a
-            let dels = get_delegators(&staking, user_a.clone(), None);
-            assert_eq!(dels, vec![del1a.clone(), del2a.clone()]);
-
-            // get all for user b
-            let dels = get_delegators(&staking, user_b.clone(), None);
-            assert_eq!(dels, vec![del1b.clone(), del1bb.clone()]);
-
-            // get all for user c
-            let dels = get_delegators(&staking, user_c.clone(), None);
-            assert_eq!(dels, vec![del2c.clone()]);
-
-            // for user with no delegations...
-            let dels = get_delegators(&staking, HumanAddr::from("no one"), None);
-            assert_eq!(dels, vec![]);
-
-            // filter a by validator (1 and 1)
-            let dels = get_delegators(&staking, user_a.clone(), Some(val1.clone()));
-            assert_eq!(dels, vec![del1a.clone()]);
-            let dels = get_delegators(&staking, user_a.clone(), Some(val2.clone()));
-            assert_eq!(dels, vec![del2a.clone()]);
-
-            // filter b by validator (2 and 0)
-            let dels = get_delegators(&staking, user_b.clone(), Some(val1.clone()));
-            assert_eq!(dels, vec![del1b.clone(), del1bb.clone()]);
-            let dels = get_delegators(&staking, user_b.clone(), Some(val2.clone()));
-            assert_eq!(dels, vec![]);
-
-            // filter c by validator (0 and 1)
-            let dels = get_delegators(&staking, user_c.clone(), Some(val1.clone()));
-            assert_eq!(dels, vec![]);
-            let dels = get_delegators(&staking, user_c.clone(), Some(val2.clone()));
-            assert_eq!(dels, vec![del2c.clone()]);
-        }
+        };
+        self.raw_query(bin.as_slice())
     }
 }
 
@@ -460,7 +182,9 @@ mod staking {
 mod test {
     use super::*;
     use crate::FfiError;
-    use cosmwasm_std::{coin, coins, from_binary};
+    use cosmwasm_std::{
+        coin, coins, from_binary, AllBalanceResponse, BalanceResponse, BankQuery, Never,
+    };
 
     #[test]
     fn mock_env_arguments() {
@@ -524,13 +248,16 @@ mod test {
     fn bank_querier_all_balances() {
         let addr = HumanAddr::from("foobar");
         let balance = vec![coin(123, "ELF"), coin(777, "FLY")];
-        let bank = BankQuerier::new(&[(&addr, &balance)]);
+        let querier = MockQuerier::new(&[(&addr, &balance)]);
 
         // all
-        let all = bank
-            .query(&BankQuery::AllBalances {
-                address: addr.clone(),
-            })
+        let all = querier
+            .handle_query::<Never>(
+                &BankQuery::AllBalances {
+                    address: addr.clone(),
+                }
+                .into(),
+            )
             .unwrap()
             .unwrap()
             .unwrap();
@@ -542,14 +269,17 @@ mod test {
     fn bank_querier_one_balance() {
         let addr = HumanAddr::from("foobar");
         let balance = vec![coin(123, "ELF"), coin(777, "FLY")];
-        let bank = BankQuerier::new(&[(&addr, &balance)]);
+        let querier = MockQuerier::new(&[(&addr, &balance)]);
 
         // one match
-        let fly = bank
-            .query(&BankQuery::Balance {
-                address: addr.clone(),
-                denom: "FLY".to_string(),
-            })
+        let fly = querier
+            .handle_query::<Never>(
+                &BankQuery::Balance {
+                    address: addr.clone(),
+                    denom: "FLY".to_string(),
+                }
+                .into(),
+            )
             .unwrap()
             .unwrap()
             .unwrap();
@@ -557,11 +287,14 @@ mod test {
         assert_eq!(res.amount, coin(777, "FLY"));
 
         // missing denom
-        let miss = bank
-            .query(&BankQuery::Balance {
-                address: addr.clone(),
-                denom: "MISS".to_string(),
-            })
+        let miss = querier
+            .handle_query::<Never>(
+                &BankQuery::Balance {
+                    address: addr.clone(),
+                    denom: "MISS".to_string(),
+                }
+                .into(),
+            )
             .unwrap()
             .unwrap()
             .unwrap();
@@ -573,13 +306,16 @@ mod test {
     fn bank_querier_missing_account() {
         let addr = HumanAddr::from("foobar");
         let balance = vec![coin(123, "ELF"), coin(777, "FLY")];
-        let bank = BankQuerier::new(&[(&addr, &balance)]);
+        let querier = MockQuerier::new(&[(&addr, &balance)]);
 
         // all balances on empty account is empty vec
-        let all = bank
-            .query(&BankQuery::AllBalances {
-                address: HumanAddr::from("elsewhere"),
-            })
+        let all = querier
+            .handle_query::<Never>(
+                &BankQuery::AllBalances {
+                    address: HumanAddr::from("elsewhere"),
+                }
+                .into(),
+            )
             .unwrap()
             .unwrap()
             .unwrap();
@@ -587,11 +323,14 @@ mod test {
         assert_eq!(res.amount, vec![]);
 
         // any denom on balances on empty account is empty coin
-        let miss = bank
-            .query(&BankQuery::Balance {
-                address: HumanAddr::from("elsewhere"),
-                denom: "ELF".to_string(),
-            })
+        let miss = querier
+            .handle_query::<Never>(
+                &BankQuery::Balance {
+                    address: HumanAddr::from("elsewhere"),
+                    denom: "ELF".to_string(),
+                }
+                .into(),
+            )
             .unwrap()
             .unwrap()
             .unwrap();

--- a/packages/vm/src/testing/mock.rs
+++ b/packages/vm/src/testing/mock.rs
@@ -251,7 +251,7 @@ impl BankQuerier {
 mod staking {
     use crate::traits::QuerierResult;
     use cosmwasm_std::{
-        to_binary, BondedDenomResponse, Delegation, DelegationsResponse, StakingQuery, Validator,
+        to_binary, BondedDenomResponse, Delegation, AllDelegationsResponse, StakingQuery, Validator,
         ValidatorsResponse,
     };
 
@@ -299,7 +299,7 @@ mod staking {
                     };
                     let delegations: Vec<_> =
                         self.delegations.iter().filter(matches).cloned().collect();
-                    let res = DelegationsResponse { delegations };
+                    let res = AllDelegationsResponse { delegations };
                     Ok(Ok(to_binary(&res)))
                 }
             }
@@ -353,7 +353,7 @@ mod staking {
                 .unwrap()
                 .unwrap()
                 .unwrap();
-            let dels: DelegationsResponse = from_binary(&raw).unwrap();
+            let dels: AllDelegationsResponse = from_binary(&raw).unwrap();
             dels.delegations
         }
 


### PR DESCRIPTION
Made some small changes to the query API based on my experience with wasmd.

- [x] Change types in cosmwasm_std and update mocks
- [x] Update mocks in cosmwasm_vm
- [x] Fix staking contract

I just crashed into the fact that all the mock code is now copied between vm and std with 98% the same code. And I don't want to update the mocks twice. I will try to auto-generate `cosmwasm_vm::testing::MockQuerier` and all sub-queriers from `cosmwasm_std::testing:MockQuerier` and all sub-queriers, as part of this PR unless there is strong objection.

@reuvenpo @webmaster128 