### PR TITLE
Improve staking contract

### DIFF
--- a/contracts/staking/src/contract.rs
+++ b/contracts/staking/src/contract.rs
@@ -102,7 +102,7 @@ pub fn transfer<S: Storage, A: Api, Q: Querier>(
 // it ensures they are all the same denom
 fn get_bonded<Q: Querier>(querier: &Q, contract: &HumanAddr) -> StdResult<Uint128> {
     let bonds = querier.query_all_delegations(contract)?;
-    if bonds.len() == 0 {
+    if bonds.is_empty() {
         return Ok(Uint128(0));
     }
     let denom = bonds[0].amount.denom.as_str();


### PR DESCRIPTION
Builds on #341 (merge that first)

I want to simplify some logic flows, and also use some queries that get delegations amounts, in order to stress-test all aspects of the API (in the comsos-sdk integration)