### PR TITLE
Remove obsolete Default implementation for Checksum

### DIFF
--- a/packages/vm/src/checksum.rs
+++ b/packages/vm/src/checksum.rs
@@ -9,8 +9,7 @@ use crate::errors::{make_cache_err, VmError};
 ///
 /// This is often referred to as "code ID" in go-cosmwasm, even if code ID
 /// usually refers to an auto-incrementing number.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Default)]
-// Note: do not remove Default, we need it in go-cosmwasm (for now)
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Checksum([u8; 32]);
 
 impl Checksum {


### PR DESCRIPTION
Not needed anymore after https://github.com/CosmWasm/go-cosmwasm/pull/86