### PR TITLE
Make MockStorage debuggable

### DIFF
--- a/packages/vm/src/testing/storage.rs
+++ b/packages/vm/src/testing/storage.rs
@@ -9,7 +9,7 @@ use crate::{FfiResult, ReadonlyStorage, Storage};
 #[cfg(feature = "iterator")]
 use cosmwasm_std::{Order, KV};
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct MockStorage {
     data: BTreeMap<Vec<u8>, Vec<u8>>,
 }


### PR DESCRIPTION
This allows you to dump a whole storage to console diring develoment:

```
println!("{:?}", store);
```

gives you

> MockStorage { data: {[0, 6, 99, 111, 110, 102, 105, 103]: [123, 34, 97, 114, 98, 105, 116, 101, 114, 34, 58, 34, 100, 109, 86, 121, 97, 87, 90, 112, 90, 88, 77, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 61, 34, 44, 34, 114, 101, 99, 105, 112, 105, 101, 110, 116, 34, 58, 34, 89, 109, 86, 117, 90, 87, 90, 112, 100, 72, 77, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 61, 34, 44, 34, 115, 111, 117, 114, 99, 101, 34, 58, 34, 89, 51, 74, 108, 89, 88, 82, 118, 99, 103, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 61, 34, 44, 34, 101, 110, 100, 95, 104, 101, 105, 103, 104, 116, 34, 58, 49, 48, 48, 48, 44, 34, 101, 110, 100, 95, 116, 105, 109, 101, 34, 58, 110, 117, 108, 108, 125]} }

Doesn't seem to be that helpful but probably saved me a significant amount of time.

This gets increasingly important now that you cannot use all the storage helpers anymore in integration tests because they use different types.