### PR TITLE
Add Default and Ord to Decimal

### DIFF
--- a/packages/std/src/math.rs
+++ b/packages/std/src/math.rs
@@ -10,7 +10,7 @@ use crate::errors::{generic_err, underflow, StdError, StdResult};
 /// A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0
 ///
 /// The greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)
-#[derive(Copy, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Copy, Clone, Default, Debug, PartialEq, Eq, PartialOrd, Ord, JsonSchema)]
 pub struct Decimal(#[schemars(with = "String")] u128);
 
 const DECIMAL_FRACTIONAL: u128 = 1_000_000_000_000_000_000;


### PR DESCRIPTION
I found it useful to have Default when writing some custom querier, and having a 0 values seems quite correct.

When making the fix, I just copied the derives from `Uint128` to `Decimal`, as the same set would make sense (0 value, equals, and comparision).