### PR TITLE
Wrap wasmer_instance in box

### DIFF
--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -28,7 +28,7 @@ pub struct CosmCache<S: Storage + 'static, A: Api + 'static, Q: Querier + 'stati
     wasm_path: PathBuf,
     supported_features: HashSet<String>,
     modules: FileSystemCache,
-    instances: Option<LruCache<Checksum, wasmer_runtime_core::Instance>>,
+    instances: Option<LruCache<Checksum, Box<wasmer_runtime_core::Instance>>>,
     stats: Stats,
     // Those two don't store data but only fix type information
     type_storage: PhantomData<S>,


### PR DESCRIPTION
Kudos to @reuvenpo for this idea to solve #245

Closes #306. This supersedes #306, with two differences
- It can be used on master, no matter if we use #245 or not. This reduces the diff.
- It only uses one heap allocation for the entire lifetime of the wasmer instance

Marked as WIP to keep this out of the 0.8.0 release. But we can merge it soon after that into master.