### PR TITLE
Add test for owner failing to unbond.

### DIFF
--- a/contracts/staking/src/contract.rs
+++ b/contracts/staking/src/contract.rs
@@ -773,6 +773,17 @@ mod tests {
         set_delegation(&mut deps.querier, 1500, "stake");
         deps.querier.update_balance(&contract_addr, vec![]);
 
+        // creator now tries to unbond these tokens - this must fail
+        let unbond_msg = HandleMsg::Unbond {
+            amount: Uint128(600),
+        };
+        let env = mock_env(&deps.api, &creator, &[]);
+        let res = handle(&mut deps, env, unbond_msg);
+        match res.unwrap_err() {
+            StdError::Underflow { .. } => {}
+            e => panic!("unexpected error: {}", e),
+        }
+
         // bob unbonds 600 tokens at 10% tax...
         // 60 are taken and send to the owner
         // 540 are unbonded in exchange for 540 * 1.5 = 810 native tokens


### PR DESCRIPTION
Checking https://github.com/CosmWasm/cosmwasm-js/pull/175#pullrequestreview-417352535

I tested this and we get the proper error from the contract on the rust side.
I bet we didn't update all the error names to the latest on the go side.