### PR TITLE
Improve vm backend method naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 0.8.1 (not yet released)
+
+**cosmwasm-vm**
+
+- Deprecated `Instance::get_gas` in favour of `Instance::get_gas_left`. The old
+  method will remain available for a while but will issue a deprecation warning
+  when used.
+
 ## 0.8.0 (not yet released)
 
 **all**

--- a/contracts/hackatom/tests/integration.rs
+++ b/contracts/hackatom/tests/integration.rs
@@ -290,7 +290,7 @@ mod singlepass_tests {
             &to_vec(&HandleMsg::CpuLoop {}).unwrap(),
         );
         assert!(handle_res.is_err());
-        assert_eq!(deps.get_gas(), 0);
+        assert_eq!(deps.get_gas_left(), 0);
     }
 
     #[test]
@@ -310,7 +310,7 @@ mod singlepass_tests {
             &to_vec(&HandleMsg::StorageLoop {}).unwrap(),
         );
         assert!(handle_res.is_err());
-        assert_eq!(deps.get_gas(), 0);
+        assert_eq!(deps.get_gas_left(), 0);
     }
 
     #[test]
@@ -330,7 +330,7 @@ mod singlepass_tests {
             &to_vec(&HandleMsg::MemoryLoop {}).unwrap(),
         );
         assert!(handle_res.is_err());
-        assert_eq!(deps.get_gas(), 0);
+        assert_eq!(deps.get_gas_left(), 0);
 
         // Ran out of gas before consuming a significant amount of memory
         assert!(deps.get_memory_size() < 2 * 1024 * 1024);
@@ -346,14 +346,14 @@ mod singlepass_tests {
         assert_eq!(0, init_res.messages.len());
 
         let handle_env = mock_env(&deps.api, creator.as_str(), &[]);
-        let gas_before = deps.get_gas();
+        let gas_before = deps.get_gas_left();
         // Note: we need to use the production-call, not the testing call (which unwraps any vm error)
         let handle_res = call_handle::<_, _, _, Never>(
             &mut deps,
             &handle_env,
             &to_vec(&HandleMsg::AllocateLargeMemory {}).unwrap(),
         );
-        let gas_used = gas_before - deps.get_gas();
+        let gas_used = gas_before - deps.get_gas_left();
 
         // TODO: this must fail, see https://github.com/CosmWasm/cosmwasm/issues/81
         assert_eq!(handle_res.is_err(), false);

--- a/packages/vm/src/backends/cranelift.rs
+++ b/packages/vm/src/backends/cranelift.rs
@@ -26,8 +26,10 @@ pub fn backend() -> &'static str {
     "cranelift"
 }
 
+/// Set the amount of gas units that can be used in the `Instance`.
 pub fn set_gas_limit(_instance: &mut Instance, _limit: u64) {}
 
+/// Get how many more gas units can be used in the `Instance`.
 pub fn get_gas_left(_instance: &Instance) -> u64 {
     FAKE_GAS_AVAILABLE
 }

--- a/packages/vm/src/backends/cranelift.rs
+++ b/packages/vm/src/backends/cranelift.rs
@@ -26,8 +26,8 @@ pub fn backend() -> &'static str {
     "cranelift"
 }
 
-pub fn set_gas(_instance: &mut Instance, _limit: u64) {}
+pub fn set_gas_limit(_instance: &mut Instance, _limit: u64) {}
 
-pub fn get_gas(_instance: &Instance) -> u64 {
+pub fn get_gas_left(_instance: &Instance) -> u64 {
     FAKE_GAS_AVAILABLE
 }

--- a/packages/vm/src/backends/mod.rs
+++ b/packages/vm/src/backends/mod.rs
@@ -16,7 +16,7 @@ pub fn compiler_for_backend(backend: &str) -> Option<Box<dyn Compiler>> {
 }
 
 #[cfg(feature = "default-cranelift")]
-pub use cranelift::{backend, compile, get_gas, set_gas};
+pub use cranelift::{backend, compile, get_gas_left, set_gas_limit};
 
 #[cfg(feature = "default-singlepass")]
-pub use singlepass::{backend, compile, get_gas, set_gas};
+pub use singlepass::{backend, compile, get_gas_left, set_gas_limit};

--- a/packages/vm/src/backends/singlepass.rs
+++ b/packages/vm/src/backends/singlepass.rs
@@ -33,7 +33,7 @@ pub fn backend() -> &'static str {
     "singlepass"
 }
 
-pub fn set_gas(instance: &mut Instance, limit: u64) {
+pub fn set_gas_limit(instance: &mut Instance, limit: u64) {
     let used = if limit > GAS_LIMIT {
         0
     } else {
@@ -42,7 +42,7 @@ pub fn set_gas(instance: &mut Instance, limit: u64) {
     metering::set_points_used(instance, used)
 }
 
-pub fn get_gas(instance: &Instance) -> u64 {
+pub fn get_gas_left(instance: &Instance) -> u64 {
     let used = metering::get_points_used(instance);
     // when running out of gas, get_points_used can exceed GAS_LIMIT
     if used > GAS_LIMIT {

--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -448,7 +448,7 @@ mod test {
         assert_eq!(cache.stats.hits_module, 1);
         assert_eq!(cache.stats.hits_instance, 0);
         assert_eq!(cache.stats.misses, 0);
-        let original_gas = instance1.get_gas();
+        let original_gas = instance1.get_gas_left();
 
         // Consume some gas
         let env = mock_env(&instance1.api, "owner1", &coins(1000, "earth"));
@@ -456,7 +456,7 @@ mod test {
         call_init::<_, _, _, Never>(&mut instance1, &env, msg)
             .unwrap()
             .unwrap();
-        assert!(instance1.get_gas() < original_gas);
+        assert!(instance1.get_gas_left() < original_gas);
         cache.store_instance(&id, instance1).unwrap();
 
         // Init from instance cache
@@ -464,7 +464,7 @@ mod test {
         assert_eq!(cache.stats.hits_module, 1);
         assert_eq!(cache.stats.hits_instance, 1);
         assert_eq!(cache.stats.misses, 0);
-        assert_eq!(instance2.get_gas(), TESTING_GAS_LIMIT);
+        assert_eq!(instance2.get_gas_left(), TESTING_GAS_LIMIT);
     }
 
     #[test]
@@ -491,7 +491,7 @@ mod test {
             Err(e) => panic!("unexpected error, {:?}", e),
             Ok(_) => panic!("call_init must run out of gas"),
         }
-        assert_eq!(instance1.get_gas(), 0);
+        assert_eq!(instance1.get_gas_left(), 0);
         cache.store_instance(&id, instance1).unwrap();
 
         // Init from instance cache
@@ -499,7 +499,7 @@ mod test {
         assert_eq!(cache.stats.hits_module, 1);
         assert_eq!(cache.stats.hits_instance, 1);
         assert_eq!(cache.stats.misses, 0);
-        assert_eq!(instance2.get_gas(), TESTING_GAS_LIMIT);
+        assert_eq!(instance2.get_gas_left(), TESTING_GAS_LIMIT);
 
         // Now it works
         let env2 = mock_env(&instance2.api, "owner2", &coins(500, "earth"));

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -9,7 +9,7 @@ use wasmer_runtime_core::{
     vm::Ctx,
 };
 
-use crate::backends::{compile, get_gas, set_gas};
+use crate::backends::{compile, get_gas_left, set_gas_limit};
 use crate::context::{
     move_into_context, move_out_of_context, setup_context, with_querier_from_context,
     with_storage_from_context,
@@ -135,7 +135,7 @@ where
         deps: Extern<S, A, Q>,
         gas_limit: u64,
     ) -> Self {
-        set_gas(&mut wasmer_instance, gas_limit);
+        set_gas_limit(&mut wasmer_instance, gas_limit);
         let required_features = required_features_from_wasmer_instance(&wasmer_instance);
         move_into_context(wasmer_instance.context_mut(), deps.storage, deps.querier);
         Instance {
@@ -176,7 +176,7 @@ where
 
     /// Returns the currently remaining gas
     pub fn get_gas(&self) -> u64 {
-        get_gas(&self.wasmer_instance)
+        get_gas_left(&self.wasmer_instance)
     }
 
     pub fn with_storage<F: FnOnce(&mut S) -> VmResult<T>, T>(&mut self, func: F) -> VmResult<T> {


### PR DESCRIPTION
- [x] documented and renamed `backends::*::get_gas` to `backends::*::get_gas_left`
- [x] documented and renamed `backends::*::set_gas` to `backends::*::set_gas_limit`
- [x] deprecated `Instance::get_gas` in favour of `Instance::get_gas_left`
- [x] documented `backends::singlepass::GAS_LIMIT`