### PR TITLE
Improve VM linting in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -477,20 +477,23 @@ jobs:
   clippy:
     docker:
       - image: rust:1.41.1
+    environment:
+      # Make sure to choose version with clippy present: https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu.html
+      NIGHTLY_TOOLCHAIN: nightly-2020-05-26
     steps:
       - checkout
       - run:
           name: Install Rust nightly
           command: |
             rustup --version
-            rustup toolchain install nightly --allow-downgrade --profile minimal --component clippy
+            rustup toolchain install $NIGHTLY_TOOLCHAIN --allow-downgrade --profile minimal --component clippy
             rustup target list --installed
       - run:
           name: Version information (default; stable)
           command: rustc --version && cargo --version
       - run:
           name: Version information (nightly)
-          command: rustc +nightly --version && cargo +nightly --version
+          command: rustc +$NIGHTLY_TOOLCHAIN --version && cargo +$NIGHTLY_TOOLCHAIN --version
       - restore_cache:
           keys:
             - cargocache-v2-clippy-rust:1.41.1-{{ checksum "Cargo.lock" }}
@@ -523,11 +526,11 @@ jobs:
       - run:
           name: Clippy linting on vm (no feature flags)
           working_directory: ~/project/packages/vm
-          command: cargo +nightly clippy -- -D warnings
+          command: cargo +$NIGHTLY_TOOLCHAIN clippy -- -D warnings
       - run:
           name: Clippy linting on vm (all feature flags)
           working_directory: ~/project/packages/vm
-          command: cargo +nightly clippy --features iterator -- -D warnings
+          command: cargo +$NIGHTLY_TOOLCHAIN clippy --features iterator -- -D warnings
       #
       # Contracts
       #

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -505,11 +505,19 @@ jobs:
           working_directory: ~/project/packages/schema
           command: cargo clippy -- -D warnings
       - run:
-          name: Clippy linting on std
+          name: Clippy linting on std (no feature flags)
           working_directory: ~/project/packages/std
-          command: cargo clippy --features iterator -- -D warnings
+          command: cargo clippy -- -D warnings
       - run:
-          name: Clippy linting on storage
+          name: Clippy linting on std (all feature flags)
+          working_directory: ~/project/packages/std
+          command: cargo clippy --features iterator,staking -- -D warnings
+      - run:
+          name: Clippy linting on storage (no feature flags)
+          working_directory: ~/project/packages/storage
+          command: cargo clippy -- -D warnings
+      - run:
+          name: Clippy linting on storage (all feature flags)
           working_directory: ~/project/packages/storage
           command: cargo clippy --features iterator -- -D warnings
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -480,8 +480,17 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Version information
-          command: rustc --version; cargo --version; rustup --version; rustup target list --installed
+          name: Install Rust nightly
+          command: |
+            rustup --version
+            rustup toolchain install nightly --allow-downgrade --profile minimal --component clippy
+            rustup target list --installed
+      - run:
+          name: Version information (default; stable)
+          command: rustc --version && cargo --version
+      - run:
+          name: Version information (nightly)
+          command: rustc +nightly --version && cargo +nightly --version
       - restore_cache:
           keys:
             - cargocache-v2-clippy-rust:1.41.1-{{ checksum "Cargo.lock" }}
@@ -504,9 +513,13 @@ jobs:
           working_directory: ~/project/packages/storage
           command: cargo clippy --features iterator -- -D warnings
       - run:
-          name: Clippy linting on vm (use flags for Rust stable support)
+          name: Clippy linting on vm (no feature flags)
           working_directory: ~/project/packages/vm
-          command: cargo clippy --no-default-features --features "default-cranelift iterator" -- -D warnings
+          command: cargo +nightly clippy -- -D warnings
+      - run:
+          name: Clippy linting on vm (all feature flags)
+          working_directory: ~/project/packages/vm
+          command: cargo +nightly clippy --features iterator -- -D warnings
       #
       # Contracts
       #

--- a/packages/vm/src/conversion.rs
+++ b/packages/vm/src/conversion.rs
@@ -7,13 +7,9 @@ use crate::errors::{make_conversion_err, VmResult};
 /// Safely converts input of type T to u32.
 /// Errors with a cosmwasm_vm::errors::VmError::ConversionErr if conversion cannot be done.
 pub fn to_u32<T: TryInto<u32> + Display + Copy>(input: T) -> VmResult<u32> {
-    input.try_into().or_else(|_| {
-        Err(make_conversion_err(
-            type_name::<T>(),
-            type_name::<u32>(),
-            input.to_string(),
-        ))
-    })
+    input
+        .try_into()
+        .map_err(|_| make_conversion_err(type_name::<T>(), type_name::<u32>(), input.to_string()))
 }
 
 /// Safely converts input of type T to i32.
@@ -22,13 +18,9 @@ pub fn to_u32<T: TryInto<u32> + Display + Copy>(input: T) -> VmResult<u32> {
 /// Used in tests and in iterator, but not with default build
 #[allow(dead_code)]
 pub fn to_i32<T: TryInto<i32> + Display + Copy>(input: T) -> VmResult<i32> {
-    input.try_into().or_else(|_| {
-        Err(make_conversion_err(
-            type_name::<T>(),
-            type_name::<i32>(),
-            input.to_string(),
-        ))
-    })
+    input
+        .try_into()
+        .map_err(|_| make_conversion_err(type_name::<T>(), type_name::<i32>(), input.to_string()))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Recently I ran into undetected issues where imports were unused without the iterator feature. With this change, clippy detects those cases.

Also use clippy from nightly to be closer to the default VM build environment.