### PR TITLE
"Nicer" Response constructors

### DIFF
--- a/packages/std/src/encoding.rs
+++ b/packages/std/src/encoding.rs
@@ -48,6 +48,12 @@ impl From<&[u8]> for Binary {
     }
 }
 
+impl From<Vec<u8>> for Binary {
+    fn from(vec: Vec<u8>) -> Self {
+        Self(vec)
+    }
+}
+
 /// Serializes as a base64 string
 impl Serialize for Binary {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>


### PR DESCRIPTION
This is a sketch of another API that might help make handlers less daunting, especially if most fields are empty. I show two versions of this (chaining and mutating) and want to get some feedback.

This can be rejected or polished depending on reaction. And the same API is definitely needed in `HandleResponse` (which would be used more, I just wanted to demo with one).