### PR TITLE
Add migrate entry point to hackatom

### DIFF
--- a/contracts/hackatom/examples/schema.rs
+++ b/contracts/hackatom/examples/schema.rs
@@ -4,7 +4,7 @@ use std::fs::create_dir_all;
 use cosmwasm_schema::{export_schema, remove_schemas, schema_for};
 use cosmwasm_std::BalanceResponse;
 
-use hackatom::contract::{HandleMsg, InitMsg, QueryMsg, State, VerifierResponse};
+use hackatom::contract::{HandleMsg, InitMsg, MigrateMsg, QueryMsg, State, VerifierResponse};
 
 fn main() {
     let mut out_dir = current_dir().unwrap();
@@ -14,6 +14,7 @@ fn main() {
 
     export_schema(&schema_for!(InitMsg), &out_dir);
     export_schema(&schema_for!(HandleMsg), &out_dir);
+    export_schema(&schema_for!(MigrateMsg), &out_dir);
     export_schema(&schema_for!(QueryMsg), &out_dir);
     export_schema(&schema_for!(State), &out_dir);
     export_schema(&schema_for!(VerifierResponse), &out_dir);

--- a/contracts/hackatom/schema/migrate_msg.json
+++ b/contracts/hackatom/schema/migrate_msg.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "MigrateMsg",
+  "description": "MigrateMsg allows a priviledged contract administrator to run a migration on the contract. In this (demo) case it is just migrating from one hackatom code to the same code, but taking advantage of the migration step to set a new validator.\n\nNote that the contract doesn't enforce permissions here, this is done by blockchain logic (in the future by blockchain governance)",
   "type": "object",
   "required": [
     "verifier"

--- a/contracts/hackatom/schema/migrate_msg.json
+++ b/contracts/hackatom/schema/migrate_msg.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "MigrateMsg",
+  "type": "object",
+  "required": [
+    "verifier"
+  ],
+  "properties": {
+    "verifier": {
+      "$ref": "#/definitions/HumanAddr"
+    }
+  },
+  "definitions": {
+    "HumanAddr": {
+      "type": "string"
+    }
+  }
+}

--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use cosmwasm_std::{
     from_slice, generic_err, log, not_found, to_binary, to_vec, unauthorized, AllBalanceResponse,
     Api, BankMsg, Binary, CanonicalAddr, Env, Extern, HandleResponse, HumanAddr, InitResponse,
-    Querier, QueryResponse, StdResult, Storage,
+    MigrateResponse, Querier, QueryResponse, StdResult, Storage,
 };
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -81,7 +81,7 @@ pub fn migrate<S: Storage, A: Api, Q: Querier>(
     deps: &mut Extern<S, A, Q>,
     _env: Env,
     msg: MigrateMsg,
-) -> StdResult<InitResponse> {
+) -> StdResult<MigrateResponse> {
     let data = deps
         .storage
         .get(CONFIG_KEY)
@@ -89,7 +89,7 @@ pub fn migrate<S: Storage, A: Api, Q: Querier>(
     let mut config: State = from_slice(&data)?;
     config.verifier = deps.api.canonical_address(&msg.verifier)?;
     deps.storage.set(CONFIG_KEY, &to_vec(&config)?)?;
-    Ok(InitResponse::default())
+    Ok(MigrateResponse::default())
 }
 
 pub fn handle<S: Storage, A: Api, Q: Querier>(

--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -13,6 +13,13 @@ pub struct InitMsg {
     pub beneficiary: HumanAddr,
 }
 
+/// MigrateMsg allows a priviledged contract administrator to run
+/// a migration on the contract. In this (demo) case it is just migrating
+/// from one hackatom code to the same code, but taking advantage of the
+/// migration step to set a new validator.
+///
+/// Note that the contract doesn't enforce permissions here, this is done
+/// by blockchain logic (in the future by blockchain governance)
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct MigrateMsg {
     pub verifier: HumanAddr,

--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -95,7 +95,7 @@ pub fn migrate<S: Storage, A: Api, Q: Querier>(
         .ok_or_else(|| not_found("State"))?;
     let mut config: State = from_slice(&data)?;
     config.verifier = deps.api.canonical_address(&msg.verifier)?;
-    deps.storage.set(CONFIG_KEY, &to_vec(&config)?)?;
+    deps.storage.set(CONFIG_KEY, &to_vec(&config)?);
     Ok(MigrateResponse::default())
 }
 

--- a/contracts/hackatom/src/lib.rs
+++ b/contracts/hackatom/src/lib.rs
@@ -4,7 +4,7 @@ pub mod contract;
 mod wasm {
     use super::contract;
     use cosmwasm_std::{
-        do_handle, do_init, do_query, ExternalApi, ExternalQuerier, ExternalStorage,
+        do_handle, do_init, do_migrate, do_query, ExternalApi, ExternalQuerier, ExternalStorage,
     };
 
     #[no_mangle]
@@ -20,6 +20,15 @@ mod wasm {
     extern "C" fn handle(env_ptr: u32, msg_ptr: u32) -> u32 {
         do_handle(
             &contract::handle::<ExternalStorage, ExternalApi, ExternalQuerier>,
+            env_ptr,
+            msg_ptr,
+        )
+    }
+
+    #[no_mangle]
+    extern "C" fn migrate(env_ptr: u32, msg_ptr: u32) -> u32 {
+        do_migrate(
+            &contract::migrate::<ExternalStorage, ExternalApi, ExternalQuerier>,
             env_ptr,
             msg_ptr,
         )

--- a/packages/std/examples/schema.rs
+++ b/packages/std/examples/schema.rs
@@ -2,7 +2,7 @@ use std::env::current_dir;
 use std::fs::create_dir_all;
 
 use cosmwasm_schema::{export_schema, export_schema_with_title, schema_for};
-use cosmwasm_std::{CosmosMsg, Env, HandleResult, InitResult, QueryResult};
+use cosmwasm_std::{CosmosMsg, Env, HandleResult, InitResult, MigrateResult, QueryResult};
 
 fn main() {
     let mut out_dir = current_dir().unwrap();
@@ -13,5 +13,6 @@ fn main() {
     export_schema(&schema_for!(CosmosMsg), &out_dir);
     export_schema_with_title(&mut schema_for!(InitResult), &out_dir, "InitResult");
     export_schema_with_title(&mut schema_for!(HandleResult), &out_dir, "HandleResult");
+    export_schema_with_title(&mut schema_for!(MigrateResult), &out_dir, "MigrateResult");
     export_schema_with_title(&mut schema_for!(QueryResult), &out_dir, "QueryResult");
 }

--- a/packages/std/schema/migrate_result.json
+++ b/packages/std/schema/migrate_result.json
@@ -1,0 +1,555 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "MigrateResult",
+  "oneOf": [
+    {
+      "type": "object",
+      "required": [
+        "Ok"
+      ],
+      "properties": {
+        "Ok": {
+          "$ref": "#/definitions/MigrateResponse_for_Never"
+        }
+      }
+    },
+    {
+      "type": "object",
+      "required": [
+        "Err"
+      ],
+      "properties": {
+        "Err": {
+          "$ref": "#/definitions/StdError"
+        }
+      }
+    }
+  ],
+  "definitions": {
+    "BankMsg": {
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "send"
+          ],
+          "properties": {
+            "send": {
+              "type": "object",
+              "required": [
+                "amount",
+                "from_address",
+                "to_address"
+              ],
+              "properties": {
+                "amount": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Coin"
+                  }
+                },
+                "from_address": {
+                  "$ref": "#/definitions/HumanAddr"
+                },
+                "to_address": {
+                  "$ref": "#/definitions/HumanAddr"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "Binary": {
+      "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>",
+      "type": "string"
+    },
+    "Coin": {
+      "type": "object",
+      "required": [
+        "amount",
+        "denom"
+      ],
+      "properties": {
+        "amount": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "denom": {
+          "type": "string"
+        }
+      }
+    },
+    "CosmosMsg_for_Never": {
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "bank"
+          ],
+          "properties": {
+            "bank": {
+              "$ref": "#/definitions/BankMsg"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "custom"
+          ],
+          "properties": {
+            "custom": {
+              "$ref": "#/definitions/Never"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "staking"
+          ],
+          "properties": {
+            "staking": {
+              "$ref": "#/definitions/StakingMsg"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "wasm"
+          ],
+          "properties": {
+            "wasm": {
+              "$ref": "#/definitions/WasmMsg"
+            }
+          }
+        }
+      ]
+    },
+    "HumanAddr": {
+      "type": "string"
+    },
+    "LogAttribute": {
+      "type": "object",
+      "required": [
+        "key",
+        "value"
+      ],
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    },
+    "MigrateResponse_for_Never": {
+      "type": "object",
+      "required": [
+        "log",
+        "messages"
+      ],
+      "properties": {
+        "data": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Binary"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "log": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LogAttribute"
+          }
+        },
+        "messages": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CosmosMsg_for_Never"
+          }
+        }
+      }
+    },
+    "Never": {
+      "description": "Never can never be instantiated and is a no-op placeholder for unsupported enums, such as contracts that don't set a custom message.",
+      "enum": []
+    },
+    "StakingMsg": {
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "delegate"
+          ],
+          "properties": {
+            "delegate": {
+              "type": "object",
+              "required": [
+                "amount",
+                "validator"
+              ],
+              "properties": {
+                "amount": {
+                  "$ref": "#/definitions/Coin"
+                },
+                "validator": {
+                  "$ref": "#/definitions/HumanAddr"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "undelegate"
+          ],
+          "properties": {
+            "undelegate": {
+              "type": "object",
+              "required": [
+                "amount",
+                "validator"
+              ],
+              "properties": {
+                "amount": {
+                  "$ref": "#/definitions/Coin"
+                },
+                "validator": {
+                  "$ref": "#/definitions/HumanAddr"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "withdraw"
+          ],
+          "properties": {
+            "withdraw": {
+              "type": "object",
+              "required": [
+                "validator"
+              ],
+              "properties": {
+                "recipient": {
+                  "description": "this is the \"withdraw address\", the one that should receive the rewards if None, then use delegator address",
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/HumanAddr"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "validator": {
+                  "$ref": "#/definitions/HumanAddr"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "redelegate"
+          ],
+          "properties": {
+            "redelegate": {
+              "type": "object",
+              "required": [
+                "amount",
+                "dst_validator",
+                "src_validator"
+              ],
+              "properties": {
+                "amount": {
+                  "$ref": "#/definitions/Coin"
+                },
+                "dst_validator": {
+                  "$ref": "#/definitions/HumanAddr"
+                },
+                "src_validator": {
+                  "$ref": "#/definitions/HumanAddr"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "StdError": {
+      "description": "Structured error type for init, handle and query.\n\nThis can be serialized and passed over the Wasm/VM boundary, which allows us to use structured error types in e.g. integration tests. In that process backtraces are stripped off.\n\nThe prefix \"Std\" means \"the standard error within the standard library\". This is not the only result/error type in cosmwasm-std.\n\nWhen new cases are added, they should describe the problem rather than what was attempted (e.g. InvalidBase64 is preferred over Base64DecodingErr). In the long run this allows us to get rid of the duplication in \"StdError::FooErr\".\n\nChecklist for adding a new error: - Add enum case - Add to PartialEq implementation - Add serialize/deserialize test - Add creator function in std_error_helpers.rs - Regenerate schemas",
+      "anyOf": [
+        {
+          "description": "Whenever there is no specific error type available",
+          "type": "object",
+          "required": [
+            "generic_err"
+          ],
+          "properties": {
+            "generic_err": {
+              "type": "object",
+              "required": [
+                "msg"
+              ],
+              "properties": {
+                "msg": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "invalid_base64"
+          ],
+          "properties": {
+            "invalid_base64": {
+              "type": "object",
+              "required": [
+                "msg"
+              ],
+              "properties": {
+                "msg": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "Whenever UTF-8 bytes cannot be decoded into a unicode string, e.g. in String::from_utf8 or str::from_utf8.",
+          "type": "object",
+          "required": [
+            "invalid_utf8"
+          ],
+          "properties": {
+            "invalid_utf8": {
+              "type": "object",
+              "required": [
+                "msg"
+              ],
+              "properties": {
+                "msg": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "not_found"
+          ],
+          "properties": {
+            "not_found": {
+              "type": "object",
+              "required": [
+                "kind"
+              ],
+              "properties": {
+                "kind": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "null_pointer"
+          ],
+          "properties": {
+            "null_pointer": {
+              "type": "object"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "parse_err"
+          ],
+          "properties": {
+            "parse_err": {
+              "type": "object",
+              "required": [
+                "msg",
+                "target"
+              ],
+              "properties": {
+                "msg": {
+                  "type": "string"
+                },
+                "target": {
+                  "description": "the target type that was attempted",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "serialize_err"
+          ],
+          "properties": {
+            "serialize_err": {
+              "type": "object",
+              "required": [
+                "msg",
+                "source"
+              ],
+              "properties": {
+                "msg": {
+                  "type": "string"
+                },
+                "source": {
+                  "description": "the source type that was attempted",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "unauthorized"
+          ],
+          "properties": {
+            "unauthorized": {
+              "type": "object"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "underflow"
+          ],
+          "properties": {
+            "underflow": {
+              "type": "object",
+              "required": [
+                "minuend",
+                "subtrahend"
+              ],
+              "properties": {
+                "minuend": {
+                  "type": "string"
+                },
+                "subtrahend": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "Uint128": {
+      "type": "string"
+    },
+    "WasmMsg": {
+      "anyOf": [
+        {
+          "description": "this dispatches a call to another contract at a known address (with known ABI)",
+          "type": "object",
+          "required": [
+            "execute"
+          ],
+          "properties": {
+            "execute": {
+              "type": "object",
+              "required": [
+                "contract_addr",
+                "msg",
+                "send"
+              ],
+              "properties": {
+                "contract_addr": {
+                  "$ref": "#/definitions/HumanAddr"
+                },
+                "msg": {
+                  "description": "msg is the json-encoded HandleMsg struct (as raw Binary)",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  ]
+                },
+                "send": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Coin"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "this instantiates a new contracts from previously uploaded wasm code",
+          "type": "object",
+          "required": [
+            "instantiate"
+          ],
+          "properties": {
+            "instantiate": {
+              "type": "object",
+              "required": [
+                "code_id",
+                "msg",
+                "send"
+              ],
+              "properties": {
+                "code_id": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                },
+                "label": {
+                  "description": "optional human-readbale label for the contract",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "msg": {
+                  "description": "msg is the json-encoded InitMsg struct (as raw Binary)",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  ]
+                },
+                "send": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Coin"
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/packages/std/src/exports.rs
+++ b/packages/std/src/exports.rs
@@ -17,9 +17,7 @@ use crate::imports::{ExternalApi, ExternalQuerier, ExternalStorage};
 use crate::memory::{alloc, consume_region, release_buffer};
 use crate::serde::{from_slice, to_vec};
 use crate::traits::Extern;
-use crate::{
-    Env, HandleResponse, HandleResult, InitResponse, InitResult, QueryResponse, QueryResult,
-};
+use crate::{Env, HandleResult, InitResult, MigrateResult, QueryResponse, QueryResult};
 
 #[cfg(feature = "staking")]
 #[no_mangle]
@@ -53,7 +51,7 @@ pub fn do_init<T, U>(
         &mut Extern<ExternalStorage, ExternalApi, ExternalQuerier>,
         Env,
         T,
-    ) -> StdResult<InitResponse<U>>,
+    ) -> InitResult<U>,
     env_ptr: u32,
     msg_ptr: u32,
 ) -> u32
@@ -72,7 +70,7 @@ pub fn do_handle<T, U>(
         &mut Extern<ExternalStorage, ExternalApi, ExternalQuerier>,
         Env,
         T,
-    ) -> StdResult<HandleResponse<U>>,
+    ) -> HandleResult<U>,
     env_ptr: u32,
     msg_ptr: u32,
 ) -> u32
@@ -105,7 +103,7 @@ pub fn do_migrate<T, U>(
         &mut Extern<ExternalStorage, ExternalApi, ExternalQuerier>,
         Env,
         T,
-    ) -> StdResult<InitResponse<U>>,
+    ) -> MigrateResult<U>,
     env_ptr: u32,
     msg_ptr: u32,
 ) -> u32
@@ -113,7 +111,7 @@ where
     T: DeserializeOwned + JsonSchema,
     U: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
 {
-    let res: InitResult<U> =
+    let res: MigrateResult<U> =
         _do_migrate(migrate_fn, env_ptr as *mut c_void, msg_ptr as *mut c_void);
     let v = to_vec(&res).unwrap();
     release_buffer(v) as u32
@@ -124,10 +122,10 @@ fn _do_init<T, U>(
         &mut Extern<ExternalStorage, ExternalApi, ExternalQuerier>,
         Env,
         T,
-    ) -> StdResult<InitResponse<U>>,
+    ) -> InitResult<U>,
     env_ptr: *mut c_void,
     msg_ptr: *mut c_void,
-) -> StdResult<InitResponse<U>>
+) -> InitResult<U>
 where
     T: DeserializeOwned + JsonSchema,
     U: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
@@ -145,10 +143,10 @@ fn _do_handle<T, U>(
         &mut Extern<ExternalStorage, ExternalApi, ExternalQuerier>,
         Env,
         T,
-    ) -> StdResult<HandleResponse<U>>,
+    ) -> HandleResult<U>,
     env_ptr: *mut c_void,
     msg_ptr: *mut c_void,
-) -> StdResult<HandleResponse<U>>
+) -> HandleResult<U>
 where
     T: DeserializeOwned + JsonSchema,
     U: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
@@ -181,10 +179,10 @@ fn _do_migrate<T, U>(
         &mut Extern<ExternalStorage, ExternalApi, ExternalQuerier>,
         Env,
         T,
-    ) -> StdResult<InitResponse<U>>,
+    ) -> MigrateResult<U>,
     env_ptr: *mut c_void,
     msg_ptr: *mut c_void,
-) -> StdResult<InitResponse<U>>
+) -> MigrateResult<U>
 where
     T: DeserializeOwned + JsonSchema,
     U: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,

--- a/packages/std/src/init_handle.rs
+++ b/packages/std/src/init_handle.rs
@@ -169,6 +169,32 @@ where
     }
 }
 
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct MigrateResponse<T = Never>
+where
+    T: Clone + fmt::Debug + PartialEq + JsonSchema,
+{
+    // let's make the positive case a struct, it contrains Msg: {...}, but also Data, Log, maybe later Events, etc.
+    pub messages: Vec<CosmosMsg<T>>,
+    pub log: Vec<LogAttribute>, // abci defines this as string
+    pub data: Option<Binary>,   // abci defines this as bytes
+}
+
+pub type MigrateResult<U = Never> = StdResult<MigrateResponse<U>>;
+
+impl<T> Default for MigrateResponse<T>
+where
+    T: Clone + fmt::Debug + PartialEq + JsonSchema,
+{
+    fn default() -> Self {
+        MigrateResponse {
+            messages: vec![],
+            log: vec![],
+            data: None,
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -48,7 +48,7 @@ mod imports;
 mod memory; // Used by exports and imports only. This assumes pointers are 32 bit long, which makes it untestable on dev machines.
 
 #[cfg(target_arch = "wasm32")]
-pub use crate::exports::{do_handle, do_init, do_query};
+pub use crate::exports::{do_handle, do_init, do_migrate, do_query};
 #[cfg(target_arch = "wasm32")]
 pub use crate::imports::{ExternalApi, ExternalQuerier, ExternalStorage};
 

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -21,7 +21,7 @@ pub use crate::errors::{
 };
 pub use crate::init_handle::{
     log, BankMsg, CosmosMsg, HandleResponse, HandleResult, InitResponse, InitResult, LogAttribute,
-    StakingMsg, WasmMsg,
+    MigrateResponse, MigrateResult, StakingMsg, WasmMsg,
 };
 #[cfg(feature = "iterator")]
 pub use crate::iterator::{Order, KV};


### PR DESCRIPTION
closes #386 

TODO:

- [x] Add migrate helpers to `std/export.rs`
- [x] Expose migrate in `hackatom`
- [x] Use `MigrateResult` instead of `InitResult`
- [x] Regenerate schemas
- [x] Unit test migrate call (rust, not wasm in vm)