### PR TITLE
Always set readonly mode

### DIFF
--- a/packages/vm/src/calls.rs
+++ b/packages/vm/src/calls.rs
@@ -73,6 +73,7 @@ pub fn call_init_raw<S: Storage + 'static, A: Api + 'static, Q: Querier + 'stati
     env: &[u8],
     msg: &[u8],
 ) -> VmResult<Vec<u8>> {
+    instance.set_storage_readonly(false);
     call_raw(instance, "init", &[env, msg], MAX_LENGTH_INIT)
 }
 
@@ -83,6 +84,7 @@ pub fn call_handle_raw<S: Storage + 'static, A: Api + 'static, Q: Querier + 'sta
     env: &[u8],
     msg: &[u8],
 ) -> VmResult<Vec<u8>> {
+    instance.set_storage_readonly(false);
     call_raw(instance, "handle", &[env, msg], MAX_LENGTH_HANDLE)
 }
 

--- a/packages/vm/src/context.rs
+++ b/packages/vm/src/context.rs
@@ -39,7 +39,7 @@ pub fn setup_context<S: Storage, Q: Querier>() -> (*mut c_void, fn(*mut c_void))
 fn create_unmanaged_context_data<S: Storage, Q: Querier>() -> *mut c_void {
     let data = ContextData::<S, Q> {
         storage: None,
-        storage_readonly: false, // TODO: Change this default to true in 0.9 for extra safety
+        storage_readonly: true,
         querier: None,
         #[cfg(feature = "iterator")]
         iterators: HashMap::new(),
@@ -292,12 +292,12 @@ mod test {
     }
 
     #[test]
-    fn is_storage_readonly_defaults_to_false() {
+    fn is_storage_readonly_defaults_to_true() {
         let mut instance = make_instance();
         let ctx = instance.context_mut();
         leave_default_data(ctx);
 
-        assert_eq!(is_storage_readonly::<MS, MQ>(ctx), false);
+        assert_eq!(is_storage_readonly::<MS, MQ>(ctx), true);
     }
 
     #[test]
@@ -307,16 +307,16 @@ mod test {
         leave_default_data(ctx);
 
         // change
-        set_storage_readonly::<MS, MQ>(ctx, true);
-        assert_eq!(is_storage_readonly::<MS, MQ>(ctx), true);
-
-        // still true
-        set_storage_readonly::<MS, MQ>(ctx, true);
-        assert_eq!(is_storage_readonly::<MS, MQ>(ctx), true);
-
-        // change back
         set_storage_readonly::<MS, MQ>(ctx, false);
         assert_eq!(is_storage_readonly::<MS, MQ>(ctx), false);
+
+        // still false
+        set_storage_readonly::<MS, MQ>(ctx, false);
+        assert_eq!(is_storage_readonly::<MS, MQ>(ctx), false);
+
+        // change back
+        set_storage_readonly::<MS, MQ>(ctx, true);
+        assert_eq!(is_storage_readonly::<MS, MQ>(ctx), true);
     }
 
     #[test]

--- a/packages/vm/src/imports.rs
+++ b/packages/vm/src/imports.rs
@@ -342,7 +342,8 @@ mod test {
                 "humanize_address" => Func::new(|_a: i32, _b: i32| -> i32 { 0 }),
             },
         };
-        let instance = Box::from(module.instantiate(&import_obj).unwrap());
+        let mut instance = Box::from(module.instantiate(&import_obj).unwrap());
+        set_storage_readonly::<MS, MQ>(instance.context_mut(), false);
         instance
     }
 

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -189,6 +189,9 @@ where
         self.get_gas_left()
     }
 
+    /// Sets the readonly storage flag on this instance. Since one instance can be used
+    /// for multiple calls in integration tests, this should be set to the desired value
+    /// right before every call.
     pub fn set_storage_readonly(&mut self, new_value: bool) {
         set_storage_readonly::<S, Q>(self.inner.context_mut(), new_value);
     }

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -454,18 +454,6 @@ mod test {
 
         assert_eq!(
             is_storage_readonly::<MS, MQ>(instance.inner.context()),
-            false
-        );
-
-        instance.set_storage_readonly(true);
-        assert_eq!(
-            is_storage_readonly::<MS, MQ>(instance.inner.context()),
-            true
-        );
-
-        instance.set_storage_readonly(true);
-        assert_eq!(
-            is_storage_readonly::<MS, MQ>(instance.inner.context()),
             true
         );
 
@@ -473,6 +461,18 @@ mod test {
         assert_eq!(
             is_storage_readonly::<MS, MQ>(instance.inner.context()),
             false
+        );
+
+        instance.set_storage_readonly(false);
+        assert_eq!(
+            is_storage_readonly::<MS, MQ>(instance.inner.context()),
+            false
+        );
+
+        instance.set_storage_readonly(true);
+        assert_eq!(
+            is_storage_readonly::<MS, MQ>(instance.inner.context()),
+            true
         );
     }
 


### PR DESCRIPTION
In #402 a bug was created: when you use an instance for query first and then for a writing access like handle, an access denied error is created.

On master we don't have such a case in this repo. After merging master into 0.9, the new test cases reveal the bug which is why 0.9 is failing at the moment.

The reusing of an instance in tests makes #404 basically impossible.