### PR TITLE
Unify VmError constructors

### DIFF
--- a/packages/vm/src/calls.rs
+++ b/packages/vm/src/calls.rs
@@ -6,7 +6,7 @@ use cosmwasm_std::{
     StdResult,
 };
 
-use crate::errors::{make_generic_err, VmResult};
+use crate::errors::{VmError, VmResult};
 use crate::instance::{Func, Instance};
 use crate::serde::{from_slice, to_vec};
 use crate::traits::{Api, Querier, Storage};
@@ -59,8 +59,9 @@ pub fn call_query<S: Storage + 'static, A: Api + 'static, Q: Querier + 'static>(
 
     // Ensure query response is valid JSON
     if let Ok(binary_response) = &result {
-        serde_json::from_slice::<serde_json::Value>(binary_response.as_slice())
-            .map_err(|e| make_generic_err(format!("Query response must be valid JSON. {}", e)))?;
+        serde_json::from_slice::<serde_json::Value>(binary_response.as_slice()).map_err(|e| {
+            VmError::generic_err(format!("Query response must be valid JSON. {}", e))
+        })?;
     }
 
     Ok(result)

--- a/packages/vm/src/checksum.rs
+++ b/packages/vm/src/checksum.rs
@@ -2,7 +2,7 @@ use std::convert::TryFrom;
 
 use sha2::{Digest, Sha256};
 
-use crate::errors::{make_cache_err, VmError};
+use crate::errors::VmError;
 
 /// A SHA-256 checksum of a Wasm blob, used to identify a Wasm code.
 /// This must remain stable since this checksum is stored in the blockchain state.
@@ -34,7 +34,7 @@ impl TryFrom<&[u8]> for Checksum {
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         if value.len() != 32 {
-            return Err(make_cache_err("Checksum not of length 32"));
+            return Err(VmError::cache_err("Checksum not of length 32"));
         }
         let mut data = [0u8; 32];
         data.copy_from_slice(value);

--- a/packages/vm/src/context.rs
+++ b/packages/vm/src/context.rs
@@ -13,8 +13,8 @@ use wasmer_runtime_core::vm::Ctx;
 use cosmwasm_std::KV;
 
 #[cfg(feature = "iterator")]
-use crate::errors::{make_iterator_does_not_exist, FfiResult};
-use crate::errors::{make_uninitialized_context_data, VmResult};
+use crate::errors::FfiResult;
+use crate::errors::{VmError, VmResult};
 use crate::traits::{Querier, Storage};
 
 /** context data **/
@@ -171,7 +171,7 @@ where
     let b = get_context_data_mut::<S, Q>(ctx);
     match b.storage.as_mut() {
         Some(data) => func(data),
-        None => Err(make_uninitialized_context_data("storage")),
+        None => Err(VmError::uninitialized_context_data("storage")),
     }
 }
 
@@ -187,7 +187,7 @@ where
     let b = get_context_data_mut::<S, Q>(ctx);
     match b.querier.as_mut() {
         Some(q) => func(q),
-        None => Err(make_uninitialized_context_data("querier")),
+        None => Err(VmError::uninitialized_context_data("querier")),
     }
 }
 
@@ -205,7 +205,7 @@ where
     let b = get_context_data_mut::<S, Q>(ctx);
     match b.iterators.get_mut(&iterator_id) {
         Some(iterator) => func(iterator),
-        None => Err(make_iterator_does_not_exist(iterator_id)),
+        None => Err(VmError::iterator_does_not_exist(iterator_id)),
     }
 }
 

--- a/packages/vm/src/conversion.rs
+++ b/packages/vm/src/conversion.rs
@@ -2,14 +2,14 @@ use std::any::type_name;
 use std::convert::TryInto;
 use std::fmt::Display;
 
-use crate::errors::{make_conversion_err, VmResult};
+use crate::errors::{VmError, VmResult};
 
 /// Safely converts input of type T to u32.
 /// Errors with a cosmwasm_vm::errors::VmError::ConversionErr if conversion cannot be done.
 pub fn to_u32<T: TryInto<u32> + Display + Copy>(input: T) -> VmResult<u32> {
-    input
-        .try_into()
-        .map_err(|_| make_conversion_err(type_name::<T>(), type_name::<u32>(), input.to_string()))
+    input.try_into().map_err(|_| {
+        VmError::conversion_err(type_name::<T>(), type_name::<u32>(), input.to_string())
+    })
 }
 
 /// Safely converts input of type T to i32.
@@ -18,9 +18,9 @@ pub fn to_u32<T: TryInto<u32> + Display + Copy>(input: T) -> VmResult<u32> {
 /// Used in tests and in iterator, but not with default build
 #[allow(dead_code)]
 pub fn to_i32<T: TryInto<i32> + Display + Copy>(input: T) -> VmResult<i32> {
-    input
-        .try_into()
-        .map_err(|_| make_conversion_err(type_name::<T>(), type_name::<i32>(), input.to_string()))
+    input.try_into().map_err(|_| {
+        VmError::conversion_err(type_name::<T>(), type_name::<i32>(), input.to_string())
+    })
 }
 
 #[cfg(test)]

--- a/packages/vm/src/errors.rs
+++ b/packages/vm/src/errors.rs
@@ -277,26 +277,26 @@ mod test {
 
     #[test]
     fn vm_error_cache_err_works() {
-        let err = VmError::cache_err("something went wrong");
-        match err {
+        let error = VmError::cache_err("something went wrong");
+        match error {
             VmError::CacheErr { msg, .. } => assert_eq!(msg, "something went wrong"),
-            _ => panic!("Unexpected error"),
+            e => panic!("Unexpected error: {:?}", e),
         }
     }
 
     #[test]
     fn vm_error_compile_err_works() {
-        let err = VmError::compile_err("something went wrong");
-        match err {
+        let error = VmError::compile_err("something went wrong");
+        match error {
             VmError::CompileErr { msg, .. } => assert_eq!(msg, "something went wrong"),
-            _ => panic!("Unexpected error"),
+            e => panic!("Unexpected error: {:?}", e),
         }
     }
 
     #[test]
     fn vm_error_conversion_err_works() {
-        let err = VmError::conversion_err("i32", "u32", "-9");
-        match err {
+        let error = VmError::conversion_err("i32", "u32", "-9");
+        match error {
             VmError::ConversionErr {
                 from_type,
                 to_type,
@@ -307,7 +307,7 @@ mod test {
                 assert_eq!(to_type, "u32");
                 assert_eq!(input, "-9");
             }
-            _ => panic!("Unexpected error"),
+            e => panic!("Unexpected error: {:?}", e),
         }
     }
 
@@ -319,35 +319,35 @@ mod test {
             VmError::GenericErr { msg, .. } => {
                 assert_eq!(msg, String::from("7 is too low"));
             }
-            e => panic!("unexpected error, {:?}", e),
+            e => panic!("Unexpected error: {:?}", e),
         }
     }
 
     #[test]
     fn vm_error_instantiation_err_works() {
-        let err = VmError::instantiation_err("something went wrong");
-        match err {
+        let error = VmError::instantiation_err("something went wrong");
+        match error {
             VmError::InstantiationErr { msg, .. } => assert_eq!(msg, "something went wrong"),
-            _ => panic!("Unexpected error"),
+            e => panic!("Unexpected error: {:?}", e),
         }
     }
 
     #[test]
     fn vm_error_integrity_err_works() {
-        let err = VmError::integrity_err();
-        match err {
+        let error = VmError::integrity_err();
+        match error {
             VmError::IntegrityErr { .. } => {}
-            _ => panic!("Unexpected error"),
+            e => panic!("Unexpected error: {:?}", e),
         }
     }
 
     #[test]
     #[cfg(feature = "iterator")]
     fn vm_error_iterator_does_not_exist_works() {
-        let err = VmError::iterator_does_not_exist(15);
-        match err {
+        let error = VmError::iterator_does_not_exist(15);
+        match error {
             VmError::IteratorDoesNotExist { id, .. } => assert_eq!(id, 15),
-            _ => panic!("Unexpected error"),
+            e => panic!("Unexpected error: {:?}", e),
         }
     }
 
@@ -359,7 +359,7 @@ mod test {
                 assert_eq!(target, "Book");
                 assert_eq!(msg, "Missing field: title");
             }
-            _ => panic!("expect different error"),
+            e => panic!("Unexpected error: {:?}", e),
         }
     }
 
@@ -371,7 +371,7 @@ mod test {
                 assert_eq!(source, "Book");
                 assert_eq!(msg, "Content too long");
             }
-            _ => panic!("expect different error"),
+            e => panic!("Unexpected error: {:?}", e),
         }
     }
 
@@ -380,42 +380,42 @@ mod test {
         let error = VmError::resolve_err("function has different signature");
         match error {
             VmError::ResolveErr { msg, .. } => assert_eq!(msg, "function has different signature"),
-            _ => panic!("expect different error"),
+            e => panic!("Unexpected error: {:?}", e),
         }
     }
 
     #[test]
     fn vm_error_region_length_too_big_works() {
-        let err = VmError::region_length_too_big(50, 20);
-        match err {
+        let error = VmError::region_length_too_big(50, 20);
+        match error {
             VmError::RegionLengthTooBig {
                 length, max_length, ..
             } => {
                 assert_eq!(length, 50);
                 assert_eq!(max_length, 20);
             }
-            _ => panic!("Unexpected error"),
+            e => panic!("Unexpected error: {:?}", e),
         }
     }
 
     #[test]
     fn vm_error_region_too_small_works() {
-        let err = VmError::region_too_small(12, 33);
-        match err {
+        let error = VmError::region_too_small(12, 33);
+        match error {
             VmError::RegionTooSmall { size, required, .. } => {
                 assert_eq!(size, 12);
                 assert_eq!(required, 33);
             }
-            _ => panic!("Unexpected error"),
+            e => panic!("Unexpected error: {:?}", e),
         }
     }
 
     #[test]
     fn vm_error_runtime_err_works() {
-        let err = VmError::runtime_err("something went wrong");
-        match err {
+        let error = VmError::runtime_err("something went wrong");
+        match error {
             VmError::RuntimeErr { msg, .. } => assert_eq!(msg, "something went wrong"),
-            _ => panic!("Unexpected error"),
+            e => panic!("Unexpected error: {:?}", e),
         }
     }
 
@@ -424,23 +424,23 @@ mod test {
         let error = VmError::static_validation_err("export xy missing");
         match error {
             VmError::StaticValidationErr { msg, .. } => assert_eq!(msg, "export xy missing"),
-            _ => panic!("expect different error"),
+            e => panic!("Unexpected error: {:?}", e),
         }
     }
 
     #[test]
     fn vm_error_uninitialized_context_data_works() {
-        let err = VmError::uninitialized_context_data("foo");
-        match err {
+        let error = VmError::uninitialized_context_data("foo");
+        match error {
             VmError::UninitializedContextData { kind, .. } => assert_eq!(kind, "foo"),
-            _ => panic!("Unexpected error"),
+            e => panic!("Unexpected error: {:?}", e),
         }
     }
 
     #[test]
     fn vm_error_write_access_denied() {
-        let err = VmError::write_access_denied();
-        match err {
+        let error = VmError::write_access_denied();
+        match error {
             VmError::WriteAccessDenied { .. } => {}
             e => panic!("Unexpected error: {:?}", e),
         }
@@ -450,37 +450,37 @@ mod test {
 
     #[test]
     fn ffi_error_foreign_panic() {
-        let err = FfiError::foreign_panic();
-        match err {
+        let error = FfiError::foreign_panic();
+        match error {
             FfiError::ForeignPanic { .. } => {}
-            _ => panic!("Unexpected error"),
+            e => panic!("Unexpected error: {:?}", e),
         }
     }
 
     #[test]
     fn ffi_error_bad_argument() {
-        let err = FfiError::bad_argument();
-        match err {
+        let error = FfiError::bad_argument();
+        match error {
             FfiError::BadArgument { .. } => {}
-            _ => panic!("Unexpected error"),
+            e => panic!("Unexpected error: {:?}", e),
         }
     }
 
     #[test]
     fn ffi_error_out_of_gas() {
-        let err = FfiError::out_of_gas();
-        match err {
+        let error = FfiError::out_of_gas();
+        match error {
             FfiError::OutOfGas { .. } => {}
-            _ => panic!("Unexpected error"),
+            e => panic!("Unexpected error: {:?}", e),
         }
     }
 
     #[test]
     fn ffi_error_other() {
-        let err = FfiError::other("broken");
-        match err {
+        let error = FfiError::other("broken");
+        match error {
             FfiError::Other { error, .. } => assert_eq!(error, "broken"),
-            _ => panic!("Unexpected error"),
+            e => panic!("Unexpected error: {:?}", e),
         }
     }
 }

--- a/packages/vm/src/errors.rs
+++ b/packages/vm/src/errors.rs
@@ -100,6 +100,84 @@ pub enum VmError {
 }
 
 impl VmError {
+    pub(crate) fn cache_err<S: Into<String>>(msg: S) -> Self {
+        CacheErr { msg: msg.into() }.build()
+    }
+
+    pub(crate) fn compile_err<S: Into<String>>(msg: S) -> Self {
+        CompileErr { msg: msg.into() }.build()
+    }
+
+    pub(crate) fn conversion_err<S: Into<String>, T: Into<String>, U: Into<String>>(
+        from_type: S,
+        to_type: T,
+        input: U,
+    ) -> Self {
+        ConversionErr {
+            from_type: from_type.into(),
+            to_type: to_type.into(),
+            input: input.into(),
+        }
+        .build()
+    }
+
+    pub(crate) fn generic_err<S: Into<String>>(msg: S) -> Self {
+        GenericErr { msg: msg.into() }.build()
+    }
+
+    pub(crate) fn instantiation_err<S: Into<String>>(msg: S) -> Self {
+        InstantiationErr { msg: msg.into() }.build()
+    }
+
+    pub(crate) fn integrity_err() -> Self {
+        IntegrityErr {}.build()
+    }
+
+    #[cfg(feature = "iterator")]
+    pub(crate) fn iterator_does_not_exist(iterator_id: u32) -> Self {
+        IteratorDoesNotExist { id: iterator_id }.build()
+    }
+
+    pub(crate) fn parse_err<T: Into<String>, M: Display>(target: T, msg: M) -> Self {
+        ParseErr {
+            target: target.into(),
+            msg: msg.to_string(),
+        }
+        .build()
+    }
+
+    pub(crate) fn serialize_err<S: Into<String>, M: Display>(source: S, msg: M) -> Self {
+        SerializeErr {
+            source: source.into(),
+            msg: msg.to_string(),
+        }
+        .build()
+    }
+
+    pub(crate) fn resolve_err<S: Into<String>>(msg: S) -> Self {
+        ResolveErr { msg: msg.into() }.build()
+    }
+
+    pub(crate) fn region_length_too_big(length: usize, max_length: usize) -> Self {
+        RegionLengthTooBig { length, max_length }.build()
+    }
+
+    pub(crate) fn region_too_small(size: usize, required: usize) -> Self {
+        RegionTooSmall { size, required }.build()
+    }
+
+    pub(crate) fn runtime_err<S: Into<String>>(msg: S) -> Self {
+        RuntimeErr { msg: msg.into() }.build()
+    }
+
+    pub(crate) fn static_validation_err<S: Into<String>>(msg: S) -> Self {
+        StaticValidationErr { msg: msg.into() }.build()
+    }
+
+    pub(crate) fn uninitialized_context_data<S: Into<String>>(kind: S) -> Self {
+        UninitializedContextData { kind: kind.into() }.build()
+    }
+
     pub(crate) fn write_access_denied() -> Self {
         WriteAccessDenied {}.build()
     }
@@ -107,107 +185,29 @@ impl VmError {
 
 impl From<wasmer_runtime_core::cache::Error> for VmError {
     fn from(original: wasmer_runtime_core::cache::Error) -> Self {
-        make_cache_err(format!("Wasmer cache error: {:?}", original))
+        VmError::cache_err(format!("Wasmer cache error: {:?}", original))
     }
 }
 
 impl From<wasmer_runtime_core::error::CompileError> for VmError {
     fn from(original: wasmer_runtime_core::error::CompileError) -> Self {
-        make_compile_err(format!("Wasmer compile error: {:?}", original))
+        VmError::compile_err(format!("Wasmer compile error: {:?}", original))
     }
 }
 
 impl From<wasmer_runtime_core::error::ResolveError> for VmError {
     fn from(original: wasmer_runtime_core::error::ResolveError) -> Self {
-        make_resolve_err(format!("Wasmer resolve error: {:?}", original))
+        VmError::resolve_err(format!("Wasmer resolve error: {:?}", original))
     }
 }
 
 impl From<wasmer_runtime_core::error::RuntimeError> for VmError {
     fn from(original: wasmer_runtime_core::error::RuntimeError) -> Self {
-        make_runtime_err(format!("Wasmer runtime error: {:?}", original))
+        VmError::runtime_err(format!("Wasmer runtime error: {:?}", original))
     }
 }
 
 pub type VmResult<T> = core::result::Result<T, VmError>;
-
-pub fn make_cache_err<S: Into<String>>(msg: S) -> VmError {
-    CacheErr { msg: msg.into() }.build()
-}
-
-pub fn make_compile_err<S: Into<String>>(msg: S) -> VmError {
-    CompileErr { msg: msg.into() }.build()
-}
-
-pub fn make_conversion_err<S: Into<String>, T: Into<String>, U: Into<String>>(
-    from_type: S,
-    to_type: T,
-    input: U,
-) -> VmError {
-    ConversionErr {
-        from_type: from_type.into(),
-        to_type: to_type.into(),
-        input: input.into(),
-    }
-    .build()
-}
-
-pub fn make_generic_err<S: Into<String>>(msg: S) -> VmError {
-    GenericErr { msg: msg.into() }.build()
-}
-
-pub fn make_instantiation_err<S: Into<String>>(msg: S) -> VmError {
-    InstantiationErr { msg: msg.into() }.build()
-}
-
-pub fn make_integrity_err() -> VmError {
-    IntegrityErr {}.build()
-}
-
-#[cfg(feature = "iterator")]
-pub fn make_iterator_does_not_exist(iterator_id: u32) -> VmError {
-    IteratorDoesNotExist { id: iterator_id }.build()
-}
-
-pub fn make_parse_err<T: Into<String>, M: Display>(target: T, msg: M) -> VmError {
-    ParseErr {
-        target: target.into(),
-        msg: msg.to_string(),
-    }
-    .build()
-}
-
-pub fn make_serialize_err<S: Into<String>, M: Display>(source: S, msg: M) -> VmError {
-    SerializeErr {
-        source: source.into(),
-        msg: msg.to_string(),
-    }
-    .build()
-}
-
-pub fn make_resolve_err<S: Into<String>>(msg: S) -> VmError {
-    ResolveErr { msg: msg.into() }.build()
-}
-
-pub fn make_region_length_too_big(length: usize, max_length: usize) -> VmError {
-    RegionLengthTooBig { length, max_length }.build()
-}
-
-pub fn make_region_too_small(size: usize, required: usize) -> VmError {
-    RegionTooSmall { size, required }.build()
-}
-
-pub fn make_runtime_err<S: Into<String>>(msg: S) -> VmError {
-    RuntimeErr { msg: msg.into() }.build()
-}
-
-pub fn make_static_validation_err<S: Into<String>>(msg: S) -> VmError {
-    StaticValidationErr { msg: msg.into() }.build()
-}
-
-pub fn make_uninitialized_context_data<S: Into<String>>(kind: S) -> VmError {
-    UninitializedContextData { kind: kind.into() }.build()
-}
 
 #[derive(Debug, Snafu)]
 pub enum FfiError {
@@ -276,19 +276,8 @@ mod test {
     // VmError constructors
 
     #[test]
-    fn vm_error_write_access_denied() {
-        let err = VmError::write_access_denied();
-        match err {
-            VmError::WriteAccessDenied { .. } => {}
-            e => panic!("Unexpected error: {:?}", e),
-        }
-    }
-
-    // VmError build helpers
-
-    #[test]
-    fn make_cache_err_works() {
-        let err = make_cache_err("something went wrong");
+    fn vm_error_cache_err_works() {
+        let err = VmError::cache_err("something went wrong");
         match err {
             VmError::CacheErr { msg, .. } => assert_eq!(msg, "something went wrong"),
             _ => panic!("Unexpected error"),
@@ -296,8 +285,8 @@ mod test {
     }
 
     #[test]
-    fn make_compile_err_works() {
-        let err = make_compile_err("something went wrong");
+    fn vm_error_compile_err_works() {
+        let err = VmError::compile_err("something went wrong");
         match err {
             VmError::CompileErr { msg, .. } => assert_eq!(msg, "something went wrong"),
             _ => panic!("Unexpected error"),
@@ -305,8 +294,8 @@ mod test {
     }
 
     #[test]
-    fn make_conversion_err_works() {
-        let err = make_conversion_err("i32", "u32", "-9");
+    fn vm_error_conversion_err_works() {
+        let err = VmError::conversion_err("i32", "u32", "-9");
         match err {
             VmError::ConversionErr {
                 from_type,
@@ -323,9 +312,9 @@ mod test {
     }
 
     #[test]
-    fn make_generic_err_works() {
+    fn vm_error_generic_err_works() {
         let guess = 7;
-        let error = make_generic_err(format!("{} is too low", guess));
+        let error = VmError::generic_err(format!("{} is too low", guess));
         match error {
             VmError::GenericErr { msg, .. } => {
                 assert_eq!(msg, String::from("7 is too low"));
@@ -335,8 +324,8 @@ mod test {
     }
 
     #[test]
-    fn make_instantiation_err_works() {
-        let err = make_instantiation_err("something went wrong");
+    fn vm_error_instantiation_err_works() {
+        let err = VmError::instantiation_err("something went wrong");
         match err {
             VmError::InstantiationErr { msg, .. } => assert_eq!(msg, "something went wrong"),
             _ => panic!("Unexpected error"),
@@ -344,8 +333,8 @@ mod test {
     }
 
     #[test]
-    fn make_integrity_err_works() {
-        let err = make_integrity_err();
+    fn vm_error_integrity_err_works() {
+        let err = VmError::integrity_err();
         match err {
             VmError::IntegrityErr { .. } => {}
             _ => panic!("Unexpected error"),
@@ -354,8 +343,8 @@ mod test {
 
     #[test]
     #[cfg(feature = "iterator")]
-    fn make_iterator_does_not_exist_works() {
-        let err = make_iterator_does_not_exist(15);
+    fn vm_error_iterator_does_not_exist_works() {
+        let err = VmError::iterator_does_not_exist(15);
         match err {
             VmError::IteratorDoesNotExist { id, .. } => assert_eq!(id, 15),
             _ => panic!("Unexpected error"),
@@ -363,8 +352,8 @@ mod test {
     }
 
     #[test]
-    fn make_parse_err_works() {
-        let error = make_parse_err("Book", "Missing field: title");
+    fn vm_error_parse_err_works() {
+        let error = VmError::parse_err("Book", "Missing field: title");
         match error {
             VmError::ParseErr { target, msg, .. } => {
                 assert_eq!(target, "Book");
@@ -375,8 +364,8 @@ mod test {
     }
 
     #[test]
-    fn make_serialize_err_works() {
-        let error = make_serialize_err("Book", "Content too long");
+    fn vm_error_serialize_err_works() {
+        let error = VmError::serialize_err("Book", "Content too long");
         match error {
             VmError::SerializeErr { source, msg, .. } => {
                 assert_eq!(source, "Book");
@@ -387,8 +376,8 @@ mod test {
     }
 
     #[test]
-    fn make_resolve_err_works() {
-        let error = make_resolve_err("function has different signature");
+    fn vm_error_resolve_err_works() {
+        let error = VmError::resolve_err("function has different signature");
         match error {
             VmError::ResolveErr { msg, .. } => assert_eq!(msg, "function has different signature"),
             _ => panic!("expect different error"),
@@ -396,8 +385,8 @@ mod test {
     }
 
     #[test]
-    fn make_region_length_too_big_works() {
-        let err = make_region_length_too_big(50, 20);
+    fn vm_error_region_length_too_big_works() {
+        let err = VmError::region_length_too_big(50, 20);
         match err {
             VmError::RegionLengthTooBig {
                 length, max_length, ..
@@ -410,8 +399,8 @@ mod test {
     }
 
     #[test]
-    fn make_region_too_small_works() {
-        let err = make_region_too_small(12, 33);
+    fn vm_error_region_too_small_works() {
+        let err = VmError::region_too_small(12, 33);
         match err {
             VmError::RegionTooSmall { size, required, .. } => {
                 assert_eq!(size, 12);
@@ -422,8 +411,8 @@ mod test {
     }
 
     #[test]
-    fn make_runtime_err_works() {
-        let err = make_runtime_err("something went wrong");
+    fn vm_error_runtime_err_works() {
+        let err = VmError::runtime_err("something went wrong");
         match err {
             VmError::RuntimeErr { msg, .. } => assert_eq!(msg, "something went wrong"),
             _ => panic!("Unexpected error"),
@@ -431,8 +420,8 @@ mod test {
     }
 
     #[test]
-    fn make_static_validation_err_works() {
-        let error = make_static_validation_err("export xy missing");
+    fn vm_error_static_validation_err_works() {
+        let error = VmError::static_validation_err("export xy missing");
         match error {
             VmError::StaticValidationErr { msg, .. } => assert_eq!(msg, "export xy missing"),
             _ => panic!("expect different error"),
@@ -440,11 +429,20 @@ mod test {
     }
 
     #[test]
-    fn make_uninitialized_context_data_works() {
-        let err = make_uninitialized_context_data("foo");
+    fn vm_error_uninitialized_context_data_works() {
+        let err = VmError::uninitialized_context_data("foo");
         match err {
             VmError::UninitializedContextData { kind, .. } => assert_eq!(kind, "foo"),
             _ => panic!("Unexpected error"),
+        }
+    }
+
+    #[test]
+    fn vm_error_write_access_denied() {
+        let err = VmError::write_access_denied();
+        match err {
+            VmError::WriteAccessDenied { .. } => {}
+            e => panic!("Unexpected error: {:?}", e),
         }
     }
 

--- a/packages/vm/src/errors.rs
+++ b/packages/vm/src/errors.rs
@@ -100,7 +100,7 @@ pub enum VmError {
 }
 
 impl VmError {
-    pub fn write_access_denied() -> Self {
+    pub(crate) fn write_access_denied() -> Self {
         WriteAccessDenied {}.build()
     }
 }

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -16,7 +16,7 @@ use crate::context::{
     with_querier_from_context, with_storage_from_context,
 };
 use crate::conversion::to_u32;
-use crate::errors::{make_instantiation_err, VmResult};
+use crate::errors::{VmError, VmResult};
 use crate::features::required_features_from_wasmer_instance;
 use crate::imports::{
     do_canonicalize_address, do_humanize_address, do_query_chain, do_read, do_remove, do_write,
@@ -129,7 +129,7 @@ where
         });
 
         let wasmer_instance = Box::from(module.instantiate(&import_obj).map_err(|original| {
-            make_instantiation_err(format!("Error instantiating module: {:?}", original))
+            VmError::instantiation_err(format!("Error instantiating module: {:?}", original))
         })?);
         Ok(Instance::from_wasmer(wasmer_instance, deps, gas_limit))
     }

--- a/packages/vm/src/memory.rs
+++ b/packages/vm/src/memory.rs
@@ -5,7 +5,7 @@ use wasmer_runtime_core::{
 };
 
 use crate::conversion::to_u32;
-use crate::errors::{make_region_length_too_big, make_region_too_small, VmResult};
+use crate::errors::{VmError, VmResult};
 
 /****** read/write to wasm memory buffer ****/
 
@@ -65,7 +65,7 @@ pub fn read_region(ctx: &Ctx, ptr: u32, max_length: usize) -> VmResult<Vec<u8>> 
     let region = get_region(ctx, ptr);
 
     if region.length > to_u32(max_length)? {
-        return Err(make_region_length_too_big(
+        return Err(VmError::region_length_too_big(
             region.length as usize,
             max_length,
         ));
@@ -110,7 +110,7 @@ pub fn write_region(ctx: &Ctx, ptr: u32, data: &[u8]) -> VmResult<()> {
 
     let region_capacity = region.capacity as usize;
     if data.len() > region_capacity {
-        return Err(make_region_too_small(region_capacity, data.len()));
+        return Err(VmError::region_too_small(region_capacity, data.len()));
     }
 
     let memory = ctx.memory(0);

--- a/packages/vm/src/serde.rs
+++ b/packages/vm/src/serde.rs
@@ -5,18 +5,18 @@
 use serde::{Deserialize, Serialize};
 use std::any::type_name;
 
-use crate::errors::{make_parse_err, make_serialize_err, VmResult};
+use crate::errors::{VmError, VmResult};
 
 pub fn from_slice<'a, T>(value: &'a [u8]) -> VmResult<T>
 where
     T: Deserialize<'a>,
 {
-    serde_json::from_slice(value).map_err(|e| make_parse_err(type_name::<T>(), e))
+    serde_json::from_slice(value).map_err(|e| VmError::parse_err(type_name::<T>(), e))
 }
 
 pub fn to_vec<T>(data: &T) -> VmResult<Vec<u8>>
 where
     T: Serialize + ?Sized,
 {
-    serde_json::to_vec(data).map_err(|e| make_serialize_err(type_name::<T>(), e))
+    serde_json::to_vec(data).map_err(|e| VmError::serialize_err(type_name::<T>(), e))
 }


### PR DESCRIPTION
This changes the constructor style of VmError to the one suggested by Reuven, which has better namespacing and less imports. Constructor functions are `pub(crate)` because `VmError` itself is public but only the VM should be allowed to create the errors. This is non-breaking because the make_* helpers were crate internal.