### PR TITLE
Update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Trait `Querier` is not `Clone` and `Send` anymore.
 - `consume_region` panics on null pointers and returns `Vec<u8>` instead of
   `StdResult<Vec<u8>>`.
-- Added contract migration mechanism. Contracts are now also expected to expose a `migrate`
+- Added contract migration mechanism. Contracts can now optionally export a `migrate`
   function with the following definition:
   ```rust
   extern "C" fn migrate(env_ptr: u32, msg_ptr: u32) -> u32;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,25 @@
   `Option<Vec<u8>>`.
 - `ReadonlyStorage::range` and all its implementations now return an iterator
   over `Option<KV>` instead of `Option<StdResult<KV>>`.
+- `Storage::{set, remove}` and all their implementations no longer have a return value.
+  Previously they returned `StdResult<()>`.
 - Trait `Querier` is not `Clone` and `Send` anymore.
+- `consume_region` panics on null pointers and returns `Vec<u8>` instead of
+  `StdResult<Vec<u8>>`.
+- Added contract migration mechanism. Contracts are now also expected to expose a `migrate`
+  function with the following definition:
+  ```rust
+  extern "C" fn migrate(env_ptr: u32, msg_ptr: u32) -> u32;
+  ```
 
 **cosmwasm-storage**
 
 - Remove `transactional_deps`. Use `transactional` that just provides a
   transactional storage instead.
+- `get_with_prefix` returns `Option<Vec<u8>>` instead of `StdResult<Option<Vec<u8>>>`.
+- `set_with_prefix` and `remove_with_prefix` return nothing instead of `StdResult<()>`.
+- `RepLog::commit` no longer returns any value (always succeeds).
+- `Op::apply` no longer returns any value (always succeeds).
 
 **cosmwasm-vm**
 
@@ -27,6 +40,10 @@
   data in the region is stored in the format `value || key || keylen`. As
   before, an empty key means _no more value_.
 - Remove `Instance::get_gas` in favour of `Instance::get_gas_left`.
+- All calls from the VM layer to the chain layer also return the amount of gas used on success.
+  (This is represented by replacing the return value with `(value, used_gas)`).
+  Gas usage across the system is then tracked in the VM layer, which allows us to halt the
+  contract during an import, as soon as we can prove that we used all allocated gas.
 
 ## 0.8.1 (not yet released)
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ extern "C" fn deallocate(pointer: u32);
 extern "C" fn init(env_ptr: u32, msg_ptr: u32) -> u32;
 extern "C" fn handle(env_ptr: u32, msg_ptr: u32) -> u32;
 extern "C" fn query(msg_ptr: u32) -> u32;
+extern "C" fn migrate(env_ptr: u32, msg_ptr: u32) -> u32;
 ```
 
 `allocate`/`deallocate` allow the host to manage data within the Wasm VM. If
@@ -122,15 +123,25 @@ The imports provided to give the contract access to the environment are:
 // A complete documentation those functions is available in the VM that provides them:
 // https://github.com/CosmWasm/cosmwasm/blob/0.7/lib/vm/src/instance.rs#L43
 //
-// TODO: use feature switches to enable precompile dependencies in the future,
-// so contracts that need less
 extern "C" {
     fn db_read(key: *const c_void) -> u32;
-    fn db_write(key: *const c_void, value: *mut c_void) -> i32;
-    fn db_remove(key: *const c_void) -> i32;
+    fn db_write(key: *const c_void, value: *mut c_void);
+    fn db_remove(key: *const c_void);
+
+    // scan creates an iterator, which can be read by consecutive next() calls
+    #[cfg(feature = "iterator")]
+    fn db_scan(start: *const c_void, end: *const c_void, order: i32) -> i32;
+    #[cfg(feature = "iterator")]
+    fn db_next(iterator_id: u32) -> u32;
+
     fn canonicalize_address(human: *const c_void, canonical: *mut c_void) -> i32;
     fn humanize_address(canonical: *const c_void, human: *mut c_void) -> i32;
+
+    // query_chain will launch a query on the chain (import)
+    // different than query which will query the state of the contract (export)
+    fn query_chain(request: *const c_void) -> u32;
 }
+
 ```
 
 (from

--- a/packages/storage/src/transactions.rs
+++ b/packages/storage/src/transactions.rs
@@ -121,11 +121,10 @@ impl RepLog {
     }
 
     /// applies the stored list of `Op`s to the provided `Storage`
-    pub fn commit<S: Storage>(self, storage: &mut S) -> StdResult<()> {
+    pub fn commit<S: Storage>(self, storage: &mut S) {
         for op in self.ops_log {
             op.apply(storage);
         }
-        Ok(())
     }
 }
 
@@ -258,7 +257,7 @@ where
 {
     let mut stx = StorageTransaction::new(storage);
     let res = callback(&mut stx)?;
-    stx.prepare().commit(storage)?;
+    stx.prepare().commit(storage);
     Ok(res)
 }
 
@@ -442,7 +441,7 @@ mod test {
         assert_eq!(check.get(b"food"), Some(b"bank".to_vec()));
 
         // now commit to base and query there
-        check.prepare().commit(&mut base).unwrap();
+        check.prepare().commit(&mut base);
         assert_eq!(base.get(b"foo"), None);
         assert_eq!(base.get(b"food"), Some(b"bank".to_vec()));
     }
@@ -459,7 +458,7 @@ mod test {
         assert_eq!(check.get(b"food"), Some(b"bank".to_vec()));
 
         // now commit to base and query there
-        check.prepare().commit(&mut base).unwrap();
+        check.prepare().commit(&mut base);
         assert_eq!(base.get(b"foo"), None);
         assert_eq!(base.get(b"food"), Some(b"bank".to_vec()));
     }
@@ -501,7 +500,7 @@ mod test {
         let mut check = StorageTransaction::new(&base);
         assert_eq!(check.get(b"foo"), Some(b"bar".to_vec()));
         check.set(b"subtx", b"works");
-        check.prepare().commit(&mut base).unwrap();
+        check.prepare().commit(&mut base);
 
         assert_eq!(base.get(b"subtx"), Some(b"works".to_vec()));
     }
@@ -521,7 +520,7 @@ mod test {
         // Can still read from base, txn is not yet committed
         assert_eq!(base.get(b"subtx"), None);
 
-        stxn1.prepare().commit(&mut base).unwrap();
+        stxn1.prepare().commit(&mut base);
         assert_eq!(base.get(b"subtx"), Some(b"works".to_vec()));
     }
 


### PR DESCRIPTION
Also refreshed some of the details on the changelog, and simplified the `RepLog::commit` function because i noticed it always succeeds while reviewing the `0.9` branch.

We should probably review the Readme as a lot of details have changed since it was written.