### PR TITLE
Add contract builds to clippy cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -496,7 +496,7 @@ jobs:
           command: rustc +$NIGHTLY_TOOLCHAIN --version && cargo +$NIGHTLY_TOOLCHAIN --version
       - restore_cache:
           keys:
-            - cargocache-v2-clippy-rust:1.41.1-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-clippy-rust:1.41.1-{{ checksum "Cargo.lock" }}-{{ checksum "contracts/hackatom/Cargo.lock" }}-{{ checksum "contracts/queue/Cargo.lock" }}-{{ checksum "contracts/reflect/Cargo.lock" }}-{{ checksum "contracts/staking/Cargo.lock" }}
       - run:
           name: Add clippy component
           command: rustup component add clippy
@@ -556,4 +556,16 @@ jobs:
             - target/debug/.fingerprint
             - target/debug/build
             - target/debug/deps
-          key: cargocache-v2-clippy-rust:1.41.1-{{ checksum "Cargo.lock" }}
+            - contracts/hackatom/target/debug/.fingerprint
+            - contracts/hackatom/target/debug/build
+            - contracts/hackatom/target/debug/deps
+            - contracts/queue/target/debug/.fingerprint
+            - contracts/queue/target/debug/build
+            - contracts/queue/target/debug/deps
+            - contracts/reflect/target/debug/.fingerprint
+            - contracts/reflect/target/debug/build
+            - contracts/reflect/target/debug/deps
+            - contracts/staking/target/debug/.fingerprint
+            - contracts/staking/target/debug/build
+            - contracts/staking/target/debug/deps
+          key: cargocache-v2-clippy-rust:1.41.1-{{ checksum "Cargo.lock" }}-{{ checksum "contracts/hackatom/Cargo.lock" }}-{{ checksum "contracts/queue/Cargo.lock" }}-{{ checksum "contracts/reflect/Cargo.lock" }}-{{ checksum "contracts/staking/Cargo.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -524,13 +524,21 @@ jobs:
           working_directory: ~/project/packages/storage
           command: cargo clippy --features iterator -- -D warnings
       - run:
-          name: Clippy linting on vm (no feature flags)
+          name: Clippy linting on vm (singlepass; no feature flags)
           working_directory: ~/project/packages/vm
           command: cargo +$NIGHTLY_TOOLCHAIN clippy -- -D warnings
       - run:
-          name: Clippy linting on vm (all feature flags)
+          name: Clippy linting on vm (singlepass; all feature flags)
           working_directory: ~/project/packages/vm
           command: cargo +$NIGHTLY_TOOLCHAIN clippy --features iterator -- -D warnings
+      - run:
+          name: Clippy linting on vm (cranelift; no feature flags)
+          working_directory: ~/project/packages/vm
+          command: cargo +$NIGHTLY_TOOLCHAIN clippy --no-default-features --features default-cranelift -- -D warnings
+      - run:
+          name: Clippy linting on vm (cranelift; all feature flags)
+          working_directory: ~/project/packages/vm
+          command: cargo +$NIGHTLY_TOOLCHAIN clippy --no-default-features --features default-cranelift,iterator -- -D warnings
       #
       # Contracts
       #

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -539,12 +539,12 @@ jobs:
           working_directory: ~/project/contracts/hackatom
           command: cargo clippy -- -D warnings
       - run:
-          name: Clippy linting on reflect
-          working_directory: ~/project/contracts/reflect
-          command: cargo clippy -- -D warnings
-      - run:
           name: Clippy linting on queue
           working_directory: ~/project/contracts/queue
+          command: cargo clippy -- -D warnings
+      - run:
+          name: Clippy linting on reflect
+          working_directory: ~/project/contracts/reflect
           command: cargo clippy -- -D warnings
       - run:
           name: Clippy linting on staking


### PR DESCRIPTION
Recently clippy became one of the longest CI jobs with 6 minutes. Turns out, clippy builds all the contracts but did not cache build results.