### PR TITLE
simplify get_context_data and get_context_data_mut

### DIFF
--- a/packages/vm/src/context.rs
+++ b/packages/vm/src/context.rs
@@ -136,17 +136,11 @@ fn destroy_unmanaged_context_data<S: Storage, Q: Querier>(ptr: *mut c_void) {
 fn get_context_data_mut<'a, 'b, S: Storage, Q: Querier>(
     ctx: &'a mut Ctx,
 ) -> &'b mut ContextData<'b, S, Q> {
-    let owned = unsafe {
-        Box::from_raw(ctx.data as *mut ContextData<S, Q>) // obtain ownership
-    };
-    Box::leak(owned) // give up ownership
+    unsafe { &mut *(ctx.data as *mut ContextData<S, Q>) }
 }
 
 fn get_context_data<'a, 'b, S: Storage, Q: Querier>(ctx: &'a Ctx) -> &'b ContextData<'b, S, Q> {
-    let owned = unsafe {
-        Box::from_raw(ctx.data as *mut ContextData<S, Q>) // obtain ownership
-    };
-    Box::leak(owned) // give up ownership
+    unsafe { &*(ctx.data as *mut ContextData<S, Q>) }
 }
 
 /// Creates a back reference from a contact to its partent instance


### PR DESCRIPTION
This simplification is a thought that came to me when porting the newer version of this repo to the Secret Network repo.
Let's see if it passes all the tests.
Basically, there's no need to pass through the `Box` methods in that case. fundamentally we were just converting a pointer to a reference, so I just made the code say that directly.

EDIT: Looks like it works :) what do you think about this @webmaster128 ?