### PR TITLE
Turn REGION_READ_LENGTH_TOO_BIG and REGION_WRITE_TOO_SMALL into communication errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,10 @@
   `NextItem`. `StorageIterator` is a custom iterator type that does not
   implement Rust's `Iterator` trait, allowing it to communicate the used gas
   value of the last `next` call to the VM.
+- Don't report any `VmError` back to the contract in `canonicalize_address` and
+  `humanize_address`. Only invalid inputs should be reported.
+- Move error cases `VmError::RegionLengthTooBig` and `VmError::RegionTooSmall`
+  into `CommunicationError`.
 
 ## 0.8.1 (2020-06-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,10 @@
   `humanize_address`. Only invalid inputs should be reported.
 - Move error cases `VmError::RegionLengthTooBig` and `VmError::RegionTooSmall`
   into `CommunicationError`.
+- In the `canonicalize_address` inplementation, invalid UTF-8 inputs now result
+  in `CommunicationError::InvalidUtf8`, which is not reported back to the
+  contract. A standard library should ensure this never happens by correctly
+  encoding string input values.
 
 ## 0.8.1 (2020-06-08)
 

--- a/packages/std/src/types.rs
+++ b/packages/std/src/types.rs
@@ -49,6 +49,12 @@ impl From<&&HumanAddr> for HumanAddr {
     }
 }
 
+impl From<String> for HumanAddr {
+    fn from(addr: String) -> Self {
+        HumanAddr(addr)
+    }
+}
+
 impl CanonicalAddr {
     pub fn as_slice(&self) -> &[u8] {
         &self.0.as_slice()

--- a/packages/vm/src/imports.rs
+++ b/packages/vm/src/imports.rs
@@ -353,7 +353,9 @@ mod test {
         let ctx = instance.context_mut();
         let result = do_read::<MS, MQ>(ctx, key_ptr);
         match result.unwrap_err() {
-            VmError::RegionLengthTooBig { length, .. } => assert_eq!(length, 300 * 1024),
+            VmError::CommunicationErr {
+                source: CommunicationError::RegionLengthTooBig { length, .. },
+            } => assert_eq!(length, 300 * 1024),
             e => panic!("Unexpected error: {:?}", e),
         }
     }
@@ -425,9 +427,13 @@ mod test {
         let ctx = instance.context_mut();
         leave_default_data(ctx);
 
-        match do_write::<MS, MQ>(ctx, key_ptr, value_ptr).unwrap_err() {
-            VmError::RegionLengthTooBig {
-                length, max_length, ..
+        let result = do_write::<MS, MQ>(ctx, key_ptr, value_ptr);
+        match result.unwrap_err() {
+            VmError::CommunicationErr {
+                source:
+                    CommunicationError::RegionLengthTooBig {
+                        length, max_length, ..
+                    },
             } => {
                 assert_eq!(length, 300 * 1024);
                 assert_eq!(max_length, MAX_LENGTH_DB_KEY);
@@ -446,9 +452,13 @@ mod test {
         let ctx = instance.context_mut();
         leave_default_data(ctx);
 
-        match do_write::<MS, MQ>(ctx, key_ptr, value_ptr).unwrap_err() {
-            VmError::RegionLengthTooBig {
-                length, max_length, ..
+        let result = do_write::<MS, MQ>(ctx, key_ptr, value_ptr);
+        match result.unwrap_err() {
+            VmError::CommunicationErr {
+                source:
+                    CommunicationError::RegionLengthTooBig {
+                        length, max_length, ..
+                    },
             } => {
                 assert_eq!(length, 300 * 1024);
                 assert_eq!(max_length, MAX_LENGTH_DB_VALUE);
@@ -523,9 +533,13 @@ mod test {
         let ctx = instance.context_mut();
         leave_default_data(ctx);
 
-        match do_remove::<MS, MQ>(ctx, key_ptr).unwrap_err() {
-            VmError::RegionLengthTooBig {
-                length, max_length, ..
+        let result = do_remove::<MS, MQ>(ctx, key_ptr);
+        match result.unwrap_err() {
+            VmError::CommunicationErr {
+                source:
+                    CommunicationError::RegionLengthTooBig {
+                        length, max_length, ..
+                    },
             } => {
                 assert_eq!(length, 300 * 1024);
                 assert_eq!(max_length, MAX_LENGTH_DB_KEY);
@@ -615,8 +629,11 @@ mod test {
         let api = MockApi::new(8);
         let result = do_canonicalize_address(api, ctx, source_ptr, dest_ptr);
         match result.unwrap_err() {
-            VmError::RegionLengthTooBig {
-                length, max_length, ..
+            VmError::CommunicationErr {
+                source:
+                    CommunicationError::RegionLengthTooBig {
+                        length, max_length, ..
+                    },
             } => {
                 assert_eq!(length, 100);
                 assert_eq!(max_length, 90);
@@ -638,7 +655,9 @@ mod test {
         let api = MockApi::new(8);
         let result = do_canonicalize_address(api, ctx, source_ptr, dest_ptr);
         match result.unwrap_err() {
-            VmError::RegionTooSmall { size, required, .. } => {
+            VmError::CommunicationErr {
+                source: CommunicationError::RegionTooSmall { size, required, .. },
+            } => {
                 assert_eq!(size, 7);
                 assert_eq!(required, 8);
             }
@@ -695,8 +714,11 @@ mod test {
         let api = MockApi::new(8);
         let result = do_humanize_address(api, ctx, source_ptr, dest_ptr);
         match result.unwrap_err() {
-            VmError::RegionLengthTooBig {
-                length, max_length, ..
+            VmError::CommunicationErr {
+                source:
+                    CommunicationError::RegionLengthTooBig {
+                        length, max_length, ..
+                    },
             } => {
                 assert_eq!(length, 33);
                 assert_eq!(max_length, 32);
@@ -718,7 +740,9 @@ mod test {
         let api = MockApi::new(8);
         let result = do_humanize_address(api, ctx, source_ptr, dest_ptr);
         match result.unwrap_err() {
-            VmError::RegionTooSmall { size, required, .. } => {
+            VmError::CommunicationErr {
+                source: CommunicationError::RegionTooSmall { size, required, .. },
+            } => {
                 assert_eq!(size, 2);
                 assert_eq!(required, 3);
             }

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -92,14 +92,16 @@ where
                 // Returns 0 on success. Returns negative value on error.
                 // Ownership of both input and output pointer is not transferred to the host.
                 "canonicalize_address" => Func::new(move |ctx: &mut Ctx, source_ptr: u32, destination_ptr: u32| -> VmResult<i32> {
-                    do_canonicalize_address(api, ctx, source_ptr, destination_ptr)
+                    do_canonicalize_address(api, ctx, source_ptr, destination_ptr)?;
+                    Ok(0) // TODO: work out error handling strategy (https://github.com/CosmWasm/cosmwasm/issues/433)
                 }),
                 // Reads canonical address from source_ptr and writes humanized representation to destination_ptr.
                 // A prepared and sufficiently large memory Region is expected at destination_ptr that points to pre-allocated memory.
                 // Returns 0 on success. Returns negative value on error.
                 // Ownership of both input and output pointer is not transferred to the host.
                 "humanize_address" => Func::new(move |ctx: &mut Ctx, source_ptr: u32, destination_ptr: u32| -> VmResult<i32> {
-                    do_humanize_address(api, ctx, source_ptr, destination_ptr)
+                    do_humanize_address(api, ctx, source_ptr, destination_ptr)?;
+                    Ok(0) // TODO: work out error handling strategy (https://github.com/CosmWasm/cosmwasm/issues/433)
                 }),
                 "query_chain" => Func::new(move |ctx: &mut Ctx, request_ptr: u32| -> VmResult<u32> {
                     do_query_chain::<S, Q>(ctx, request_ptr)

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -422,15 +422,18 @@ mod test {
             .write_memory(region_ptr, &data)
             .expect("error writing");
 
-        match instance.read_memory(region_ptr, max_length) {
-            Err(VmError::RegionLengthTooBig {
-                length, max_length, ..
-            }) => {
+        let result = instance.read_memory(region_ptr, max_length);
+        match result.unwrap_err() {
+            VmError::CommunicationErr {
+                source:
+                    CommunicationError::RegionLengthTooBig {
+                        length, max_length, ..
+                    },
+            } => {
                 assert_eq!(length, 6);
                 assert_eq!(max_length, 5);
             }
-            Err(err) => panic!("unexpected error: {:?}", err),
-            Ok(_) => panic!("must not succeed"),
+            err => panic!("unexpected error: {:?}", err),
         };
 
         instance.deallocate(region_ptr).expect("error deallocating");

--- a/packages/vm/src/memory.rs
+++ b/packages/vm/src/memory.rs
@@ -5,7 +5,7 @@ use wasmer_runtime_core::{
 };
 
 use crate::conversion::to_u32;
-use crate::errors::{CommunicationError, CommunicationResult, VmError, VmResult};
+use crate::errors::{CommunicationError, CommunicationResult, VmResult};
 
 /****** read/write to wasm memory buffer ****/
 
@@ -65,10 +65,9 @@ pub fn read_region(ctx: &Ctx, ptr: u32, max_length: usize) -> VmResult<Vec<u8>> 
     let region = get_region(ctx, ptr)?;
 
     if region.length > to_u32(max_length)? {
-        return Err(VmError::region_length_too_big(
-            region.length as usize,
-            max_length,
-        ));
+        return Err(
+            CommunicationError::region_length_too_big(region.length as usize, max_length).into(),
+        );
     }
 
     let memory = ctx.memory(0);
@@ -110,7 +109,7 @@ pub fn write_region(ctx: &Ctx, ptr: u32, data: &[u8]) -> VmResult<()> {
 
     let region_capacity = region.capacity as usize;
     if data.len() > region_capacity {
-        return Err(VmError::region_too_small(region_capacity, data.len()));
+        return Err(CommunicationError::region_too_small(region_capacity, data.len()).into());
     }
 
     let memory = ctx.memory(0);

--- a/packages/vm/src/memory.rs
+++ b/packages/vm/src/memory.rs
@@ -90,6 +90,12 @@ pub fn read_region(ctx: &Ctx, ptr: u32, max_length: usize) -> VmResult<Vec<u8>> 
     }
 }
 
+pub fn read_string_region(ctx: &Ctx, ptr: u32, max_length: usize) -> VmResult<String> {
+    let data = read_region(ctx, ptr, max_length)?;
+    let out = String::from_utf8(data).map_err(CommunicationError::invalid_utf8)?;
+    Ok(out)
+}
+
 /// maybe_read_region is like read_region, but gracefully handles null pointer (0) by returning None
 /// meant to be used where the argument is optional (like scan)
 #[cfg(feature = "iterator")]


### PR DESCRIPTION
Based on #430

- [x] Implement
- [x] Rebase after #430 is merged
- [x] CHANGELOG entry
- [x] Write follow-up ticket for `canonicalize_address`/`humanize_address` error handling: #433