### PR TITLE
Added `entry_points!` macro to reduce boilerplate when writing contracts

### DIFF
--- a/contracts/burner/src/lib.rs
+++ b/contracts/burner/src/lib.rs
@@ -2,47 +2,4 @@ pub mod contract;
 pub mod msg;
 
 #[cfg(target_arch = "wasm32")]
-mod wasm {
-    use super::contract;
-    use cosmwasm_std::{
-        do_handle, do_init, do_migrate, do_query, ExternalApi, ExternalQuerier, ExternalStorage,
-    };
-
-    #[no_mangle]
-    extern "C" fn init(env_ptr: u32, msg_ptr: u32) -> u32 {
-        do_init(
-            &contract::init::<ExternalStorage, ExternalApi, ExternalQuerier>,
-            env_ptr,
-            msg_ptr,
-        )
-    }
-
-    #[no_mangle]
-    extern "C" fn handle(env_ptr: u32, msg_ptr: u32) -> u32 {
-        do_handle(
-            &contract::handle::<ExternalStorage, ExternalApi, ExternalQuerier>,
-            env_ptr,
-            msg_ptr,
-        )
-    }
-
-    #[no_mangle]
-    extern "C" fn migrate(env_ptr: u32, msg_ptr: u32) -> u32 {
-        do_migrate(
-            &contract::migrate::<ExternalStorage, ExternalApi, ExternalQuerier>,
-            env_ptr,
-            msg_ptr,
-        )
-    }
-
-    #[no_mangle]
-    extern "C" fn query(msg_ptr: u32) -> u32 {
-        do_query(
-            &contract::query::<ExternalStorage, ExternalApi, ExternalQuerier>,
-            msg_ptr,
-        )
-    }
-
-    // Other C externs like cosmwasm_vm_version_1, allocate, deallocate are available
-    // automatically because we `use cosmwasm_std`.
-}
+cosmwasm_std::entry_points!(contract);

--- a/contracts/burner/src/lib.rs
+++ b/contracts/burner/src/lib.rs
@@ -2,4 +2,4 @@ pub mod contract;
 pub mod msg;
 
 #[cfg(target_arch = "wasm32")]
-cosmwasm_std::entry_points!(contract);
+cosmwasm_std::entry_points_with_migration!(contract);

--- a/contracts/burner/src/lib.rs
+++ b/contracts/burner/src/lib.rs
@@ -2,4 +2,4 @@ pub mod contract;
 pub mod msg;
 
 #[cfg(target_arch = "wasm32")]
-cosmwasm_std::entry_points_with_migration!(contract);
+cosmwasm_std::create_entry_points_with_migration!(contract);

--- a/contracts/hackatom/src/lib.rs
+++ b/contracts/hackatom/src/lib.rs
@@ -1,4 +1,4 @@
 pub mod contract;
 
 #[cfg(target_arch = "wasm32")]
-cosmwasm_std::entry_points_with_migration!(contract);
+cosmwasm_std::create_entry_points_with_migration!(contract);

--- a/contracts/hackatom/src/lib.rs
+++ b/contracts/hackatom/src/lib.rs
@@ -1,47 +1,4 @@
 pub mod contract;
 
 #[cfg(target_arch = "wasm32")]
-mod wasm {
-    use super::contract;
-    use cosmwasm_std::{
-        do_handle, do_init, do_migrate, do_query, ExternalApi, ExternalQuerier, ExternalStorage,
-    };
-
-    #[no_mangle]
-    extern "C" fn init(env_ptr: u32, msg_ptr: u32) -> u32 {
-        do_init(
-            &contract::init::<ExternalStorage, ExternalApi, ExternalQuerier>,
-            env_ptr,
-            msg_ptr,
-        )
-    }
-
-    #[no_mangle]
-    extern "C" fn handle(env_ptr: u32, msg_ptr: u32) -> u32 {
-        do_handle(
-            &contract::handle::<ExternalStorage, ExternalApi, ExternalQuerier>,
-            env_ptr,
-            msg_ptr,
-        )
-    }
-
-    #[no_mangle]
-    extern "C" fn migrate(env_ptr: u32, msg_ptr: u32) -> u32 {
-        do_migrate(
-            &contract::migrate::<ExternalStorage, ExternalApi, ExternalQuerier>,
-            env_ptr,
-            msg_ptr,
-        )
-    }
-
-    #[no_mangle]
-    extern "C" fn query(msg_ptr: u32) -> u32 {
-        do_query(
-            &contract::query::<ExternalStorage, ExternalApi, ExternalQuerier>,
-            msg_ptr,
-        )
-    }
-
-    // Other C externs like cosmwasm_vm_version_1, allocate, deallocate are available
-    // automatically because we `use cosmwasm_std`.
-}
+cosmwasm_std::entry_points!(contract);

--- a/contracts/hackatom/src/lib.rs
+++ b/contracts/hackatom/src/lib.rs
@@ -1,4 +1,4 @@
 pub mod contract;
 
 #[cfg(target_arch = "wasm32")]
-cosmwasm_std::entry_points!(contract);
+cosmwasm_std::entry_points_with_migration!(contract);

--- a/contracts/queue/src/lib.rs
+++ b/contracts/queue/src/lib.rs
@@ -1,38 +1,4 @@
 pub mod contract;
 
 #[cfg(target_arch = "wasm32")]
-mod wasm {
-    use super::contract;
-    use cosmwasm_std::{
-        do_handle, do_init, do_query, ExternalApi, ExternalQuerier, ExternalStorage,
-    };
-
-    #[no_mangle]
-    extern "C" fn init(env_ptr: u32, msg_ptr: u32) -> u32 {
-        do_init(
-            &contract::init::<ExternalStorage, ExternalApi, ExternalQuerier>,
-            env_ptr,
-            msg_ptr,
-        )
-    }
-
-    #[no_mangle]
-    extern "C" fn handle(env_ptr: u32, msg_ptr: u32) -> u32 {
-        do_handle(
-            &contract::handle::<ExternalStorage, ExternalApi, ExternalQuerier>,
-            env_ptr,
-            msg_ptr,
-        )
-    }
-
-    #[no_mangle]
-    extern "C" fn query(msg_ptr: u32) -> u32 {
-        do_query(
-            &contract::query::<ExternalStorage, ExternalApi, ExternalQuerier>,
-            msg_ptr,
-        )
-    }
-
-    // Other C externs like cosmwasm_vm_version_1, allocate, deallocate are available
-    // automatically because we `use cosmwasm_std`.
-}
+cosmwasm_std::entry_points!(contract);

--- a/contracts/queue/src/lib.rs
+++ b/contracts/queue/src/lib.rs
@@ -1,4 +1,4 @@
 pub mod contract;
 
 #[cfg(target_arch = "wasm32")]
-cosmwasm_std::entry_points!(contract);
+cosmwasm_std::create_entry_points!(contract);

--- a/contracts/reflect/src/lib.rs
+++ b/contracts/reflect/src/lib.rs
@@ -6,4 +6,4 @@ pub mod state;
 pub mod testing;
 
 #[cfg(target_arch = "wasm32")]
-cosmwasm_std::entry_points!(contract);
+cosmwasm_std::create_entry_points!(contract);

--- a/contracts/reflect/src/lib.rs
+++ b/contracts/reflect/src/lib.rs
@@ -6,38 +6,4 @@ pub mod state;
 pub mod testing;
 
 #[cfg(target_arch = "wasm32")]
-mod wasm {
-    use super::contract;
-    use cosmwasm_std::{
-        do_handle, do_init, do_query, ExternalApi, ExternalQuerier, ExternalStorage,
-    };
-
-    #[no_mangle]
-    extern "C" fn init(env_ptr: u32, msg_ptr: u32) -> u32 {
-        do_init(
-            &contract::init::<ExternalStorage, ExternalApi, ExternalQuerier>,
-            env_ptr,
-            msg_ptr,
-        )
-    }
-
-    #[no_mangle]
-    extern "C" fn handle(env_ptr: u32, msg_ptr: u32) -> u32 {
-        do_handle(
-            &contract::handle::<ExternalStorage, ExternalApi, ExternalQuerier>,
-            env_ptr,
-            msg_ptr,
-        )
-    }
-
-    #[no_mangle]
-    extern "C" fn query(msg_ptr: u32) -> u32 {
-        do_query(
-            &contract::query::<ExternalStorage, ExternalApi, ExternalQuerier>,
-            msg_ptr,
-        )
-    }
-
-    // Other C externs like cosmwasm_vm_version_1, allocate, deallocate are available
-    // automatically because we `use cosmwasm_std`.
-}
+cosmwasm_std::entry_points!(contract);

--- a/contracts/staking/src/lib.rs
+++ b/contracts/staking/src/lib.rs
@@ -3,38 +3,4 @@ pub mod msg;
 pub mod state;
 
 #[cfg(target_arch = "wasm32")]
-mod wasm {
-    use super::contract;
-    use cosmwasm_std::{
-        do_handle, do_init, do_query, ExternalApi, ExternalQuerier, ExternalStorage,
-    };
-
-    #[no_mangle]
-    extern "C" fn init(env_ptr: u32, msg_ptr: u32) -> u32 {
-        do_init(
-            &contract::init::<ExternalStorage, ExternalApi, ExternalQuerier>,
-            env_ptr,
-            msg_ptr,
-        )
-    }
-
-    #[no_mangle]
-    extern "C" fn handle(env_ptr: u32, msg_ptr: u32) -> u32 {
-        do_handle(
-            &contract::handle::<ExternalStorage, ExternalApi, ExternalQuerier>,
-            env_ptr,
-            msg_ptr,
-        )
-    }
-
-    #[no_mangle]
-    extern "C" fn query(msg_ptr: u32) -> u32 {
-        do_query(
-            &contract::query::<ExternalStorage, ExternalApi, ExternalQuerier>,
-            msg_ptr,
-        )
-    }
-
-    // Other C externs like cosmwasm_vm_version_1, allocate, deallocate are available
-    // automatically because we `use cosmwasm_std`.
-}
+cosmwasm_std::entry_points!(contract);

--- a/contracts/staking/src/lib.rs
+++ b/contracts/staking/src/lib.rs
@@ -3,4 +3,4 @@ pub mod msg;
 pub mod state;
 
 #[cfg(target_arch = "wasm32")]
-cosmwasm_std::entry_points!(contract);
+cosmwasm_std::create_entry_points!(contract);

--- a/packages/std/src/entry_points.rs
+++ b/packages/std/src/entry_points.rs
@@ -3,13 +3,13 @@
 ///
 /// This macro should be invoced in a global scope, and the argument to the macro
 /// should be the name of a rust module that is imported in the invocation scope.
-/// The module should export four functions with the following signatures:
+/// The module should export three functions with the following signatures:
 /// ```
 /// # use cosmwasm_std::{
 /// #     Storage, Api, Querier, Extern, Env, StdResult, Binary,
 /// #     InitResult, HandleResult, QueryResult,
 /// # };
-///
+/// #
 /// # type InitMsg = ();
 /// pub fn init<S: Storage, A: Api, Q: Querier>(
 ///     deps: &mut Extern<S, A, Q>,

--- a/packages/std/src/entry_points.rs
+++ b/packages/std/src/entry_points.rs
@@ -1,7 +1,7 @@
 /// This macro generates the boilerplate required to call into the
 /// contract-specific logic from the entry-points to the WASM module.
 ///
-/// This macro should be invoced in a global scope, and the argument to the macro
+/// It macro should be invoked in a global scope, and the argument to the macro
 /// should be the name of a rust module that is imported in the invocation scope.
 /// The module should export three functions with the following signatures:
 /// ```
@@ -37,6 +37,14 @@
 /// }
 /// ```
 /// Where `InitMsg`, `HandleMsg`, and `QueryMsg` are types that implement `DeserializeOwned + JsonSchema`
+///
+/// # Example
+///
+/// ```ignore
+/// use contract; // The contract module
+///
+/// cosmwasm_std::entry_points!(contract);
+/// ```
 #[macro_export]
 macro_rules! entry_points {
     (@migration; $contract:ident, true) => {
@@ -113,6 +121,14 @@ macro_rules! entry_points {
 /// }
 /// ```
 /// Where `MigrateMsg` is a type that implements `DeserializeOwned + JsonSchema`
+///
+/// # Example
+///
+/// ```ignore
+/// use contract; // The contract module
+///
+/// cosmwasm_std::entry_points_with_migration!(contract);
+/// ```
 #[macro_export]
 macro_rules! entry_points_with_migration {
     ($contract:ident) => {

--- a/packages/std/src/entry_points.rs
+++ b/packages/std/src/entry_points.rs
@@ -36,6 +36,7 @@
 /// #   Ok(Binary(Vec::new()))
 /// }
 /// ```
+/// Where `InitMsg`, `HandleMsg`, and `QueryMsg` are types that implement `DeserializeOwned + JsonSchema`
 #[macro_export]
 macro_rules! entry_points {
     (@migration; $contract:ident, true) => {
@@ -111,6 +112,7 @@ macro_rules! entry_points {
 /// #   Ok(Default::default())
 /// }
 /// ```
+/// Where `MigrateMsg` is a type that implements `DeserializeOwned + JsonSchema`
 #[macro_export]
 macro_rules! entry_points_with_migration {
     ($contract:ident) => {

--- a/packages/std/src/entry_points.rs
+++ b/packages/std/src/entry_points.rs
@@ -43,10 +43,10 @@
 /// ```ignore
 /// use contract; // The contract module
 ///
-/// cosmwasm_std::entry_points!(contract);
+/// cosmwasm_std::create_entry_points!(contract);
 /// ```
 #[macro_export]
-macro_rules! entry_points {
+macro_rules! create_entry_points {
     (@migration; $contract:ident, true) => {
         #[no_mangle]
         extern "C" fn migrate(env_ptr: u32, msg_ptr: u32) -> u32 {
@@ -94,7 +94,7 @@ macro_rules! entry_points {
                 )
             }
 
-            $crate::entry_points!(@migration; $contract, $migration);
+            $crate::create_entry_points!(@migration; $contract, $migration);
 
             // Other C externs like cosmwasm_vm_version_1, allocate, deallocate are available
             // automatically because we `use cosmwasm_std`.
@@ -102,11 +102,11 @@ macro_rules! entry_points {
     };
 
     ($contract:ident) => {
-        $crate::entry_points!(@inner; $contract, migration = false);
+        $crate::create_entry_points!(@inner; $contract, migration = false);
     };
 }
 
-/// This macro is very similar to the `entry_points` macro, except it also requires the `migrate` method:
+/// This macro is very similar to the `create_entry_points` macro, except it also requires the `migrate` method:
 /// ```
 /// # use cosmwasm_std::{
 /// #     Storage, Api, Querier, Extern, Env, StdResult, Binary, MigrateResult,
@@ -127,11 +127,11 @@ macro_rules! entry_points {
 /// ```ignore
 /// use contract; // The contract module
 ///
-/// cosmwasm_std::entry_points_with_migration!(contract);
+/// cosmwasm_std::create_entry_points_with_migration!(contract);
 /// ```
 #[macro_export]
-macro_rules! entry_points_with_migration {
+macro_rules! create_entry_points_with_migration {
     ($contract:ident) => {
-        $crate::entry_points!(@inner; $contract, migration = true);
+        $crate::create_entry_points!(@inner; $contract, migration = true);
     };
 }

--- a/packages/std/src/entry_points.rs
+++ b/packages/std/src/entry_points.rs
@@ -1,9 +1,9 @@
 /// This macro generates the boilerplate required to call into the
-/// contract-specific logic from the entry-points to the WASM module.
+/// contract-specific logic from the entry-points to the Wasm module.
 ///
-/// It macro should be invoked in a global scope, and the argument to the macro
-/// should be the name of a rust module that is imported in the invocation scope.
-/// The module should export three functions with the following signatures:
+/// It should be invoked in a module scope(that is, not inside a function), and the argument to the macro
+/// should be the name of a second rust module that is imported in the invocation scope.
+/// The second module should export three functions with the following signatures:
 /// ```
 /// # use cosmwasm_std::{
 /// #     Storage, Api, Querier, Extern, Env, StdResult, Binary,

--- a/packages/std/src/entry_points.rs
+++ b/packages/std/src/entry_points.rs
@@ -1,0 +1,97 @@
+/// This macro generates the boilerplate required to call into the
+/// contract-specific logic from the entry-points to the WASM module.
+///
+/// This macro should be invoced in a global scope, and the argument to the macro
+/// should be the name of a rust module that is imported in the invocation scope.
+/// The module should export four functions with the following signatures:
+/// ```
+/// # use cosmwasm_std::{
+/// #     Storage, Api, Querier, Extern, Env, StdResult, Binary,
+/// #     InitResult, HandleResult, QueryResult, MigrateResult,
+/// # };
+///
+/// # type InitMsg = ();
+/// pub fn init<S: Storage, A: Api, Q: Querier>(
+///     deps: &mut Extern<S, A, Q>,
+///     env: Env,
+///     msg: InitMsg,
+/// ) -> InitResult {
+/// #   Ok(Default::default())
+/// }
+///
+/// # type MigrateMsg = ();
+/// pub fn migrate<S: Storage, A: Api, Q: Querier>(
+///     deps: &mut Extern<S, A, Q>,
+///     _env: Env,
+///     msg: MigrateMsg,
+/// ) -> MigrateResult {
+/// #   Ok(Default::default())
+/// }
+///
+/// # type HandleMsg = ();
+/// pub fn handle<S: Storage, A: Api, Q: Querier>(
+///     deps: &mut Extern<S, A, Q>,
+///     env: Env,
+///     msg: HandleMsg,
+/// ) -> HandleResult {
+/// #   Ok(Default::default())
+/// }
+///
+/// # type QueryMsg = ();
+/// pub fn query<S: Storage, A: Api, Q: Querier>(
+///     deps: &Extern<S, A, Q>,
+///     msg: QueryMsg,
+/// ) -> QueryResult {
+/// #   Ok(Binary(Vec::new()))
+/// }
+/// ```
+#[macro_export]
+macro_rules! entry_points {
+    ($contract:ident) => {
+        mod wasm {
+            use super::$contract;
+            use cosmwasm_std::{
+                do_handle, do_init, do_migrate, do_query, ExternalApi, ExternalQuerier,
+                ExternalStorage,
+            };
+
+            #[no_mangle]
+            extern "C" fn init(env_ptr: u32, msg_ptr: u32) -> u32 {
+                do_init(
+                    &$contract::init::<ExternalStorage, ExternalApi, ExternalQuerier>,
+                    env_ptr,
+                    msg_ptr,
+                )
+            }
+
+            #[no_mangle]
+            extern "C" fn handle(env_ptr: u32, msg_ptr: u32) -> u32 {
+                do_handle(
+                    &$contract::handle::<ExternalStorage, ExternalApi, ExternalQuerier>,
+                    env_ptr,
+                    msg_ptr,
+                )
+            }
+
+            #[no_mangle]
+            extern "C" fn query(msg_ptr: u32) -> u32 {
+                do_query(
+                    &$contract::query::<ExternalStorage, ExternalApi, ExternalQuerier>,
+                    msg_ptr,
+                )
+            }
+
+            #[no_mangle]
+            extern "C" fn migrate(env_ptr: u32, msg_ptr: u32) -> u32 {
+                do_migrate(
+                    &$contract::migrate::<ExternalStorage, ExternalApi, ExternalQuerier>,
+                    env_ptr,
+                    msg_ptr,
+                )
+            }
+
+            // Other C externs like cosmwasm_vm_version_1, allocate, deallocate are available
+            // automatically because we `use cosmwasm_std`.
+        }
+    };
+}

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod coins;
 mod encoding;
+mod entry_points;
 mod errors;
 mod init_handle;
 #[cfg(feature = "iterator")]


### PR DESCRIPTION
I wrote this macro to allow us to reduce boilerplate when writing our own contracts, and figured it would be a good idea to suggest it upstream.

It's not the most flexible macro ever (and trust me, [I know how to make macros flexible](https://github.com/reuvenpo/rust-py-comp)) but i had trouble taking the paths to the implementation functions or even just to the contract module itself in a flexible way [because of a weird limitation of macro rules](https://github.com/rust-lang/rust/issues/48067).

I added a doc-comment to the macro definition, and replaced the boilerplate in the example contracts to showcase the macro.

To illustrate, hackatom's `lib.rs` file now looks like this:
```rust
pub mod contract;

#[cfg(target_arch = "wasm32")]
cosmwasm_std::entry_points_with_migration!(contract);
```

Update: looks like I can't always require migrate to exist. I'll try to make that work.
Update: Done.