### PR TITLE
Avoid the need of into_binary

### DIFF
--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -2,7 +2,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use cosmwasm_std::{
-    from_slice, into_binary, log, to_vec, AllBalanceResponse, Api, BankMsg, CanonicalAddr, Env,
+    from_slice, log, to_binary, to_vec, AllBalanceResponse, Api, BankMsg, CanonicalAddr, Env,
     Extern, HandleResponse, HumanAddr, InitResponse, MigrateResponse, Querier, QueryResponse,
     StdError, StdResult, Storage,
 };
@@ -208,10 +208,8 @@ pub fn query<S: Storage, A: Api, Q: Querier>(
     msg: QueryMsg,
 ) -> StdResult<QueryResponse> {
     match msg {
-        QueryMsg::Verifier {} => query_verifier(deps).and_then(into_binary),
-        QueryMsg::OtherBalance { address } => {
-            query_other_balance(deps, address).and_then(into_binary)
-        }
+        QueryMsg::Verifier {} => to_binary(&query_verifier(deps)?),
+        QueryMsg::OtherBalance { address } => to_binary(&query_other_balance(deps, address)?),
     }
 }
 

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -33,7 +33,7 @@ pub use crate::query::{
     Delegation, FullDelegation, QueryRequest, QueryResponse, QueryResult, StakingQuery, Validator,
     ValidatorsResponse, WasmQuery,
 };
-pub use crate::serde::{from_binary, from_slice, into_binary, to_binary, to_vec};
+pub use crate::serde::{from_binary, from_slice, to_binary, to_vec};
 pub use crate::storage::MemoryStorage;
 pub use crate::traits::{Api, Extern, Querier, QuerierResult, ReadonlyStorage, Storage};
 pub use crate::types::{

--- a/packages/std/src/serde.rs
+++ b/packages/std/src/serde.rs
@@ -30,13 +30,6 @@ where
     to_vec(data).map(Binary)
 }
 
-pub fn into_binary<T>(data: T) -> StdResult<Binary>
-where
-    T: Serialize,
-{
-    to_vec(&data).map(Binary)
-}
-
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION
The contract changes make sense to me. However, I don't like the `into_binary` signature because:
- The name sounds like it refers to [Into](https://doc.rust-lang.org/std/convert/trait.Into.html) but then it behaves very differently
- Taking an owned `data` as an argument has no advantage in the implementation

This diff shows how to utilize the existing API.

What you can also do is just

```rust
    match msg {
        QueryMsg::Verifier {} => to_binary(&query_verifier(deps)?),
        QueryMsg::OtherBalance { address } => to_binary(&query_other_balance(deps, address)?),
    }
```