### PR TITLE
Add full gas reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 0.9.4 (unreleased)
+
+**cosmwasm-vm**
+
+- Add `Instance::create_gas_report` returning a gas report including the
+  original limit, the remaining gas and the internally/externally used gas.
+
 ## 0.9.3 (2020-07-08)
 
 **cosmwasm-storage**

--- a/packages/vm/src/backends/cranelift.rs
+++ b/packages/vm/src/backends/cranelift.rs
@@ -1,8 +1,7 @@
 #![cfg(any(feature = "cranelift", feature = "default-cranelift"))]
 use wasmer_clif_backend::CraneliftCompiler;
 use wasmer_runtime_core::{
-    backend::Compiler, backend::CompilerConfig, compile_with_config, module::Module,
-    Instance as WasmerInstance,
+    backend::Compiler, backend::CompilerConfig, compile_with_config, module::Module, vm::Ctx,
 };
 
 use crate::errors::VmResult;
@@ -26,10 +25,10 @@ pub fn backend() -> &'static str {
     "cranelift"
 }
 
-/// Set the amount of gas units that can be used in the instance.
-pub fn set_gas_limit(_instance: &mut WasmerInstance, _limit: u64) {}
+/// Set the amount of gas units that can be used in the context.
+pub fn set_gas_limit(_ctx: &mut Ctx, _limit: u64) {}
 
-/// Get how many more gas units can be used in the instance.
-pub fn get_gas_left(_instance: &WasmerInstance) -> u64 {
+/// Get how many more gas units can be used in the context.
+pub fn get_gas_left(_ctx: &Ctx) -> u64 {
     FAKE_GAS_AVAILABLE
 }

--- a/packages/vm/src/backends/singlepass.rs
+++ b/packages/vm/src/backends/singlepass.rs
@@ -5,7 +5,7 @@ use wasmer_runtime_core::{
     codegen::{MiddlewareChain, StreamingCompiler},
     compile_with,
     module::Module,
-    Instance as WasmerInstance,
+    vm::Ctx,
 };
 use wasmer_singlepass_backend::ModuleCodeGenerator as SinglePassMCG;
 
@@ -41,15 +41,15 @@ pub fn backend() -> &'static str {
     "singlepass"
 }
 
-/// Set the amount of gas units that can be used in the instance.
-pub fn set_gas_limit(instance: &mut WasmerInstance, limit: u64) {
+/// Set the amount of gas units that can be used in the context.
+pub fn set_gas_limit(ctx: &mut Ctx, limit: u64) {
     let used = GAS_LIMIT.saturating_sub(limit);
-    metering::set_points_used(instance, used)
+    metering::set_points_used_ctx(ctx, used)
 }
 
-/// Get how many more gas units can be used in the instance.
-pub fn get_gas_left(instance: &WasmerInstance) -> u64 {
-    let used = metering::get_points_used(instance);
-    // when running out of gas, get_points_used can exceed GAS_LIMIT
+/// Get how many more gas units can be used in the context.
+pub fn get_gas_left(ctx: &Ctx) -> u64 {
+    let used = metering::get_points_used_ctx(ctx);
+    // when running out of gas, get_points_used_ctx can exceed GAS_LIMIT
     GAS_LIMIT.saturating_sub(used)
 }

--- a/packages/vm/src/context.rs
+++ b/packages/vm/src/context.rs
@@ -192,8 +192,15 @@ pub(crate) fn move_into_context<S: Storage, Q: Querier>(target: &mut Ctx, storag
     b.querier = Some(querier);
 }
 
-pub fn get_gas_state<'a, 'b, S: Storage, Q: Querier + 'b>(ctx: &'a mut Ctx) -> &'b mut GasState {
+pub fn get_gas_state_mut<'a, 'b, S: Storage, Q: Querier + 'b>(
+    ctx: &'a mut Ctx,
+) -> &'b mut GasState {
     &mut get_context_data_mut::<S, Q>(ctx).gas_state
+}
+
+#[allow(unused)]
+pub fn get_gas_state<'a, 'b, S: Storage, Q: Querier + 'b>(ctx: &'a Ctx) -> &'b GasState {
+    &get_context_data::<S, Q>(ctx).gas_state
 }
 
 #[cfg(feature = "default-singlepass")]
@@ -437,7 +444,7 @@ mod test {
 
         let gas_limit = 100;
         set_gas_limit(instance.context_mut(), gas_limit);
-        get_gas_state::<MS, MQ>(instance.context_mut()).set_gas_limit(gas_limit);
+        get_gas_state_mut::<MS, MQ>(instance.context_mut()).set_gas_limit(gas_limit);
         let context = instance.context_mut();
 
         // Consume all the Gas that we allocated
@@ -459,7 +466,7 @@ mod test {
 
         let gas_limit = 100;
         set_gas_limit(instance.context_mut(), gas_limit);
-        get_gas_state::<MS, MQ>(instance.context_mut()).set_gas_limit(gas_limit);
+        get_gas_state_mut::<MS, MQ>(instance.context_mut()).set_gas_limit(gas_limit);
         let context = instance.context_mut();
 
         // Consume all the Gas that we allocated

--- a/packages/vm/src/context.rs
+++ b/packages/vm/src/context.rs
@@ -24,10 +24,10 @@ use crate::traits::{Querier, Storage};
 #[derive(Clone, PartialEq, Debug, Default)]
 pub struct GasState {
     /// Gas limit for the computation.
-    gas_limit: u64,
+    pub gas_limit: u64,
     /// Tracking the gas used in the cosmos SDK, in cosmwasm units.
     #[allow(unused)]
-    externally_used_gas: u64,
+    pub externally_used_gas: u64,
 }
 
 impl GasState {
@@ -61,7 +61,7 @@ impl GasState {
     ///
     /// We need the amount of gas left in wasmer since it is not tracked inside this object.
     #[allow(unused)]
-    fn get_gas_used_in_wasmer(&self, wasmer_gas_left: u64) -> u64 {
+    pub(crate) fn get_gas_used_in_wasmer(&self, wasmer_gas_left: u64) -> u64 {
         self.gas_limit
             .saturating_sub(self.externally_used_gas)
             .saturating_sub(wasmer_gas_left)
@@ -198,7 +198,6 @@ pub fn get_gas_state_mut<'a, 'b, S: Storage, Q: Querier + 'b>(
     &mut get_context_data_mut::<S, Q>(ctx).gas_state
 }
 
-#[allow(unused)]
 pub fn get_gas_state<'a, 'b, S: Storage, Q: Querier + 'b>(ctx: &'a Ctx) -> &'b GasState {
     &get_context_data::<S, Q>(ctx).gas_state
 }

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -13,7 +13,7 @@ use wasmer_runtime_core::{
 
 use crate::backends::{compile, get_gas_left, set_gas_limit};
 use crate::context::{
-    get_gas_state, move_into_context, move_out_of_context, set_storage_readonly,
+    get_gas_state_mut, move_into_context, move_out_of_context, set_storage_readonly,
     set_wasmer_instance, setup_context, with_querier_from_context, with_storage_from_context,
 };
 use crate::conversion::to_u32;
@@ -140,7 +140,7 @@ where
         gas_limit: u64,
     ) -> Self {
         set_gas_limit(wasmer_instance.context_mut(), gas_limit);
-        get_gas_state::<S, Q>(wasmer_instance.context_mut()).set_gas_limit(gas_limit);
+        get_gas_state_mut::<S, Q>(wasmer_instance.context_mut()).set_gas_limit(gas_limit);
         let required_features = required_features_from_wasmer_instance(wasmer_instance.as_ref());
         let instance_ptr = NonNull::from(wasmer_instance.as_ref());
         set_wasmer_instance::<S, Q>(wasmer_instance.context_mut(), Some(instance_ptr));

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -139,7 +139,7 @@ where
         deps: Extern<S, A, Q>,
         gas_limit: u64,
     ) -> Self {
-        set_gas_limit(wasmer_instance.as_mut(), gas_limit);
+        set_gas_limit(wasmer_instance.context_mut(), gas_limit);
         get_gas_state::<S, Q>(wasmer_instance.context_mut()).set_gas_limit(gas_limit);
         let required_features = required_features_from_wasmer_instance(wasmer_instance.as_ref());
         let instance_ptr = NonNull::from(wasmer_instance.as_ref());
@@ -178,7 +178,7 @@ where
 
     /// Returns the currently remaining gas.
     pub fn get_gas_left(&self) -> u64 {
-        get_gas_left(&self.inner)
+        get_gas_left(self.inner.context())
     }
 
     /// Sets the readonly storage flag on this instance. Since one instance can be used

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -13,7 +13,7 @@ use wasmer_runtime_core::{
 
 use crate::backends::{compile, get_gas_left, set_gas_limit};
 use crate::context::{
-    get_gas_state_mut, move_into_context, move_out_of_context, set_storage_readonly,
+    get_gas_state, get_gas_state_mut, move_into_context, move_out_of_context, set_storage_readonly,
     set_wasmer_instance, setup_context, with_querier_from_context, with_storage_from_context,
 };
 use crate::conversion::to_u32;
@@ -28,6 +28,19 @@ use crate::memory::{get_memory_info, read_region, write_region};
 use crate::traits::{Api, Extern, Querier, Storage};
 
 static WASM_PAGE_SIZE: u64 = 64 * 1024;
+
+#[derive(Copy, Clone, Debug)]
+pub struct GasReport {
+    /// The original limit the instance was created with
+    pub limit: u64,
+    /// The remaining gas that can be spend
+    pub remaining: u64,
+    /// The amount of gas that was spend and metered externally in operations triggered by this instance
+    pub used_externally: u64,
+    /// The amount of gas that was spend and metered internally (i.e. by executing Wasm and calling
+    /// API methods which are not metered externally)
+    pub used_internally: u64,
+}
 
 pub struct Instance<S: Storage + 'static, A: Api + 'static, Q: Querier + 'static> {
     /// We put this instance in a box to maintain a constant memory address for the entire
@@ -178,7 +191,21 @@ where
 
     /// Returns the currently remaining gas.
     pub fn get_gas_left(&self) -> u64 {
-        get_gas_left(self.inner.context())
+        self.create_gas_report().remaining
+    }
+
+    /// Creates and returns a gas report.
+    /// This is a snapshot and multiple reports can be created during the lifetime of
+    /// an instance.
+    pub fn create_gas_report(&self) -> GasReport {
+        let state = get_gas_state::<S, Q>(self.inner.context()).clone();
+        let gas_left = get_gas_left(self.inner.context());
+        GasReport {
+            limit: state.gas_limit,
+            remaining: gas_left,
+            used_externally: state.externally_used_gas,
+            used_internally: state.get_gas_used_in_wasmer(gas_left),
+        }
     }
 
     /// Sets the readonly storage flag on this instance. Since one instance can be used
@@ -250,7 +277,7 @@ mod test {
     use crate::traits::Storage;
     use crate::{call_init, FfiError};
     use cosmwasm_std::{
-        coin, from_binary, AllBalanceResponse, BalanceResponse, BankQuery, Empty, HumanAddr,
+        coin, coins, from_binary, AllBalanceResponse, BalanceResponse, BankQuery, Empty, HumanAddr,
         QueryRequest,
     };
     use wabt::wat2wasm;
@@ -467,6 +494,63 @@ mod test {
         let instance = mock_instance_with_gas_limit(&CONTRACT, 123321);
         let orig_gas = instance.get_gas_left();
         assert_eq!(orig_gas, 123321);
+    }
+
+    #[test]
+    #[cfg(feature = "default-cranelift")]
+    fn create_gas_report_works_cranelift() {
+        const LIMIT: u64 = 7_000_000;
+        /// Value hardcoded in cranelift backend
+        const FAKE_REMANING: u64 = 1_000_000;
+        let mut instance = mock_instance_with_gas_limit(&CONTRACT, LIMIT);
+
+        let report1 = instance.create_gas_report();
+        assert_eq!(report1.used_externally, 0);
+        assert_eq!(report1.used_internally, LIMIT - FAKE_REMANING);
+        assert_eq!(report1.limit, LIMIT);
+        assert_eq!(report1.remaining, FAKE_REMANING);
+
+        // init contract
+        let env = mock_env(&instance.api, "creator", &coins(1000, "earth"));
+        let msg = r#"{"verifier": "verifies", "beneficiary": "benefits"}"#.as_bytes();
+        call_init::<_, _, _, Empty>(&mut instance, &env, msg)
+            .unwrap()
+            .unwrap();
+
+        let report2 = instance.create_gas_report();
+        assert_eq!(report2.used_externally, 0);
+        assert_eq!(report2.used_internally, LIMIT - FAKE_REMANING);
+        assert_eq!(report2.limit, LIMIT);
+        assert_eq!(report2.remaining, FAKE_REMANING);
+    }
+
+    #[test]
+    #[cfg(feature = "default-singlepass")]
+    fn create_gas_report_works_singlepass() {
+        const LIMIT: u64 = 7_000_000;
+        let mut instance = mock_instance_with_gas_limit(&CONTRACT, LIMIT);
+
+        let report1 = instance.create_gas_report();
+        assert_eq!(report1.used_externally, 0);
+        assert_eq!(report1.used_internally, 0);
+        assert_eq!(report1.limit, LIMIT);
+        assert_eq!(report1.remaining, LIMIT);
+
+        // init contract
+        let env = mock_env(&instance.api, "creator", &coins(1000, "earth"));
+        let msg = r#"{"verifier": "verifies", "beneficiary": "benefits"}"#.as_bytes();
+        call_init::<_, _, _, Empty>(&mut instance, &env, msg)
+            .unwrap()
+            .unwrap();
+
+        let report2 = instance.create_gas_report();
+        assert_eq!(report2.used_externally, 134);
+        assert_eq!(report2.used_internally, 70676);
+        assert_eq!(report2.limit, LIMIT);
+        assert_eq!(
+            report2.remaining,
+            LIMIT - report2.used_externally - report2.used_internally
+        );
     }
 
     #[test]

--- a/packages/vm/src/lib.rs
+++ b/packages/vm/src/lib.rs
@@ -26,7 +26,7 @@ pub use crate::errors::{
     CommunicationError, CommunicationResult, FfiError, FfiResult, VmError, VmResult,
 };
 pub use crate::features::features_from_csv;
-pub use crate::instance::Instance;
+pub use crate::instance::{GasReport, Instance};
 pub use crate::modules::FileSystemCache;
 pub use crate::serde::{from_slice, to_vec};
 pub use crate::traits::{Api, Extern, Querier, QuerierResult, Storage};


### PR DESCRIPTION
Closes #479

In https://github.com/CosmWasm/cosmwasm/pull/475 it was discovered that right now there is no way to report the internally used gas. This leads to a wrong calculation of the gas usage since the externally used gas is charged twice (in Comsos SDK and as part of `*gas_used = gas_limit - instance.get_gas_left();`. See also https://github.com/CosmWasm/go-cosmwasm/issues/119