### PR TITLE
Response Context builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@
 - Implement `From<&[u8; $N]> for Binary` and `From<[u8; $N]> for Binary` for all
   `$N <= 32`.
 - Add `Context` object that can be used to build Init/Handle/Migrate response
-  via `emit`, `send_action`, `set_data` and then convert to the proper type
-  via `try_into`. Option to simplify response construction.
+  via `add_event`, `add_message`, `set_data` and then convert to the proper type
+  via `into` or `try_into`. Option to simplify response construction.
 
 **cosmwasm-vm**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
   favour of `StdError::generic_err` and friends.
 - Implement `From<&[u8; $N]> for Binary` and `From<[u8; $N]> for Binary` for all
   `$N <= 32`.
+- Add `Context` object that can be used to build Init/Handle/Migrate response
+  via `emit`, `send_action`, `set_data` and then convert to the proper type
+  via `try_into`. Option to simplify response construction.
 
 **cosmwasm-vm**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Implement `From<&[u8; $N]> for Binary` and `From<[u8; $N]> for Binary` for all
   `$N <= 32`.
 - Add `Context` object that can be used to build Init/Handle/Migrate response
-  via `add_event`, `add_message`, `set_data` and then convert to the proper type
+  via `add_log`, `add_message`, `set_data` and then convert to the proper type
   via `into` or `try_into`. Option to simplify response construction.
 
 **cosmwasm-vm**

--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -1,8 +1,9 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::convert::TryInto;
 
 use cosmwasm_std::{
-    from_slice, log, to_binary, to_vec, AllBalanceResponse, Api, BankMsg, CanonicalAddr, Env,
+    from_slice, to_binary, to_vec, AllBalanceResponse, Api, BankMsg, CanonicalAddr, Context, Env,
     Extern, HandleResponse, HumanAddr, InitResponse, MigrateResponse, Querier, QueryResponse,
     StdError, StdResult, Storage,
 };
@@ -82,11 +83,10 @@ pub fn init<S: Storage, A: Api, Q: Querier>(
         })?,
     );
 
-    // This adds some unrelated data and log for testing purposes
-    Ok(InitResponse {
-        log: vec![log("Let the", "hacking begin")],
-        messages: vec![],
-    })
+    // This adds some unrelated log for testing purposes
+    let mut ctx = Context::new();
+    ctx.emit("Let the", "hacking begin");
+    ctx.try_into()
 }
 
 pub fn migrate<S: Storage, A: Api, Q: Querier>(
@@ -101,7 +101,8 @@ pub fn migrate<S: Storage, A: Api, Q: Querier>(
     let mut config: State = from_slice(&data)?;
     config.verifier = deps.api.canonical_address(&msg.verifier)?;
     deps.storage.set(CONFIG_KEY, &to_vec(&config)?);
-    Ok(MigrateResponse::default())
+
+    Context::new().try_into()
 }
 
 pub fn handle<S: Storage, A: Api, Q: Querier>(
@@ -134,17 +135,16 @@ fn do_release<S: Storage, A: Api, Q: Querier>(
         let from_addr = deps.api.human_address(&env.contract.address)?;
         let balance = deps.querier.query_all_balances(&from_addr)?;
 
-        let res = HandleResponse {
-            log: vec![log("action", "release"), log("destination", &to_addr)],
-            messages: vec![BankMsg::Send {
-                from_address: from_addr,
-                to_address: to_addr,
-                amount: balance,
-            }
-            .into()],
-            data: Some(vec![0xF0, 0x0B, 0xAA].into()),
-        };
-        Ok(res)
+        let mut ctx = Context::new();
+        ctx.emit("action", "release");
+        ctx.emit("destination", &to_addr);
+        ctx.send_action(BankMsg::Send {
+            from_address: from_addr,
+            to_address: to_addr,
+            amount: balance,
+        });
+        ctx.set_data(&[0xF0, 0x0B, 0xAA]);
+        ctx.try_into()
     } else {
         Err(StdError::unauthorized())
     }
@@ -240,7 +240,7 @@ mod tests {
         mock_dependencies, mock_dependencies_with_balances, mock_env, MOCK_CONTRACT_ADDR,
     };
     // import trait ReadonlyStorage to get access to read
-    use cosmwasm_std::{coins, ReadonlyStorage, StdError};
+    use cosmwasm_std::{coins, log, ReadonlyStorage, StdError};
 
     #[test]
     fn proper_initialization() {

--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -85,7 +85,7 @@ pub fn init<S: Storage, A: Api, Q: Querier>(
 
     // This adds some unrelated log for testing purposes
     let mut ctx = Context::new();
-    ctx.add_event("Let the", "hacking begin");
+    ctx.add_log("Let the", "hacking begin");
     ctx.try_into()
 }
 
@@ -136,8 +136,8 @@ fn do_release<S: Storage, A: Api, Q: Querier>(
         let balance = deps.querier.query_all_balances(&from_addr)?;
 
         let mut ctx = Context::new();
-        ctx.add_event("action", "release");
-        ctx.add_event("destination", &to_addr);
+        ctx.add_log("action", "release");
+        ctx.add_log("destination", &to_addr);
         ctx.add_message(BankMsg::Send {
             from_address: from_addr,
             to_address: to_addr,

--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -85,7 +85,7 @@ pub fn init<S: Storage, A: Api, Q: Querier>(
 
     // This adds some unrelated log for testing purposes
     let mut ctx = Context::new();
-    ctx.emit("Let the", "hacking begin");
+    ctx.add_event("Let the", "hacking begin");
     ctx.try_into()
 }
 
@@ -102,7 +102,7 @@ pub fn migrate<S: Storage, A: Api, Q: Querier>(
     config.verifier = deps.api.canonical_address(&msg.verifier)?;
     deps.storage.set(CONFIG_KEY, &to_vec(&config)?);
 
-    Context::new().try_into()
+    Ok(MigrateResponse::default())
 }
 
 pub fn handle<S: Storage, A: Api, Q: Querier>(
@@ -136,15 +136,15 @@ fn do_release<S: Storage, A: Api, Q: Querier>(
         let balance = deps.querier.query_all_balances(&from_addr)?;
 
         let mut ctx = Context::new();
-        ctx.emit("action", "release");
-        ctx.emit("destination", &to_addr);
-        ctx.send_action(BankMsg::Send {
+        ctx.add_event("action", "release");
+        ctx.add_event("destination", &to_addr);
+        ctx.add_message(BankMsg::Send {
             from_address: from_addr,
             to_address: to_addr,
             amount: balance,
         });
         ctx.set_data(&[0xF0, 0x0B, 0xAA]);
-        ctx.try_into()
+        Ok(ctx.into())
     } else {
         Err(StdError::unauthorized())
     }

--- a/packages/std/src/init_handle.rs
+++ b/packages/std/src/init_handle.rs
@@ -268,7 +268,7 @@ where
         Context::default()
     }
 
-    pub fn add_event<K: ToString, V: ToString>(&mut self, key: K, value: V) {
+    pub fn add_log<K: ToString, V: ToString>(&mut self, key: K, value: V) {
         self.log.push(log(key, value));
     }
 
@@ -368,8 +368,8 @@ mod test {
         let mut ctx = Context::new();
 
         // build it up with the builder commands
-        ctx.add_event("sender", &HumanAddr::from("john"));
-        ctx.add_event("action", "test");
+        ctx.add_log("sender", &HumanAddr::from("john"));
+        ctx.add_log("action", "test");
         ctx.add_message(BankMsg::Send {
             from_address: HumanAddr::from("goo"),
             to_address: HumanAddr::from("foo"),

--- a/packages/std/src/init_handle.rs
+++ b/packages/std/src/init_handle.rs
@@ -251,16 +251,25 @@ where
     data: Option<Binary>,
 }
 
-impl<T> Context<T>
+impl<T> Default for Context<T>
 where
     T: Clone + fmt::Debug + PartialEq + JsonSchema,
 {
-    pub fn new() -> Self {
+    fn default() -> Self {
         Context {
             messages: vec![],
             log: vec![],
             data: None,
         }
+    }
+}
+
+impl<T> Context<T>
+where
+    T: Clone + fmt::Debug + PartialEq + JsonSchema,
+{
+    pub fn new() -> Self {
+        Context::default()
     }
 
     pub fn emit<K: ToString, V: ToString>(&mut self, key: K, value: V) {

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -18,8 +18,8 @@ pub use crate::coins::{coin, coins, has_coins, Coin};
 pub use crate::encoding::Binary;
 pub use crate::errors::{StdError, StdResult, SystemError, SystemResult};
 pub use crate::init_handle::{
-    log, BankMsg, CosmosMsg, HandleResponse, HandleResult, InitResponse, InitResult, LogAttribute,
-    MigrateResponse, MigrateResult, StakingMsg, WasmMsg,
+    log, BankMsg, Context, CosmosMsg, HandleResponse, HandleResult, InitResponse, InitResult,
+    LogAttribute, MigrateResponse, MigrateResult, StakingMsg, WasmMsg,
 };
 #[cfg(feature = "iterator")]
 pub use crate::iterator::{Order, KV};


### PR DESCRIPTION
Implement suggestion from https://github.com/CosmWasm/cosmwasm/issues/476#issuecomment-658768297

Add a `Context` type with the following

```rust
impl<T> Context<T>
{
    pub fn new() -> Self { }

    pub fn emit<K: ToString, V: ToString>(&mut self, key: K, value: V) { }

    pub fn send_action<U: Into<CosmosMsg<T>>>(&mut self, msg: U) { }

    pub fn set_data<U: Into<Binary>>(&mut self, data: U) { }
}
```

It can easily be built up in steps, handling type conversion transparently, and then `try_into` any of the Response types.

This is a second, optional API to build the response types. I'd like to get some real-world feedback on the usage