### PR TITLE
Split FfiError::Other

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
   sends invalid UTF-8 in places that expect strings.
 - Remove `FfiError::Other` in favour of `FfiError::UserErr` and
   `FfiError::Unknown`.
+- The `canonicalize_address` import now reports user errors to the contract.
 
 ## 0.9.4 (2020-07-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
   return data and the gas cost consistently across all APIs using `FfiResult`.
 - Create error type `FfiError::InvalidUtf8` for the cases where the backend
   sends invalid UTF-8 in places that expect strings.
+- Remove `FfiError::Other` in favour of `FfiError::UserErr` and
+  `FfiError::Unknown`.
 
 ## 0.9.4 (2020-07-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
   data and gas usage.
 - Remove `NextItem` in favour of `FfiSuccess<T>`, which is used to store the
   return data and the gas cost consistently across all APIs using `FfiResult`.
+  The error type of `FfiResult` changed to `FfiFailure = (FfiError, GasInfo)`,
+  such that both success and error cases always contain gas information.
 - Create error type `FfiError::InvalidUtf8` for the cases where the backend
   sends invalid UTF-8 in places that expect strings.
 - Remove `FfiError::Other` in favour of `FfiError::UserErr` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,8 @@
   sends invalid UTF-8 in places that expect strings.
 - Remove `FfiError::Other` in favour of `FfiError::UserErr` and
   `FfiError::Unknown`.
-- The `canonicalize_address` import now reports user errors to the contract.
+- The `canonicalize_address` and `humanize_address` imports now report user
+  errors to the contract.
 
 ## 0.9.4 (2020-07-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
   data and gas usage.
 - Remove `NextItem` in favour of `FfiSuccess<T>`, which is used to store the
   return data and the gas cost consistently across all APIs using `FfiResult`.
+- Create error type `FfiError::InvalidUtf8` for the cases where the backend
+  sends invalid UTF-8 in places that expect strings.
 
 ## 0.9.4 (2020-07-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,10 +27,9 @@
 - Create dedicated `RegionValidationError` and `RegionValidationResult`.
 - `Api::human_address` and `Api::canonical_address` now return a pair of return
   data and gas usage.
-- Remove `NextItem` in favour of `FfiSuccess<T>`, which is used to store the
-  return data and the gas cost consistently across all APIs using `FfiResult`.
-  The error type of `FfiResult` changed to `FfiFailure = (FfiError, GasInfo)`,
-  such that both success and error cases always contain gas information.
+- Remove `NextItem` in favour of a more advanced `FfiResult<T>`, which is used
+  to store the return result and the gas information consistently across all
+  APIs. `FfiResult<T>` was changed to `(Result<T, FfiError>, GasInfo)`.
 - Create error type `FfiError::InvalidUtf8` for the cases where the backend
   sends invalid UTF-8 in places that expect strings.
 - Remove `FfiError::Other` in favour of `FfiError::UserErr` and

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -9,21 +9,17 @@ major releases of `cosmwasm`. Note that you can also view the
 Integration tests:
 
 - Calls to `Api::human_address` and `Api::canonical_address` now return a pair
-  of return data and gas usage. Change
+  of result and gas information. Change
 
   ```rust
-  // before 1
+  // before
   verifier: deps.api.canonical_address(&verifier).unwrap(),
 
-  // after 1
-  verifier: deps.api.canonical_address(&verifier).unwrap().0,
-
-  // before 2
-  let contract_addr = deps.api.human_address(&init_env.contract.address).unwrap();
-
-  // after 2
-  let (contract_addr, _gas_used) = deps.api.human_address(&init_env.contract.address).unwrap();
+  // after
+  verifier: deps.api.canonical_address(&verifier).0.unwrap(),
   ```
+
+  The same applies for all calls of `Querier` and `Storage`.
 
 ## 0.8 -> 0.9
 

--- a/contracts/burner/tests/integration.rs
+++ b/contracts/burner/tests/integration.rs
@@ -51,13 +51,13 @@ fn migrate_cleans_up_data() {
 
     // store some sample data
     deps.with_storage(|storage| {
-        storage.set(b"foo", b"bar").unwrap();
-        storage.set(b"key2", b"data2").unwrap();
-        storage.set(b"key3", b"cool stuff").unwrap();
+        storage.set(b"foo", b"bar").0.unwrap();
+        storage.set(b"key2", b"data2").0.unwrap();
+        storage.set(b"key3", b"cool stuff").0.unwrap();
         let cnt = storage
             .range(None, None, Order::Ascending)
-            .unwrap()
             .0
+            .unwrap()
             .elements()
             .unwrap()
             .len();
@@ -90,8 +90,8 @@ fn migrate_cleans_up_data() {
     deps.with_storage(|storage| {
         let cnt = storage
             .range(None, None, Order::Ascending)
-            .unwrap()
             .0
+            .unwrap()
             .elements()
             .unwrap()
             .len();

--- a/contracts/hackatom/tests/integration.rs
+++ b/contracts/hackatom/tests/integration.rs
@@ -43,9 +43,9 @@ fn proper_initialization() {
     let beneficiary = HumanAddr(String::from("benefits"));
     let creator = HumanAddr(String::from("creator"));
     let expected_state = State {
-        verifier: deps.api.canonical_address(&verifier).unwrap().0,
-        beneficiary: deps.api.canonical_address(&beneficiary).unwrap().0,
-        funder: deps.api.canonical_address(&creator).unwrap().0,
+        verifier: deps.api.canonical_address(&verifier).0.unwrap(),
+        beneficiary: deps.api.canonical_address(&beneficiary).0.unwrap(),
+        funder: deps.api.canonical_address(&creator).0.unwrap(),
     };
 
     let msg = InitMsg {
@@ -64,8 +64,8 @@ fn proper_initialization() {
         .with_storage(|store| {
             let data = store
                 .get(CONFIG_KEY)
-                .expect("error reading db")
                 .0
+                .expect("error reading db")
                 .expect("no data stored");
             from_slice(&data)
         })
@@ -183,7 +183,11 @@ fn handle_release_works() {
     };
     let init_amount = coins(1000, "earth");
     let init_env = mock_env(&deps.api, creator.as_str(), &init_amount);
-    let (contract_addr, _gas_used) = deps.api.human_address(&init_env.contract.address).unwrap();
+    let contract_addr = deps
+        .api
+        .human_address(&init_env.contract.address)
+        .0
+        .unwrap();
     let init_res: InitResponse = init(&mut deps, init_env, init_msg).unwrap();
     assert_eq!(init_res.messages.len(), 0);
 
@@ -230,7 +234,11 @@ fn handle_release_fails_for_wrong_sender() {
     };
     let init_amount = coins(1000, "earth");
     let init_env = mock_env(&deps.api, creator.as_str(), &init_amount);
-    let (contract_addr, _gas_used) = deps.api.human_address(&init_env.contract.address).unwrap();
+    let contract_addr = deps
+        .api
+        .human_address(&init_env.contract.address)
+        .0
+        .unwrap();
     let init_res: InitResponse = init(&mut deps, init_env, init_msg).unwrap();
     assert_eq!(init_res.messages.len(), 0);
 
@@ -254,8 +262,8 @@ fn handle_release_fails_for_wrong_sender() {
         .with_storage(|store| {
             Ok(store
                 .get(CONFIG_KEY)
-                .expect("error reading db")
                 .0
+                .expect("error reading db")
                 .expect("no data stored"))
         })
         .unwrap();
@@ -263,9 +271,9 @@ fn handle_release_fails_for_wrong_sender() {
     assert_eq!(
         state,
         State {
-            verifier: deps.api.canonical_address(&verifier).unwrap().0,
-            beneficiary: deps.api.canonical_address(&beneficiary).unwrap().0,
-            funder: deps.api.canonical_address(&creator).unwrap().0,
+            verifier: deps.api.canonical_address(&verifier).0.unwrap(),
+            beneficiary: deps.api.canonical_address(&beneficiary).0.unwrap(),
+            funder: deps.api.canonical_address(&creator).0.unwrap(),
         }
     );
 }

--- a/contracts/reflect/tests/integration.rs
+++ b/contracts/reflect/tests/integration.rs
@@ -85,7 +85,7 @@ fn reflect() {
     let env = mock_env(&deps.api, "creator", &[]);
     let payload = vec![
         BankMsg::Send {
-            from_address: deps.api.human_address(&env.contract.address).unwrap().0,
+            from_address: deps.api.human_address(&env.contract.address).0.unwrap(),
             to_address: HumanAddr::from("friend"),
             amount: coins(1, "token"),
         }
@@ -119,7 +119,7 @@ fn reflect_requires_owner() {
     // signer is not owner
     let env = mock_env(&deps.api, "someone", &[]);
     let payload = vec![BankMsg::Send {
-        from_address: deps.api.human_address(&env.contract.address).unwrap().0,
+        from_address: deps.api.human_address(&env.contract.address).0.unwrap(),
         to_address: HumanAddr::from("friend"),
         amount: coins(1, "token"),
     }

--- a/packages/vm/src/context.rs
+++ b/packages/vm/src/context.rs
@@ -423,6 +423,7 @@ mod test {
         let mut storage = MockStorage::new();
         storage
             .set(INIT_KEY, INIT_VALUE)
+            .0
             .expect("error setting value");
         let querier: MockQuerier<Empty> =
             MockQuerier::new(&[(&HumanAddr::from(INIT_ADDR), &coins(INIT_AMOUNT, INIT_DENOM))]);
@@ -446,7 +447,7 @@ mod test {
         assert!(s.is_some());
         assert!(q.is_some());
         assert_eq!(
-            s.unwrap().get(INIT_KEY).unwrap().0,
+            s.unwrap().get(INIT_KEY).0.unwrap(),
             Some(INIT_VALUE.to_vec())
         );
 
@@ -614,8 +615,8 @@ mod test {
         let ctx = instance.context_mut();
         leave_default_data(ctx);
 
-        let (val, _used_gas) = with_storage_from_context::<MS, MQ, _, _>(ctx, |store| {
-            Ok(store.get(INIT_KEY).expect("error getting value"))
+        let val = with_storage_from_context::<MS, MQ, _, _>(ctx, |store| {
+            Ok(store.get(INIT_KEY).0.expect("error getting value"))
         })
         .unwrap();
         assert_eq!(val, Some(INIT_VALUE.to_vec()));
@@ -624,14 +625,17 @@ mod test {
         let set_value: &[u8] = b"data";
 
         with_storage_from_context::<MS, MQ, _, _>(ctx, |store| {
-            store.set(set_key, set_value).expect("error setting value");
+            store
+                .set(set_key, set_value)
+                .0
+                .expect("error setting value");
             Ok(())
         })
         .unwrap();
 
         with_storage_from_context::<MS, MQ, _, _>(ctx, |store| {
-            assert_eq!(store.get(INIT_KEY).unwrap().0, Some(INIT_VALUE.to_vec()));
-            assert_eq!(store.get(set_key).unwrap().0, Some(set_value.to_vec()));
+            assert_eq!(store.get(INIT_KEY).0.unwrap(), Some(INIT_VALUE.to_vec()));
+            assert_eq!(store.get(set_key).0.unwrap(), Some(set_value.to_vec()));
             Ok(())
         })
         .unwrap();
@@ -660,12 +664,10 @@ mod test {
             let req: QueryRequest<Empty> = QueryRequest::Bank(BankQuery::AllBalances {
                 address: HumanAddr::from(INIT_ADDR),
             });
-            let ffi_result = querier.raw_query(&to_vec(&req).unwrap());
-            let ffi_success = ffi_result.unwrap();
-            Ok(ffi_success)
+            let (result, _gas_info) = querier.raw_query(&to_vec(&req).unwrap());
+            Ok(result.unwrap())
         })
         .unwrap()
-        .0
         .unwrap()
         .unwrap();
         let balance: AllBalanceResponse = from_binary(&res).unwrap();
@@ -695,7 +697,7 @@ mod test {
 
         let id = add_iterator::<MS, MQ>(ctx, Box::new(MockIterator::empty()));
         with_iterator_from_context::<MS, MQ, _, ()>(ctx, id, |iter| {
-            assert!(iter.next().unwrap().0.is_none());
+            assert!(iter.next().0.unwrap().is_none());
             Ok(())
         })
         .expect("must not error");

--- a/packages/vm/src/context.rs
+++ b/packages/vm/src/context.rs
@@ -341,7 +341,7 @@ where
 {
     let b = get_context_data_mut::<S, Q>(ctx);
     match b.querier.as_mut() {
-        Some(q) => func(q),
+        Some(querier) => func(querier),
         None => Err(VmError::uninitialized_context_data("querier")),
     }
 }
@@ -660,7 +660,9 @@ mod test {
             let req: QueryRequest<Empty> = QueryRequest::Bank(BankQuery::AllBalances {
                 address: HumanAddr::from(INIT_ADDR),
             });
-            Ok(querier.raw_query(&to_vec(&req).unwrap())?)
+            let ffi_result = querier.raw_query(&to_vec(&req).unwrap());
+            let ffi_success = ffi_result.unwrap();
+            Ok(ffi_success)
         })
         .unwrap()
         .0

--- a/packages/vm/src/ffi.rs
+++ b/packages/vm/src/ffi.rs
@@ -6,10 +6,13 @@ use std::string::FromUtf8Error;
 /// non-negligible computational cost and must always have gas information
 /// attached. In order to prevent new calls from forgetting such gas information
 /// to be passed, the inner success and failure types contain gas information.
-pub type FfiResult<T> = core::result::Result<FfiSuccess<T>, FfiError>;
+pub type FfiResult<T> = core::result::Result<FfiSuccess<T>, FfiFailure>;
 
 /// A return element and the gas cost of this FFI call
 pub type FfiSuccess<T> = (T, GasInfo);
+
+/// A return element and the gas cost of this FFI call
+pub type FfiFailure = (FfiError, GasInfo);
 
 #[derive(Copy, Clone, Debug)]
 pub struct GasInfo {

--- a/packages/vm/src/ffi.rs
+++ b/packages/vm/src/ffi.rs
@@ -6,13 +6,7 @@ use std::string::FromUtf8Error;
 /// non-negligible computational cost and must always have gas information
 /// attached. In order to prevent new calls from forgetting such gas information
 /// to be passed, the inner success and failure types contain gas information.
-pub type FfiResult<T> = core::result::Result<FfiSuccess<T>, FfiFailure>;
-
-/// A return element and the gas cost of this FFI call
-pub type FfiSuccess<T> = (T, GasInfo);
-
-/// A return element and the gas cost of this FFI call
-pub type FfiFailure = (FfiError, GasInfo);
+pub type FfiResult<T> = (core::result::Result<T, FfiError>, GasInfo);
 
 #[derive(Copy, Clone, Debug)]
 pub struct GasInfo {

--- a/packages/vm/src/ffi.rs
+++ b/packages/vm/src/ffi.rs
@@ -46,11 +46,6 @@ pub enum FfiError {
     InvalidUtf8 { backtrace: snafu::Backtrace },
     #[snafu(display("Ran out of gas during FFI call"))]
     OutOfGas {},
-    #[snafu(display("Error during FFI call: {}", error))]
-    Other {
-        error: String,
-        backtrace: snafu::Backtrace,
-    },
     #[snafu(display("Unknown error during FFI call: {:?}", msg))]
     Unknown {
         msg: Option<String>,
@@ -75,16 +70,6 @@ impl FfiError {
 
     pub fn out_of_gas() -> Self {
         OutOfGas {}.build()
-    }
-
-    pub fn other<S>(error: S) -> Self
-    where
-        S: Into<String>,
-    {
-        Other {
-            error: error.into(),
-        }
-        .build()
     }
 
     pub fn unknown<S: ToString>(msg: S) -> Self {
@@ -142,15 +127,6 @@ mod test {
         let error = FfiError::out_of_gas();
         match error {
             FfiError::OutOfGas { .. } => {}
-            e => panic!("Unexpected error: {:?}", e),
-        }
-    }
-
-    #[test]
-    fn ffi_error_other() {
-        let error = FfiError::other("broken");
-        match error {
-            FfiError::Other { error, .. } => assert_eq!(error, "broken"),
             e => panic!("Unexpected error: {:?}", e),
         }
     }

--- a/packages/vm/src/imports.rs
+++ b/packages/vm/src/imports.rs
@@ -39,17 +39,10 @@ const MAX_LENGTH_QUERY_CHAIN_REQUEST: usize = 64 * KI;
 pub fn do_read<S: Storage, Q: Querier>(ctx: &mut Ctx, key_ptr: u32) -> VmResult<u32> {
     let key = read_region(ctx, key_ptr, MAX_LENGTH_DB_KEY)?;
 
-    let ffi_result = with_storage_from_context::<S, Q, _, _>(ctx, |store| Ok(store.get(&key)))?;
-    let value = match ffi_result {
-        Ok((value, gas_info)) => {
-            process_gas_info::<S, Q>(ctx, gas_info)?;
-            Ok(value)
-        }
-        Err((err, gas_info)) => {
-            process_gas_info::<S, Q>(ctx, gas_info)?;
-            Err(VmError::from(err))
-        }
-    }?;
+    let (result, gas_info) =
+        with_storage_from_context::<S, Q, _, _>(ctx, |store| Ok(store.get(&key)))?;
+    process_gas_info::<S, Q>(ctx, gas_info)?;
+    let value = result?;
 
     let out_data = match value {
         Some(data) => data,
@@ -71,18 +64,10 @@ pub fn do_write<S: Storage, Q: Querier>(
     let key = read_region(ctx, key_ptr, MAX_LENGTH_DB_KEY)?;
     let value = read_region(ctx, value_ptr, MAX_LENGTH_DB_VALUE)?;
 
-    let ffi_result =
+    let (result, gas_info) =
         with_storage_from_context::<S, Q, _, _>(ctx, |store| Ok(store.set(&key, &value)))?;
-    match ffi_result {
-        Ok(((), gas_info)) => {
-            process_gas_info::<S, Q>(ctx, gas_info)?;
-            Ok(())
-        }
-        Err((err, gas_info)) => {
-            process_gas_info::<S, Q>(ctx, gas_info)?;
-            Err(VmError::from(err))
-        }
-    }?;
+    process_gas_info::<S, Q>(ctx, gas_info)?;
+    result?;
 
     Ok(())
 }
@@ -94,17 +79,10 @@ pub fn do_remove<S: Storage, Q: Querier>(ctx: &mut Ctx, key_ptr: u32) -> VmResul
 
     let key = read_region(ctx, key_ptr, MAX_LENGTH_DB_KEY)?;
 
-    let ffi_result = with_storage_from_context::<S, Q, _, _>(ctx, |store| Ok(store.remove(&key)))?;
-    match ffi_result {
-        Ok(((), gas_info)) => {
-            process_gas_info::<S, Q>(ctx, gas_info)?;
-            Ok(())
-        }
-        Err((err, gas_info)) => {
-            process_gas_info::<S, Q>(ctx, gas_info)?;
-            Err(VmError::from(err))
-        }
-    }?;
+    let (result, gas_info) =
+        with_storage_from_context::<S, Q, _, _>(ctx, |store| Ok(store.remove(&key)))?;
+    process_gas_info::<S, Q>(ctx, gas_info)?;
+    result?;
 
     Ok(())
 }
@@ -126,20 +104,15 @@ pub fn do_canonicalize_address<A: Api, S: Storage, Q: Querier>(
     };
     let human: HumanAddr = source_string.into();
 
-    match api.canonical_address(&human) {
-        Ok((canonical, gas_info)) => {
-            process_gas_info::<S, Q>(ctx, gas_info)?;
+    let (result, gas_info) = api.canonical_address(&human);
+    process_gas_info::<S, Q>(ctx, gas_info)?;
+    match result {
+        Ok(canonical) => {
             write_region(ctx, destination_ptr, canonical.as_slice())?;
             Ok(0)
         }
-        Err((FfiError::UserErr { msg, .. }, gas_info)) => {
-            process_gas_info::<S, Q>(ctx, gas_info)?;
-            Ok(write_to_contract::<S, Q>(ctx, msg.as_bytes())?)
-        }
-        Err((err, gas_info)) => {
-            process_gas_info::<S, Q>(ctx, gas_info)?;
-            Err(VmError::from(err))
-        }
+        Err(FfiError::UserErr { msg, .. }) => Ok(write_to_contract::<S, Q>(ctx, msg.as_bytes())?),
+        Err(err) => Err(VmError::from(err)),
     }
 }
 
@@ -151,20 +124,15 @@ pub fn do_humanize_address<A: Api, S: Storage, Q: Querier>(
 ) -> VmResult<u32> {
     let canonical = Binary(read_region(ctx, source_ptr, MAX_LENGTH_CANONICAL_ADDRESS)?);
 
-    match api.human_address(&CanonicalAddr(canonical)) {
-        Ok((human, gas_info)) => {
-            process_gas_info::<S, Q>(ctx, gas_info)?;
+    let (result, gas_info) = api.human_address(&CanonicalAddr(canonical));
+    process_gas_info::<S, Q>(ctx, gas_info)?;
+    match result {
+        Ok(human) => {
             write_region(ctx, destination_ptr, human.as_str().as_bytes())?;
             Ok(0)
         }
-        Err((FfiError::UserErr { msg, .. }, gas_info)) => {
-            process_gas_info::<S, Q>(ctx, gas_info)?;
-            Ok(write_to_contract::<S, Q>(ctx, msg.as_bytes())?)
-        }
-        Err((err, gas_info)) => {
-            process_gas_info::<S, Q>(ctx, gas_info)?;
-            Err(VmError::from(err))
-        }
+        Err(FfiError::UserErr { msg, .. }) => Ok(write_to_contract::<S, Q>(ctx, msg.as_bytes())?),
+        Err(err) => Err(VmError::from(err)),
     }
 }
 
@@ -185,20 +153,10 @@ fn write_to_contract<S: Storage, Q: Querier>(ctx: &mut Ctx, input: &[u8]) -> VmR
 pub fn do_query_chain<S: Storage, Q: Querier>(ctx: &mut Ctx, request_ptr: u32) -> VmResult<u32> {
     let request = read_region(ctx, request_ptr, MAX_LENGTH_QUERY_CHAIN_REQUEST)?;
 
-    let ffi_result =
+    let (result, gas_info) =
         with_querier_from_context::<S, Q, _, _>(ctx, |querier| Ok(querier.raw_query(&request)))?;
-    let res = match ffi_result {
-        Ok((res, gas_info)) => {
-            process_gas_info::<S, Q>(ctx, gas_info)?;
-            Ok(res)
-        }
-        Err((err, gas_info)) => {
-            process_gas_info::<S, Q>(ctx, gas_info)?;
-            Err(VmError::from(err))
-        }
-    }?;
-
-    let serialized = to_vec(&res)?;
+    process_gas_info::<S, Q>(ctx, gas_info)?;
+    let serialized = to_vec(&result?)?;
     write_to_contract::<S, Q>(ctx, &serialized)
 }
 
@@ -215,41 +173,23 @@ pub fn do_scan<S: Storage + 'static, Q: Querier>(
         .try_into()
         .map_err(|_| CommunicationError::invalid_order(order))?;
 
-    let ffi_result = with_storage_from_context::<S, Q, _, _>(ctx, |store| {
+    let (result, gas_info) = with_storage_from_context::<S, Q, _, _>(ctx, |store| {
         Ok(store.range(start.as_deref(), end.as_deref(), order))
     })?;
-    let iterator_id = match ffi_result {
-        Ok((iterator, gas_info)) => {
-            process_gas_info::<S, Q>(ctx, gas_info)?;
-            let new_id = add_iterator::<S, Q>(ctx, iterator);
-            Ok(new_id)
-        }
-        Err((err, gas_info)) => {
-            process_gas_info::<S, Q>(ctx, gas_info)?;
-            Err(VmError::from(err))
-        }
-    }?;
-
+    process_gas_info::<S, Q>(ctx, gas_info)?;
+    let iterator = result?;
+    let iterator_id = add_iterator::<S, Q>(ctx, iterator);
     Ok(iterator_id)
 }
 
 #[cfg(feature = "iterator")]
 pub fn do_next<S: Storage, Q: Querier>(ctx: &mut Ctx, iterator_id: u32) -> VmResult<u32> {
-    let ffi_result =
+    let (result, gas_info) =
         with_iterator_from_context::<S, Q, _, _>(ctx, iterator_id, |iter| Ok(iter.next()))?;
-    let kv = match ffi_result {
-        Ok((kv, gas_info)) => {
-            process_gas_info::<S, Q>(ctx, gas_info)?;
-            Ok(kv)
-        }
-        Err((err, gas_info)) => {
-            process_gas_info::<S, Q>(ctx, gas_info)?;
-            Err(VmError::from(err))
-        }
-    }?;
+    process_gas_info::<S, Q>(ctx, gas_info)?;
 
     // Empty key will later be treated as _no more element_.
-    let (key, value) = kv.unwrap_or_else(|| (Vec::<u8>::new(), Vec::<u8>::new()));
+    let (key, value) = result?.unwrap_or_else(|| (Vec::<u8>::new(), Vec::<u8>::new()));
 
     // Build value || key || keylen
     let keylen_bytes = to_u32(key.len())?.to_be_bytes();
@@ -327,8 +267,8 @@ mod test {
     fn leave_default_data(ctx: &mut Ctx) {
         // create some mock data
         let mut storage = MockStorage::new();
-        storage.set(KEY1, VALUE1).expect("error setting");
-        storage.set(KEY2, VALUE2).expect("error setting");
+        storage.set(KEY1, VALUE1).0.expect("error setting");
+        storage.set(KEY2, VALUE2).0.expect("error setting");
         let querier: MockQuerier<Empty> =
             MockQuerier::new(&[(&HumanAddr::from(INIT_ADDR), &coins(INIT_AMOUNT, INIT_DENOM))]);
         move_into_context(ctx, storage, querier);
@@ -412,8 +352,11 @@ mod test {
 
         do_write::<MS, MQ>(ctx, key_ptr, value_ptr).unwrap();
 
-        let (val, _gas_info) = with_storage_from_context::<MS, MQ, _, _>(ctx, |store| {
-            Ok(store.get(b"new storage key").expect("error getting value"))
+        let val = with_storage_from_context::<MS, MQ, _, _>(ctx, |store| {
+            Ok(store
+                .get(b"new storage key")
+                .0
+                .expect("error getting value"))
         })
         .unwrap();
         assert_eq!(val, Some(b"new value".to_vec()));
@@ -431,8 +374,8 @@ mod test {
 
         do_write::<MS, MQ>(ctx, key_ptr, value_ptr).unwrap();
 
-        let (val, _gas_info) = with_storage_from_context::<MS, MQ, _, _>(ctx, |store| {
-            Ok(store.get(KEY1).expect("error getting value"))
+        let val = with_storage_from_context::<MS, MQ, _, _>(ctx, |store| {
+            Ok(store.get(KEY1).0.expect("error getting value"))
         })
         .unwrap();
         assert_eq!(val, Some(VALUE2.to_vec()));
@@ -450,8 +393,11 @@ mod test {
 
         do_write::<MS, MQ>(ctx, key_ptr, value_ptr).unwrap();
 
-        let (val, _gas_info) = with_storage_from_context::<MS, MQ, _, _>(ctx, |store| {
-            Ok(store.get(b"new storage key").expect("error getting value"))
+        let val = with_storage_from_context::<MS, MQ, _, _>(ctx, |store| {
+            Ok(store
+                .get(b"new storage key")
+                .0
+                .expect("error getting value"))
         })
         .unwrap();
         assert_eq!(val, Some(b"".to_vec()));
@@ -537,8 +483,8 @@ mod test {
 
         do_remove::<MS, MQ>(ctx, key_ptr).unwrap();
 
-        let (value, _gas_info) = with_storage_from_context::<MS, MQ, _, _>(ctx, |store| {
-            Ok(store.get(existing_key).expect("error getting value"))
+        let value = with_storage_from_context::<MS, MQ, _, _>(ctx, |store| {
+            Ok(store.get(existing_key).0.expect("error getting value"))
         })
         .unwrap();
         assert_eq!(value, None);
@@ -557,8 +503,8 @@ mod test {
         // Note: right now we cannot differnetiate between an existent and a non-existent key
         do_remove::<MS, MQ>(ctx, key_ptr).unwrap();
 
-        let (value, _gas_info) = with_storage_from_context::<MS, MQ, _, _>(ctx, |store| {
-            Ok(store.get(non_existent_key).expect("error getting value"))
+        let value = with_storage_from_context::<MS, MQ, _, _>(ctx, |store| {
+            Ok(store.get(non_existent_key).0.expect("error getting value"))
         })
         .unwrap();
         assert_eq!(value, None);
@@ -911,15 +857,15 @@ mod test {
 
         let item =
             with_iterator_from_context::<MS, MQ, _, _>(ctx, id, |iter| Ok(iter.next())).unwrap();
-        assert_eq!(item.unwrap().0.unwrap(), (KEY1.to_vec(), VALUE1.to_vec()));
+        assert_eq!(item.0.unwrap().unwrap(), (KEY1.to_vec(), VALUE1.to_vec()));
 
         let item =
             with_iterator_from_context::<MS, MQ, _, _>(ctx, id, |iter| Ok(iter.next())).unwrap();
-        assert_eq!(item.unwrap().0.unwrap(), (KEY2.to_vec(), VALUE2.to_vec()));
+        assert_eq!(item.0.unwrap().unwrap(), (KEY2.to_vec(), VALUE2.to_vec()));
 
         let item =
             with_iterator_from_context::<MS, MQ, _, _>(ctx, id, |iter| Ok(iter.next())).unwrap();
-        assert!(item.unwrap().0.is_none());
+        assert!(item.0.unwrap().is_none());
     }
 
     #[test]
@@ -935,15 +881,15 @@ mod test {
 
         let item =
             with_iterator_from_context::<MS, MQ, _, _>(ctx, id, |iter| Ok(iter.next())).unwrap();
-        assert_eq!(item.unwrap().0.unwrap(), (KEY2.to_vec(), VALUE2.to_vec()));
+        assert_eq!(item.0.unwrap().unwrap(), (KEY2.to_vec(), VALUE2.to_vec()));
 
         let item =
             with_iterator_from_context::<MS, MQ, _, _>(ctx, id, |iter| Ok(iter.next())).unwrap();
-        assert_eq!(item.unwrap().0.unwrap(), (KEY1.to_vec(), VALUE1.to_vec()));
+        assert_eq!(item.0.unwrap().unwrap(), (KEY1.to_vec(), VALUE1.to_vec()));
 
         let item =
             with_iterator_from_context::<MS, MQ, _, _>(ctx, id, |iter| Ok(iter.next())).unwrap();
-        assert!(item.unwrap().0.is_none());
+        assert!(item.0.unwrap().is_none());
     }
 
     #[test]
@@ -961,11 +907,11 @@ mod test {
 
         let item =
             with_iterator_from_context::<MS, MQ, _, _>(ctx, id, |iter| Ok(iter.next())).unwrap();
-        assert_eq!(item.unwrap().0.unwrap(), (KEY1.to_vec(), VALUE1.to_vec()));
+        assert_eq!(item.0.unwrap().unwrap(), (KEY1.to_vec(), VALUE1.to_vec()));
 
         let item =
             with_iterator_from_context::<MS, MQ, _, _>(ctx, id, |iter| Ok(iter.next())).unwrap();
-        assert!(item.unwrap().0.is_none());
+        assert!(item.0.unwrap().is_none());
     }
 
     #[test]
@@ -984,27 +930,27 @@ mod test {
         // first item, first iterator
         let item =
             with_iterator_from_context::<MS, MQ, _, _>(ctx, id1, |iter| Ok(iter.next())).unwrap();
-        assert_eq!(item.unwrap().0.unwrap(), (KEY1.to_vec(), VALUE1.to_vec()));
+        assert_eq!(item.0.unwrap().unwrap(), (KEY1.to_vec(), VALUE1.to_vec()));
 
         // second item, first iterator
         let item =
             with_iterator_from_context::<MS, MQ, _, _>(ctx, id1, |iter| Ok(iter.next())).unwrap();
-        assert_eq!(item.unwrap().0.unwrap(), (KEY2.to_vec(), VALUE2.to_vec()));
+        assert_eq!(item.0.unwrap().unwrap(), (KEY2.to_vec(), VALUE2.to_vec()));
 
         // first item, second iterator
         let item =
             with_iterator_from_context::<MS, MQ, _, _>(ctx, id2, |iter| Ok(iter.next())).unwrap();
-        assert_eq!(item.unwrap().0.unwrap(), (KEY2.to_vec(), VALUE2.to_vec()));
+        assert_eq!(item.0.unwrap().unwrap(), (KEY2.to_vec(), VALUE2.to_vec()));
 
         // end, first iterator
         let item =
             with_iterator_from_context::<MS, MQ, _, _>(ctx, id1, |iter| Ok(iter.next())).unwrap();
-        assert!(item.unwrap().0.is_none());
+        assert!(item.0.unwrap().is_none());
 
         // second item, second iterator
         let item =
             with_iterator_from_context::<MS, MQ, _, _>(ctx, id2, |iter| Ok(iter.next())).unwrap();
-        assert_eq!(item.unwrap().0.unwrap(), (KEY1.to_vec(), VALUE1.to_vec()));
+        assert_eq!(item.0.unwrap().unwrap(), (KEY1.to_vec(), VALUE1.to_vec()));
     }
 
     #[test]

--- a/packages/vm/src/imports.rs
+++ b/packages/vm/src/imports.rs
@@ -573,9 +573,9 @@ mod test {
         let result = do_canonicalize_address::<MA, MS, MQ>(api, ctx, source_ptr3, dest_ptr);
         match result.unwrap_err() {
             VmError::FfiErr {
-                source: FfiError::Other { error, .. },
+                source: FfiError::UserErr { msg, .. },
             } => {
-                assert_eq!(error, "Invalid input: human address too long");
+                assert_eq!(msg, "Invalid input: human address too long");
             }
             err => panic!("Incorrect error returned: {:?}", err),
         }
@@ -660,7 +660,7 @@ mod test {
         let result = do_humanize_address::<MA, MS, MQ>(api, ctx, source_ptr, dest_ptr);
         match result.unwrap_err() {
             VmError::FfiErr {
-                source: FfiError::Other { .. },
+                source: FfiError::UserErr { .. },
             } => {}
             err => panic!("Incorrect error returned: {:?}", err),
         };

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -588,7 +588,7 @@ mod test {
         // initial check
         instance
             .with_storage(|store| {
-                assert!(store.get(b"foo").unwrap().0.is_none());
+                assert!(store.get(b"foo").0.unwrap().is_none());
                 Ok(())
             })
             .unwrap();
@@ -596,7 +596,7 @@ mod test {
         // write some data
         instance
             .with_storage(|store| {
-                store.set(b"foo", b"bar").unwrap();
+                store.set(b"foo", b"bar").0.unwrap();
                 Ok(())
             })
             .unwrap();
@@ -604,7 +604,7 @@ mod test {
         // read some data
         instance
             .with_storage(|store| {
-                assert_eq!(store.get(b"foo").unwrap().0, Some(b"bar".to_vec()));
+                assert_eq!(store.get(b"foo").0.unwrap(), Some(b"bar".to_vec()));
                 Ok(())
             })
             .unwrap();
@@ -634,8 +634,8 @@ mod test {
                         address: rich_addr.clone(),
                         denom: "silver".to_string(),
                     }))
-                    .unwrap()
                     .0
+                    .unwrap()
                     .unwrap()
                     .unwrap();
                 let BalanceResponse { amount } = from_binary(&response).unwrap();
@@ -652,8 +652,8 @@ mod test {
                     .handle_query::<Empty>(&QueryRequest::Bank(BankQuery::AllBalances {
                         address: rich_addr.clone(),
                     }))
-                    .unwrap()
                     .0
+                    .unwrap()
                     .unwrap()
                     .unwrap();
                 let AllBalanceResponse { amount } = from_binary(&response).unwrap();
@@ -684,8 +684,8 @@ mod test {
                         address: rich_addr.clone(),
                         denom: "silver".to_string(),
                     }))
-                    .unwrap()
                     .0
+                    .unwrap()
                     .unwrap()
                     .unwrap();
                 let BalanceResponse { amount } = from_binary(&response).unwrap();
@@ -710,8 +710,8 @@ mod test {
                         address: rich_addr.clone(),
                         denom: "silver".to_string(),
                     }))
-                    .unwrap()
                     .0
+                    .unwrap()
                     .unwrap()
                     .unwrap();
                 let BalanceResponse { amount } = from_binary(&response).unwrap();

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -428,8 +428,8 @@ mod test {
         // from wasmer `RuntimeError` to `VmError` unwraps errors that happen in WASM imports.
         match init_result.unwrap_err() {
             VmError::FfiErr {
-                source: FfiError::Other { error, .. },
-            } if error == error_message => {}
+                source: FfiError::Unknown { msg, .. },
+            } if msg == Some(error_message.to_string()) => {}
             other => panic!("unexpected error: {:?}", other),
         }
     }

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -633,7 +633,8 @@ mod test {
                     .handle_query::<Empty>(&QueryRequest::Bank(BankQuery::Balance {
                         address: rich_addr.clone(),
                         denom: "silver".to_string(),
-                    }))?
+                    }))
+                    .unwrap()
                     .0
                     .unwrap()
                     .unwrap();
@@ -650,7 +651,8 @@ mod test {
                 let response = querier
                     .handle_query::<Empty>(&QueryRequest::Bank(BankQuery::AllBalances {
                         address: rich_addr.clone(),
-                    }))?
+                    }))
+                    .unwrap()
                     .0
                     .unwrap()
                     .unwrap();
@@ -681,7 +683,8 @@ mod test {
                     .handle_query::<Empty>(&QueryRequest::Bank(BankQuery::Balance {
                         address: rich_addr.clone(),
                         denom: "silver".to_string(),
-                    }))?
+                    }))
+                    .unwrap()
                     .0
                     .unwrap()
                     .unwrap();
@@ -706,7 +709,8 @@ mod test {
                     .handle_query::<Empty>(&QueryRequest::Bank(BankQuery::Balance {
                         address: rich_addr.clone(),
                         denom: "silver".to_string(),
-                    }))?
+                    }))
+                    .unwrap()
                     .0
                     .unwrap()
                     .unwrap();

--- a/packages/vm/src/lib.rs
+++ b/packages/vm/src/lib.rs
@@ -28,7 +28,7 @@ pub use crate::errors::{
     VmError, VmResult,
 };
 pub use crate::features::features_from_csv;
-pub use crate::ffi::{FfiError, FfiResult, FfiSuccess, GasInfo};
+pub use crate::ffi::{FfiError, FfiFailure, FfiResult, FfiSuccess, GasInfo};
 pub use crate::instance::{GasReport, Instance};
 pub use crate::modules::FileSystemCache;
 pub use crate::serde::{from_slice, to_vec};

--- a/packages/vm/src/lib.rs
+++ b/packages/vm/src/lib.rs
@@ -28,7 +28,7 @@ pub use crate::errors::{
     VmError, VmResult,
 };
 pub use crate::features::features_from_csv;
-pub use crate::ffi::{FfiError, FfiFailure, FfiResult, FfiSuccess, GasInfo};
+pub use crate::ffi::{FfiError, FfiResult, GasInfo};
 pub use crate::instance::{GasReport, Instance};
 pub use crate::modules::FileSystemCache;
 pub use crate::serde::{from_slice, to_vec};

--- a/packages/vm/src/testing/instance.rs
+++ b/packages/vm/src/testing/instance.rs
@@ -28,13 +28,13 @@ pub fn mock_instance(
 pub fn mock_instance_with_failing_api(
     wasm: &[u8],
     contract_balance: &[Coin],
-    error_message: &'static str,
+    backend_error: &'static str,
 ) -> Instance<MockStorage, MockApi, MockQuerier> {
     mock_instance_with_options(
         wasm,
         MockInstanceOptions {
             contract_balance: Some(contract_balance),
-            error_message: Some(error_message),
+            backend_error: Some(backend_error),
             ..Default::default()
         },
     )
@@ -73,8 +73,8 @@ pub struct MockInstanceOptions<'a> {
     pub balances: &'a [(&'a HumanAddr, &'a [Coin])],
     /// This option is merged into balances and might override an existing value
     pub contract_balance: Option<&'a [Coin]>,
-    /// When set to Some, all calls to the API fail with FfiError::Other containing this message
-    pub error_message: Option<&'static str>,
+    /// When set, all calls to the API fail with FfiError::Unknown containing this message
+    pub backend_error: Option<&'static str>,
 
     // instance
     pub supported_features: HashSet<String>,
@@ -88,7 +88,7 @@ impl Default for MockInstanceOptions<'_> {
             canonical_address_length: 20,
             balances: Default::default(),
             contract_balance: Default::default(),
-            error_message: None,
+            backend_error: None,
 
             // instance
             supported_features: features_from_csv("staking"),
@@ -114,8 +114,8 @@ pub fn mock_instance_with_options(
         balances.push((&contract_address, contract_balance));
     }
 
-    let api = if let Some(error_message) = options.error_message {
-        MockApi::new_failing(options.canonical_address_length, error_message)
+    let api = if let Some(backend_error) = options.backend_error {
+        MockApi::new_failing(options.canonical_address_length, backend_error)
     } else {
         MockApi::new(options.canonical_address_length)
     };

--- a/packages/vm/src/testing/mock.rs
+++ b/packages/vm/src/testing/mock.rs
@@ -82,21 +82,21 @@ impl Api for MockApi {
         let gas_info = GasInfo::with_cost(GAS_COST_CANONICALIZE);
 
         if let Some(backend_error) = self.backend_error {
-            return Err((FfiError::unknown(backend_error), gas_info));
+            return (Err(FfiError::unknown(backend_error)), gas_info);
         }
 
         // Dummy input validation. This is more sophisticated for formats like bech32, where format and checksum are validated.
         if human.len() < 3 {
-            return Err((
-                FfiError::user_err("Invalid input: human address too short"),
+            return (
+                Err(FfiError::user_err("Invalid input: human address too short")),
                 gas_info,
-            ));
+            );
         }
         if human.len() > self.canonical_length {
-            return Err((
-                FfiError::user_err("Invalid input: human address too long"),
+            return (
+                Err(FfiError::user_err("Invalid input: human address too long")),
                 gas_info,
-            ));
+            );
         }
 
         let mut out = Vec::from(human.as_str());
@@ -105,21 +105,23 @@ impl Api for MockApi {
             out.extend(vec![0u8; append]);
         }
 
-        Ok((CanonicalAddr(Binary(out)), gas_info))
+        (Ok(CanonicalAddr(Binary(out))), gas_info)
     }
 
     fn human_address(&self, canonical: &CanonicalAddr) -> FfiResult<HumanAddr> {
         let gas_info = GasInfo::with_cost(GAS_COST_HUMANIZE);
 
         if let Some(backend_error) = self.backend_error {
-            return Err((FfiError::unknown(backend_error), gas_info));
+            return (Err(FfiError::unknown(backend_error)), gas_info);
         }
 
         if canonical.len() != self.canonical_length {
-            return Err((
-                FfiError::user_err("Invalid input: canonical address length not correct"),
+            return (
+                Err(FfiError::user_err(
+                    "Invalid input: canonical address length not correct",
+                )),
                 gas_info,
-            ));
+            );
         }
 
         // remove trailing 0's (TODO: fix this - but fine for first tests)
@@ -130,10 +132,11 @@ impl Api for MockApi {
             .filter(|&x| x != 0)
             .collect();
 
-        match String::from_utf8(trimmed) {
-            Ok(human) => Ok((HumanAddr(human), gas_info)),
-            Err(err) => Err((err.into(), gas_info)),
-        }
+        let result = match String::from_utf8(trimmed) {
+            Ok(human) => Ok(HumanAddr(human)),
+            Err(err) => Err(err.into()),
+        };
+        (result, gas_info)
     }
 }
 
@@ -148,14 +151,14 @@ pub fn mock_env<T: Api, U: Into<HumanAddr>>(api: &T, sender: U, sent: &[Coin]) -
             chain_id: "cosmos-testnet-14002".to_string(),
         },
         message: MessageInfo {
-            sender: api.canonical_address(&sender.into()).unwrap().0,
+            sender: api.canonical_address(&sender.into()).0.unwrap(),
             sent_funds: sent.to_vec(),
         },
         contract: ContractInfo {
             address: api
                 .canonical_address(&HumanAddr::from(MOCK_CONTRACT_ADDR))
-                .unwrap()
-                .0,
+                .0
+                .unwrap(),
         },
     }
 }
@@ -211,7 +214,7 @@ impl<C: DeserializeOwned> Querier for MockQuerier<C> {
                     * (to_binary(&response).unwrap().len() as u64)),
         );
         // We don't use FFI in the mock implementation, so FfiResult is always Ok() regardless of error on other levels
-        Ok((response, gas_info))
+        (Ok(response), gas_info)
     }
 }
 
@@ -222,13 +225,13 @@ impl MockQuerier {
             Ok(raw) => raw,
             Err(err) => {
                 let gas_info = GasInfo::with_externally_used(err.to_string().len() as u64);
-                return Ok((
-                    Err(SystemError::InvalidRequest {
+                return (
+                    Ok(Err(SystemError::InvalidRequest {
                         error: format!("Serializing query request: {}", err),
                         request: b"N/A".into(),
-                    }),
+                    })),
                     gas_info,
-                ));
+                );
             }
         };
         self.raw_query(request_binary.as_slice())
@@ -262,21 +265,22 @@ mod test {
     fn flip_addresses() {
         let api = MockApi::new(20);
         let human = HumanAddr("shorty".to_string());
-        let (canon, _gas_cost) = api.canonical_address(&human).unwrap();
+        let canon = api.canonical_address(&human).0.unwrap();
         assert_eq!(canon.len(), 20);
         assert_eq!(&canon.as_slice()[0..6], human.as_str().as_bytes());
         assert_eq!(&canon.as_slice()[6..], &[0u8; 14]);
 
-        let (recovered, _gas_cost) = api.human_address(&canon).unwrap();
-        assert_eq!(human, recovered);
+        let (recovered, _gas_cost) = api.human_address(&canon);
+        assert_eq!(recovered.unwrap(), human);
     }
 
     #[test]
     fn human_address_input_length() {
         let api = MockApi::new(10);
         let input = CanonicalAddr(Binary(vec![61; 11]));
-        match api.human_address(&input).unwrap_err() {
-            (FfiError::UserErr { .. }, _gas_info) => {}
+        let (result, _gas_info) = api.human_address(&input);
+        match result.unwrap_err() {
+            FfiError::UserErr { .. } => {}
             err => panic!("Unexpected error: {:?}", err),
         }
     }
@@ -285,8 +289,8 @@ mod test {
     fn canonical_address_min_input_length() {
         let api = MockApi::new(10);
         let human = HumanAddr("1".to_string());
-        match api.canonical_address(&human).unwrap_err() {
-            (FfiError::UserErr { .. }, _gas_info) => {}
+        match api.canonical_address(&human).0.unwrap_err() {
+            FfiError::UserErr { .. } => {}
             err => panic!("Unexpected error: {:?}", err),
         }
     }
@@ -295,8 +299,8 @@ mod test {
     fn canonical_address_max_input_length() {
         let api = MockApi::new(10);
         let human = HumanAddr("longer-than-10".to_string());
-        match api.canonical_address(&human).unwrap_err() {
-            (FfiError::UserErr { .. }, _gas_info) => {}
+        match api.canonical_address(&human).0.unwrap_err() {
+            FfiError::UserErr { .. } => {}
             err => panic!("Unexpected error: {:?}", err),
         }
     }
@@ -315,8 +319,8 @@ mod test {
                 }
                 .into(),
             )
-            .unwrap()
             .0
+            .unwrap()
             .unwrap()
             .unwrap();
         let res: AllBalanceResponse = from_binary(&all).unwrap();
@@ -338,8 +342,8 @@ mod test {
                 }
                 .into(),
             )
-            .unwrap()
             .0
+            .unwrap()
             .unwrap()
             .unwrap();
         let res: BalanceResponse = from_binary(&fly).unwrap();
@@ -354,8 +358,8 @@ mod test {
                 }
                 .into(),
             )
-            .unwrap()
             .0
+            .unwrap()
             .unwrap()
             .unwrap();
         let res: BalanceResponse = from_binary(&miss).unwrap();
@@ -376,8 +380,8 @@ mod test {
                 }
                 .into(),
             )
-            .unwrap()
             .0
+            .unwrap()
             .unwrap()
             .unwrap();
         let res: AllBalanceResponse = from_binary(&all).unwrap();
@@ -392,8 +396,8 @@ mod test {
                 }
                 .into(),
             )
-            .unwrap()
             .0
+            .unwrap()
             .unwrap()
             .unwrap();
         let res: BalanceResponse = from_binary(&miss).unwrap();

--- a/packages/vm/src/testing/mock.rs
+++ b/packages/vm/src/testing/mock.rs
@@ -118,9 +118,7 @@ impl Api for MockApi {
             .cloned()
             .filter(|&x| x != 0)
             .collect();
-        // decode UTF-8 bytes into string
-        let human = String::from_utf8(trimmed)
-            .map_err(|_| FfiError::other("Could not parse human address result as utf-8"))?;
+        let human = String::from_utf8(trimmed)?;
 
         let gas_info = GasInfo::with_cost(GAS_COST_HUMANIZE);
         Ok((HumanAddr(human), gas_info))

--- a/packages/vm/src/traits.rs
+++ b/packages/vm/src/traits.rs
@@ -39,8 +39,12 @@ pub trait StorageIterator {
         Self: Sized,
     {
         let mut out: Vec<KV> = Vec::new();
-        while let (Some(kv), _gas_used) = self.next()? {
-            out.push(kv);
+        loop {
+            match self.next() {
+                Ok((Some(kv), _gas_info)) => out.push(kv),
+                Ok((None, _gas_info)) => break,
+                Err((err, _gas_info)) => return Err(err),
+            }
         }
         Ok(out)
     }

--- a/packages/vm/src/traits.rs
+++ b/packages/vm/src/traits.rs
@@ -40,10 +40,11 @@ pub trait StorageIterator {
     {
         let mut out: Vec<KV> = Vec::new();
         loop {
-            match self.next() {
-                Ok((Some(kv), _gas_info)) => out.push(kv),
-                Ok((None, _gas_info)) => break,
-                Err((err, _gas_info)) => return Err(err),
+            let (result, _gas_info) = self.next();
+            match result {
+                Ok(Some(kv)) => out.push(kv),
+                Ok(None) => break,
+                Err(err) => return Err(err),
             }
         }
         Ok(out)


### PR DESCRIPTION
Closes #445

As discussed in the ticket plus two changes:
- All `FfiError`s now come with `gas_info`. This ensures gas consumption is calculated properly in all error cases. This is important for chains where unused gas is refunded. It is also more elegant than adding gas information to one error case only.
- Instead of "input error" or "api error", I now choose the name "user error", which should make clear that those errors are the caller's fault, not the backend's fault.