### PR TITLE
External storage range alternative impl

### DIFF
--- a/packages/std/src/imports.rs
+++ b/packages/std/src/imports.rs
@@ -78,20 +78,26 @@ impl ReadonlyStorage for ExternalStorage {
             (None, None) => unsafe { db_scan(0, 0, order) },
             (Some(s), None) => {
                 let start = build_region(s);
-                let start_ptr = start.as_ref() as *const Region;
-                unsafe { db_scan(start_ptr as u32, 0, order) }
+                let start_ref = start.as_ref();
+                unsafe { db_scan(start_ref as *const Region as u32, 0, order) }
             }
             (None, Some(e)) => {
                 let end = build_region(e);
-                let end_ptr = end.as_ref() as *const Region;
-                unsafe { db_scan(0, end_ptr as u32, order) }
+                let end_ref = end.as_ref();
+                unsafe { db_scan(0, end_ref as *const Region as u32, order) }
             }
             (Some(s), Some(e)) => {
                 let start = build_region(s);
-                let start_ptr = start.as_ref() as *const Region;
+                let start_ref = start.as_ref();
                 let end = build_region(e);
-                let end_ptr = end.as_ref() as *const Region;
-                unsafe { db_scan(start_ptr as u32, end_ptr as u32, order) }
+                let end_ref = end.as_ref();
+                unsafe {
+                    db_scan(
+                        start_ref as *const Region as u32,
+                        end_ref as *const Region as u32,
+                        order,
+                    )
+                }
             }
         };
         let iter = ExternalIterator { iterator_id };

--- a/packages/std/src/imports.rs
+++ b/packages/std/src/imports.rs
@@ -5,7 +5,7 @@ use crate::encoding::Binary;
 use crate::errors::{StdError, StdResult};
 #[cfg(feature = "iterator")]
 use crate::iterator::{Order, KV};
-use crate::memory::{alloc, build_region, consume_region, Region};
+use crate::memory::{alloc, build_region, consume_region, get_region_address, Region};
 use crate::serde::from_slice;
 use crate::traits::{Api, Querier, QuerierResult, ReadonlyStorage, Storage};
 
@@ -69,36 +69,16 @@ impl ReadonlyStorage for ExternalStorage {
         end: Option<&[u8]>,
         order: Order,
     ) -> Box<dyn Iterator<Item = KV>> {
-        let order = order as i32;
-
         // There is lots of gotchas on turning options into regions for FFI, thus this design
         // See: https://github.com/CosmWasm/cosmwasm/pull/509
-        // Note: start and end (Regions) must remain in scope as long as the start_ptr / end_ptr do
-        let iterator_id = match (start, end) {
-            (None, None) => unsafe { db_scan(0, 0, order) },
-            (Some(s), None) => {
-                let start = build_region(s);
-                let start_ref = start.as_ref();
-                unsafe { db_scan(start_ref as *const Region as u32, 0, order) }
-            }
-            (None, Some(e)) => {
-                let end = build_region(e);
-                let end_ref = end.as_ref();
-                unsafe { db_scan(0, end_ref as *const Region as u32, order) }
-            }
-            (Some(s), Some(e)) => {
-                let start = build_region(s);
-                let start_ref = start.as_ref();
-                let end = build_region(e);
-                let end_ref = end.as_ref();
-                unsafe {
-                    db_scan(
-                        start_ref as *const Region as u32,
-                        end_ref as *const Region as u32,
-                        order,
-                    )
-                }
-            }
+        let start_region = start.map(build_region);
+        let end_region = end.map(build_region);
+        let iterator_id = unsafe {
+            db_scan(
+                start_region.as_ref().map(get_region_address).unwrap_or(0),
+                end_region.as_ref().map(get_region_address).unwrap_or(0),
+                order as i32,
+            )
         };
         let iter = ExternalIterator { iterator_id };
         Box::new(iter)

--- a/packages/std/src/imports.rs
+++ b/packages/std/src/imports.rs
@@ -73,13 +73,9 @@ impl ReadonlyStorage for ExternalStorage {
         // See: https://github.com/CosmWasm/cosmwasm/pull/509
         let start_region = start.map(build_region);
         let end_region = end.map(build_region);
-        let iterator_id = unsafe {
-            db_scan(
-                start_region.as_ref().map(get_region_address).unwrap_or(0),
-                end_region.as_ref().map(get_region_address).unwrap_or(0),
-                order as i32,
-            )
-        };
+        let start_region = start_region.as_ref().map(get_region_address).unwrap_or(0);
+        let end_region = end_region.as_ref().map(get_region_address).unwrap_or(0);
+        let iterator_id = unsafe { db_scan(start_region, end_region, order as i32) };
         let iter = ExternalIterator { iterator_id };
         Box::new(iter)
     }

--- a/packages/std/src/imports.rs
+++ b/packages/std/src/imports.rs
@@ -78,20 +78,20 @@ impl ReadonlyStorage for ExternalStorage {
             (None, None) => unsafe { db_scan(0, 0, order) },
             (Some(s), None) => {
                 let start = build_region(s);
-                let start_ptr = &*start as *const Region as u32;
-                unsafe { db_scan(start_ptr, 0, order) }
+                let start_ptr = start.as_ref() as *const Region;
+                unsafe { db_scan(start_ptr as u32, 0, order) }
             }
             (None, Some(e)) => {
                 let end = build_region(e);
-                let end_ptr = &*end as *const Region as u32;
-                unsafe { db_scan(0, end_ptr, order) }
+                let end_ptr = end.as_ref() as *const Region;
+                unsafe { db_scan(0, end_ptr as u32, order) }
             }
             (Some(s), Some(e)) => {
                 let start = build_region(s);
-                let start_ptr = &*start as *const Region as u32;
+                let start_ptr = start.as_ref() as *const Region;
                 let end = build_region(e);
-                let end_ptr = &*end as *const Region as u32;
-                unsafe { db_scan(start_ptr, end_ptr, order) }
+                let end_ptr = end.as_ref() as *const Region;
+                unsafe { db_scan(start_ptr as u32, end_ptr as u32, order) }
             }
         };
         let iter = ExternalIterator { iterator_id };

--- a/packages/std/src/imports.rs
+++ b/packages/std/src/imports.rs
@@ -5,7 +5,7 @@ use crate::encoding::Binary;
 use crate::errors::{StdError, StdResult};
 #[cfg(feature = "iterator")]
 use crate::iterator::{Order, KV};
-use crate::memory::{alloc, build_region, consume_region, get_region_address, Region};
+use crate::memory::{alloc, build_region, consume_region, get_optional_region_address, Region};
 use crate::serde::from_slice;
 use crate::traits::{Api, Querier, QuerierResult, ReadonlyStorage, Storage};
 
@@ -73,9 +73,9 @@ impl ReadonlyStorage for ExternalStorage {
         // See: https://github.com/CosmWasm/cosmwasm/pull/509
         let start_region = start.map(build_region);
         let end_region = end.map(build_region);
-        let start_region = start_region.as_ref().map(get_region_address).unwrap_or(0);
-        let end_region = end_region.as_ref().map(get_region_address).unwrap_or(0);
-        let iterator_id = unsafe { db_scan(start_region, end_region, order as i32) };
+        let start_region_addr = get_optional_region_address(&start_region.as_ref());
+        let end_region_addr = get_optional_region_address(&end_region.as_ref());
+        let iterator_id = unsafe { db_scan(start_region_addr, end_region_addr, order as i32) };
         let iter = ExternalIterator { iterator_id };
         Box::new(iter)
     }

--- a/packages/std/src/memory.rs
+++ b/packages/std/src/memory.rs
@@ -84,8 +84,13 @@ pub fn build_region(data: &[u8]) -> Box<Region> {
 
 fn build_region_from_components(offset: u32, capacity: u32, length: u32) -> Box<Region> {
     Box::new(Region {
-        offset: offset,
-        capacity: capacity,
-        length: length,
+        offset,
+        capacity,
+        length,
     })
+}
+
+/// Returns the address of the Region as an offset in linear memory
+pub fn get_region_address(region: &Box<Region>) -> u32 {
+    region.as_ref() as *const Region as u32
 }

--- a/packages/std/src/memory.rs
+++ b/packages/std/src/memory.rs
@@ -94,3 +94,9 @@ fn build_region_from_components(offset: u32, capacity: u32, length: u32) -> Box<
 pub fn get_region_address(region: &Box<Region>) -> u32 {
     region.as_ref() as *const Region as u32
 }
+
+/// Returns the address of the optional Region as an offset in linear memory,
+/// or zero if not present
+pub fn get_optional_region_address(region: &Option<&Box<Region>>) -> u32 {
+    region.map(get_region_address).unwrap_or(0)
+}


### PR DESCRIPTION
There are other places in which this same strategy (`into_raw()` for pointers to regions) could be used. When we agree on this, I can change those too if you want.

We could also use a combination of your fix with this, like keeping the different matches, and using `into_raw()`. That would spare us the `if`s at the end