### PR TITLE
Fix error type in ExternalQuerier::raw_query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 - Rename `log` to `attr`.
 - Rename `Context::add_log` to `Context::add_attribute`.
 - Add `Api::debug` for emitting debug messages during development.
+- Fix error type for response parsing errors in `ExternalQuerier::raw_query`.
+  This was `Ok(Err(ParseError))` instead of `Err(SystemError::InvalidResponse)`,
+  implying an error created in the target contract.
 
 **cosmwasm-vm**
 

--- a/packages/std/src/mock.rs
+++ b/packages/std/src/mock.rs
@@ -253,7 +253,7 @@ impl BankQuerier {
     }
 
     pub fn query(&self, request: &BankQuery) -> QuerierResult {
-        match request {
+        let contract_result: StdResult<Binary> = match request {
             BankQuery::Balance { address, denom } => {
                 // proper error on not found, serialize result on found
                 let amount = self
@@ -267,16 +267,18 @@ impl BankQuerier {
                         denom: denom.to_string(),
                     },
                 };
-                Ok(to_binary(&bank_res))
+                to_binary(&bank_res)
             }
             BankQuery::AllBalances { address } => {
                 // proper error on not found, serialize result on found
                 let bank_res = AllBalanceResponse {
                     amount: self.balances.get(address).cloned().unwrap_or_default(),
                 };
-                Ok(to_binary(&bank_res))
+                to_binary(&bank_res)
             }
-        }
+        };
+        // system result is always ok in the mock implementation
+        Ok(contract_result)
     }
 }
 
@@ -297,18 +299,18 @@ impl StakingQuerier {
     }
 
     pub fn query(&self, request: &StakingQuery) -> QuerierResult {
-        match request {
+        let contract_result: StdResult<Binary> = match request {
             StakingQuery::BondedDenom {} => {
                 let res = BondedDenomResponse {
                     denom: self.denom.clone(),
                 };
-                Ok(to_binary(&res))
+                to_binary(&res)
             }
             StakingQuery::Validators {} => {
                 let res = ValidatorsResponse {
                     validators: self.validators.clone(),
                 };
-                Ok(to_binary(&res))
+                to_binary(&res)
             }
             StakingQuery::AllDelegations { delegator } => {
                 let delegations: Vec<_> = self
@@ -319,7 +321,7 @@ impl StakingQuerier {
                     .map(|d| d.into())
                     .collect();
                 let res = AllDelegationsResponse { delegations };
-                Ok(to_binary(&res))
+                to_binary(&res)
             }
             StakingQuery::Delegation {
                 delegator,
@@ -332,9 +334,11 @@ impl StakingQuerier {
                 let res = DelegationResponse {
                     delegation: delegation.cloned(),
                 };
-                Ok(to_binary(&res))
+                to_binary(&res)
             }
-        }
+        };
+        // system result is always ok in the mock implementation
+        Ok(contract_result)
     }
 }
 


### PR DESCRIPTION
I'm quite confident this is a bug in the standrad library. How this is probably flattened away to `StdError` in most use cases via

```rust
pub trait Querier {
    // ..

    /// query is a shorthand for custom_query when we are not using a custom type,
    /// this allows us to avoid specifying "Empty" in all the type definitions.
    fn query<T: DeserializeOwned>(&self, request: &QueryRequest<Empty>) -> StdResult<T> {
        self.custom_query(request)
    }

    /// Makes the query and parses the response. Also handles custom queries,
    /// so you need to specify the custom query type in the function parameters.
    /// If you are no using a custom query, just use `query` for easier interface.
    ///
    /// Any error (System Error, Error or called contract, or Parse Error) are flattened into
    /// one level. Only use this if you don't need to check the SystemError
    /// eg. If you don't differentiate between contract missing and contract returned error
    fn custom_query<T: Serialize, U: DeserializeOwned>(
        &self,
        request: &QueryRequest<T>,
    ) -> StdResult<U> {

  // ...
}
```

Anyone interested in a backport to 0.10.x?