### PR TITLE
Add GenericCoin trait

### DIFF
--- a/packages/std/src/coins.rs
+++ b/packages/std/src/coins.rs
@@ -3,6 +3,12 @@ use serde::{Deserialize, Serialize};
 
 use crate::math::Uint128;
 
+pub trait GenericCoin {
+    fn key(&self) -> String;
+    fn value(&self) -> Uint128;
+    fn add_value(&mut self, add_value: Uint128);
+}
+
 #[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq, JsonSchema)]
 pub struct Coin {
     pub denom: String,
@@ -15,6 +21,20 @@ impl Coin {
             amount: Uint128(amount),
             denom: denom.to_string(),
         }
+    }
+}
+
+impl GenericCoin for Coin {
+    fn key(&self) -> String {
+        self.denom.clone()
+    }
+
+    fn value(&self) -> Uint128 {
+        self.amount
+    }
+
+    fn add_value(&mut self, add_value: Uint128) {
+        self.amount += add_value;
     }
 }
 

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -16,7 +16,7 @@ mod traits;
 mod types;
 
 pub use crate::addresses::{CanonicalAddr, HumanAddr};
-pub use crate::coins::{coin, coins, has_coins, Coin};
+pub use crate::coins::{coin, coins, has_coins, Coin, GenericCoin};
 pub use crate::encoding::Binary;
 pub use crate::errors::{StdError, StdResult, SystemError, SystemResult};
 #[cfg(feature = "iterator")]


### PR DESCRIPTION
Adds a simple `GenericCoin` trait, to treat native and cw20 coins generically.

Complemented with an equivalent PR in the cosmwasm-plus repo.