### PR TITLE
Secondary indexes support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,14 @@
   namespace in `PrefixedStorage::new`, `PrefixedStorage::multilevel`,
   `ReadonlyPrefixedStorage::new`, `ReadonlyPrefixedStorage::multilevel`,
   `prefixed` and `prefixed_read`.
+- Remove `Bucket::multilevel` as it was a misnomer. Provide support for
+  composite `PrimaryKey`s in storage, using `Pk2` and `Pk3` for 2 or 3 items
+  keys. Add `Bucket::range_prefixed` to provide the first section(s) of the
+  composite key and iterate under that.
+- Bucket stores all data under `(namespace, "_pk", key)`, where the first two
+  are length-prefixed. This is a different layout from previous form
+  where it was `(namespace, key)` and this is intended to support co-existence
+  with `IndexedBucket`. (It only changes the raw storage layout, APIs don't change).
 
 **cosmwasm-vm**
 

--- a/packages/storage/src/bucket.rs
+++ b/packages/storage/src/bucket.rs
@@ -179,6 +179,26 @@ where
         Box::new(mapped)
     }
 
+    // TODO: test this, just an idea now, need more work on Pks
+    // Also, how much do we trim from the keys? Leave just the last part of the PK, right?
+
+    /// This lets us grab all items under the beginning of a composite key.
+    /// If we store under `Pk2(owner, spender)`, then we pass `prefixes: &[owner]` here
+    /// To list all spenders under the owner
+    #[cfg(feature = "iterator")]
+    pub fn range_prefixed<'c>(
+        &'c self,
+        prefixes: &[&[u8]],
+        start: Option<&[u8]>,
+        end: Option<&[u8]>,
+        order: Order,
+    ) -> Box<dyn Iterator<Item = StdResult<KV<T>>> + 'c> {
+        let namespace = nested_namespaces_with_key(&[&self.namespace, PREFIX_PK], prefixes, b"");
+        let mapped =
+            range_with_prefix(self.storage, &namespace, start, end, order).map(deserialize_kv::<T>);
+        Box::new(mapped)
+    }
+
     /// Loads the data, perform the specified action, and store the result
     /// in the database. This is shorthand for some common sequences, which may be useful.
     ///

--- a/packages/storage/src/indexed_bucket.rs
+++ b/packages/storage/src/indexed_bucket.rs
@@ -77,10 +77,6 @@ where
     // index is stored (namespace, idx): key -> b"1"
     // idx is prefixed and appended to namespace
     pub fn add_to_index(&mut self, idx: &[u8], key: &[u8]) {
-        // TODO: make this a bit cleaner
-        let mut index_space = self.prefix_idx.clone();
-        let mut key_prefix = to_length_prefixed(idx);
-        index_space.append(&mut key_prefix);
         set_with_prefix(self.storage, &self.index_space(idx), key, b"1");
     }
 
@@ -127,18 +123,8 @@ where
     /// this is mainly an internal function, but can be used direcly if you just want to list ids cheaply
     pub fn pks_by_index<'b>(&'b self, idx: &[u8]) -> Box<dyn Iterator<Item = Vec<u8>> + 'b> {
         let start = self.index_space(idx);
-        // end is the next byte
-        let mut end = start.clone();
-        let l = end.len();
-        end[l - 1] += 1;
-        let mapped = range_with_prefix(
-            self.storage,
-            &self.prefix_idx,
-            Some(&start),
-            Some(&end),
-            Order::Ascending,
-        )
-        .map(|(k, _)| k);
+        let mapped =
+            range_with_prefix(self.storage, &start, None, None, Order::Ascending).map(|(k, _)| k);
         Box::new(mapped)
     }
 

--- a/packages/storage/src/indexed_bucket.rs
+++ b/packages/storage/src/indexed_bucket.rs
@@ -260,6 +260,7 @@ where
 mod test {
     use super::*;
 
+    use crate::indexes::{index_i32, index_string};
     use cosmwasm_std::testing::MockStorage;
     use serde::{Deserialize, Serialize};
 
@@ -269,21 +270,13 @@ mod test {
         pub age: i32,
     }
 
-    fn by_name(data: &Data) -> Vec<u8> {
-        data.name.as_bytes().to_vec()
-    }
-
-    fn by_age(data: &Data) -> Vec<u8> {
-        data.age.to_be_bytes().into()
-    }
-
     #[test]
     fn store_and_load_by_index() {
         let mut store = MockStorage::new();
-        let mut bucket = IndexedBucket::new(&mut store, b"data")
-            .with_index("name", by_name)
+        let mut bucket = IndexedBucket::<_, Data>::new(&mut store, b"data")
+            .with_index("name", |d| index_string(&d.name))
             .unwrap()
-            .with_unique_index("age", by_age)
+            .with_unique_index("age", |d| index_i32(d.age))
             .unwrap();
 
         // save data

--- a/packages/storage/src/indexed_bucket.rs
+++ b/packages/storage/src/indexed_bucket.rs
@@ -9,8 +9,8 @@ use std::marker::PhantomData;
 use crate::indexes::{Index, MultiIndex, UniqueIndex};
 use crate::length_prefixed::namespaces_with_key;
 use crate::namespace_helpers::range_with_prefix;
+use crate::to_length_prefixed_nested;
 use crate::type_helpers::{deserialize_kv, may_deserialize, must_deserialize};
-use crate::{to_length_prefixed, to_length_prefixed_nested};
 
 /// reserved name, no index may register
 const PREFIX_PK: &[u8] = b"_pk";
@@ -73,17 +73,6 @@ where
         let key = namespaces_with_key(&[self.namespace, PREFIX_PK], pk);
         let value = self.storage.get(&key);
         may_deserialize(&value)
-    }
-
-    pub fn index_space(&self, index_name: &str, idx: &[u8]) -> Vec<u8> {
-        let mut index_space = self.prefix_idx(index_name);
-        let mut key_prefix = to_length_prefixed(idx);
-        index_space.append(&mut key_prefix);
-        index_space
-    }
-
-    pub fn prefix_idx(&self, index_name: &str) -> Vec<u8> {
-        to_length_prefixed_nested(&[self.namespace, index_name.as_bytes()])
     }
 
     /// iterates over the items in pk order

--- a/packages/storage/src/indexed_bucket.rs
+++ b/packages/storage/src/indexed_bucket.rs
@@ -50,12 +50,8 @@ where
     T: Serialize + DeserializeOwned,
 {
     pub fn set_pk(&mut self, key: &[u8], updated: &T) -> StdResult<()> {
-        Ok(set_with_prefix(
-            self.storage,
-            &self.prefix_pk,
-            key,
-            &to_vec(updated)?,
-        ))
+        set_with_prefix(self.storage, &self.prefix_pk, key, &to_vec(updated)?);
+        Ok(())
     }
 
     pub fn remove_pk(&mut self, key: &[u8]) {

--- a/packages/storage/src/indexed_bucket.rs
+++ b/packages/storage/src/indexed_bucket.rs
@@ -147,10 +147,10 @@ where
         }
     }
 
-    fn get_index(&self, name: &str) -> Option<&Box<dyn Index<S, T> + 'x>> {
+    fn get_index(&self, name: &str) -> Option<&dyn Index<S, T>> {
         for existing in self.indexes.iter() {
             if existing.name() == name {
-                return Some(existing);
+                return Some(existing.as_ref());
             }
         }
         None

--- a/packages/storage/src/indexed_bucket.rs
+++ b/packages/storage/src/indexed_bucket.rs
@@ -1,0 +1,180 @@
+// this module requires iterator to be useful at all
+#![cfg(feature = "iterator")]
+
+use cosmwasm_std::{to_vec, Order, StdError, StdResult, Storage, KV};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+use crate::namespace_helpers::{
+    get_with_prefix, range_with_prefix, remove_with_prefix, set_with_prefix,
+};
+use crate::type_helpers::{deserialize_kv, may_deserialize, must_deserialize};
+use crate::{to_length_prefixed, to_length_prefixed_nested};
+
+/// IndexedBucket works like a bucket but has a secondary index
+/// This is a WIP.
+/// Step 1 - allow exactly 1 secondary index, no multi-prefix on primary key
+/// Step 2 - allow multiple named secondary indexes, no multi-prefix on primary key
+/// Step 3 - allow multiple named secondary indexes, clean composite key support
+///
+/// Current Status: 0
+pub struct IndexedBucket<'a, S, T>
+where
+    S: Storage,
+    T: Serialize + DeserializeOwned,
+{
+    storage: &'a mut S,
+    prefix_pk: Vec<u8>,
+    prefix_idx: Vec<u8>,
+    indexer: fn(&T) -> Vec<u8>,
+}
+
+impl<'a, S, T> IndexedBucket<'a, S, T>
+where
+    S: Storage,
+    T: Serialize + DeserializeOwned,
+{
+    pub fn new(storage: &'a mut S, namespace: &[u8], indexer: fn(&T) -> Vec<u8>) -> Self {
+        IndexedBucket {
+            storage,
+            prefix_pk: to_length_prefixed_nested(&[namespace, b"pk"]),
+            prefix_idx: to_length_prefixed_nested(&[namespace, b"idx"]),
+            indexer,
+        }
+    }
+
+    /// save will serialize the model and store, returns an error on serialization issues.
+    /// this must load the old value to update the indexes properly
+    /// if you loaded the old value earlier in the same function, use replace to avoid needless db reads
+    pub fn save(&mut self, key: &[u8], data: &T) -> StdResult<()> {
+        let old_data = self.may_load(key)?;
+        self.replace(key, Some(data), old_data.as_ref())
+    }
+
+    pub fn remove(&mut self, key: &[u8]) -> StdResult<()> {
+        let old_data = self.may_load(key)?;
+        self.replace(key, None, old_data.as_ref())
+    }
+
+    /// replace writes data to key. old_data must be the current stored value (from a previous load)
+    /// and is used to properly update the index. This is used by save, replace, and update
+    /// and can be called directly if you want to optimize
+    pub fn replace(&mut self, key: &[u8], data: Option<&T>, old_data: Option<&T>) -> StdResult<()> {
+        if let Some(old) = old_data {
+            let old_idx = (self.indexer)(old);
+            self.remove_from_index(&old_idx, key);
+        }
+        if let Some(updated) = data {
+            let new_idx = (self.indexer)(updated);
+            self.add_to_index(&new_idx, key);
+            set_with_prefix(self.storage, &self.prefix_pk, key, &to_vec(updated)?);
+        } else {
+            remove_with_prefix(self.storage, &self.prefix_pk, key);
+        }
+        Ok(())
+    }
+
+    // index is stored (namespace, idx): key -> b"1"
+    // idx is prefixed and appended to namespace
+    pub fn add_to_index(&mut self, idx: &[u8], key: &[u8]) {
+        // TODO: make this a bit cleaner
+        let mut index_space = self.prefix_idx.clone();
+        let mut key_prefix = to_length_prefixed(idx);
+        index_space.append(&mut key_prefix);
+        set_with_prefix(self.storage, &self.index_space(idx), key, b"1");
+    }
+
+    // index is stored (namespace, idx): key -> b"1"
+    // idx is prefixed and appended to namespace
+    pub fn remove_from_index(&mut self, idx: &[u8], key: &[u8]) {
+        remove_with_prefix(self.storage, &self.index_space(idx), key);
+    }
+
+    // TODO: make this a bit cleaner
+    fn index_space(&self, idx: &[u8]) -> Vec<u8> {
+        let mut index_space = self.prefix_idx.clone();
+        let mut key_prefix = to_length_prefixed(idx);
+        index_space.append(&mut key_prefix);
+        index_space
+    }
+
+    /// load will return an error if no data is set at the given key, or on parse error
+    pub fn load(&self, key: &[u8]) -> StdResult<T> {
+        let value = get_with_prefix(self.storage, &self.prefix_pk, key);
+        must_deserialize(&value)
+    }
+
+    /// may_load will parse the data stored at the key if present, returns Ok(None) if no data there.
+    /// returns an error on issues parsing
+    pub fn may_load(&self, key: &[u8]) -> StdResult<Option<T>> {
+        let value = get_with_prefix(self.storage, &self.prefix_pk, key);
+        may_deserialize(&value)
+    }
+
+    /// iterates over the items in pk order
+    pub fn range<'b>(
+        &'b self,
+        start: Option<&[u8]>,
+        end: Option<&[u8]>,
+        order: Order,
+    ) -> Box<dyn Iterator<Item = StdResult<KV<T>>> + 'b> {
+        let mapped = range_with_prefix(self.storage, &self.prefix_pk, start, end, order)
+            .map(deserialize_kv::<T>);
+        Box::new(mapped)
+    }
+
+    /// returns all pks that where stored under this secondary index, always Ascending
+    /// this is mainly an internal function, but can be used direcly if you just want to list ids cheaply
+    pub fn pks_by_index<'b>(&'b self, idx: &[u8]) -> Box<dyn Iterator<Item = Vec<u8>> + 'b> {
+        let start = self.index_space(idx);
+        // end is the next byte
+        let mut end = start.clone();
+        let l = end.len();
+        end[l - 1] += 1;
+        let mapped = range_with_prefix(
+            self.storage,
+            &self.prefix_idx,
+            Some(&start),
+            Some(&end),
+            Order::Ascending,
+        )
+        .map(|(k, _)| k);
+        Box::new(mapped)
+    }
+
+    /// returns all items that match this secondary index, always by pk Ascending
+    pub fn items_by_index<'b>(
+        &'b self,
+        idx: &[u8],
+    ) -> Box<dyn Iterator<Item = StdResult<KV<T>>> + 'b> {
+        let mapped = self.pks_by_index(idx).map(move |pk| {
+            let v = self.load(&pk)?;
+            Ok((pk, v))
+        });
+        Box::new(mapped)
+    }
+
+    /// Loads the data, perform the specified action, and store the result
+    /// in the database. This is shorthand for some common sequences, which may be useful.
+    ///
+    /// If the data exists, `action(Some(value))` is called. Otherwise `action(None)` is called.
+    pub fn update<A, E>(&mut self, key: &[u8], action: A) -> Result<T, E>
+    where
+        A: FnOnce(Option<T>) -> Result<T, E>,
+        E: From<StdError>,
+    {
+        // we cannot copy index and it is consumed by the action, so we cannot use input inside replace
+        // thus, we manually take care of removing the old index on success
+        let input = self.may_load(key)?;
+        let old_idx = input.as_ref().map(self.indexer);
+
+        let output = action(input)?;
+
+        // manually remove the old index if needed
+        if let Some(idx) = old_idx {
+            self.remove_from_index(&idx, key);
+        }
+        self.replace(key, Some(&output), None)?;
+        Ok(output)
+    }
+}

--- a/packages/storage/src/indexes.rs
+++ b/packages/storage/src/indexes.rs
@@ -1,0 +1,232 @@
+// this module requires iterator to be useful at all
+#![cfg(feature = "iterator")]
+
+use cosmwasm_std::{from_slice, to_vec, Binary, Order, StdResult, Storage, KV};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use std::marker::PhantomData;
+
+use crate::indexed_bucket::Core;
+use crate::namespace_helpers::{
+    get_with_prefix, range_with_prefix, remove_with_prefix, set_with_prefix,
+};
+
+/// MARKER is stored in the multi-index as value, but we only look at the key (which is pk)
+const MARKER: &[u8] = b"1";
+
+// 2 main variants:
+//  * store (namespace, index_name, idx_value, key) -> b"1" - allows many and references pk
+//  * store (namespace, index_name, idx_value) -> {key, value} - allows one and copies pk and data
+//  // this would be the primary key - we abstract that too???
+//  * store (namespace, index_name, pk) -> value - allows one with data
+pub(crate) trait Index<S, T>
+where
+    S: Storage,
+    T: Serialize + DeserializeOwned + Clone,
+{
+    // TODO: do we make this any Vec<u8> ?
+    fn name(&self) -> String;
+    fn index(&self, data: &T) -> Vec<u8>;
+
+    fn insert(&self, core: &mut Core<S, T>, pk: &[u8], data: &T) -> StdResult<()>;
+    fn remove(&self, core: &mut Core<S, T>, pk: &[u8], old_data: &T) -> StdResult<()>;
+
+    // these should be implemented by all
+    fn pks_by_index<'c>(
+        &self,
+        core: &'c Core<S, T>,
+        idx: &[u8],
+    ) -> Box<dyn Iterator<Item = Vec<u8>> + 'c>;
+
+    /// returns all items that match this secondary index, always by pk Ascending
+    fn items_by_index<'c>(
+        &self,
+        core: &'c Core<S, T>,
+        idx: &[u8],
+    ) -> Box<dyn Iterator<Item = StdResult<KV<T>>> + 'c>;
+
+    // TODO: range over secondary index values? (eg. all results with 30 < age < 40)
+}
+
+pub(crate) struct MultiIndex<'a, S, T>
+where
+    S: Storage,
+    T: Serialize + DeserializeOwned + Clone,
+{
+    idx_fn: fn(&T) -> Vec<u8>,
+    _name: &'a str,
+    _phantom: PhantomData<S>,
+}
+
+impl<'a, S, T> MultiIndex<'a, S, T>
+where
+    S: Storage,
+    T: Serialize + DeserializeOwned + Clone,
+{
+    pub fn new(idx_fn: fn(&T) -> Vec<u8>, name: &'a str) -> Self {
+        MultiIndex {
+            idx_fn,
+            _name: name,
+            _phantom: Default::default(),
+        }
+    }
+}
+
+impl<'a, S, T> Index<S, T> for MultiIndex<'a, S, T>
+where
+    S: Storage,
+    T: Serialize + DeserializeOwned + Clone,
+{
+    fn name(&self) -> String {
+        self._name.to_string()
+    }
+
+    fn index(&self, data: &T) -> Vec<u8> {
+        (self.idx_fn)(data)
+    }
+
+    fn insert(&self, core: &mut Core<S, T>, pk: &[u8], data: &T) -> StdResult<()> {
+        let idx = self.index(data);
+        set_with_prefix(
+            core.storage,
+            &core.index_space(&self._name, &idx),
+            pk,
+            MARKER,
+        );
+        Ok(())
+    }
+
+    fn remove(&self, core: &mut Core<S, T>, pk: &[u8], old_data: &T) -> StdResult<()> {
+        let idx = self.index(old_data);
+        remove_with_prefix(core.storage, &core.index_space(&self._name, &idx), pk);
+        Ok(())
+    }
+
+    fn pks_by_index<'c>(
+        &self,
+        core: &'c Core<S, T>,
+        idx: &[u8],
+    ) -> Box<dyn Iterator<Item = Vec<u8>> + 'c> {
+        let start = core.index_space(&self._name, idx);
+        let mapped =
+            range_with_prefix(core.storage, &start, None, None, Order::Ascending).map(|(k, _)| k);
+        Box::new(mapped)
+    }
+
+    /// returns all items that match this secondary index, always by pk Ascending
+    fn items_by_index<'c>(
+        &self,
+        core: &'c Core<S, T>,
+        idx: &[u8],
+    ) -> Box<dyn Iterator<Item = StdResult<KV<T>>> + 'c> {
+        let mapped = self.pks_by_index(core, idx).map(move |pk| {
+            let v = core.load(&pk)?;
+            Ok((pk, v))
+        });
+        Box::new(mapped)
+    }
+}
+
+#[derive(Deserialize, Serialize, Clone)]
+pub(crate) struct UniqueRef<T: Clone> {
+    pk: Binary,
+    value: T,
+}
+
+pub(crate) struct UniqueIndex<'a, S, T>
+where
+    S: Storage,
+    T: Serialize + DeserializeOwned + Clone,
+{
+    idx_fn: fn(&T) -> Vec<u8>,
+    _name: &'a str,
+    _phantom: PhantomData<S>,
+}
+
+impl<'a, S, T> UniqueIndex<'a, S, T>
+where
+    S: Storage,
+    T: Serialize + DeserializeOwned + Clone,
+{
+    pub fn new(idx_fn: fn(&T) -> Vec<u8>, name: &'a str) -> Self {
+        UniqueIndex {
+            idx_fn,
+            _name: name,
+            _phantom: Default::default(),
+        }
+    }
+}
+
+impl<'a, S, T> Index<S, T> for UniqueIndex<'a, S, T>
+where
+    S: Storage,
+    T: Serialize + DeserializeOwned + Clone,
+{
+    fn name(&self) -> String {
+        self._name.to_string()
+    }
+
+    fn index(&self, data: &T) -> Vec<u8> {
+        (self.idx_fn)(data)
+    }
+
+    // we store (namespace, index_name, idx_value) -> { pk, value }
+    fn insert(&self, core: &mut Core<S, T>, pk: &[u8], data: &T) -> StdResult<()> {
+        let idx = self.index(data);
+        let reference = UniqueRef::<T> {
+            pk: pk.into(),
+            value: data.clone(),
+        };
+        set_with_prefix(
+            core.storage,
+            &core.prefix_idx(&self._name),
+            &idx,
+            &to_vec(&reference)?,
+        );
+        Ok(())
+    }
+
+    // we store (namespace, index_name, idx_value) -> { pk, value }
+    fn remove(&self, core: &mut Core<S, T>, _pk: &[u8], old_data: &T) -> StdResult<()> {
+        let idx = self.index(old_data);
+        remove_with_prefix(core.storage, &core.prefix_idx(&self._name), &idx);
+        Ok(())
+    }
+
+    // there is exactly 0 or 1 here...
+    fn pks_by_index<'c>(
+        &self,
+        core: &'c Core<S, T>,
+        idx: &[u8],
+    ) -> Box<dyn Iterator<Item = Vec<u8>> + 'c> {
+        let data = get_with_prefix(core.storage, &core.prefix_idx(&self._name), &idx);
+        let res = match data {
+            Some(bin) => vec![bin],
+            None => vec![],
+        };
+        let mapped = res.into_iter().map(|bin| {
+            // TODO: update types so we can return error here
+            let parsed: UniqueRef<T> = from_slice(&bin).unwrap();
+            parsed.pk.into_vec()
+        });
+        Box::new(mapped)
+    }
+
+    /// returns all items that match this secondary index, always by pk Ascending
+    fn items_by_index<'c>(
+        &self,
+        core: &'c Core<S, T>,
+        idx: &[u8],
+    ) -> Box<dyn Iterator<Item = StdResult<KV<T>>> + 'c> {
+        let data = get_with_prefix(core.storage, &core.prefix_idx(&self._name), &idx);
+        let res = match data {
+            Some(bin) => vec![bin],
+            None => vec![],
+        };
+        let mapped = res.into_iter().map(|bin| {
+            let parsed: UniqueRef<T> = from_slice(&bin)?;
+            Ok((parsed.pk.into_vec(), parsed.value))
+        });
+        Box::new(mapped)
+    }
+}

--- a/packages/storage/src/indexes.rs
+++ b/packages/storage/src/indexes.rs
@@ -13,6 +13,20 @@ use crate::namespace_helpers::range_with_prefix;
 /// MARKER is stored in the multi-index as value, but we only look at the key (which is pk)
 const MARKER: &[u8] = b"1";
 
+pub fn index_string(data: &str) -> Vec<u8> {
+    data.as_bytes().to_vec()
+}
+
+// Look at https://docs.rs/endiannezz/0.4.1/endiannezz/trait.Primitive.html
+// if you want to make this generic over all ints
+pub fn index_u64(data: u64) -> Vec<u8> {
+    data.to_be_bytes().into()
+}
+
+pub fn index_i32(data: i32) -> Vec<u8> {
+    data.to_be_bytes().into()
+}
+
 // 2 main variants:
 //  * store (namespace, index_name, idx_value, key) -> b"1" - allows many and references pk
 //  * store (namespace, index_name, idx_value) -> {key, value} - allows one and copies pk and data

--- a/packages/storage/src/length_prefixed.rs
+++ b/packages/storage/src/length_prefixed.rs
@@ -47,6 +47,31 @@ pub fn namespaces_with_key(namespaces: &[&[u8]], key: &[u8]) -> Vec<u8> {
     out
 }
 
+/// Customization of namespaces_with_key for when
+/// there are multiple sets we do not want to combine just to call this
+pub fn nested_namespaces_with_key(top_names: &[&[u8]], sub_names: &[&[u8]], key: &[u8]) -> Vec<u8> {
+    let mut size = key.len();
+    for &namespace in top_names {
+        size += namespace.len() + 2;
+    }
+    for &namespace in sub_names {
+        size += namespace.len() + 2;
+    }
+
+    let mut out = Vec::with_capacity(size);
+    for &namespace in top_names {
+        out.extend_from_slice(&encode_length(namespace));
+        out.extend_from_slice(namespace);
+    }
+    for &namespace in sub_names {
+        out.extend_from_slice(&encode_length(namespace));
+        out.extend_from_slice(namespace);
+    }
+    out.extend_from_slice(key);
+    out
+}
+
+
 /// Encodes the length of a given namespace as a 2 byte big endian encoded integer
 fn encode_length(namespace: &[u8]) -> [u8; 2] {
     if namespace.len() > 0xFFFF {

--- a/packages/storage/src/length_prefixed.rs
+++ b/packages/storage/src/length_prefixed.rs
@@ -29,6 +29,23 @@ pub fn to_length_prefixed_nested(namespaces: &[&[u8]]) -> Vec<u8> {
     out
 }
 
+/// This is equivalent concat(to_length_prefixed_nested(namespaces), key)
+/// But more efficient when the intermediate namespaces often must be recalculated
+pub fn namespaces_with_key(namespaces: &[&[u8]], key: &[u8]) -> Vec<u8> {
+    let mut size = key.len();
+    for &namespace in namespaces {
+        size += namespace.len() + 2;
+    }
+
+    let mut out = Vec::with_capacity(size);
+    for &namespace in namespaces {
+        out.extend_from_slice(&encode_length(namespace));
+        out.extend_from_slice(namespace);
+    }
+    out.extend_from_slice(key);
+    out
+}
+
 /// Encodes the length of a given namespace as a 2 byte big endian encoded integer
 fn encode_length(namespace: &[u8]) -> [u8; 2] {
     if namespace.len() > 0xFFFF {

--- a/packages/storage/src/length_prefixed.rs
+++ b/packages/storage/src/length_prefixed.rs
@@ -31,6 +31,7 @@ pub fn to_length_prefixed_nested(namespaces: &[&[u8]]) -> Vec<u8> {
 
 /// This is equivalent concat(to_length_prefixed_nested(namespaces), key)
 /// But more efficient when the intermediate namespaces often must be recalculated
+#[allow(dead_code)]
 pub fn namespaces_with_key(namespaces: &[&[u8]], key: &[u8]) -> Vec<u8> {
     let mut size = key.len();
     for &namespace in namespaces {

--- a/packages/storage/src/length_prefixed.rs
+++ b/packages/storage/src/length_prefixed.rs
@@ -71,7 +71,6 @@ pub fn nested_namespaces_with_key(top_names: &[&[u8]], sub_names: &[&[u8]], key:
     out
 }
 
-
 /// Encodes the length of a given namespace as a 2 byte big endian encoded integer
 fn encode_length(namespace: &[u8]) -> [u8; 2] {
     if namespace.len() > 0xFFFF {

--- a/packages/storage/src/length_prefixed.rs
+++ b/packages/storage/src/length_prefixed.rs
@@ -29,6 +29,14 @@ pub fn to_length_prefixed_nested(namespaces: &[&[u8]]) -> Vec<u8> {
     out
 }
 
+pub fn length_prefixed_with_key(namespace: &[u8], key: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(namespace.len() + 2 + key.len());
+    out.extend_from_slice(&encode_length(namespace));
+    out.extend_from_slice(namespace);
+    out.extend_from_slice(key);
+    out
+}
+
 /// This is equivalent concat(to_length_prefixed_nested(namespaces), key)
 /// But more efficient when the intermediate namespaces often must be recalculated
 #[allow(dead_code)]
@@ -78,6 +86,12 @@ fn encode_length(namespace: &[u8]) -> [u8; 2] {
     }
     let length_bytes = (namespace.len() as u32).to_be_bytes();
     [length_bytes[2], length_bytes[3]]
+}
+
+// pub(crate) fn decode_length(prefix: [u8; 2]) -> usize {
+pub(crate) fn decode_length(prefix: &[u8]) -> usize {
+    // TODO: enforce exactly 2 bytes somehow, but usable with slices
+    (prefix[0] as usize) * 256 + (prefix[1] as usize)
 }
 
 #[cfg(test)]

--- a/packages/storage/src/lib.rs
+++ b/packages/storage/src/lib.rs
@@ -13,6 +13,7 @@ mod typed;
 pub use bucket::{bucket, bucket_read, Bucket, ReadonlyBucket};
 #[cfg(feature = "iterator")]
 pub use indexed_bucket::IndexedBucket;
+#[cfg(feature = "iterator")]
 pub use indexes::{index_i32, index_string, index_u64};
 pub use length_prefixed::{to_length_prefixed, to_length_prefixed_nested};
 pub use prefixed_storage::{prefixed, prefixed_read, PrefixedStorage, ReadonlyPrefixedStorage};

--- a/packages/storage/src/lib.rs
+++ b/packages/storage/src/lib.rs
@@ -11,7 +11,7 @@ mod typed;
 
 pub use bucket::{bucket, bucket_read, Bucket, ReadonlyBucket};
 #[cfg(feature = "iterator")]
-pub use indexed_bucket::IndexedBucket;
+pub use indexed_bucket::{Core, IndexedBucket, MultiIndex};
 pub use length_prefixed::{to_length_prefixed, to_length_prefixed_nested};
 pub use prefixed_storage::{prefixed, prefixed_read, PrefixedStorage, ReadonlyPrefixedStorage};
 pub use sequence::{currval, nextval, sequence};

--- a/packages/storage/src/lib.rs
+++ b/packages/storage/src/lib.rs
@@ -10,6 +10,7 @@ mod type_helpers;
 mod typed;
 
 pub use bucket::{bucket, bucket_read, Bucket, ReadonlyBucket};
+#[cfg(feature = "iterator")]
 pub use indexed_bucket::IndexedBucket;
 pub use length_prefixed::{to_length_prefixed, to_length_prefixed_nested};
 pub use prefixed_storage::{prefixed, prefixed_read, PrefixedStorage, ReadonlyPrefixedStorage};

--- a/packages/storage/src/lib.rs
+++ b/packages/storage/src/lib.rs
@@ -1,5 +1,6 @@
 mod bucket;
 mod indexed_bucket;
+mod indexes;
 mod length_prefixed;
 mod namespace_helpers;
 mod prefixed_storage;
@@ -11,7 +12,7 @@ mod typed;
 
 pub use bucket::{bucket, bucket_read, Bucket, ReadonlyBucket};
 #[cfg(feature = "iterator")]
-pub use indexed_bucket::{Core, IndexedBucket, MultiIndex, UniqueIndex};
+pub use indexed_bucket::IndexedBucket;
 pub use length_prefixed::{to_length_prefixed, to_length_prefixed_nested};
 pub use prefixed_storage::{prefixed, prefixed_read, PrefixedStorage, ReadonlyPrefixedStorage};
 pub use sequence::{currval, nextval, sequence};

--- a/packages/storage/src/lib.rs
+++ b/packages/storage/src/lib.rs
@@ -11,7 +11,7 @@ mod typed;
 
 pub use bucket::{bucket, bucket_read, Bucket, ReadonlyBucket};
 #[cfg(feature = "iterator")]
-pub use indexed_bucket::{Core, IndexedBucket, MultiIndex};
+pub use indexed_bucket::{Core, IndexedBucket, MultiIndex, UniqueIndex};
 pub use length_prefixed::{to_length_prefixed, to_length_prefixed_nested};
 pub use prefixed_storage::{prefixed, prefixed_read, PrefixedStorage, ReadonlyPrefixedStorage};
 pub use sequence::{currval, nextval, sequence};

--- a/packages/storage/src/lib.rs
+++ b/packages/storage/src/lib.rs
@@ -13,6 +13,7 @@ mod typed;
 pub use bucket::{bucket, bucket_read, Bucket, ReadonlyBucket};
 #[cfg(feature = "iterator")]
 pub use indexed_bucket::IndexedBucket;
+pub use indexes::{index_i32, index_string, index_u64};
 pub use length_prefixed::{to_length_prefixed, to_length_prefixed_nested};
 pub use prefixed_storage::{prefixed, prefixed_read, PrefixedStorage, ReadonlyPrefixedStorage};
 pub use sequence::{currval, nextval, sequence};

--- a/packages/storage/src/lib.rs
+++ b/packages/storage/src/lib.rs
@@ -10,7 +10,7 @@ mod transactions;
 mod type_helpers;
 mod typed;
 
-pub use bucket::{bucket, bucket_read, Bucket, ReadonlyBucket};
+pub use bucket::{bucket, bucket_read, Bucket, Pk2, Pk3, PrimaryKey, ReadonlyBucket};
 #[cfg(feature = "iterator")]
 pub use indexed_bucket::IndexedBucket;
 #[cfg(feature = "iterator")]

--- a/packages/storage/src/lib.rs
+++ b/packages/storage/src/lib.rs
@@ -1,4 +1,5 @@
 mod bucket;
+mod indexed_bucket;
 mod length_prefixed;
 mod namespace_helpers;
 mod prefixed_storage;
@@ -9,6 +10,7 @@ mod type_helpers;
 mod typed;
 
 pub use bucket::{bucket, bucket_read, Bucket, ReadonlyBucket};
+pub use indexed_bucket::IndexedBucket;
 pub use length_prefixed::{to_length_prefixed, to_length_prefixed_nested};
 pub use prefixed_storage::{prefixed, prefixed_read, PrefixedStorage, ReadonlyPrefixedStorage};
 pub use sequence::{currval, nextval, sequence};


### PR DESCRIPTION
Closes #468 

Merge #559 first, then I will rebase on top.

This is a work in four steps

1. allow exactly 1 secondary index, no multi-prefix on primary key
2. allow multiple named secondary indexes, no multi-prefix on primary key
3. add support for unique indexes
4. allow multiple named secondary indexes, clean composite key support

All are now done (4th was done in #558 as a side-effect of re-using bucket code)

- [x] Create one secondary index
- [x] Create multiple secondary indexes
- [x] Basic write/query tests
- [x] Basic update/remove tests
- [x] Revise API design
- [x] Add unique indexes
- [ ] Add ReadOnlyIndexedBucket (Not needed if https://github.com/CosmWasm/cosmwasm/pull/559 is merged)
- [ ] Better unit test coverage
- [ ] Improve docstrings
- [ ] Update CHANGELOG
- [ ] Update MIGRATING
- [ ] Update README - revise with #558 and #559 as well

Update:

As part of an attempt to make `ReadOnlyIndexedBucket`, I came across the annoyance that `Bucket` and `ReadonlyBucket` are different types, but only based on the mutabilty of the storage object. If we didn't store that, we could have one class that just took methods that were either `&Storage` or `&mut Storage`. And this would improve composition.

For `PrefixedStorage`, I see the desire to have the Storage object inside (this is a separate wrapper), but for the more complex cases that do not implement Storage themselves, this seems much overhead. I made PR #559 to implement this (on master, independent of the secondary index work)
