### PR TITLE
Merge Core and Bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,14 @@
   namespace in `PrefixedStorage::new`, `PrefixedStorage::multilevel`,
   `ReadonlyPrefixedStorage::new`, `ReadonlyPrefixedStorage::multilevel`,
   `prefixed` and `prefixed_read`.
+- Remove `Bucket::multilevel` as it was a misnomer. Provide support for
+  composite `PrimaryKey`s in storage, using `Pk2` and `Pk3` for 2 or 3 items
+  keys. Add `Bucket::range_prefixed` to provide the first section(s) of the
+  composite key and iterate under that.
+- Bucket stores all data under `(namespace, "_pk", key)`, where the first two
+  are length-prefixed. This is a different layout from previous form
+  where it was `(namespace, key)` and this is intended to support co-existence
+  with `IndexedBucket`. (It only changes the raw storage layout, APIs don't change).
 
 **cosmwasm-vm**
 

--- a/packages/storage/src/bucket.rs
+++ b/packages/storage/src/bucket.rs
@@ -179,6 +179,26 @@ where
         Box::new(mapped)
     }
 
+    // TODO: test this, just an idea now, need more work on Pks
+    // Also, how much do we trim from the keys? Leave just the last part of the PK, right?
+
+    /// This lets us grab all items under the beginning of a composite key.
+    /// If we store under `Pk2(owner, spender)`, then we pass `prefixes: &[owner]` here
+    /// To list all spenders under the owner
+    #[cfg(feature = "iterator")]
+    pub fn range_prefixed<'c>(
+        &'c self,
+        prefixes: &[&[u8]],
+        start: Option<&[u8]>,
+        end: Option<&[u8]>,
+        order: Order,
+    ) -> Box<dyn Iterator<Item = StdResult<KV<T>>> + 'c> {
+        let namespace = nested_namespaces_with_key(&[&self.namespace, PREFIX_PK], prefixes, b"");
+        let mapped =
+            range_with_prefix(self.storage, &namespace, start, end, order).map(deserialize_kv::<T>);
+        Box::new(mapped)
+    }
+
     /// Loads the data, perform the specified action, and store the result
     /// in the database. This is shorthand for some common sequences, which may be useful.
     ///

--- a/packages/storage/src/length_prefixed.rs
+++ b/packages/storage/src/length_prefixed.rs
@@ -47,6 +47,31 @@ pub fn namespaces_with_key(namespaces: &[&[u8]], key: &[u8]) -> Vec<u8> {
     out
 }
 
+/// Customization of namespaces_with_key for when
+/// there are multiple sets we do not want to combine just to call this
+pub fn nested_namespaces_with_key(top_names: &[&[u8]], sub_names: &[&[u8]], key: &[u8]) -> Vec<u8> {
+    let mut size = key.len();
+    for &namespace in top_names {
+        size += namespace.len() + 2;
+    }
+    for &namespace in sub_names {
+        size += namespace.len() + 2;
+    }
+
+    let mut out = Vec::with_capacity(size);
+    for &namespace in top_names {
+        out.extend_from_slice(&encode_length(namespace));
+        out.extend_from_slice(namespace);
+    }
+    for &namespace in sub_names {
+        out.extend_from_slice(&encode_length(namespace));
+        out.extend_from_slice(namespace);
+    }
+    out.extend_from_slice(key);
+    out
+}
+
+
 /// Encodes the length of a given namespace as a 2 byte big endian encoded integer
 fn encode_length(namespace: &[u8]) -> [u8; 2] {
     if namespace.len() > 0xFFFF {

--- a/packages/storage/src/length_prefixed.rs
+++ b/packages/storage/src/length_prefixed.rs
@@ -71,7 +71,6 @@ pub fn nested_namespaces_with_key(top_names: &[&[u8]], sub_names: &[&[u8]], key:
     out
 }
 
-
 /// Encodes the length of a given namespace as a 2 byte big endian encoded integer
 fn encode_length(namespace: &[u8]) -> [u8; 2] {
     if namespace.len() > 0xFFFF {

--- a/packages/storage/src/length_prefixed.rs
+++ b/packages/storage/src/length_prefixed.rs
@@ -29,6 +29,14 @@ pub fn to_length_prefixed_nested(namespaces: &[&[u8]]) -> Vec<u8> {
     out
 }
 
+pub fn length_prefixed_with_key(namespace: &[u8], key: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(namespace.len() + 2 + key.len());
+    out.extend_from_slice(&encode_length(namespace));
+    out.extend_from_slice(namespace);
+    out.extend_from_slice(key);
+    out
+}
+
 /// This is equivalent concat(to_length_prefixed_nested(namespaces), key)
 /// But more efficient when the intermediate namespaces often must be recalculated
 #[allow(dead_code)]
@@ -78,6 +86,12 @@ fn encode_length(namespace: &[u8]) -> [u8; 2] {
     }
     let length_bytes = (namespace.len() as u32).to_be_bytes();
     [length_bytes[2], length_bytes[3]]
+}
+
+// pub(crate) fn decode_length(prefix: [u8; 2]) -> usize {
+pub(crate) fn decode_length(prefix: &[u8]) -> usize {
+    // TODO: enforce exactly 2 bytes somehow, but usable with slices
+    (prefix[0] as usize) * 256 + (prefix[1] as usize)
 }
 
 #[cfg(test)]

--- a/packages/storage/src/lib.rs
+++ b/packages/storage/src/lib.rs
@@ -10,7 +10,7 @@ mod transactions;
 mod type_helpers;
 mod typed;
 
-pub use bucket::{bucket, bucket_read, Bucket, ReadonlyBucket};
+pub use bucket::{bucket, bucket_read, Bucket, Pk2, Pk3, PrimaryKey, ReadonlyBucket};
 #[cfg(feature = "iterator")]
 pub use indexed_bucket::IndexedBucket;
 #[cfg(feature = "iterator")]


### PR DESCRIPTION
Optional refactor as part of #557 

Combines the features of Core into Bucket. It should require fewer Vec allocations than the older bucket, and makes it extensible to be used inside an IndexedBucket (it scopes the primary key to leave space for indexes)

Downside: This stores all the bucket data under `(namespace, "_pk", key)` rather than `(namespace, key)` which adds 5 bytes ("_pk" plus 2 byte prefix) to key length and requires a migration step if moving from a pre-0.11 contract. If we do stick with this, I will expose a function to be used for migration.

Here I also remove the multilevel portion (which was improper implementation of composite keys) and produce proper support for composite primary keys.

- [x] Update Bucket API/implementation (remove multilevel, add "_pk")
- [x] Remove Core, base IndexedBucket on Bucket
- [x] Create/parse composite "PrimaryKey" types  outside of the bucket
- [x] `range_prefix` over part of a composite key
- [x] Update CHANGELOG, MIGRATING
