### PR TITLE
Replace Storage::range with ::scan and ::next

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # CHANGELOG
 
+## 0.12.0 (unreleased)
+
+**cosmwasm-vm**
+
+- Remove `Storage::range` and `StorageIterator`. The storage implementation is
+  now responsible for maintaining iterators internally and make them accessible
+  via the new `Storage::scan` and `Storage::next` methods.
+- Add `FfiError::IteratorDoesNotExist`. Looking at this, `FfiError` should
+  probably be renamed to something that includes before, on and behind the FFI
+  boundary to Go.
+- `MockStorage` now implementes the new `Storage` trait and has an additional
+  `MockStorage::all` for getting all elements of an iterator in tests.
+
 ## 0.11.1 (2020-10-12)
 
 **cosmwasm-std**

--- a/contracts/burner/tests/integration.rs
+++ b/contracts/burner/tests/integration.rs
@@ -21,7 +21,6 @@ use cosmwasm_std::{
     coins, BankMsg, ContractResult, HumanAddr, InitResponse, MigrateResponse, Order,
 };
 use cosmwasm_vm::testing::{init, migrate, mock_env, mock_info, mock_instance, MOCK_CONTRACT_ADDR};
-use cosmwasm_vm::StorageIterator;
 
 use burner::msg::{InitMsg, MigrateMsg};
 use cosmwasm_vm::Storage;
@@ -55,13 +54,8 @@ fn migrate_cleans_up_data() {
         storage.set(b"foo", b"bar").0.unwrap();
         storage.set(b"key2", b"data2").0.unwrap();
         storage.set(b"key3", b"cool stuff").0.unwrap();
-        let cnt = storage
-            .range(None, None, Order::Ascending)
-            .0
-            .unwrap()
-            .elements()
-            .unwrap()
-            .len();
+        let iter_id = storage.scan(None, None, Order::Ascending).0.unwrap();
+        let cnt = storage.all(iter_id).0.unwrap().len();
         assert_eq!(3, cnt);
         Ok(())
     })
@@ -89,13 +83,8 @@ fn migrate_cleans_up_data() {
 
     // check there is no data in storage
     deps.with_storage(|storage| {
-        let cnt = storage
-            .range(None, None, Order::Ascending)
-            .0
-            .unwrap()
-            .elements()
-            .unwrap()
-            .len();
+        let iter_id = storage.scan(None, None, Order::Ascending).0.unwrap();
+        let cnt = storage.all(iter_id).0.unwrap().len();
         assert_eq!(0, cnt);
         Ok(())
     })

--- a/packages/vm/src/context.rs
+++ b/packages/vm/src/context.rs
@@ -1,11 +1,6 @@
 //! Internal details to be used by instance.rs only
-#[cfg(feature = "iterator")]
-use std::collections::HashMap;
-#[cfg(feature = "iterator")]
-use std::convert::TryInto;
+
 use std::ffi::c_void;
-#[cfg(not(feature = "iterator"))]
-use std::marker::PhantomData;
 use std::ptr::NonNull;
 
 use wasmer_runtime_core::{
@@ -17,8 +12,6 @@ use wasmer_runtime_core::{
 use crate::backends::decrease_gas_left;
 use crate::errors::{VmError, VmResult};
 use crate::ffi::GasInfo;
-#[cfg(feature = "iterator")]
-use crate::traits::StorageIterator;
 use crate::traits::{Querier, Storage};
 
 /** context data **/
@@ -70,17 +63,13 @@ impl GasState {
     }
 }
 
-struct ContextData<'a, S: Storage, Q: Querier> {
+struct ContextData<S: Storage, Q: Querier> {
     gas_state: GasState,
     storage: Option<S>,
     storage_readonly: bool,
     querier: Option<Q>,
     /// A non-owning link to the wasmer instance
     wasmer_instance: Option<NonNull<WasmerInstance>>,
-    #[cfg(feature = "iterator")]
-    iterators: HashMap<u32, Box<dyn StorageIterator + 'a>>,
-    #[cfg(not(feature = "iterator"))]
-    iterators: PhantomData<&'a mut ()>,
 }
 
 pub fn setup_context<S: Storage, Q: Querier>(gas_limit: u64) -> (*mut c_void, fn(*mut c_void)) {
@@ -97,10 +86,6 @@ fn create_unmanaged_context_data<S: Storage, Q: Querier>(gas_limit: u64) -> *mut
         storage_readonly: true,
         querier: None,
         wasmer_instance: None,
-        #[cfg(feature = "iterator")]
-        iterators: HashMap::new(),
-        #[cfg(not(feature = "iterator"))]
-        iterators: PhantomData::default(),
     };
     let heap_data = Box::new(data); // move from stack to heap
     Box::into_raw(heap_data) as *mut c_void // give up ownership
@@ -109,9 +94,7 @@ fn create_unmanaged_context_data<S: Storage, Q: Querier>(gas_limit: u64) -> *mut
 fn destroy_unmanaged_context_data<S: Storage, Q: Querier>(ptr: *mut c_void) {
     if !ptr.is_null() {
         // obtain ownership and drop instance of ContextData when box gets out of scope
-        let mut dying = unsafe { Box::from_raw(ptr as *mut ContextData<S, Q>) };
-        // Ensure all iterators are dropped before the storage
-        destroy_iterators(&mut dying);
+        let _dying = unsafe { Box::from_raw(ptr as *mut ContextData<S, Q>) };
     }
 }
 
@@ -137,7 +120,7 @@ fn destroy_unmanaged_context_data<S: Storage, Q: Querier>(ptr: *mut c_void) {
 // probably triggers unsoundness.
 fn get_context_data_mut<'a, 'b, S: Storage, Q: Querier>(
     ctx: &'a mut Ctx,
-) -> &'b mut ContextData<'b, S, Q> {
+) -> &'b mut ContextData<S, Q> {
     unsafe {
         let ptr = ctx.data as *mut ContextData<S, Q>;
         ptr.as_mut()
@@ -145,7 +128,7 @@ fn get_context_data_mut<'a, 'b, S: Storage, Q: Querier>(
     }
 }
 
-fn get_context_data<'a, 'b, S: Storage, Q: Querier>(ctx: &'a Ctx) -> &'b ContextData<'b, S, Q> {
+fn get_context_data<'a, 'b, S: Storage, Q: Querier>(ctx: &'a Ctx) -> &'b ContextData<S, Q> {
     unsafe {
         let ptr = ctx.data as *mut ContextData<S, Q>;
         ptr.as_ref()
@@ -164,25 +147,12 @@ pub fn set_wasmer_instance<S: Storage, Q: Querier>(
     }
 }
 
-#[cfg(feature = "iterator")]
-fn destroy_iterators<S: Storage, Q: Querier>(context: &mut ContextData<S, Q>) {
-    context.iterators.clear();
-}
-
-#[cfg(not(feature = "iterator"))]
-fn destroy_iterators<S: Storage, Q: Querier>(_context: &mut ContextData<S, Q>) {}
-
 /// Returns the original storage and querier as owned instances, and closes any remaining
 /// iterators. This is meant to be called when recycling the instance.
 pub(crate) fn move_out_of_context<S: Storage, Q: Querier>(
     source: &mut Ctx,
 ) -> (Option<S>, Option<Q>) {
-    let mut b = get_context_data_mut::<S, Q>(source);
-    // Destroy all existing iterators which are (in contrast to the storage)
-    // not reused between different instances.
-    // This is also important because the iterators are pointers to Go memory which should not be stored long term
-    // Paragraphs 5-7: https://golang.org/cmd/cgo/#hdr-Passing_pointers
-    destroy_iterators(&mut b);
+    let b = get_context_data_mut::<S, Q>(source);
     (b.storage.take(), b.querier.take())
 }
 
@@ -270,28 +240,6 @@ pub fn set_storage_readonly<S: Storage, Q: Querier>(ctx: &mut Ctx, new_value: bo
     context_data.storage_readonly = new_value;
 }
 
-/// Add the iterator to the context's data. A new ID is assigned and returned.
-/// IDs are guaranteed to be in the range [0, 2**31-1], i.e. fit in the non-negative part if type i32.
-#[cfg(feature = "iterator")]
-#[must_use = "without the returned iterator ID, the iterator cannot be accessed"]
-pub fn add_iterator<'a, S: Storage, Q: Querier>(
-    ctx: &mut Ctx,
-    iter: Box<dyn StorageIterator + 'a>,
-) -> u32 {
-    let b = get_context_data_mut::<S, Q>(ctx);
-    let last_id: u32 = b
-        .iterators
-        .len()
-        .try_into()
-        .expect("Found more iterator IDs than supported");
-    let new_id = last_id + 1;
-    if new_id > (i32::MAX as u32) {
-        panic!("Iterator ID exceeded i32::MAX. This must not happen.");
-    }
-    b.iterators.insert(new_id, iter);
-    new_id
-}
-
 pub(crate) fn with_func_from_context<S, Q, Args, Rets, Callback, CallbackData>(
     ctx: &mut Ctx,
     name: &str,
@@ -351,8 +299,6 @@ mod test {
     use super::*;
     use crate::backends::{compile, decrease_gas_left, set_gas_left};
     use crate::errors::VmError;
-    #[cfg(feature = "iterator")]
-    use crate::testing::MockIterator;
     use crate::testing::{MockQuerier, MockStorage};
     use crate::traits::Storage;
     use cosmwasm_std::{
@@ -516,29 +462,6 @@ mod test {
         // change back
         set_storage_readonly::<MS, MQ>(ctx, true);
         assert_eq!(is_storage_readonly::<MS, MQ>(ctx), true);
-    }
-
-    #[test]
-    #[cfg(feature = "iterator")]
-    fn add_iterator_works() {
-        let mut instance = make_instance();
-        let ctx = instance.context_mut();
-        leave_default_data(ctx);
-
-        assert_eq!(get_context_data_mut::<MS, MQ>(ctx).iterators.len(), 0);
-        let id1 = add_iterator::<MS, MQ>(ctx, Box::new(MockIterator::empty()));
-        let id2 = add_iterator::<MS, MQ>(ctx, Box::new(MockIterator::empty()));
-        let id3 = add_iterator::<MS, MQ>(ctx, Box::new(MockIterator::empty()));
-        assert_eq!(get_context_data_mut::<MS, MQ>(ctx).iterators.len(), 3);
-        assert!(get_context_data_mut::<MS, MQ>(ctx)
-            .iterators
-            .contains_key(&id1));
-        assert!(get_context_data_mut::<MS, MQ>(ctx)
-            .iterators
-            .contains_key(&id2));
-        assert!(get_context_data_mut::<MS, MQ>(ctx)
-            .iterators
-            .contains_key(&id3));
     }
 
     #[test]

--- a/packages/vm/src/context.rs
+++ b/packages/vm/src/context.rs
@@ -99,25 +99,6 @@ fn destroy_unmanaged_context_data<S: Storage, Q: Querier>(ptr: *mut c_void) {
 }
 
 /// Get a mutable reference to the context's data. Ownership remains in the Context.
-// NOTE: This is actually not really implemented safely at the moment. I did this as a
-// nicer and less-terrible version of the previous solution to the following issue:
-//
-//                                                   +--->> Go pointer
-//                                                   |
-// Ctx ->> ContextData +-> iterators: Box<dyn Iterator + 'a> --+
-//                     |                                       |
-//                     +-> storage: impl Storage <<------------+
-//                     |
-//                     +-> querier: impl Querier
-//
-// ->  : Ownership
-// ->> : Mutable borrow
-//
-// As you can see, there's a cyclical reference here... changing this function to return the same lifetime as it
-// returns (and adjusting a few other functions to only have one lifetime instead of two) triggers an error
-// elsewhere where we try to add iterators to the context. That's not legal according to Rust's rules, and it
-// complains that we're trying to borrow ctx mutably twice. This needs a better solution because this function
-// probably triggers unsoundness.
 fn get_context_data_mut<'a, 'b, S: Storage, Q: Querier>(
     ctx: &'a mut Ctx,
 ) -> &'b mut ContextData<S, Q> {

--- a/packages/vm/src/errors/vm_error.rs
+++ b/packages/vm/src/errors/vm_error.rs
@@ -43,11 +43,6 @@ pub enum VmError {
     },
     #[snafu(display("Hash doesn't match stored data"))]
     IntegrityErr { backtrace: snafu::Backtrace },
-    #[snafu(display("Iterator with ID {} does not exist", id))]
-    IteratorDoesNotExist {
-        id: u32,
-        backtrace: snafu::Backtrace,
-    },
     #[snafu(display("Error parsing into type {}: {}", target, msg))]
     ParseErr {
         /// the target type that was attempted
@@ -126,11 +121,6 @@ impl VmError {
 
     pub(crate) fn integrity_err() -> Self {
         IntegrityErr {}.build()
-    }
-
-    #[cfg(feature = "iterator")]
-    pub(crate) fn iterator_does_not_exist(iterator_id: u32) -> Self {
-        IteratorDoesNotExist { id: iterator_id }.build()
     }
 
     pub(crate) fn parse_err<T: Into<String>, M: Display>(target: T, msg: M) -> Self {
@@ -304,16 +294,6 @@ mod test {
         let error = VmError::integrity_err();
         match error {
             VmError::IntegrityErr { .. } => {}
-            e => panic!("Unexpected error: {:?}", e),
-        }
-    }
-
-    #[test]
-    #[cfg(feature = "iterator")]
-    fn iterator_does_not_exist_works() {
-        let error = VmError::iterator_does_not_exist(15);
-        match error {
-            VmError::IteratorDoesNotExist { id, .. } => assert_eq!(id, 15),
             e => panic!("Unexpected error: {:?}", e),
         }
     }

--- a/packages/vm/src/ffi.rs
+++ b/packages/vm/src/ffi.rs
@@ -1,5 +1,6 @@
 use snafu::Snafu;
 use std::fmt::Debug;
+use std::ops::AddAssign;
 use std::string::FromUtf8Error;
 
 /// A result type for calling into the backend via FFI. Such a call causes
@@ -40,6 +41,15 @@ impl GasInfo {
             cost: 0,
             externally_used: 0,
         }
+    }
+}
+
+impl AddAssign for GasInfo {
+    fn add_assign(&mut self, other: Self) {
+        *self = GasInfo {
+            cost: self.cost + other.cost,
+            externally_used: self.externally_used + other.cost,
+        };
     }
 }
 

--- a/packages/vm/src/ffi.rs
+++ b/packages/vm/src/ffi.rs
@@ -51,6 +51,11 @@ pub enum FfiError {
     BadArgument { backtrace: snafu::Backtrace },
     #[snafu(display("VM received invalid UTF-8 data from backend"))]
     InvalidUtf8 { backtrace: snafu::Backtrace },
+    #[snafu(display("Iterator with ID {} does not exist", id))]
+    IteratorDoesNotExist {
+        id: u32,
+        backtrace: snafu::Backtrace,
+    },
     #[snafu(display("Ran out of gas during FFI call"))]
     OutOfGas {},
     #[snafu(display("Unknown error during FFI call: {:?}", msg))]
@@ -73,6 +78,10 @@ impl FfiError {
 
     pub fn bad_argument() -> Self {
         BadArgument {}.build()
+    }
+
+    pub fn iterator_does_not_exist(iterator_id: u32) -> Self {
+        IteratorDoesNotExist { id: iterator_id }.build()
     }
 
     pub fn out_of_gas() -> Self {
@@ -146,6 +155,15 @@ mod test {
         let error = FfiError::bad_argument();
         match error {
             FfiError::BadArgument { .. } => {}
+            e => panic!("Unexpected error: {:?}", e),
+        }
+    }
+
+    #[test]
+    fn iterator_does_not_exist_works() {
+        let error = FfiError::iterator_does_not_exist(15);
+        match error {
+            FfiError::IteratorDoesNotExist { id, .. } => assert_eq!(id, 15),
             e => panic!("Unexpected error: {:?}", e),
         }
     }

--- a/packages/vm/src/imports.rs
+++ b/packages/vm/src/imports.rs
@@ -10,7 +10,7 @@ use wasmer_runtime_core::vm::Ctx;
 
 use crate::backends::get_gas_left;
 #[cfg(feature = "iterator")]
-use crate::context::{add_iterator, with_iterator_from_context};
+use crate::context::with_iterator_from_context;
 use crate::context::{
     is_storage_readonly, process_gas_info, with_func_from_context, with_querier_from_context,
     with_storage_from_context,
@@ -190,11 +190,10 @@ pub fn do_scan<S: Storage, Q: Querier>(
         .map_err(|_| CommunicationError::invalid_order(order))?;
 
     let (result, gas_info) = with_storage_from_context::<S, Q, _, _>(ctx, |store| {
-        Ok(store.range(start.as_deref(), end.as_deref(), order))
+        Ok(store.scan(start.as_deref(), end.as_deref(), order))
     })?;
     process_gas_info::<S, Q>(ctx, gas_info)?;
-    let iterator = result?;
-    let iterator_id = add_iterator::<S, Q>(ctx, iterator);
+    let iterator_id = result?;
     Ok(iterator_id)
 }
 

--- a/packages/vm/src/imports.rs
+++ b/packages/vm/src/imports.rs
@@ -9,8 +9,6 @@ use cosmwasm_std::{Binary, CanonicalAddr, HumanAddr};
 use wasmer_runtime_core::vm::Ctx;
 
 use crate::backends::get_gas_left;
-#[cfg(feature = "iterator")]
-use crate::context::with_iterator_from_context;
 use crate::context::{
     is_storage_readonly, process_gas_info, with_func_from_context, with_querier_from_context,
     with_storage_from_context,
@@ -875,15 +873,15 @@ mod test {
         assert_eq!(1, id);
 
         let item =
-            with_iterator_from_context::<MS, MQ, _, _>(ctx, id, |iter| Ok(iter.next())).unwrap();
+            with_storage_from_context::<MS, MQ, _, _>(ctx, |store| Ok(store.next(id))).unwrap();
         assert_eq!(item.0.unwrap().unwrap(), (KEY1.to_vec(), VALUE1.to_vec()));
 
         let item =
-            with_iterator_from_context::<MS, MQ, _, _>(ctx, id, |iter| Ok(iter.next())).unwrap();
+            with_storage_from_context::<MS, MQ, _, _>(ctx, |store| Ok(store.next(id))).unwrap();
         assert_eq!(item.0.unwrap().unwrap(), (KEY2.to_vec(), VALUE2.to_vec()));
 
         let item =
-            with_iterator_from_context::<MS, MQ, _, _>(ctx, id, |iter| Ok(iter.next())).unwrap();
+            with_storage_from_context::<MS, MQ, _, _>(ctx, |store| Ok(store.next(id))).unwrap();
         assert!(item.0.unwrap().is_none());
     }
 
@@ -899,15 +897,15 @@ mod test {
         assert_eq!(1, id);
 
         let item =
-            with_iterator_from_context::<MS, MQ, _, _>(ctx, id, |iter| Ok(iter.next())).unwrap();
+            with_storage_from_context::<MS, MQ, _, _>(ctx, |store| Ok(store.next(id))).unwrap();
         assert_eq!(item.0.unwrap().unwrap(), (KEY2.to_vec(), VALUE2.to_vec()));
 
         let item =
-            with_iterator_from_context::<MS, MQ, _, _>(ctx, id, |iter| Ok(iter.next())).unwrap();
+            with_storage_from_context::<MS, MQ, _, _>(ctx, |store| Ok(store.next(id))).unwrap();
         assert_eq!(item.0.unwrap().unwrap(), (KEY1.to_vec(), VALUE1.to_vec()));
 
         let item =
-            with_iterator_from_context::<MS, MQ, _, _>(ctx, id, |iter| Ok(iter.next())).unwrap();
+            with_storage_from_context::<MS, MQ, _, _>(ctx, |store| Ok(store.next(id))).unwrap();
         assert!(item.0.unwrap().is_none());
     }
 
@@ -925,11 +923,11 @@ mod test {
         let id = do_scan::<MS, MQ>(ctx, start, end, Order::Ascending.into()).unwrap();
 
         let item =
-            with_iterator_from_context::<MS, MQ, _, _>(ctx, id, |iter| Ok(iter.next())).unwrap();
+            with_storage_from_context::<MS, MQ, _, _>(ctx, |store| Ok(store.next(id))).unwrap();
         assert_eq!(item.0.unwrap().unwrap(), (KEY1.to_vec(), VALUE1.to_vec()));
 
         let item =
-            with_iterator_from_context::<MS, MQ, _, _>(ctx, id, |iter| Ok(iter.next())).unwrap();
+            with_storage_from_context::<MS, MQ, _, _>(ctx, |store| Ok(store.next(id))).unwrap();
         assert!(item.0.unwrap().is_none());
     }
 
@@ -948,27 +946,27 @@ mod test {
 
         // first item, first iterator
         let item =
-            with_iterator_from_context::<MS, MQ, _, _>(ctx, id1, |iter| Ok(iter.next())).unwrap();
+            with_storage_from_context::<MS, MQ, _, _>(ctx, |store| Ok(store.next(id1))).unwrap();
         assert_eq!(item.0.unwrap().unwrap(), (KEY1.to_vec(), VALUE1.to_vec()));
 
         // second item, first iterator
         let item =
-            with_iterator_from_context::<MS, MQ, _, _>(ctx, id1, |iter| Ok(iter.next())).unwrap();
+            with_storage_from_context::<MS, MQ, _, _>(ctx, |store| Ok(store.next(id1))).unwrap();
         assert_eq!(item.0.unwrap().unwrap(), (KEY2.to_vec(), VALUE2.to_vec()));
 
         // first item, second iterator
         let item =
-            with_iterator_from_context::<MS, MQ, _, _>(ctx, id2, |iter| Ok(iter.next())).unwrap();
+            with_storage_from_context::<MS, MQ, _, _>(ctx, |store| Ok(store.next(id2))).unwrap();
         assert_eq!(item.0.unwrap().unwrap(), (KEY2.to_vec(), VALUE2.to_vec()));
 
         // end, first iterator
         let item =
-            with_iterator_from_context::<MS, MQ, _, _>(ctx, id1, |iter| Ok(iter.next())).unwrap();
+            with_storage_from_context::<MS, MQ, _, _>(ctx, |store| Ok(store.next(id1))).unwrap();
         assert!(item.0.unwrap().is_none());
 
         // second item, second iterator
         let item =
-            with_iterator_from_context::<MS, MQ, _, _>(ctx, id2, |iter| Ok(iter.next())).unwrap();
+            with_storage_from_context::<MS, MQ, _, _>(ctx, |store| Ok(store.next(id2))).unwrap();
         assert_eq!(item.0.unwrap().unwrap(), (KEY1.to_vec(), VALUE1.to_vec()));
     }
 

--- a/packages/vm/src/lib.rs
+++ b/packages/vm/src/lib.rs
@@ -33,6 +33,3 @@ pub use crate::instance::{GasReport, Instance};
 pub use crate::modules::FileSystemCache;
 pub use crate::serde::{from_slice, to_vec};
 pub use crate::traits::{Api, Extern, Querier, Storage};
-
-#[cfg(feature = "iterator")]
-pub use crate::traits::StorageIterator;

--- a/packages/vm/src/testing/mod.rs
+++ b/packages/vm/src/testing/mod.rs
@@ -16,6 +16,4 @@ pub use mock::{
     MOCK_CONTRACT_ADDR,
 };
 pub use querier::MockQuerier;
-#[cfg(feature = "iterator")]
-pub use storage::MockIterator;
 pub use storage::MockStorage;

--- a/packages/vm/src/testing/storage.rs
+++ b/packages/vm/src/testing/storage.rs
@@ -1,5 +1,9 @@
 use std::collections::BTreeMap;
 #[cfg(feature = "iterator")]
+use std::collections::HashMap;
+#[cfg(feature = "iterator")]
+use std::convert::TryInto;
+#[cfg(feature = "iterator")]
 use std::ops::{Bound, RangeBounds};
 
 #[cfg(feature = "iterator")]
@@ -7,6 +11,8 @@ use cosmwasm_std::{Order, KV};
 
 #[cfg(feature = "iterator")]
 use crate::traits::StorageIterator;
+#[cfg(feature = "iterator")]
+use crate::FfiError;
 use crate::{FfiResult, GasInfo, Storage};
 
 #[cfg(feature = "iterator")]
@@ -44,14 +50,39 @@ impl StorageIterator for MockIterator<'_> {
     }
 }
 
+#[cfg(feature = "iterator")]
+#[derive(Default, Debug)]
+struct Iter {
+    data: Vec<KV>,
+    position: usize,
+}
+
 #[derive(Default, Debug)]
 pub struct MockStorage {
     data: BTreeMap<Vec<u8>, Vec<u8>>,
+    #[cfg(feature = "iterator")]
+    iterators: HashMap<u32, Iter>,
 }
 
 impl MockStorage {
     pub fn new() -> Self {
         MockStorage::default()
+    }
+
+    #[cfg(feature = "iterator")]
+    pub fn all(&mut self, iterator_id: u32) -> FfiResult<Vec<KV>> {
+        let mut out: Vec<KV> = Vec::new();
+        let mut total = GasInfo::free();
+        loop {
+            let (value, info) = self.next(iterator_id);
+            total.cost += info.cost; // TODO: implement GasInfo+GasInfo
+            if let Some(v) = value.unwrap() {
+                out.push(v);
+            } else {
+                break;
+            }
+        }
+        (Ok(out), total)
     }
 }
 
@@ -62,38 +93,57 @@ impl Storage for MockStorage {
     }
 
     #[cfg(feature = "iterator")]
-    /// range allows iteration over a set of keys, either forwards or backwards
-    /// uses standard rust range notation, and eg db.range(b"foo"..b"bar") also works reverse
-    fn range<'a>(
-        &'a self,
-        start: Option<&[u8]>,
-        end: Option<&[u8]>,
-        order: Order,
-    ) -> FfiResult<Box<dyn StorageIterator + 'a>> {
+    fn scan(&mut self, start: Option<&[u8]>, end: Option<&[u8]>, order: Order) -> FfiResult<u32> {
         let gas_info = GasInfo::with_externally_used(GAS_COST_RANGE);
         let bounds = range_bounds(start, end);
 
-        // BTreeMap.range panics if range is start > end.
-        // However, this cases represent just empty range and we treat it as such.
-        match (bounds.start_bound(), bounds.end_bound()) {
-            (Bound::Included(start), Bound::Excluded(end)) if start > end => {
-                return (Ok(Box::new(MockIterator::empty())), gas_info);
-            }
-            _ => {}
-        }
-
-        let original_iter = self.data.range(bounds);
-        let iter: Box<dyn Iterator<Item = (KV, u64)>> = match order {
-            Order::Ascending => Box::new(original_iter.map(clone_item).map(|item| {
-                let gas_cost = (item.0.len() + item.1.len()) as u64;
-                (item, gas_cost)
-            })),
-            Order::Descending => Box::new(original_iter.rev().map(clone_item).map(|item| {
-                let gas_cost = (item.0.len() + item.1.len()) as u64;
-                (item, gas_cost)
-            })),
+        let values: Vec<KV> = match (bounds.start_bound(), bounds.end_bound()) {
+            // BTreeMap.range panics if range is start > end.
+            // However, this cases represent just empty range and we treat it as such.
+            (Bound::Included(start), Bound::Excluded(end)) if start > end => Vec::new(),
+            _ => match order {
+                Order::Ascending => self.data.range(bounds).map(clone_item).collect(),
+                Order::Descending => self.data.range(bounds).rev().map(clone_item).collect(),
+            },
         };
-        (Ok(Box::new(MockIterator { source: iter })), gas_info)
+
+        let last_id: u32 = self
+            .iterators
+            .len()
+            .try_into()
+            .expect("Found more iterator IDs than supported");
+        let new_id = last_id + 1;
+        let iter = Iter {
+            data: values,
+            position: 0,
+        };
+        self.iterators.insert(new_id, iter);
+
+        (Ok(new_id), gas_info)
+    }
+
+    #[cfg(feature = "iterator")]
+    fn next(&mut self, iterator_id: u32) -> FfiResult<Option<KV>> {
+        let iterator = match self.iterators.get_mut(&iterator_id) {
+            Some(i) => i,
+            None => {
+                return (
+                    Err(FfiError::iterator_does_not_exist(iterator_id)),
+                    GasInfo::free(),
+                )
+            }
+        };
+
+        let (value, gas_info): (Option<KV>, GasInfo) = if iterator.data.len() > iterator.position {
+            let item = iterator.data[iterator.position].clone();
+            iterator.position += 1;
+            let gas_cost = (item.0.len() + item.1.len()) as u64;
+            (Some(item), GasInfo::with_cost(gas_cost))
+        } else {
+            (None, GasInfo::with_externally_used(GAS_COST_LAST_ITERATION))
+        };
+
+        (Ok(value), gas_info)
     }
 
     fn set(&mut self, key: &[u8], value: &[u8]) -> FfiResult<()> {
@@ -160,16 +210,8 @@ mod test {
 
         // ensure we had previously set "foo" = "bar"
         assert_eq!(store.get(b"foo").0.unwrap(), Some(b"bar".to_vec()));
-        assert_eq!(
-            store
-                .range(None, None, Order::Ascending)
-                .0
-                .unwrap()
-                .elements()
-                .unwrap()
-                .len(),
-            1
-        );
+        let iter_id = store.scan(None, None, Order::Ascending).0.unwrap();
+        assert_eq!(store.all(iter_id).0.unwrap().len(), 1);
 
         // setup - add some data, and delete part of it as well
         store.set(b"ant", b"hill").0.expect("error setting value");
@@ -181,8 +223,8 @@ mod test {
 
         // unbounded
         {
-            let iter = store.range(None, None, Order::Ascending).0.unwrap();
-            let elements = iter.elements().unwrap();
+            let iter_id = store.scan(None, None, Order::Ascending).0.unwrap();
+            let elements = store.all(iter_id).0.unwrap();
             assert_eq!(
                 elements,
                 vec![
@@ -195,8 +237,8 @@ mod test {
 
         // unbounded (descending)
         {
-            let iter = store.range(None, None, Order::Descending).0.unwrap();
-            let elements = iter.elements().unwrap();
+            let iter_id = store.scan(None, None, Order::Descending).0.unwrap();
+            let elements = store.all(iter_id).0.unwrap();
             assert_eq!(
                 elements,
                 vec![
@@ -209,21 +251,21 @@ mod test {
 
         // bounded
         {
-            let iter = store
-                .range(Some(b"f"), Some(b"n"), Order::Ascending)
+            let iter_id = store
+                .scan(Some(b"f"), Some(b"n"), Order::Ascending)
                 .0
                 .unwrap();
-            let elements = iter.elements().unwrap();
+            let elements = store.all(iter_id).0.unwrap();
             assert_eq!(elements, vec![(b"foo".to_vec(), b"bar".to_vec())]);
         }
 
         // bounded (descending)
         {
-            let iter = store
-                .range(Some(b"air"), Some(b"loop"), Order::Descending)
+            let iter_id = store
+                .scan(Some(b"air"), Some(b"loop"), Order::Descending)
                 .0
                 .unwrap();
-            let elements = iter.elements().unwrap();
+            let elements = store.all(iter_id).0.unwrap();
             assert_eq!(
                 elements,
                 vec![
@@ -235,48 +277,48 @@ mod test {
 
         // bounded empty [a, a)
         {
-            let iter = store
-                .range(Some(b"foo"), Some(b"foo"), Order::Ascending)
+            let iter_id = store
+                .scan(Some(b"foo"), Some(b"foo"), Order::Ascending)
                 .0
                 .unwrap();
-            let elements = iter.elements().unwrap();
+            let elements = store.all(iter_id).0.unwrap();
             assert_eq!(elements, vec![]);
         }
 
         // bounded empty [a, a) (descending)
         {
-            let iter = store
-                .range(Some(b"foo"), Some(b"foo"), Order::Descending)
+            let iter_id = store
+                .scan(Some(b"foo"), Some(b"foo"), Order::Descending)
                 .0
                 .unwrap();
-            let elements = iter.elements().unwrap();
+            let elements = store.all(iter_id).0.unwrap();
             assert_eq!(elements, vec![]);
         }
 
         // bounded empty [a, b) with b < a
         {
-            let iter = store
-                .range(Some(b"z"), Some(b"a"), Order::Ascending)
+            let iter_id = store
+                .scan(Some(b"z"), Some(b"a"), Order::Ascending)
                 .0
                 .unwrap();
-            let elements = iter.elements().unwrap();
+            let elements = store.all(iter_id).0.unwrap();
             assert_eq!(elements, vec![]);
         }
 
         // bounded empty [a, b) with b < a (descending)
         {
-            let iter = store
-                .range(Some(b"z"), Some(b"a"), Order::Descending)
+            let iter_id = store
+                .scan(Some(b"z"), Some(b"a"), Order::Descending)
                 .0
                 .unwrap();
-            let elements = iter.elements().unwrap();
+            let elements = store.all(iter_id).0.unwrap();
             assert_eq!(elements, vec![]);
         }
 
         // right unbounded
         {
-            let iter = store.range(Some(b"f"), None, Order::Ascending).0.unwrap();
-            let elements = iter.elements().unwrap();
+            let iter_id = store.scan(Some(b"f"), None, Order::Ascending).0.unwrap();
+            let elements = store.all(iter_id).0.unwrap();
             assert_eq!(
                 elements,
                 vec![
@@ -288,8 +330,8 @@ mod test {
 
         // right unbounded (descending)
         {
-            let iter = store.range(Some(b"f"), None, Order::Descending).0.unwrap();
-            let elements = iter.elements().unwrap();
+            let iter_id = store.scan(Some(b"f"), None, Order::Descending).0.unwrap();
+            let elements = store.all(iter_id).0.unwrap();
             assert_eq!(
                 elements,
                 vec![
@@ -301,15 +343,15 @@ mod test {
 
         // left unbounded
         {
-            let iter = store.range(None, Some(b"f"), Order::Ascending).0.unwrap();
-            let elements = iter.elements().unwrap();
+            let iter_id = store.scan(None, Some(b"f"), Order::Ascending).0.unwrap();
+            let elements = store.all(iter_id).0.unwrap();
             assert_eq!(elements, vec![(b"ant".to_vec(), b"hill".to_vec()),]);
         }
 
         // left unbounded (descending)
         {
-            let iter = store.range(None, Some(b"no"), Order::Descending).0.unwrap();
-            let elements = iter.elements().unwrap();
+            let iter_id = store.scan(None, Some(b"no"), Order::Descending).0.unwrap();
+            let elements = store.all(iter_id).0.unwrap();
             assert_eq!(
                 elements,
                 vec![

--- a/packages/vm/src/testing/storage.rs
+++ b/packages/vm/src/testing/storage.rs
@@ -75,7 +75,7 @@ impl MockStorage {
         let mut total = GasInfo::free();
         loop {
             let (value, info) = self.next(iterator_id);
-            total.cost += info.cost; // TODO: implement GasInfo+GasInfo
+            total += info;
             if let Some(v) = value.unwrap() {
                 out.push(v);
             } else {

--- a/packages/vm/src/testing/storage.rs
+++ b/packages/vm/src/testing/storage.rs
@@ -10,8 +10,6 @@ use std::ops::{Bound, RangeBounds};
 use cosmwasm_std::{Order, KV};
 
 #[cfg(feature = "iterator")]
-use crate::traits::StorageIterator;
-#[cfg(feature = "iterator")]
 use crate::FfiError;
 use crate::{FfiResult, GasInfo, Storage};
 
@@ -20,35 +18,6 @@ const GAS_COST_LAST_ITERATION: u64 = 37;
 
 #[cfg(feature = "iterator")]
 const GAS_COST_RANGE: u64 = 11;
-
-/// A storage iterator for testing only. This type uses a Rust iterator
-/// as a data source, which does not provide a gas value for the last iteration.
-#[cfg(feature = "iterator")]
-pub struct MockIterator<'a> {
-    source: Box<dyn Iterator<Item = (KV, u64)> + 'a>,
-}
-
-#[cfg(feature = "iterator")]
-impl MockIterator<'_> {
-    pub fn empty() -> Self {
-        MockIterator {
-            source: Box::new(std::iter::empty()),
-        }
-    }
-}
-
-#[cfg(feature = "iterator")]
-impl StorageIterator for MockIterator<'_> {
-    fn next(&mut self) -> FfiResult<Option<KV>> {
-        match self.source.next() {
-            Some((kv, gas_used)) => (Ok(Some(kv)), GasInfo::with_externally_used(gas_used)),
-            None => (
-                Ok(None),
-                GasInfo::with_externally_used(GAS_COST_LAST_ITERATION),
-            ),
-        }
-    }
-}
 
 #[cfg(feature = "iterator")]
 #[derive(Default, Debug)]

--- a/packages/vm/src/testing/storage.rs
+++ b/packages/vm/src/testing/storage.rs
@@ -74,12 +74,17 @@ impl MockStorage {
         let mut out: Vec<KV> = Vec::new();
         let mut total = GasInfo::free();
         loop {
-            let (value, info) = self.next(iterator_id);
+            let (result, info) = self.next(iterator_id);
             total += info;
-            if let Some(v) = value.unwrap() {
-                out.push(v);
-            } else {
-                break;
+            match result {
+                Err(err) => return (Err(err), total),
+                Ok(ok) => {
+                    if let Some(v) = ok {
+                        out.push(v);
+                    } else {
+                        break;
+                    }
+                }
             }
         }
         (Ok(out), total)

--- a/packages/vm/src/traits.rs
+++ b/packages/vm/src/traits.rs
@@ -77,6 +77,8 @@ pub trait Storage {
     ///
     /// This call must not change data in the storage, but creating and storing a new iterator can be a mutating operation on
     /// the Storage implementation.
+    /// The implementation must ensure that iterator IDs are assigned in a deterministic manner as this is
+    /// environment data that is injected into the contract.
     #[cfg(feature = "iterator")]
     fn scan(&mut self, start: Option<&[u8]>, end: Option<&[u8]>, order: Order) -> FfiResult<u32>;
 

--- a/packages/vm/src/traits.rs
+++ b/packages/vm/src/traits.rs
@@ -2,8 +2,6 @@ use cosmwasm_std::{Binary, CanonicalAddr, ContractResult, HumanAddr, SystemResul
 #[cfg(feature = "iterator")]
 use cosmwasm_std::{Order, KV};
 
-#[cfg(feature = "iterator")]
-use crate::ffi::FfiError;
 use crate::ffi::FfiResult;
 
 /// Holds all external dependencies of the contract.
@@ -26,35 +24,6 @@ impl<S: Storage, A: Api, Q: Querier> Extern<S, A, Q> {
             api: self.api,
             querier: transform(self.querier),
         }
-    }
-}
-
-#[cfg(feature = "iterator")]
-pub trait StorageIterator {
-    fn next(&mut self) -> FfiResult<Option<KV>>;
-
-    /// Collects all elements, ignoring gas costs
-    fn elements(mut self) -> Result<Vec<KV>, FfiError>
-    where
-        Self: Sized,
-    {
-        let mut out: Vec<KV> = Vec::new();
-        loop {
-            let (result, _gas_info) = self.next();
-            match result {
-                Ok(Some(kv)) => out.push(kv),
-                Ok(None) => break,
-                Err(err) => return Err(err),
-            }
-        }
-        Ok(out)
-    }
-}
-
-#[cfg(feature = "iterator")]
-impl<I: StorageIterator + ?Sized> StorageIterator for Box<I> {
-    fn next(&mut self) -> FfiResult<Option<KV>> {
-        (**self).next()
     }
 }
 


### PR DESCRIPTION
This is for 0.12 and Wasmer reborn. It can stay open for a while until the 0.11 testnets are up.

Closes #565
Closes #335

- [x] Update interface and mock implementation
- [x] Add CHANGELOG entries
- [x] Update comment on `fn get_context_data_mut`
