### PR TITLE
Deref magic

### DIFF
--- a/packages/std/src/addresses.rs
+++ b/packages/std/src/addresses.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 
 use crate::encoding::Binary;
+use std::ops::Deref;
 
 // Added Eq and Hash to allow this to be a key in a HashMap (MockQuerier)
 #[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq, Eq, JsonSchema, Hash)]
@@ -52,6 +53,14 @@ impl From<String> for HumanAddr {
     }
 }
 
+impl Deref for HumanAddr {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_str()
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq, JsonSchema)]
 pub struct CanonicalAddr(pub Binary);
 
@@ -70,6 +79,14 @@ impl From<Vec<u8>> for CanonicalAddr {
 impl From<CanonicalAddr> for Vec<u8> {
     fn from(source: CanonicalAddr) -> Vec<u8> {
         source.0.into()
+    }
+}
+
+impl Deref for CanonicalAddr {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
     }
 }
 

--- a/packages/std/src/encoding.rs
+++ b/packages/std/src/encoding.rs
@@ -4,6 +4,7 @@ use schemars::JsonSchema;
 use serde::{de, ser, Deserialize, Deserializer, Serialize};
 
 use crate::errors::{StdError, StdResult};
+use std::ops::Deref;
 
 /// Binary is a wrapper around Vec<u8> to add base64 de/serialization
 /// with serde. It also adds some helper methods to help encode inline.
@@ -68,6 +69,14 @@ impl fmt::Display for Binary {
 impl From<&[u8]> for Binary {
     fn from(binary: &[u8]) -> Self {
         Self(binary.to_vec())
+    }
+}
+
+impl Deref for Binary {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
     }
 }
 

--- a/packages/std/src/encoding.rs
+++ b/packages/std/src/encoding.rs
@@ -184,7 +184,7 @@ mod test {
         let encoded = Binary(binary.clone()).to_base64();
         assert_eq!(8, encoded.len());
         let decoded = Binary::from_base64(&encoded).unwrap();
-        assert_eq!(binary.as_slice(), decoded.as_slice());
+        assert_eq!(binary.deref(), decoded.deref());
     }
 
     #[test]

--- a/packages/std/src/serde.rs
+++ b/packages/std/src/serde.rs
@@ -90,6 +90,18 @@ mod test {
     }
 
     #[test]
+    fn from_slice_or_binary() {
+        let msg = SomeMsg::Refund {};
+        let serialized: Binary = to_binary(&msg).unwrap();
+
+        let parse_binary: SomeMsg = from_binary(&serialized).unwrap();
+        assert_eq!(parse_binary, msg);
+
+        let parse_slice: SomeMsg = from_slice(&serialized).unwrap();
+        assert_eq!(parse_slice, msg);
+    }
+
+    #[test]
     fn to_vec_works_for_special_chars() {
         let msg = SomeMsg::Cowsay {
             text: "foo\"bar\\\"bla".to_string(),


### PR DESCRIPTION
Added some Deref helpers on `CanoncialAddr`, `HumanAddr`, and `Binary`. Finally solved something I was trying to do months ago... automatically convert to `&[u8]` or `&str` respectively in function args.

```rust
let human = HumanAddr::from("cosm");
fn_that_takes_str(&human);
// previously:
fn_that_takes_str(human.as_slice());

let canon = CanonicalAddr::from(b"foobar");
String::from_utf8_lossy(&canon);
// previously
String::from_utf8_lossy(canon.as_slice());

let b: Binary = Binary::from(b"1234");
let msg: Msg = from_slice(&b);
// no more need for from_binary
```

