### PR TITLE
Add dref magic docs

### DIFF
--- a/packages/std/src/addresses.rs
+++ b/packages/std/src/addresses.rs
@@ -1,9 +1,9 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::fmt;
+use std::ops::Deref;
 
 use crate::encoding::Binary;
-use std::ops::Deref;
 
 // Added Eq and Hash to allow this to be a key in a HashMap (MockQuerier)
 #[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq, Eq, JsonSchema, Hash)]

--- a/packages/std/src/addresses.rs
+++ b/packages/std/src/addresses.rs
@@ -86,6 +86,11 @@ impl From<CanonicalAddr> for Vec<u8> {
     }
 }
 
+/// Just like Vec<u8>, CanonicalAddr is a smart pointer to [u8].
+/// This implements `*canonical_address` for us and allows us to
+/// do `&*canonical_address`, returning a `&[u8]` from a `&CanonicalAddr`.
+/// With [deref coercions](https://doc.rust-lang.org/1.22.1/book/first-edition/deref-coercions.html#deref-coercions),
+/// this allows us to use `&canonical_address` whenever a `&[u8]` is required.
 impl Deref for CanonicalAddr {
     type Target = [u8];
 
@@ -259,5 +264,20 @@ mod test {
         let embedded = format!("Address: {}", address);
         assert_eq!(embedded, "Address: 1203AB00FF");
         assert_eq!(address.to_string(), "1203AB00FF");
+    }
+
+    #[test]
+    fn canonical_addr_implements_deref() {
+        // Dereference to [u8]
+        let bytes: &[u8] = &[0u8, 187, 61, 11, 250, 0];
+        let canonical_addr = CanonicalAddr::from(bytes);
+        assert_eq!(*canonical_addr, [0u8, 187, 61, 11, 250, 0]);
+
+        // This checks deref coercions from &CanonicalAddr to &[u8] works
+        let bytes: &[u8] = &[0u8, 187, 61, 11, 250, 0];
+        let canonical_addr = CanonicalAddr::from(bytes);
+        assert_eq!(canonical_addr.len(), 6);
+        let canonical_addr_slice: &[u8] = &canonical_addr;
+        assert_eq!(canonical_addr_slice, &[0u8, 187, 61, 11, 250, 0]);
     }
 }

--- a/packages/std/src/addresses.rs
+++ b/packages/std/src/addresses.rs
@@ -45,6 +45,12 @@ impl From<String> for HumanAddr {
     }
 }
 
+/// Just like String, HumanAddr is a smart pointer to str.
+/// This implements `*human_address` for us, which is not very valuable directly
+/// because str has no known size and cannot be stored in variables. But it allows us to
+/// do `&*human_address`, returning a `&str` from a `&HumanAddr`.
+/// With [deref coercions](https://doc.rust-lang.org/1.22.1/book/first-edition/deref-coercions.html#deref-coercions),
+/// this allows us to use `&human_address` whenever a `&str` is required.
 impl Deref for HumanAddr {
     type Target = str;
 
@@ -140,6 +146,19 @@ mod test {
         let embedded = format!("Address: {}", human_addr);
         assert_eq!(embedded, "Address: cos934gh9034hg04g0h134");
         assert_eq!(human_addr.to_string(), "cos934gh9034hg04g0h134");
+    }
+
+    #[test]
+    fn human_addr_implements_deref() {
+        // We cannot test *human_addr directly since the resulting type str has no known size
+        let human_addr = HumanAddr::from("cos934gh9034hg04g0h134");
+        assert_eq!(&*human_addr, "cos934gh9034hg04g0h134");
+
+        // This checks deref coercions from &HumanAddr to &str works
+        let human_addr = HumanAddr::from("cos934gh9034hg04g0h134");
+        assert_eq!(human_addr.len(), 22);
+        let human_addr_str: &str = &human_addr;
+        assert_eq!(human_addr_str, "cos934gh9034hg04g0h134");
     }
 
     #[test]

--- a/packages/std/src/addresses.rs
+++ b/packages/std/src/addresses.rs
@@ -53,6 +53,12 @@ impl Deref for HumanAddr {
     }
 }
 
+impl PartialEq<str> for HumanAddr {
+    fn eq(&self, other: &str) -> bool {
+        self.0 == other
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq, JsonSchema)]
 pub struct CanonicalAddr(pub Binary);
 
@@ -134,6 +140,12 @@ mod test {
         let embedded = format!("Address: {}", human_addr);
         assert_eq!(embedded, "Address: cos934gh9034hg04g0h134");
         assert_eq!(human_addr.to_string(), "cos934gh9034hg04g0h134");
+    }
+
+    #[test]
+    fn human_addr_implements_partial_eq() {
+        let human_addr = HumanAddr::from("cos934gh9034hg04g0h134");
+        assert_eq!(&human_addr, "cos934gh9034hg04g0h134");
     }
 
     #[test]

--- a/packages/std/src/encoding.rs
+++ b/packages/std/src/encoding.rs
@@ -44,6 +44,11 @@ impl From<&[u8]> for Binary {
     }
 }
 
+/// Just like Vec<u8>, Binary is a smart pointer to [u8].
+/// This implements `*binary` for us and allows us to
+/// do `&*binary`, returning a `&[u8]` from a `&Binary`.
+/// With [deref coercions](https://doc.rust-lang.org/1.22.1/book/first-edition/deref-coercions.html#deref-coercions),
+/// this allows us to use `&binary` whenever a `&[u8]` is required.
 impl Deref for Binary {
     type Target = [u8];
 
@@ -324,5 +329,18 @@ mod test {
         let serialized = to_vec(&invalid_str).unwrap();
         let res = from_slice::<Binary>(&serialized);
         assert!(res.is_err());
+    }
+
+    #[test]
+    fn binary_implements_deref() {
+        // Dereference to [u8]
+        let binary = Binary(vec![7u8, 35, 49, 101, 0, 255]);
+        assert_eq!(*binary, [7u8, 35, 49, 101, 0, 255]);
+
+        // This checks deref coercions from &Binary to &[u8] works
+        let binary = Binary(vec![7u8, 35, 49, 101, 0, 255]);
+        assert_eq!(binary.len(), 6);
+        let binary_slice: &[u8] = &binary;
+        assert_eq!(binary_slice, &[7u8, 35, 49, 101, 0, 255]);
     }
 }


### PR DESCRIPTION
I was thinking about deprecating `HumanAddr::as_str()` and friends, as you should not need it anymore. However, `&human` is still `&HumanAddr`, even when you can pass it to a `&str`. So there might be places where `&human` is not the best way.