### PR TITLE
Rename `Extern` to `Deps`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Rename `StdError::ParseErr::source` to `StdError::ParseErr::source_type` and
   `StdError::SerializeErr::target` to `StdError::SerializeErr::target_type` to
   work around speacial treatment of the field name `source` in thiserror.
+- Rename `Extern` to `Deps` to unify naming.
 
 **cosmwasm-vm**
 

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -23,6 +23,26 @@ major releases of `cosmwasm`. Note that you can also view the
   In order to use backtraces for debugging, run
   `RUST_BACKTRACE=1 cargo +nightly unit-test --features backtraces`.
 
+- Rename the type `Extern` to `Deps` in `init`/`handle`/`migrate`/`query`, e.g.
+
+  ```rust
+  // before
+  pub fn migrate<S: Storage, A: Api, Q: Querier>(
+      deps: &mut Extern<S, A, Q>,
+      _env: Env,
+      _info: MessageInfo,
+      msg: MigrateMsg,
+  ) -> Result<MigrateResponse, HackError> {
+
+  // after
+  pub fn migrate<S: Storage, A: Api, Q: Querier>(
+    deps: &mut Deps<S, A, Q>,
+    _env: Env,
+    _info: MessageInfo,
+    msg: MigrateMsg,
+  ) -> Result<MigrateResponse, HackError> {
+  ```
+
 ## 0.10 -> 0.11
 
 - Contracts now support any custom error type `E: ToString + From<StdError>`.

--- a/README.md
+++ b/README.md
@@ -188,27 +188,27 @@ custom `InitMsg` and `HandleMsg` structs for parsing your custom message types
 
 ```rust
 pub fn init<S: Storage, A: Api, Q: Querier>(
-    deps: &mut Extern<S, A, Q>,
+    deps: &mut Deps<S, A, Q>,
     env: Env,
     info: MessageInfo,
     msg: InitMsg,
 ) -> StdResult<InitResponse> {}
 
 pub fn handle<S: Storage, A: Api, Q: Querier>(
-    deps: &mut Extern<S, A, Q>,
+    deps: &mut Deps<S, A, Q>,
     env: Env,
     info: MessageInfo,
     msg: HandleMsg,
 ) -> Result<HandleResponse, ContractError> { }
 
 pub fn query<S: Storage, A: Api, Q: Querier>(
-    deps: &Extern<S, A, Q>,
+    deps: &Deps<S, A, Q>,
     env: Env,
     msg: QueryMsg,
 ) -> StdResult<Binary> { }
 
 pub fn migrate<S: Storage, A: Api, Q: Querier>(
-    deps: &mut Extern<S, A, Q>,
+    deps: &mut Deps<S, A, Q>,
     env: Env,
     info: MessageInfo,
     msg: HandleMsg,

--- a/contracts/burner/src/contract.rs
+++ b/contracts/burner/src/contract.rs
@@ -1,12 +1,12 @@
 use cosmwasm_std::{
-    attr, Api, BankMsg, Binary, Env, Extern, HandleResponse, InitResponse, MessageInfo,
+    attr, Api, BankMsg, Binary, Deps, Env, HandleResponse, InitResponse, MessageInfo,
     MigrateResponse, Order, Querier, StdError, StdResult, Storage,
 };
 
 use crate::msg::{HandleMsg, InitMsg, MigrateMsg, QueryMsg};
 
 pub fn init<S: Storage, A: Api, Q: Querier>(
-    _deps: &mut Extern<S, A, Q>,
+    _deps: &mut Deps<S, A, Q>,
     _env: Env,
     _info: MessageInfo,
     _msg: InitMsg,
@@ -17,7 +17,7 @@ pub fn init<S: Storage, A: Api, Q: Querier>(
 }
 
 pub fn handle<S: Storage, A: Api, Q: Querier>(
-    _deps: &mut Extern<S, A, Q>,
+    _deps: &mut Deps<S, A, Q>,
     _env: Env,
     _info: MessageInfo,
     _msg: HandleMsg,
@@ -28,7 +28,7 @@ pub fn handle<S: Storage, A: Api, Q: Querier>(
 }
 
 pub fn migrate<S: Storage, A: Api, Q: Querier>(
-    deps: &mut Extern<S, A, Q>,
+    deps: &mut Deps<S, A, Q>,
     env: Env,
     _info: MessageInfo,
     msg: MigrateMsg,
@@ -62,7 +62,7 @@ pub fn migrate<S: Storage, A: Api, Q: Querier>(
 }
 
 pub fn query<S: Storage, A: Api, Q: Querier>(
-    _deps: &Extern<S, A, Q>,
+    _deps: &Deps<S, A, Q>,
     _env: Env,
     _msg: QueryMsg,
 ) -> StdResult<Binary> {

--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -5,7 +5,7 @@ use std::convert::TryInto;
 
 use cosmwasm_std::{
     from_slice, to_binary, to_vec, AllBalanceResponse, Api, BankMsg, Binary, CanonicalAddr,
-    Context, Env, Extern, HandleResponse, HumanAddr, InitResponse, MessageInfo, MigrateResponse,
+    Context, Deps, Env, HandleResponse, HumanAddr, InitResponse, MessageInfo, MigrateResponse,
     Querier, QueryRequest, QueryResponse, StdError, StdResult, Storage, WasmQuery,
 };
 
@@ -87,7 +87,7 @@ pub struct RecurseResponse {
 pub const CONFIG_KEY: &[u8] = b"config";
 
 pub fn init<S: Storage, A: Api, Q: Querier>(
-    deps: &mut Extern<S, A, Q>,
+    deps: &mut Deps<S, A, Q>,
     _env: Env,
     info: MessageInfo,
     msg: InitMsg,
@@ -110,7 +110,7 @@ pub fn init<S: Storage, A: Api, Q: Querier>(
 }
 
 pub fn migrate<S: Storage, A: Api, Q: Querier>(
-    deps: &mut Extern<S, A, Q>,
+    deps: &mut Deps<S, A, Q>,
     _env: Env,
     _info: MessageInfo,
     msg: MigrateMsg,
@@ -127,7 +127,7 @@ pub fn migrate<S: Storage, A: Api, Q: Querier>(
 }
 
 pub fn handle<S: Storage, A: Api, Q: Querier>(
-    deps: &mut Extern<S, A, Q>,
+    deps: &mut Deps<S, A, Q>,
     env: Env,
     info: MessageInfo,
     msg: HandleMsg,
@@ -144,7 +144,7 @@ pub fn handle<S: Storage, A: Api, Q: Querier>(
 }
 
 fn do_release<S: Storage, A: Api, Q: Querier>(
-    deps: &mut Extern<S, A, Q>,
+    deps: &mut Deps<S, A, Q>,
     env: Env,
     info: MessageInfo,
 ) -> Result<HandleResponse, HackError> {
@@ -184,7 +184,7 @@ fn do_cpu_loop() -> Result<HandleResponse, HackError> {
 }
 
 fn do_storage_loop<S: Storage, A: Api, Q: Querier>(
-    deps: &mut Extern<S, A, Q>,
+    deps: &mut Deps<S, A, Q>,
 ) -> Result<HandleResponse, HackError> {
     let mut test_case = 0u64;
     loop {
@@ -295,7 +295,7 @@ fn do_user_errors_in_api_calls<A: Api>(api: &A) -> Result<HandleResponse, HackEr
 }
 
 pub fn query<S: Storage, A: Api, Q: Querier>(
-    deps: &Extern<S, A, Q>,
+    deps: &Deps<S, A, Q>,
     env: Env,
     msg: QueryMsg,
 ) -> StdResult<QueryResponse> {
@@ -309,7 +309,7 @@ pub fn query<S: Storage, A: Api, Q: Querier>(
 }
 
 fn query_verifier<S: Storage, A: Api, Q: Querier>(
-    deps: &Extern<S, A, Q>,
+    deps: &Deps<S, A, Q>,
 ) -> StdResult<VerifierResponse> {
     let data = deps
         .storage
@@ -321,7 +321,7 @@ fn query_verifier<S: Storage, A: Api, Q: Querier>(
 }
 
 fn query_other_balance<S: Storage, A: Api, Q: Querier>(
-    deps: &Extern<S, A, Q>,
+    deps: &Deps<S, A, Q>,
     address: HumanAddr,
 ) -> StdResult<AllBalanceResponse> {
     let amount = deps.querier.query_all_balances(address)?;
@@ -329,7 +329,7 @@ fn query_other_balance<S: Storage, A: Api, Q: Querier>(
 }
 
 fn query_recurse<S: Storage, A: Api, Q: Querier>(
-    deps: &Extern<S, A, Q>,
+    deps: &Deps<S, A, Q>,
     depth: u32,
     work: u32,
     contract: HumanAddr,

--- a/contracts/reflect/src/contract.rs
+++ b/contracts/reflect/src/contract.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::{
-    attr, to_binary, to_vec, Api, Binary, ContractResult, CosmosMsg, Env, Extern, HandleResponse,
+    attr, to_binary, to_vec, Api, Binary, ContractResult, CosmosMsg, Deps, Env, HandleResponse,
     HumanAddr, InitResponse, MessageInfo, Querier, QueryRequest, StdError, StdResult, Storage,
     SystemResult,
 };
@@ -12,7 +12,7 @@ use crate::msg::{
 use crate::state::{config, config_read, State};
 
 pub fn init<S: Storage, A: Api, Q: Querier>(
-    deps: &mut Extern<S, A, Q>,
+    deps: &mut Deps<S, A, Q>,
     _env: Env,
     info: MessageInfo,
     _msg: InitMsg,
@@ -26,7 +26,7 @@ pub fn init<S: Storage, A: Api, Q: Querier>(
 }
 
 pub fn handle<S: Storage, A: Api, Q: Querier>(
-    deps: &mut Extern<S, A, Q>,
+    deps: &mut Deps<S, A, Q>,
     env: Env,
     info: MessageInfo,
     msg: HandleMsg,
@@ -38,7 +38,7 @@ pub fn handle<S: Storage, A: Api, Q: Querier>(
 }
 
 pub fn try_reflect<S: Storage, A: Api, Q: Querier>(
-    deps: &mut Extern<S, A, Q>,
+    deps: &mut Deps<S, A, Q>,
     _env: Env,
     info: MessageInfo,
     msgs: Vec<CosmosMsg<CustomMsg>>,
@@ -65,7 +65,7 @@ pub fn try_reflect<S: Storage, A: Api, Q: Querier>(
 }
 
 pub fn try_change_owner<S: Storage, A: Api, Q: Querier>(
-    deps: &mut Extern<S, A, Q>,
+    deps: &mut Deps<S, A, Q>,
     _env: Env,
     info: MessageInfo,
     owner: HumanAddr,
@@ -89,7 +89,7 @@ pub fn try_change_owner<S: Storage, A: Api, Q: Querier>(
 }
 
 pub fn query<S: Storage, A: Api, Q: Querier>(
-    deps: &Extern<S, A, Q>,
+    deps: &Deps<S, A, Q>,
     _env: Env,
     msg: QueryMsg,
 ) -> StdResult<Binary> {
@@ -101,7 +101,7 @@ pub fn query<S: Storage, A: Api, Q: Querier>(
     }
 }
 
-fn query_owner<S: Storage, A: Api, Q: Querier>(deps: &Extern<S, A, Q>) -> StdResult<OwnerResponse> {
+fn query_owner<S: Storage, A: Api, Q: Querier>(deps: &Deps<S, A, Q>) -> StdResult<OwnerResponse> {
     let state = config_read(&deps.storage).load()?;
     let resp = OwnerResponse {
         owner: deps.api.human_address(&state.owner)?,
@@ -110,7 +110,7 @@ fn query_owner<S: Storage, A: Api, Q: Querier>(deps: &Extern<S, A, Q>) -> StdRes
 }
 
 fn query_capitalized<S: Storage, A: Api, Q: Querier>(
-    deps: &Extern<S, A, Q>,
+    deps: &Deps<S, A, Q>,
     text: String,
 ) -> StdResult<CapitalizedResponse> {
     let req = SpecialQuery::Capitalized { text }.into();
@@ -119,7 +119,7 @@ fn query_capitalized<S: Storage, A: Api, Q: Querier>(
 }
 
 fn query_chain<S: Storage, A: Api, Q: Querier>(
-    deps: &Extern<S, A, Q>,
+    deps: &Deps<S, A, Q>,
     request: &QueryRequest<SpecialQuery>,
 ) -> StdResult<ChainResponse> {
     let raw = to_vec(request).map_err(|serialize_err| {
@@ -139,7 +139,7 @@ fn query_chain<S: Storage, A: Api, Q: Querier>(
 }
 
 fn query_raw<S: Storage, A: Api, Q: Querier>(
-    deps: &Extern<S, A, Q>,
+    deps: &Deps<S, A, Q>,
     contract: HumanAddr,
     key: Binary,
 ) -> StdResult<RawResponse> {

--- a/contracts/reflect/src/testing.rs
+++ b/contracts/reflect/src/testing.rs
@@ -1,18 +1,18 @@
 use crate::msg::{SpecialQuery, SpecialResponse};
 
 use cosmwasm_std::testing::{MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR};
-use cosmwasm_std::{to_binary, Binary, Coin, ContractResult, Extern, HumanAddr, SystemResult};
+use cosmwasm_std::{to_binary, Binary, Coin, ContractResult, Deps, HumanAddr, SystemResult};
 
 /// A drop-in replacement for cosmwasm_std::testing::mock_dependencies
 /// this uses our CustomQuerier.
 pub fn mock_dependencies_with_custom_querier(
     contract_balance: &[Coin],
-) -> Extern<MockStorage, MockApi, MockQuerier<SpecialQuery>> {
+) -> Deps<MockStorage, MockApi, MockQuerier<SpecialQuery>> {
     let contract_addr = HumanAddr::from(MOCK_CONTRACT_ADDR);
     let custom_querier: MockQuerier<SpecialQuery> =
         MockQuerier::new(&[(&contract_addr, contract_balance)])
             .with_custom_handler(|query| SystemResult::Ok(custom_query_execute(&query)));
-    Extern {
+    Deps {
         storage: MockStorage::default(),
         api: MockApi::default(),
         querier: custom_querier,

--- a/contracts/staking/src/contract.rs
+++ b/contracts/staking/src/contract.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::{
-    attr, coin, to_binary, Api, BankMsg, Binary, Decimal, Env, Extern, HandleResponse, HumanAddr,
+    attr, coin, to_binary, Api, BankMsg, Binary, Decimal, Deps, Env, HandleResponse, HumanAddr,
     InitResponse, MessageInfo, Querier, StakingMsg, StdError, StdResult, Storage, Uint128, WasmMsg,
 };
 
@@ -16,7 +16,7 @@ use crate::state::{
 const FALLBACK_RATIO: Decimal = Decimal::one();
 
 pub fn init<S: Storage, A: Api, Q: Querier>(
-    deps: &mut Extern<S, A, Q>,
+    deps: &mut Deps<S, A, Q>,
     _env: Env,
     info: MessageInfo,
     msg: InitMsg,
@@ -55,7 +55,7 @@ pub fn init<S: Storage, A: Api, Q: Querier>(
 }
 
 pub fn handle<S: Storage, A: Api, Q: Querier>(
-    deps: &mut Extern<S, A, Q>,
+    deps: &mut Deps<S, A, Q>,
     env: Env,
     info: MessageInfo,
     msg: HandleMsg,
@@ -73,7 +73,7 @@ pub fn handle<S: Storage, A: Api, Q: Querier>(
 }
 
 pub fn transfer<S: Storage, A: Api, Q: Querier>(
-    deps: &mut Extern<S, A, Q>,
+    deps: &mut Deps<S, A, Q>,
     _env: Env,
     info: MessageInfo,
     recipient: HumanAddr,
@@ -136,7 +136,7 @@ fn assert_bonds(supply: &Supply, bonded: Uint128) -> StdResult<()> {
 }
 
 pub fn bond<S: Storage, A: Api, Q: Querier>(
-    deps: &mut Extern<S, A, Q>,
+    deps: &mut Deps<S, A, Q>,
     env: Env,
     info: MessageInfo,
 ) -> StdResult<HandleResponse> {
@@ -192,7 +192,7 @@ pub fn bond<S: Storage, A: Api, Q: Querier>(
 }
 
 pub fn unbond<S: Storage, A: Api, Q: Querier>(
-    deps: &mut Extern<S, A, Q>,
+    deps: &mut Deps<S, A, Q>,
     env: Env,
     info: MessageInfo,
     amount: Uint128,
@@ -262,7 +262,7 @@ pub fn unbond<S: Storage, A: Api, Q: Querier>(
 }
 
 pub fn claim<S: Storage, A: Api, Q: Querier>(
-    deps: &mut Extern<S, A, Q>,
+    deps: &mut Deps<S, A, Q>,
     env: Env,
     info: MessageInfo,
 ) -> StdResult<HandleResponse> {
@@ -315,7 +315,7 @@ pub fn claim<S: Storage, A: Api, Q: Querier>(
 /// then issue a callback to itself via _bond_all_tokens
 /// to reinvest the new earnings (and anything else that accumulated)
 pub fn reinvest<S: Storage, A: Api, Q: Querier>(
-    deps: &mut Extern<S, A, Q>,
+    deps: &mut Deps<S, A, Q>,
     env: Env,
     _info: MessageInfo,
 ) -> StdResult<HandleResponse> {
@@ -345,7 +345,7 @@ pub fn reinvest<S: Storage, A: Api, Q: Querier>(
 }
 
 pub fn _bond_all_tokens<S: Storage, A: Api, Q: Querier>(
-    deps: &mut Extern<S, A, Q>,
+    deps: &mut Deps<S, A, Q>,
     env: Env,
     info: MessageInfo,
 ) -> Result<HandleResponse, StakingError> {
@@ -389,7 +389,7 @@ pub fn _bond_all_tokens<S: Storage, A: Api, Q: Querier>(
 }
 
 pub fn query<S: Storage, A: Api, Q: Querier>(
-    deps: &Extern<S, A, Q>,
+    deps: &Deps<S, A, Q>,
     _env: Env,
     msg: QueryMsg,
 ) -> StdResult<Binary> {
@@ -402,13 +402,13 @@ pub fn query<S: Storage, A: Api, Q: Querier>(
 }
 
 pub fn query_token_info<S: Storage, A: Api, Q: Querier>(
-    deps: &Extern<S, A, Q>,
+    deps: &Deps<S, A, Q>,
 ) -> StdResult<TokenInfoResponse> {
     token_info_read(&deps.storage).load()
 }
 
 pub fn query_balance<S: Storage, A: Api, Q: Querier>(
-    deps: &Extern<S, A, Q>,
+    deps: &Deps<S, A, Q>,
     address: HumanAddr,
 ) -> StdResult<BalanceResponse> {
     let address_raw = deps.api.canonical_address(&address)?;
@@ -419,7 +419,7 @@ pub fn query_balance<S: Storage, A: Api, Q: Querier>(
 }
 
 pub fn query_claims<S: Storage, A: Api, Q: Querier>(
-    deps: &Extern<S, A, Q>,
+    deps: &Deps<S, A, Q>,
     address: HumanAddr,
 ) -> StdResult<ClaimsResponse> {
     let address_raw = deps.api.canonical_address(&address)?;
@@ -430,7 +430,7 @@ pub fn query_claims<S: Storage, A: Api, Q: Querier>(
 }
 
 pub fn query_investment<S: Storage, A: Api, Q: Querier>(
-    deps: &Extern<S, A, Q>,
+    deps: &Deps<S, A, Q>,
 ) -> StdResult<InvestmentResponse> {
     let invest = invest_info_read(&deps.storage).load()?;
     let supply = total_supply_read(&deps.storage).load()?;
@@ -506,14 +506,14 @@ mod tests {
     }
 
     fn get_balance<S: Storage, A: Api, Q: Querier, U: Into<HumanAddr>>(
-        deps: &Extern<S, A, Q>,
+        deps: &Deps<S, A, Q>,
         addr: U,
     ) -> Uint128 {
         query_balance(&deps, addr.into()).unwrap().balance
     }
 
     fn get_claims<S: Storage, A: Api, Q: Querier, U: Into<HumanAddr>>(
-        deps: &Extern<S, A, Q>,
+        deps: &Deps<S, A, Q>,
         addr: U,
     ) -> Uint128 {
         query_claims(&deps, addr.into()).unwrap().claims

--- a/packages/std/src/deps.rs
+++ b/packages/std/src/deps.rs
@@ -1,0 +1,24 @@
+use crate::traits::{Api, Querier, Storage};
+
+/// Holds all external dependencies of the contract.
+/// Designed to allow easy dependency injection at runtime.
+/// This cannot be copied or cloned since it would behave differently
+/// for mock storages and a bridge storage in the VM.
+pub struct Deps<S: Storage, A: Api, Q: Querier> {
+    pub storage: S,
+    pub api: A,
+    pub querier: Q,
+}
+
+impl<S: Storage, A: Api, Q: Querier> Deps<S, A, Q> {
+    /// change_querier is a helper mainly for test code when swapping out the Querier
+    /// from the auto-generated one from mock_dependencies. This changes the type of
+    /// Deps so replaces requires some boilerplate.
+    pub fn change_querier<T: Querier, F: Fn(Q) -> T>(self, transform: F) -> Deps<S, A, T> {
+        Deps {
+            storage: self.storage,
+            api: self.api,
+            querier: transform(self.querier),
+        }
+    }
+}

--- a/packages/std/src/entry_points.rs
+++ b/packages/std/src/entry_points.rs
@@ -6,13 +6,13 @@
 /// The second module should export three functions with the following signatures:
 /// ```
 /// # use cosmwasm_std::{
-/// #     Storage, Api, Querier, Extern, Env, StdResult, Binary, MessageInfo,
+/// #     Storage, Api, Querier, Deps, Env, StdResult, Binary, MessageInfo,
 /// #     InitResult, HandleResult, QueryResult,
 /// # };
 /// #
 /// # type InitMsg = ();
 /// pub fn init<S: Storage, A: Api, Q: Querier>(
-///     deps: &mut Extern<S, A, Q>,
+///     deps: &mut Deps<S, A, Q>,
 ///     env: Env,
 ///     info: MessageInfo,
 ///     msg: InitMsg,
@@ -22,7 +22,7 @@
 ///
 /// # type HandleMsg = ();
 /// pub fn handle<S: Storage, A: Api, Q: Querier>(
-///     deps: &mut Extern<S, A, Q>,
+///     deps: &mut Deps<S, A, Q>,
 ///     env: Env,
 ///     info: MessageInfo,
 ///     msg: HandleMsg,
@@ -32,7 +32,7 @@
 ///
 /// # type QueryMsg = ();
 /// pub fn query<S: Storage, A: Api, Q: Querier>(
-///     deps: &Extern<S, A, Q>,
+///     deps: &Deps<S, A, Q>,
 ///     env: Env,
 ///     msg: QueryMsg,
 /// ) -> QueryResult {
@@ -116,11 +116,11 @@ macro_rules! create_entry_points {
 /// This macro is very similar to the `create_entry_points` macro, except it also requires the `migrate` method:
 /// ```
 /// # use cosmwasm_std::{
-/// #     Storage, Api, Querier, Extern, Env, StdResult, Binary, MigrateResult, MessageInfo,
+/// #     Storage, Api, Querier, Deps, Env, StdResult, Binary, MigrateResult, MessageInfo,
 /// # };
 /// # type MigrateMsg = ();
 /// pub fn migrate<S: Storage, A: Api, Q: Querier>(
-///     deps: &mut Extern<S, A, Q>,
+///     deps: &mut Deps<S, A, Q>,
 ///     _env: Env,
 ///     _info: MessageInfo,
 ///     msg: MigrateMsg,

--- a/packages/std/src/exports.rs
+++ b/packages/std/src/exports.rs
@@ -11,13 +11,13 @@ use std::vec::Vec;
 use schemars::JsonSchema;
 use serde::{de::DeserializeOwned, Serialize};
 
+use crate::deps::Deps;
 use crate::imports::{ExternalApi, ExternalQuerier, ExternalStorage};
 use crate::memory::{alloc, consume_region, release_buffer, Region};
 use crate::results::{
     ContractResult, HandleResponse, InitResponse, MigrateResponse, QueryResponse,
 };
 use crate::serde::{from_slice, to_vec};
-use crate::traits::Extern;
 use crate::types::Env;
 use crate::MessageInfo;
 
@@ -69,7 +69,7 @@ macro_rules! r#try_into_contract_result {
 /// - `E`: error type for responses
 pub fn do_init<M, C, E>(
     init_fn: &dyn Fn(
-        &mut Extern<ExternalStorage, ExternalApi, ExternalQuerier>,
+        &mut Deps<ExternalStorage, ExternalApi, ExternalQuerier>,
         Env,
         MessageInfo,
         M,
@@ -100,7 +100,7 @@ where
 /// - `E`: error type for responses
 pub fn do_handle<M, C, E>(
     handle_fn: &dyn Fn(
-        &mut Extern<ExternalStorage, ExternalApi, ExternalQuerier>,
+        &mut Deps<ExternalStorage, ExternalApi, ExternalQuerier>,
         Env,
         MessageInfo,
         M,
@@ -131,7 +131,7 @@ where
 /// - `E`: error type for responses
 pub fn do_migrate<M, C, E>(
     migrate_fn: &dyn Fn(
-        &mut Extern<ExternalStorage, ExternalApi, ExternalQuerier>,
+        &mut Deps<ExternalStorage, ExternalApi, ExternalQuerier>,
         Env,
         MessageInfo,
         M,
@@ -161,7 +161,7 @@ where
 /// - `E`: error type for responses
 pub fn do_query<M, E>(
     query_fn: &dyn Fn(
-        &Extern<ExternalStorage, ExternalApi, ExternalQuerier>,
+        &Deps<ExternalStorage, ExternalApi, ExternalQuerier>,
         Env,
         M,
     ) -> Result<QueryResponse, E>,
@@ -179,7 +179,7 @@ where
 
 fn _do_init<M, C, E>(
     init_fn: &dyn Fn(
-        &mut Extern<ExternalStorage, ExternalApi, ExternalQuerier>,
+        &mut Deps<ExternalStorage, ExternalApi, ExternalQuerier>,
         Env,
         MessageInfo,
         M,
@@ -207,7 +207,7 @@ where
 
 fn _do_handle<M, C, E>(
     handle_fn: &dyn Fn(
-        &mut Extern<ExternalStorage, ExternalApi, ExternalQuerier>,
+        &mut Deps<ExternalStorage, ExternalApi, ExternalQuerier>,
         Env,
         MessageInfo,
         M,
@@ -235,7 +235,7 @@ where
 
 fn _do_migrate<M, C, E>(
     migrate_fn: &dyn Fn(
-        &mut Extern<ExternalStorage, ExternalApi, ExternalQuerier>,
+        &mut Deps<ExternalStorage, ExternalApi, ExternalQuerier>,
         Env,
         MessageInfo,
         M,
@@ -263,7 +263,7 @@ where
 
 fn _do_query<M, E>(
     query_fn: &dyn Fn(
-        &Extern<ExternalStorage, ExternalApi, ExternalQuerier>,
+        &Deps<ExternalStorage, ExternalApi, ExternalQuerier>,
         Env,
         M,
     ) -> Result<QueryResponse, E>,
@@ -285,8 +285,8 @@ where
 }
 
 /// Makes all bridges to external dependencies (i.e. Wasm imports) that are injected by the VM
-fn make_dependencies() -> Extern<ExternalStorage, ExternalApi, ExternalQuerier> {
-    Extern {
+fn make_dependencies() -> Deps<ExternalStorage, ExternalApi, ExternalQuerier> {
+    Deps {
         storage: ExternalStorage::new(),
         api: ExternalApi::new(),
         querier: ExternalQuerier::new(),

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -4,6 +4,7 @@
 
 mod addresses;
 mod coins;
+mod deps;
 mod encoding;
 mod entry_points;
 mod errors;
@@ -19,6 +20,7 @@ mod types;
 
 pub use crate::addresses::{CanonicalAddr, HumanAddr};
 pub use crate::coins::{coin, coins, has_coins, Coin};
+pub use crate::deps::Deps;
 pub use crate::encoding::Binary;
 pub use crate::errors::{StdError, StdResult, SystemError};
 #[cfg(feature = "iterator")]
@@ -36,7 +38,7 @@ pub use crate::results::{
 };
 pub use crate::serde::{from_binary, from_slice, to_binary, to_vec};
 pub use crate::storage::MemoryStorage;
-pub use crate::traits::{Api, Extern, Querier, QuerierResult, ReadonlyStorage, Storage};
+pub use crate::traits::{Api, Querier, QuerierResult, ReadonlyStorage, Storage};
 pub use crate::types::{BlockInfo, ContractInfo, Empty, Env, MessageInfo};
 
 // Exposed in wasm build only

--- a/packages/std/src/mock.rs
+++ b/packages/std/src/mock.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 
 use crate::addresses::{CanonicalAddr, HumanAddr};
 use crate::coins::Coin;
+use crate::deps::Deps;
 use crate::encoding::Binary;
 use crate::errors::{StdError, StdResult, SystemError};
 use crate::query::{
@@ -13,16 +14,16 @@ use crate::query::{
 use crate::results::{ContractResult, SystemResult};
 use crate::serde::{from_slice, to_binary};
 use crate::storage::MemoryStorage;
-use crate::traits::{Api, Extern, Querier, QuerierResult};
+use crate::traits::{Api, Querier, QuerierResult};
 use crate::types::{BlockInfo, ContractInfo, Empty, Env, MessageInfo};
 
 pub const MOCK_CONTRACT_ADDR: &str = "cosmos2contract";
 
 /// All external requirements that can be injected for unit tests.
 /// It sets the given balance for the contract itself, nothing else
-pub fn mock_dependencies(contract_balance: &[Coin]) -> Extern<MockStorage, MockApi, MockQuerier> {
+pub fn mock_dependencies(contract_balance: &[Coin]) -> Deps<MockStorage, MockApi, MockQuerier> {
     let contract_addr = HumanAddr::from(MOCK_CONTRACT_ADDR);
-    Extern {
+    Deps {
         storage: MockStorage::default(),
         api: MockApi::default(),
         querier: MockQuerier::new(&[(&contract_addr, contract_balance)]),
@@ -33,8 +34,8 @@ pub fn mock_dependencies(contract_balance: &[Coin]) -> Extern<MockStorage, MockA
 /// Sets all balances provided (yoy must explicitly set contract balance if desired)
 pub fn mock_dependencies_with_balances(
     balances: &[(&HumanAddr, &[Coin])],
-) -> Extern<MockStorage, MockApi, MockQuerier> {
-    Extern {
+) -> Deps<MockStorage, MockApi, MockQuerier> {
+    Deps {
         storage: MockStorage::default(),
         api: MockApi::default(),
         querier: MockQuerier::new(balances),

--- a/packages/std/src/traits.rs
+++ b/packages/std/src/traits.rs
@@ -18,29 +18,6 @@ use crate::results::{ContractResult, SystemResult};
 use crate::serde::{from_binary, to_binary, to_vec};
 use crate::types::Empty;
 
-/// Holds all external dependencies of the contract.
-/// Designed to allow easy dependency injection at runtime.
-/// This cannot be copied or cloned since it would behave differently
-/// for mock storages and a bridge storage in the VM.
-pub struct Extern<S: Storage, A: Api, Q: Querier> {
-    pub storage: S,
-    pub api: A,
-    pub querier: Q,
-}
-
-impl<S: Storage, A: Api, Q: Querier> Extern<S, A, Q> {
-    /// change_querier is a helper mainly for test code when swapping out the Querier
-    /// from the auto-generated one from mock_dependencies. This changes the type of
-    /// Extern so replaces requires some boilerplate.
-    pub fn change_querier<T: Querier, F: Fn(Q) -> T>(self, transform: F) -> Extern<S, A, T> {
-        Extern {
-            storage: self.storage,
-            api: self.api,
-            querier: transform(self.querier),
-        }
-    }
-}
-
 /// ReadonlyStorage is access to the contracts persistent data store
 pub trait ReadonlyStorage {
     /// Returns None when key does not exist.


### PR DESCRIPTION
Step 1 for #588. The VM part work cause big merge conflicts with the Wasmer Reborn work, so I'd do that later.