### PR TITLE
Improve naming and docs for &dyn ReadonlyStorage cast

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -34,8 +34,9 @@ major releases of `cosmwasm`. Note that you can also view the
   * `&mut Extern<S, A, Q>` => `DepsMut`
   * `&Extern<S, A, Q>` => `DepsRef`
   * `&mut deps.storage` => `deps.storage`  where passing into `state.rs` helpers
-  * `&deps.storage` => `deps.storage.as_ref()` where passing into `state.rs` helpers
-  
+  * `&deps.storage` => `deps.storage.as_readonly()` where passing into
+    `state.rs` helpers that expect `&dyn ReadonlyStorage`
+
   On the top, remove `use cosmwasm_std::{Api, Extern, Querier, Storage}`. Add `use cosmwasm_std::{DepsMut, DepsRef}`.
   
   *In test code only:*

--- a/contracts/reflect/src/contract.rs
+++ b/contracts/reflect/src/contract.rs
@@ -98,7 +98,7 @@ pub fn query(deps: DepsRef, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
 }
 
 fn query_owner(deps: DepsRef) -> StdResult<OwnerResponse> {
-    let state = config_read(deps.storage.as_ref()).load()?;
+    let state = config_read(deps.storage.as_readonly()).load()?;
     let resp = OwnerResponse {
         owner: deps.api.human_address(&state.owner)?,
     };

--- a/packages/std/src/imports.rs
+++ b/packages/std/src/imports.rs
@@ -103,8 +103,10 @@ impl Storage for ExternalStorage {
         unsafe { db_remove(key_ptr) };
     }
 
-    // this is needed so a &dyn Storage trait object can access the readonly methods
-    fn as_ref(&self) -> &dyn ReadonlyStorage {
+    /// Converts a `&dyn Storage` to a reference of the super trait `&dyn ReadonlyStorage`,
+    /// which unfortunately Rust does not allow us to do directly
+    /// (see https://github.com/rust-lang/rfcs/issues/2368 and linked threads).
+    fn as_readonly(&self) -> &dyn ReadonlyStorage {
         self
     }
 }

--- a/packages/std/src/storage.rs
+++ b/packages/std/src/storage.rs
@@ -80,8 +80,10 @@ impl Storage for MemoryStorage {
         self.data.remove(key);
     }
 
-    // this is needed so a &dyn Storage trait object can access the readonly methods
-    fn as_ref(&self) -> &dyn ReadonlyStorage {
+    /// Converts a `&dyn Storage` to a reference of the super trait `&dyn ReadonlyStorage`,
+    /// which unfortunately Rust does not allow us to do directly
+    /// (see https://github.com/rust-lang/rfcs/issues/2368 and linked threads).
+    fn as_readonly(&self) -> &dyn ReadonlyStorage {
         self
     }
 }

--- a/packages/std/src/traits.rs
+++ b/packages/std/src/traits.rs
@@ -50,8 +50,10 @@ pub trait Storage: ReadonlyStorage {
     /// before and one that didn't exist. See https://github.com/CosmWasm/cosmwasm/issues/290
     fn remove(&mut self, key: &[u8]);
 
-    // this is needed so a &dyn Storage trait object can access the readonly methods
-    fn as_ref(&self) -> &dyn ReadonlyStorage;
+    /// Converts a `&dyn Storage` to a reference of the super trait `&dyn ReadonlyStorage`,
+    /// which unfortunately Rust does not allow us to do directly
+    /// (see https://github.com/rust-lang/rfcs/issues/2368 and linked threads).
+    fn as_readonly(&self) -> &dyn ReadonlyStorage;
 }
 
 /// Api are callbacks to system functions implemented outside of the wasm modules.

--- a/packages/storage/src/bucket.rs
+++ b/packages/storage/src/bucket.rs
@@ -74,14 +74,14 @@ where
 
     /// load will return an error if no data is set at the given key, or on parse error
     pub fn load(&self, key: &[u8]) -> StdResult<T> {
-        let value = get_with_prefix(self.storage.as_ref(), &self.prefix, key);
+        let value = get_with_prefix(self.storage.as_readonly(), &self.prefix, key);
         must_deserialize(&value)
     }
 
     /// may_load will parse the data stored at the key if present, returns Ok(None) if no data there.
     /// returns an error on issues parsing
     pub fn may_load(&self, key: &[u8]) -> StdResult<Option<T>> {
-        let value = get_with_prefix(self.storage.as_ref(), &self.prefix, key);
+        let value = get_with_prefix(self.storage.as_readonly(), &self.prefix, key);
         may_deserialize(&value)
     }
 
@@ -92,7 +92,7 @@ where
         end: Option<&[u8]>,
         order: Order,
     ) -> Box<dyn Iterator<Item = StdResult<KV<T>>> + 'b> {
-        let mapped = range_with_prefix(self.storage.as_ref(), &self.prefix, start, end, order)
+        let mapped = range_with_prefix(self.storage.as_readonly(), &self.prefix, start, end, order)
             .map(deserialize_kv::<T>);
         Box::new(mapped)
     }

--- a/packages/storage/src/prefixed_storage.rs
+++ b/packages/storage/src/prefixed_storage.rs
@@ -134,8 +134,10 @@ where
         remove_with_prefix(self.storage, &self.prefix, key);
     }
 
-    // this is needed so a &dyn Storage trait object can access the readonly methods
-    fn as_ref(&self) -> &dyn ReadonlyStorage {
+    /// Converts a `&dyn Storage` to a reference of the super trait `&dyn ReadonlyStorage`,
+    /// which unfortunately Rust does not allow us to do directly
+    /// (see https://github.com/rust-lang/rfcs/issues/2368 and linked threads).
+    fn as_readonly(&self) -> &dyn ReadonlyStorage {
         self
     }
 }

--- a/packages/storage/src/transactions.rs
+++ b/packages/storage/src/transactions.rs
@@ -104,8 +104,10 @@ impl<'a, S: ReadonlyStorage> Storage for StorageTransaction<'a, S> {
         self.rep_log.append(op);
     }
 
-    // this is needed so a &dyn Storage trait object can access the readonly methods
-    fn as_ref(&self) -> &dyn ReadonlyStorage {
+    /// Converts a `&dyn Storage` to a reference of the super trait `&dyn ReadonlyStorage`,
+    /// which unfortunately Rust does not allow us to do directly
+    /// (see https://github.com/rust-lang/rfcs/issues/2368 and linked threads).
+    fn as_readonly(&self) -> &dyn ReadonlyStorage {
         self
     }
 }


### PR DESCRIPTION
`as_ref` is ambiguous and here we already have a ref, but need a different one.