### PR TITLE
Add in-memory cache for Modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,8 @@
 - Fix return type of `FileSystemCache::load` to `VmResult<Option<Module>>` in
   order to differentiate missing files from errors.
 - Add in-memory caching for recently used Wasm modules.
-- Rename `CosmCache` to just `cosmwasm_vm::Cache`.
+- Rename `CosmCache` to just `cosmwasm_vm::Cache` and add `CacheOptions` to
+  configure it.
 
 ## 0.11.2 (2020-10-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - Fix return type of `FileSystemCache::load` to `VmResult<Option<Module>>` in
   order to differentiate missing files from errors.
 - Add in-memory caching for recently used Wasm modules.
+- Rename `CosmCache` to just `cosmwasm_vm::Cache`.
 
 ## 0.11.2 (2020-10-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 - Make `FileSystemCache` crate internal. This should be used via `CosmCache`.
 - Fix return type of `FileSystemCache::load` to `VmResult<Option<Module>>` in
   order to differentiate missing files from errors.
+- Add in-memory caching for recently used Wasm modules.
 
 ## 0.11.2 (2020-10-26)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "clru"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6add52b3696a2015ab5bab92e99e75e8a9eb7a10b76b92dbb3a43f25adbd7629"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,6 +147,7 @@ dependencies = [
 name = "cosmwasm-vm"
 version = "0.11.2"
 dependencies = [
+ "clru",
  "cosmwasm-std",
  "hex",
  "memmap",

--- a/contracts/burner/Cargo.lock
+++ b/contracts/burner/Cargo.lock
@@ -103,6 +103,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "clru"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6add52b3696a2015ab5bab92e99e75e8a9eb7a10b76b92dbb3a43f25adbd7629"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,6 +137,7 @@ dependencies = [
 name = "cosmwasm-vm"
 version = "0.11.2"
 dependencies = [
+ "clru",
  "cosmwasm-std",
  "hex",
  "memmap",

--- a/contracts/hackatom/Cargo.lock
+++ b/contracts/hackatom/Cargo.lock
@@ -92,6 +92,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "clru"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6add52b3696a2015ab5bab92e99e75e8a9eb7a10b76b92dbb3a43f25adbd7629"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,6 +134,7 @@ dependencies = [
 name = "cosmwasm-vm"
 version = "0.11.2"
 dependencies = [
+ "clru",
  "cosmwasm-std",
  "hex",
  "memmap",

--- a/contracts/queue/Cargo.lock
+++ b/contracts/queue/Cargo.lock
@@ -92,6 +92,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "clru"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6add52b3696a2015ab5bab92e99e75e8a9eb7a10b76b92dbb3a43f25adbd7629"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,6 +126,7 @@ dependencies = [
 name = "cosmwasm-vm"
 version = "0.11.2"
 dependencies = [
+ "clru",
  "cosmwasm-std",
  "hex",
  "memmap",

--- a/contracts/reflect/Cargo.lock
+++ b/contracts/reflect/Cargo.lock
@@ -92,6 +92,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "clru"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6add52b3696a2015ab5bab92e99e75e8a9eb7a10b76b92dbb3a43f25adbd7629"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,6 +134,7 @@ dependencies = [
 name = "cosmwasm-vm"
 version = "0.11.2"
 dependencies = [
+ "clru",
  "cosmwasm-std",
  "hex",
  "memmap",

--- a/contracts/staking/Cargo.lock
+++ b/contracts/staking/Cargo.lock
@@ -92,6 +92,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "clru"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6add52b3696a2015ab5bab92e99e75e8a9eb7a10b76b92dbb3a43f25adbd7629"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,6 +134,7 @@ dependencies = [
 name = "cosmwasm-vm"
 version = "0.11.2"
 dependencies = [
+ "clru",
  "cosmwasm-std",
  "hex",
  "memmap",

--- a/packages/vm/Cargo.toml
+++ b/packages/vm/Cargo.toml
@@ -30,6 +30,7 @@ iterator = ["cosmwasm-std/iterator"]
 staking = ["cosmwasm-std/staking"]
 
 [dependencies]
+clru = "0.2.0"
 # Uses the path when built locally; uses the given version from crates.io when published
 cosmwasm-std = { path = "../std", version = "0.11.2" }
 serde_json = "1.0"

--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -73,7 +73,7 @@ where
         check_wasm(wasm, &self.supported_features)?;
         let checksum = save_wasm_to_disk(&self.wasm_path, wasm)?;
         let module = compile(wasm)?;
-        self.fs_cache.store(&checksum, module)?;
+        self.fs_cache.store(&checksum, &module)?;
         Ok(checksum)
     }
 

--- a/packages/vm/src/lib.rs
+++ b/packages/vm/src/lib.rs
@@ -18,7 +18,7 @@ mod size;
 pub mod testing;
 mod traits;
 
-pub use crate::cache::CosmCache;
+pub use crate::cache::Cache;
 pub use crate::calls::{
     call_handle, call_handle_raw, call_init, call_init_raw, call_migrate, call_migrate_raw,
     call_query, call_query_raw,

--- a/packages/vm/src/lib.rs
+++ b/packages/vm/src/lib.rs
@@ -18,7 +18,7 @@ mod size;
 pub mod testing;
 mod traits;
 
-pub use crate::cache::Cache;
+pub use crate::cache::{Cache, CacheOptions};
 pub use crate::calls::{
     call_handle, call_handle_raw, call_init, call_init_raw, call_migrate, call_migrate_raw,
     call_query, call_query_raw,

--- a/packages/vm/src/lib.rs
+++ b/packages/vm/src/lib.rs
@@ -14,6 +14,7 @@ mod memory;
 mod middleware;
 mod modules;
 mod serde;
+mod size;
 pub mod testing;
 mod traits;
 
@@ -31,4 +32,5 @@ pub use crate::features::features_from_csv;
 pub use crate::ffi::{FfiError, FfiResult, GasInfo};
 pub use crate::instance::{GasReport, Instance, InstanceOptions};
 pub use crate::serde::{from_slice, to_vec};
+pub use crate::size::Size;
 pub use crate::traits::{Api, Extern, Querier, Storage};

--- a/packages/vm/src/modules/file_system_cache.rs
+++ b/packages/vm/src/modules/file_system_cache.rs
@@ -121,6 +121,10 @@ mod tests {
     fn test_file_system_cache_run() {
         use wasmer_runtime_core::{imports, typed_func::Func};
 
+        let tmp_dir = TempDir::new().unwrap();
+        let mut cache = unsafe { FileSystemCache::new(tmp_dir.path()).unwrap() };
+
+        // Create module
         let wasm = wat::parse_str(
             r#"(module
             (type $t0 (func (param i32) (result i32)))
@@ -132,34 +136,29 @@ mod tests {
         )
         .unwrap();
         let checksum = Checksum::generate(&wasm);
-
         let module = compile(&wasm).unwrap();
 
-        // assert we are using the proper backend
-        assert_eq!(BACKEND_NAME.to_string(), module.info().backend.to_string());
-
-        let tmp_dir = TempDir::new().unwrap();
-        let mut fs_cache = unsafe { FileSystemCache::new(tmp_dir.path()).unwrap() };
-
         // Module does not exist
-        let cached = fs_cache.load(&checksum).unwrap();
+        let cached = cache.load(&checksum).unwrap();
         assert!(cached.is_none());
 
         // Store module
-        fs_cache.store(&checksum, module.clone()).unwrap();
+        cache.store(&checksum, module.clone()).unwrap();
 
         // Load module
-        let cached = fs_cache.load(&checksum).unwrap();
+        let cached = cache.load(&checksum).unwrap();
         assert!(cached.is_some());
 
-        let cached_module = cached.unwrap();
-        let import_object = imports! {};
-        let instance = cached_module.instantiate(&import_object).unwrap();
-        let add_one: Func<i32, i32> = instance.exports.get("add_one").unwrap();
-
-        let value = add_one.call(42).unwrap();
-
-        // verify it works
-        assert_eq!(value, 43);
+        // Check the returned module is functional.
+        // This is not really testing the cache API but better safe than sorry.
+        {
+            assert_eq!(module.info().backend.to_string(), BACKEND_NAME.to_string());
+            let cached_module = cached.unwrap();
+            let import_object = imports! {};
+            let instance = cached_module.instantiate(&import_object).unwrap();
+            let add_one: Func<i32, i32> = instance.exports.get("add_one").unwrap();
+            let value = add_one.call(42).unwrap();
+            assert_eq!(value, 43);
+        }
     }
 }

--- a/packages/vm/src/modules/file_system_cache.rs
+++ b/packages/vm/src/modules/file_system_cache.rs
@@ -92,7 +92,8 @@ impl FileSystemCache {
         Ok(Some(module))
     }
 
-    pub fn store(&mut self, checksum: &Checksum, module: Module) -> VmResult<()> {
+    /// Stores a serialization of the module to the file system
+    pub fn store(&mut self, checksum: &Checksum, module: &Module) -> VmResult<()> {
         let backend_str = module.info().backend.to_string();
         let modules_dir = self.path.clone().join(backend_str);
         fs::create_dir_all(&modules_dir)
@@ -143,7 +144,7 @@ mod tests {
         assert!(cached.is_none());
 
         // Store module
-        cache.store(&checksum, module.clone()).unwrap();
+        cache.store(&checksum, &module).unwrap();
 
         // Load module
         let cached = cache.load(&checksum).unwrap();

--- a/packages/vm/src/modules/in_memory_cache.rs
+++ b/packages/vm/src/modules/in_memory_cache.rs
@@ -1,0 +1,81 @@
+use clru::CLruCache;
+use wasmer_runtime_core::module::Module;
+
+use crate::{Checksum, Size, VmResult};
+
+const ESTIMATED_MODULE_SIZE: Size = Size::mebi(10);
+
+/// An in-memory module cache
+pub struct InMemoryCache {
+    lru: CLruCache<Checksum, Module>,
+}
+
+impl InMemoryCache {
+    /// Creates a new cache with the given size (in bytes)
+    pub fn new(size: Size) -> Self {
+        let max_entries = size.0 / ESTIMATED_MODULE_SIZE.0;
+        InMemoryCache {
+            lru: CLruCache::new(max_entries),
+        }
+    }
+
+    pub fn store(&mut self, checksum: &Checksum, module: Module) -> VmResult<()> {
+        self.lru.put(*checksum, module);
+        Ok(())
+    }
+
+    pub fn load(&mut self, checksum: &Checksum) -> VmResult<Option<&Module>> {
+        let optional = self.lru.get(checksum);
+        Ok(optional)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backends::{compile, BACKEND_NAME};
+
+    #[test]
+    fn test_in_memory_cache_run() {
+        use wasmer_runtime_core::{imports, typed_func::Func};
+
+        let mut cache = InMemoryCache::new(Size::mebi(200));
+
+        // Create module
+        let wasm = wat::parse_str(
+            r#"(module
+            (type $t0 (func (param i32) (result i32)))
+            (func $add_one (export "add_one") (type $t0) (param $p0 i32) (result i32)
+                get_local $p0
+                i32.const 1
+                i32.add))
+            "#,
+        )
+        .unwrap();
+        let checksum = Checksum::generate(&wasm);
+        let module = compile(&wasm).unwrap();
+
+        // Module does not exist
+        let cached = cache.load(&checksum).unwrap();
+        assert!(cached.is_none());
+
+        // Store module
+        cache.store(&checksum, module.clone()).unwrap();
+
+        // Load module
+        let cached = cache.load(&checksum).unwrap();
+        assert!(cached.is_some());
+
+        // Check the returned module is functional.
+        // This is not really testing the cache API but better safe than sorry.
+        {
+            assert_eq!(module.info().backend.to_string(), BACKEND_NAME.to_string());
+            let cached_module = cached.unwrap();
+            let import_object = imports! {};
+            let instance = cached_module.instantiate(&import_object).unwrap();
+            let add_one: Func<i32, i32> = instance.exports.get("add_one").unwrap();
+            let value = add_one.call(42).unwrap();
+            assert_eq!(value, 43);
+        }
+    }
+}

--- a/packages/vm/src/modules/mod.rs
+++ b/packages/vm/src/modules/mod.rs
@@ -1,3 +1,5 @@
 mod file_system_cache;
+mod in_memory_cache;
 
 pub use file_system_cache::FileSystemCache;
+pub use in_memory_cache::InMemoryCache;

--- a/packages/vm/src/size.rs
+++ b/packages/vm/src/size.rs
@@ -1,0 +1,62 @@
+pub struct Size(pub usize);
+
+impl Size {
+    /// Creates a size of `n` kilo
+    pub const fn kilo(n: usize) -> Self {
+        Size(n * 1000)
+    }
+
+    /// Creates a size of `n` kibi
+    pub const fn kibi(n: usize) -> Self {
+        Size(n * 1024)
+    }
+
+    /// Creates a size of `n` mega
+    pub const fn mega(n: usize) -> Self {
+        Size(n * 1000 * 1000)
+    }
+
+    /// Creates a size of `n` mebi
+    pub const fn mebi(n: usize) -> Self {
+        Size(n * 1024 * 1024)
+    }
+
+    /// Creates a size of `n` giga
+    pub const fn giga(n: usize) -> Self {
+        Size(n * 1000 * 1000 * 1000)
+    }
+
+    /// Creates a size of `n` gibi
+    pub const fn gibi(n: usize) -> Self {
+        Size(n * 1024 * 1024 * 1024)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn constructors_work() {
+        assert_eq!(Size(0).0, 0);
+        assert_eq!(Size(3).0, 3);
+
+        assert_eq!(Size::kilo(0).0, 0);
+        assert_eq!(Size::kilo(3).0, 3000);
+
+        assert_eq!(Size::kibi(0).0, 0);
+        assert_eq!(Size::kibi(3).0, 3072);
+
+        assert_eq!(Size::mega(0).0, 0);
+        assert_eq!(Size::mega(3).0, 3000000);
+
+        assert_eq!(Size::mebi(0).0, 0);
+        assert_eq!(Size::mebi(3).0, 3145728);
+
+        assert_eq!(Size::giga(0).0, 0);
+        assert_eq!(Size::giga(3).0, 3000000000);
+
+        assert_eq!(Size::gibi(0).0, 0);
+        assert_eq!(Size::gibi(3).0, 3221225472);
+    }
+}


### PR DESCRIPTION
This brings back memory caching, but on Module instead of Instance level this time.

Closes #603