### PR TITLE
Transactions support refcell and box

### DIFF
--- a/packages/storage/src/lib.rs
+++ b/packages/storage/src/lib.rs
@@ -12,4 +12,4 @@ pub use length_prefixed::{to_length_prefixed, to_length_prefixed_nested};
 pub use prefixed_storage::{prefixed, prefixed_read, PrefixedStorage, ReadonlyPrefixedStorage};
 pub use sequence::{currval, nextval, sequence};
 pub use singleton::{singleton, singleton_read, ReadonlySingleton, Singleton};
-pub use transactions::{transactional, RepLog, StorageTransaction};
+pub use transactions::{RepLog, StorageTransaction};


### PR DESCRIPTION
I was forking the transactions module to complete https://github.com/CosmWasm/cosmwasm-plus/pull/134 as I wanted to use `Ref<Storage>` not just `&Storage`. I decided to make the original module more generic and test those cases and update function sigs as needed. 

`StorageTransaction::new()` works when the original storage is
* `MemoryStorage`
* `RefCell<MemoryStorage>`
* `Box<MemoryStorage>`
* `Box<dyn Storage>`
* `RefCell<Box<dyn Storage>>` (this one is tricky and may be hard to work with in practice)
