### PR TITLE
Add helper so handler can call other handler

### DIFF
--- a/packages/std/src/deps.rs
+++ b/packages/std/src/deps.rs
@@ -50,4 +50,49 @@ impl<'a> DepsMut<'a> {
             querier: self.querier,
         }
     }
+
+    pub fn dup(&'_ mut self) -> DepsMut<'_> {
+        DepsMut {
+            storage: self.storage,
+            api: self.api,
+            querier: self.querier,
+        }
+    }
+}
+
+impl<'a> Deps<'a> {
+    pub fn dup(&'_ self) -> Deps<'_> {
+        Deps {
+            storage: self.storage,
+            api: self.api,
+            querier: self.querier,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::mock::mock_dependencies;
+
+    // ensure we can call these many times, eg. as sub-calls
+    fn handle(mut deps: DepsMut) {
+        handle2(deps.dup());
+        query(deps.as_ref());
+        handle2(deps.dup());
+    }
+    fn handle2(_deps: DepsMut) {}
+
+    fn query(deps: Deps) {
+        query2(deps.dup());
+        query2(deps.dup());
+    }
+    fn query2(_deps: Deps) {}
+
+    #[test]
+    fn ensure_easy_reuse() {
+        let mut deps = mock_dependencies(&[]);
+        handle(deps.as_mut());
+        query(deps.as_ref())
+    }
 }

--- a/packages/std/src/deps.rs
+++ b/packages/std/src/deps.rs
@@ -51,18 +51,8 @@ impl<'a> DepsMut<'a> {
         }
     }
 
-    pub fn dup(&'_ mut self) -> DepsMut<'_> {
+    pub fn branch(&'_ mut self) -> DepsMut<'_> {
         DepsMut {
-            storage: self.storage,
-            api: self.api,
-            querier: self.querier,
-        }
-    }
-}
-
-impl<'a> Deps<'a> {
-    pub fn dup(&'_ self) -> Deps<'_> {
-        Deps {
             storage: self.storage,
             api: self.api,
             querier: self.querier,
@@ -77,15 +67,15 @@ mod test {
 
     // ensure we can call these many times, eg. as sub-calls
     fn handle(mut deps: DepsMut) {
-        handle2(deps.dup());
+        handle2(deps.branch());
         query(deps.as_ref());
-        handle2(deps.dup());
+        handle2(deps.branch());
     }
     fn handle2(_deps: DepsMut) {}
 
     fn query(deps: Deps) {
-        query2(deps.dup());
-        query2(deps.dup());
+        query2(deps.clone());
+        query2(deps.clone());
     }
     fn query2(_deps: Deps) {}
 


### PR DESCRIPTION
When porting all the cosmwasm-plus contracts, I hit issues with handlers calling other handlers.
I finally realized we could do this, just missing the helper.

For the concrete use case I am solving, see: https://github.com/CosmWasm/cosmwasm-plus/pull/136/commits/48fc535af060531c5ccf60e2a594bc4ea76d1803 