### PR TITLE
Add Github Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Contract Development
 
 on: 
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,9 @@ on:
     branches:
       - master
   push:
-    branches-ignore:
-      - '**'
+    branches:
+      - master
+      - 0.[0-9]+
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,14 @@
 name: CI
 
 on: 
+  pull_request:
+    branches:
+      - master
   push:
     branches:
       - github-actions
+    tags:
+      - /^v[0-9]+\.[0-9]+\.[0-9]+.*/
 
 jobs:
   test-hackatom:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,6 @@ on:
     branches:
       - master
       - 0.[0-9]+
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+*'
 
 jobs:
   test-hackatom:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,6 @@ jobs:
           override: true
       - name: Build hackatom wasm
         run: cargo wasm --locked
-      - name: Check hackatom
-        run: cargo check --locked --tests
       - name: Unit Test hackatom
         run: cargo unit-test --locked
       - name: Integration Test hackatom

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on: 
+  push:
+    branches:
+      - github-actions
+
+jobs:
+  test-hackatom:
+    name: ${{ matrix.build }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - build: macOS
+            os: macOS-latest
+          - build: Windows
+            os: windows-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./contracts/hackatom
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.47.0
+          target: wasm32-unknown-unknown
+          profile: minimal
+          override: true
+      - name: Build hackatom wasm
+        run: cargo wasm --locked
+      - name: Check hackatom
+        run: cargo check --locked --tests
+      - name: Unit Test hackatom
+        run: cargo unit-test --locked
+      - name: Integration Test hackatom
+        run: cargo integration-test --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   test-hackatom:
-    name: Rust stable on ${{ matrix.build }}
+    name: ${{ matrix.build }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
-      - name: Install rust
+      - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
           toolchain: 1.47.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,31 @@ jobs:
         run: cargo unit-test --locked
       - name: Integration Test hackatom
         run: cargo integration-test --locked
+  test-hackatom-in-singlepass-vm:
+    name: ${{ matrix.build }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - build: macOS
+            os: macOS-latest
+          - build: Windows
+            os: windows-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./contracts/hackatom
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          target: wasm32-unknown-unknown
+          profile: minimal
+          override: true
+      - name: Build hackatom wasm
+        run: cargo wasm --locked
+      - name: Integration Test hackatom
+        run: cargo integration-test --no-default-features --features singlepass --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test-hackatom:
-    name: ${{ matrix.build }}
+    name: Rust stable on ${{ matrix.build }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -39,15 +39,13 @@ jobs:
       - name: Integration Test hackatom
         run: cargo integration-test --locked
   test-hackatom-in-singlepass-vm:
-    name: ${{ matrix.build }}
+    name: Rust nightly on ${{ matrix.build }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         include:
           - build: macOS
             os: macOS-latest
-          - build: Windows
-            os: windows-latest
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,10 @@ on:
     branches:
       - master
   push:
-    branches:
-      - github-actions
+    branches-ignore:
+      - '**'
     tags:
-      - /^v[0-9]+\.[0-9]+\.[0-9]+.*/
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
 
 jobs:
   test-hackatom:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,29 +40,3 @@ jobs:
         run: cargo unit-test --locked
       - name: Integration Test hackatom
         run: cargo integration-test --locked
-  test-hackatom-in-singlepass-vm:
-    name: Rust nightly on ${{ matrix.build }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        include:
-          - build: macOS
-            os: macOS-latest
-    defaults:
-      run:
-        shell: bash
-        working-directory: ./contracts/hackatom
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
-      - name: Install rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          target: wasm32-unknown-unknown
-          profile: minimal
-          override: true
-      - name: Build hackatom wasm
-        run: cargo wasm --locked
-      - name: Integration Test hackatom
-        run: cargo integration-test --no-default-features --features singlepass --locked

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -21,6 +21,9 @@ pull_request_rules:
       - "status-success=ci/circleci: contract_staking"
       - "status-success=ci/circleci: fmt"
       - "status-success=ci/circleci: clippy"
+      - "status-success=Windows"
+      - "status-success=macOS"
+
     actions:
       merge:
         method: merge


### PR DESCRIPTION
Github Actions workflow for running hackatom contract tests, in macOS and Windows.

Currently runs on version tags (untested) and on push requests against master.

Closes #630.