### PR TITLE
Allow us to fulfill &dyn Querier where we have &QuerierWrapper

### DIFF
--- a/packages/std/src/traits.rs
+++ b/packages/std/src/traits.rs
@@ -1,4 +1,5 @@
 use serde::{de::DeserializeOwned, Serialize};
+use std::ops::Deref;
 
 use crate::addresses::{CanonicalAddr, HumanAddr};
 use crate::binary::Binary;
@@ -17,7 +18,6 @@ use crate::query::{
 use crate::results::{ContractResult, SystemResult};
 use crate::serde::{from_binary, to_binary, to_vec};
 use crate::types::Empty;
-use std::ops::Deref;
 
 /// Storage provides read and write access to a persistent storage.
 /// If you only want to provide read access, provide `&Storage`

--- a/packages/std/src/traits.rs
+++ b/packages/std/src/traits.rs
@@ -87,6 +87,8 @@ pub trait Querier {
 #[derive(Copy, Clone)]
 pub struct QuerierWrapper<'a>(&'a dyn Querier);
 
+/// This allows us to use self.raw_query to access the querier.
+/// It also allows external callers to access the querier easily.
 impl<'a> Deref for QuerierWrapper<'a> {
     type Target = dyn Querier + 'a;
 
@@ -98,13 +100,6 @@ impl<'a> Deref for QuerierWrapper<'a> {
 impl<'a> QuerierWrapper<'a> {
     pub fn new(querier: &'a dyn Querier) -> Self {
         QuerierWrapper(querier)
-    }
-
-    /// This allows us to pass through binary queries from one level to another without
-    /// knowing the custom format, or we can decode it, with the knowledge of the allowed
-    /// types. You probably want one of the simpler auto-generated helper methods
-    pub fn raw_query(&self, bin_request: &[u8]) -> QuerierResult {
-        self.0.raw_query(bin_request)
     }
 
     /// query is a shorthand for custom_query when we are not using a custom type,


### PR DESCRIPTION
I have the issue of trying to call a function that works on `&dyn Querier`, but "only" having `&QuerierWrapper` from `Deps`.

I would need to either expose read access to the underlying querier, but since QuerierWrapper already implements `raw_query` with a pass-through, we just need to explicitly implement the trait. This is not a functional code change, but explicitly implementing the trait.

The issue came up in https://github.com/CosmWasm/cosmwasm-plus/pull/150