### PR TITLE
Use manual implementation of PartialEq for StdError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 **cosmwasm-std**
 
-- `StdError` now implements `PartialEq` (ignoring backtrace if any). This
-  allows simpler `assert_eq!()` when testing error conditions (rather
-  than match statements as now).
+- `StdError` now implements `PartialEq` (ignoring backtrace if any). This allows
+  simpler `assert_eq!()` when testing error conditions (rather than match
+  statements as now).
 
 ## 0.12.1 (2020-12-09)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,7 +129,6 @@ dependencies = [
  "base64",
  "chrono",
  "cosmwasm-schema",
- "derivative",
  "schemars",
  "serde",
  "serde-json-wasm",
@@ -287,17 +286,6 @@ checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
 dependencies = [
  "generic-array 0.12.3",
  "subtle",
-]
-
-[[package]]
-name = "derivative"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb582b60359da160a9477ee80f15c8d784c477e69c217ef2cdd4169c24ea380f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/contracts/burner/Cargo.lock
+++ b/contracts/burner/Cargo.lock
@@ -127,7 +127,6 @@ name = "cosmwasm-std"
 version = "0.12.1"
 dependencies = [
  "base64",
- "derivative",
  "schemars",
  "serde",
  "serde-json-wasm",
@@ -275,17 +274,6 @@ checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
 dependencies = [
  "generic-array 0.12.3",
  "subtle",
-]
-
-[[package]]
-name = "derivative"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb582b60359da160a9477ee80f15c8d784c477e69c217ef2cdd4169c24ea380f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/contracts/hackatom/Cargo.lock
+++ b/contracts/hackatom/Cargo.lock
@@ -116,7 +116,6 @@ name = "cosmwasm-std"
 version = "0.12.1"
 dependencies = [
  "base64",
- "derivative",
  "schemars",
  "serde",
  "serde-json-wasm",
@@ -272,17 +271,6 @@ checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
 dependencies = [
  "generic-array 0.12.3",
  "subtle",
-]
-
-[[package]]
-name = "derivative"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb582b60359da160a9477ee80f15c8d784c477e69c217ef2cdd4169c24ea380f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/contracts/queue/Cargo.lock
+++ b/contracts/queue/Cargo.lock
@@ -116,7 +116,6 @@ name = "cosmwasm-std"
 version = "0.12.1"
 dependencies = [
  "base64",
- "derivative",
  "schemars",
  "serde",
  "serde-json-wasm",
@@ -265,17 +264,6 @@ checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
  "generic-array 0.14.4",
  "subtle",
-]
-
-[[package]]
-name = "derivative"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb582b60359da160a9477ee80f15c8d784c477e69c217ef2cdd4169c24ea380f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/contracts/reflect/Cargo.lock
+++ b/contracts/reflect/Cargo.lock
@@ -116,7 +116,6 @@ name = "cosmwasm-std"
 version = "0.12.1"
 dependencies = [
  "base64",
- "derivative",
  "schemars",
  "serde",
  "serde-json-wasm",
@@ -272,17 +271,6 @@ checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
 dependencies = [
  "generic-array 0.12.3",
  "subtle",
-]
-
-[[package]]
-name = "derivative"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb582b60359da160a9477ee80f15c8d784c477e69c217ef2cdd4169c24ea380f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/contracts/staking/Cargo.lock
+++ b/contracts/staking/Cargo.lock
@@ -116,7 +116,6 @@ name = "cosmwasm-std"
 version = "0.12.1"
 dependencies = [
  "base64",
- "derivative",
  "schemars",
  "serde",
  "serde-json-wasm",
@@ -272,17 +271,6 @@ checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
 dependencies = [
  "generic-array 0.12.3",
  "subtle",
-]
-
-[[package]]
-name = "derivative"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb582b60359da160a9477ee80f15c8d784c477e69c217ef2cdd4169c24ea380f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -34,7 +34,6 @@ serde-json-wasm = { version = "0.2.1" }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive", "alloc"] }
 thiserror = "1.0"
-derivative = "2.1.1"
 
 [dev-dependencies]
 cosmwasm-schema = { path = "../schema" }

--- a/packages/std/src/errors/std_error.rs
+++ b/packages/std/src/errors/std_error.rs
@@ -354,6 +354,21 @@ mod test {
     }
 
     #[test]
+    fn implements_partial_eq() {
+        let u1 = StdError::underflow(3, 5);
+        let u2 = StdError::underflow(3, 5);
+        let u3 = StdError::underflow(3, 7);
+        let s1 = StdError::serialize_err("Book", "Content too long");
+        let s2 = StdError::serialize_err("Book", "Content too long");
+        let s3 = StdError::serialize_err("Book", "Title too long");
+        assert_eq!(u1, u2);
+        assert_ne!(u1, u3);
+        assert_ne!(u1, s1);
+        assert_eq!(s1, s2);
+        assert_ne!(s1, s3);
+    }
+
+    #[test]
     fn from_std_str_utf8error_works() {
         let error: StdError = str::from_utf8(b"Hello \xF0\x90\x80World")
             .unwrap_err()

--- a/packages/std/src/errors/std_error.rs
+++ b/packages/std/src/errors/std_error.rs
@@ -1,4 +1,3 @@
-use derivative::Derivative;
 #[cfg(feature = "backtraces")]
 use std::backtrace::Backtrace;
 use thiserror::Error;
@@ -18,22 +17,19 @@ use thiserror::Error;
 /// Checklist for adding a new error:
 /// - Add enum case
 /// - Add creator function in std_error_helpers.rs
-#[derive(Error, Debug, Derivative)]
-#[derivative(PartialEq)]
+#[derive(Error, Debug)]
 pub enum StdError {
     /// Whenever there is no specific error type available
     #[error("Generic error: {msg}")]
     GenericErr {
         msg: String,
         #[cfg(feature = "backtraces")]
-        #[derivative(PartialEq = "ignore")]
         backtrace: Backtrace,
     },
     #[error("Invalid Base64 string: {msg}")]
     InvalidBase64 {
         msg: String,
         #[cfg(feature = "backtraces")]
-        #[derivative(PartialEq = "ignore")]
         backtrace: Backtrace,
     },
     #[error("Invalid data size: expected={expected} actual={actual}")]
@@ -41,7 +37,6 @@ pub enum StdError {
         expected: u64,
         actual: u64,
         #[cfg(feature = "backtraces")]
-        #[derivative(PartialEq = "ignore")]
         backtrace: Backtrace,
     },
     /// Whenever UTF-8 bytes cannot be decoded into a unicode string, e.g. in String::from_utf8 or str::from_utf8.
@@ -49,14 +44,12 @@ pub enum StdError {
     InvalidUtf8 {
         msg: String,
         #[cfg(feature = "backtraces")]
-        #[derivative(PartialEq = "ignore")]
         backtrace: Backtrace,
     },
     #[error("{kind} not found")]
     NotFound {
         kind: String,
         #[cfg(feature = "backtraces")]
-        #[derivative(PartialEq = "ignore")]
         backtrace: Backtrace,
     },
     #[error("Error parsing into type {target_type}: {msg}")]
@@ -65,7 +58,6 @@ pub enum StdError {
         target_type: String,
         msg: String,
         #[cfg(feature = "backtraces")]
-        #[derivative(PartialEq = "ignore")]
         backtrace: Backtrace,
     },
     #[error("Error serializing type {source_type}: {msg}")]
@@ -74,7 +66,6 @@ pub enum StdError {
         source_type: String,
         msg: String,
         #[cfg(feature = "backtraces")]
-        #[derivative(PartialEq = "ignore")]
         backtrace: Backtrace,
     },
     #[error("Cannot subtract {subtrahend} from {minuend}")]
@@ -82,7 +73,6 @@ pub enum StdError {
         minuend: String,
         subtrahend: String,
         #[cfg(feature = "backtraces")]
-        #[derivative(PartialEq = "ignore")]
         backtrace: Backtrace,
     },
 }
@@ -154,6 +144,149 @@ impl StdError {
             subtrahend: subtrahend.to_string(),
             #[cfg(feature = "backtraces")]
             backtrace: Backtrace::capture(),
+        }
+    }
+}
+
+impl PartialEq<StdError> for StdError {
+    fn eq(&self, rhs: &StdError) -> bool {
+        match self {
+            StdError::GenericErr {
+                msg,
+                #[cfg(feature = "backtraces")]
+                    backtrace: _,
+            } => {
+                if let StdError::GenericErr {
+                    msg: rhs_msg,
+                    #[cfg(feature = "backtraces")]
+                        backtrace: _,
+                } = rhs
+                {
+                    msg == rhs_msg
+                } else {
+                    false
+                }
+            }
+            StdError::InvalidBase64 {
+                msg,
+                #[cfg(feature = "backtraces")]
+                    backtrace: _,
+            } => {
+                if let StdError::InvalidBase64 {
+                    msg: rhs_msg,
+                    #[cfg(feature = "backtraces")]
+                        backtrace: _,
+                } = rhs
+                {
+                    msg == rhs_msg
+                } else {
+                    false
+                }
+            }
+            StdError::InvalidDataSize {
+                expected,
+                actual,
+                #[cfg(feature = "backtraces")]
+                    backtrace: _,
+            } => {
+                if let StdError::InvalidDataSize {
+                    expected: rhs_expected,
+                    actual: rhs_actual,
+                    #[cfg(feature = "backtraces")]
+                        backtrace: _,
+                } = rhs
+                {
+                    expected == rhs_expected && actual == rhs_actual
+                } else {
+                    false
+                }
+            }
+            StdError::InvalidUtf8 {
+                msg,
+                #[cfg(feature = "backtraces")]
+                    backtrace: _,
+            } => {
+                if let StdError::InvalidUtf8 {
+                    msg: rhs_msg,
+                    #[cfg(feature = "backtraces")]
+                        backtrace: _,
+                } = rhs
+                {
+                    msg == rhs_msg
+                } else {
+                    false
+                }
+            }
+            StdError::NotFound {
+                kind,
+                #[cfg(feature = "backtraces")]
+                    backtrace: _,
+            } => {
+                if let StdError::NotFound {
+                    kind: rhs_kind,
+                    #[cfg(feature = "backtraces")]
+                        backtrace: _,
+                } = rhs
+                {
+                    kind == rhs_kind
+                } else {
+                    false
+                }
+            }
+            StdError::ParseErr {
+                target_type,
+                msg,
+                #[cfg(feature = "backtraces")]
+                    backtrace: _,
+            } => {
+                if let StdError::ParseErr {
+                    target_type: rhs_target_type,
+                    msg: rhs_msg,
+                    #[cfg(feature = "backtraces")]
+                        backtrace: _,
+                } = rhs
+                {
+                    target_type == rhs_target_type && msg == rhs_msg
+                } else {
+                    false
+                }
+            }
+            StdError::SerializeErr {
+                source_type,
+                msg,
+                #[cfg(feature = "backtraces")]
+                    backtrace: _,
+            } => {
+                if let StdError::SerializeErr {
+                    source_type: rhs_source_type,
+                    msg: rhs_msg,
+                    #[cfg(feature = "backtraces")]
+                        backtrace: _,
+                } = rhs
+                {
+                    source_type == rhs_source_type && msg == rhs_msg
+                } else {
+                    false
+                }
+            }
+            StdError::Underflow {
+                minuend,
+                subtrahend,
+                #[cfg(feature = "backtraces")]
+                    backtrace: _,
+            } => {
+                if let StdError::Underflow {
+                    minuend: rhs_minuend,
+                    subtrahend: rhs_subtrahend,
+                    #[cfg(feature = "backtraces")]
+                        backtrace: _,
+                } = rhs
+                {
+                    minuend == rhs_minuend && subtrahend == rhs_subtrahend
+                } else {
+                    false
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Okay, this got a little longer but now uses a safe implementation that is hard to break when the error cases change.