### PR TITLE
Issue#674

### DIFF
--- a/contracts/hackatom/schema/migrate_msg.json
+++ b/contracts/hackatom/schema/migrate_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "MigrateMsg",
-  "description": "MigrateMsg allows a priviledged contract administrator to run a migration on the contract. In this (demo) case it is just migrating from one hackatom code to the same code, but taking advantage of the migration step to set a new validator.\n\nNote that the contract doesn't enforce permissions here, this is done by blockchain logic (in the future by blockchain governance)",
+  "description": "MigrateMsg allows a privileged contract administrator to run a migration on the contract. In this (demo) case it is just migrating from one hackatom code to the same code, but taking advantage of the migration step to set a new validator.\n\nNote that the contract doesn't enforce permissions here, this is done by blockchain logic (in the future by blockchain governance)",
   "type": "object",
   "required": [
     "verifier"

--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -30,6 +30,12 @@ pub struct MigrateMsg {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum SystemMsg {
+    Migrate(MigrateMsg),
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct State {
     pub verifier: CanonicalAddr,
     pub beneficiary: CanonicalAddr,
@@ -109,11 +115,11 @@ pub fn init(
     Ok(ctx.try_into()?)
 }
 
-pub fn migrate(
+pub fn system(
     deps: DepsMut,
     _env: Env,
     _info: MessageInfo,
-    msg: MigrateMsg,
+    msg: SystemMsg,
 ) -> Result<MigrateResponse, HackError> {
     let data = deps
         .storage

--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -17,7 +17,7 @@ pub struct InitMsg {
     pub beneficiary: HumanAddr,
 }
 
-/// MigrateMsg allows a priviledged contract administrator to run
+/// MigrateMsg allows a privileged contract administrator to run
 /// a migration on the contract. In this (demo) case it is just migrating
 /// from one hackatom code to the same code, but taking advantage of the
 /// migration step to set a new validator.
@@ -31,9 +31,7 @@ pub struct MigrateMsg {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
-pub enum SystemMsg {
-    Migrate(MigrateMsg),
-}
+pub enum SystemMsg { Migrate(MigrateMsg), }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct State {

--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -144,7 +144,7 @@ pub fn system(
     let mut config: State = from_slice(&data)?;
     match msg {
         SystemMsg::Migrate(migrate_msg) => {
-            config.verifier = deps.api.canonical_address(migrate_msg.verifier)?
+            config.verifier = deps.api.canonical_address(&migrate_msg.verifier)?
         }
     }
     deps.storage.set(CONFIG_KEY, &to_vec(&config)?);

--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -6,7 +6,7 @@ use std::convert::TryInto;
 use cosmwasm_std::{
     from_slice, to_binary, to_vec, AllBalanceResponse, Api, BankMsg, Binary, CanonicalAddr,
     Context, Deps, DepsMut, Env, HandleResponse, HumanAddr, InitResponse, MessageInfo,
-    MigrateResponse, SystemResponse, QueryRequest, QueryResponse, StdError, StdResult, WasmQuery,
+    MigrateResponse, QueryRequest, QueryResponse, StdError, StdResult, SystemResponse, WasmQuery,
 };
 
 use crate::errors::HackError;
@@ -31,7 +31,9 @@ pub struct MigrateMsg {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
-pub enum SystemMsg { Migrate(MigrateMsg), }
+pub enum SystemMsg {
+    Migrate(MigrateMsg),
+}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct State {
@@ -150,7 +152,6 @@ pub fn system(
     deps.storage.set(CONFIG_KEY, &to_vec(&config)?);
 
     Ok(SystemResponse::default())
-
 }
 
 pub fn handle(
@@ -474,7 +475,6 @@ mod tests {
         // check it is 'some other verifier'
         let query_response = query_verifier(deps.as_ref()).unwrap();
         assert_eq!(query_response.verifier, new_verifier);
-
     }
 
     #[test]

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -33,7 +33,7 @@ pub use crate::query::{
 };
 pub use crate::results::{
     attr, Attribute, BankMsg, Context, ContractResult, CosmosMsg, HandleResponse, HandleResult,
-    InitResponse, InitResult, MigrateResponse, MigrateResult, SystemResponse, SystemRes, QueryResult,
+    InitResponse, InitResult, MigrateResponse, MigrateResult, SystemResponse, SystemRes, QueryResponse, QueryResult,
     StakingMsg, SystemResult, WasmMsg,
 };
 pub use crate::serde::{from_binary, from_slice, to_binary, to_vec};

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -33,8 +33,8 @@ pub use crate::query::{
 };
 pub use crate::results::{
     attr, Attribute, BankMsg, Context, ContractResult, CosmosMsg, HandleResponse, HandleResult,
-    InitResponse, InitResult, MigrateResponse, MigrateResult, SystemResponse, SystemRes, QueryResponse, QueryResult,
-    StakingMsg, SystemResult, WasmMsg,
+    InitResponse, InitResult, MigrateResponse, MigrateResult, QueryResponse, QueryResult,
+    StakingMsg, SystemRes, SystemResponse, SystemResult, WasmMsg,
 };
 pub use crate::serde::{from_binary, from_slice, to_binary, to_vec};
 pub use crate::storage::MemoryStorage;

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -33,7 +33,7 @@ pub use crate::query::{
 };
 pub use crate::results::{
     attr, Attribute, BankMsg, Context, ContractResult, CosmosMsg, HandleResponse, HandleResult,
-    InitResponse, InitResult, MigrateResponse, MigrateResult, QueryResponse, QueryResult,
+    InitResponse, InitResult, MigrateResponse, MigrateResult, SystemResponse, SystemRes, QueryResult,
     StakingMsg, SystemResult, WasmMsg,
 };
 pub use crate::serde::{from_binary, from_slice, to_binary, to_vec};

--- a/packages/std/src/results/migrate.rs
+++ b/packages/std/src/results/migrate.rs
@@ -33,4 +33,24 @@ where
     }
 }
 
+pub struct SystemResponse<T = Empty>
+where
+    T: Clone + fmt::Debug + PartialEq + JsonSchema,
+{
+    pub messages: Vec<CosmosMsg<T>>,
+    /// The attributes that will be emitted as part of a "wasm" event
+    pub attributes: Vec<Attribute>,
+    pub data: Option<Binary>,
+}
+impl<T> Default for SystemResponse {
+    fn default() -> Self {
+        SystemResponse {
+            messages: vec![],
+            attributes: vec![],
+            data: None,
+        }
+    }
+}
+
 pub type MigrateResult<U = Empty> = Result<MigrateResponse<U>, StdError>;
+pub type SystemResult<U = Empty> = Result<SystemResponse<U>, StdError>;

--- a/packages/std/src/results/migrate.rs
+++ b/packages/std/src/results/migrate.rs
@@ -32,25 +32,5 @@ where
         }
     }
 }
-
-pub struct SystemResponse<T = Empty>
-where
-    T: Clone + fmt::Debug + PartialEq + JsonSchema,
-{
-    pub messages: Vec<CosmosMsg<T>>,
-    /// The attributes that will be emitted as part of a "wasm" event
-    pub attributes: Vec<Attribute>,
-    pub data: Option<Binary>,
-}
-impl<T> Default for SystemResponse {
-    fn default() -> Self {
-        SystemResponse {
-            messages: vec![],
-            attributes: vec![],
-            data: None,
-        }
-    }
-}
-
 pub type MigrateResult<U = Empty> = Result<MigrateResponse<U>, StdError>;
-pub type SystemResult<U = Empty> = Result<SystemResponse<U>, StdError>;
+

--- a/packages/std/src/results/migrate.rs
+++ b/packages/std/src/results/migrate.rs
@@ -33,4 +33,3 @@ where
     }
 }
 pub type MigrateResult<U = Empty> = Result<MigrateResponse<U>, StdError>;
-

--- a/packages/std/src/results/mod.rs
+++ b/packages/std/src/results/mod.rs
@@ -9,6 +9,7 @@ mod init;
 mod migrate;
 mod query;
 mod system_result;
+mod system;
 
 pub use attribute::{attr, Attribute};
 pub use context::Context;
@@ -17,5 +18,6 @@ pub use cosmos_msg::{BankMsg, CosmosMsg, StakingMsg, WasmMsg};
 pub use handle::{HandleResponse, HandleResult};
 pub use init::{InitResponse, InitResult};
 pub use migrate::{MigrateResponse, MigrateResult};
+pub use system::{SystemResponse, SystemResult as SystemRes};
 pub use query::{QueryResponse, QueryResult};
 pub use system_result::SystemResult;

--- a/packages/std/src/results/mod.rs
+++ b/packages/std/src/results/mod.rs
@@ -8,8 +8,8 @@ mod handle;
 mod init;
 mod migrate;
 mod query;
-mod system_result;
 mod system;
+mod system_result;
 
 pub use attribute::{attr, Attribute};
 pub use context::Context;
@@ -18,6 +18,6 @@ pub use cosmos_msg::{BankMsg, CosmosMsg, StakingMsg, WasmMsg};
 pub use handle::{HandleResponse, HandleResult};
 pub use init::{InitResponse, InitResult};
 pub use migrate::{MigrateResponse, MigrateResult};
-pub use system::{SystemResponse, SystemResult as SystemRes};
 pub use query::{QueryResponse, QueryResult};
+pub use system::{SystemResponse, SystemResult as SystemRes};
 pub use system_result::SystemResult;

--- a/packages/std/src/results/system.rs
+++ b/packages/std/src/results/system.rs
@@ -19,7 +19,7 @@ pub struct SystemResponse<T = Empty>
     pub attributes: Vec<Attribute>,
     pub data: Option<Binary>,
 }
-impl<T> Default for SystemResponse {
+impl<T> Default for SystemResponse<T> {
     fn default() -> Self {
         SystemResponse {
             messages: vec![],

--- a/packages/std/src/results/system.rs
+++ b/packages/std/src/results/system.rs
@@ -9,6 +9,7 @@ use crate::types::Empty;
 use super::attribute::Attribute;
 use super::cosmos_msg::CosmosMsg;
 
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct SystemResponse<T = Empty>
     where
         T: Clone + fmt::Debug + PartialEq + JsonSchema,

--- a/packages/std/src/results/system.rs
+++ b/packages/std/src/results/system.rs
@@ -19,7 +19,10 @@ pub struct SystemResponse<T = Empty>
     pub attributes: Vec<Attribute>,
     pub data: Option<Binary>,
 }
-impl<T> Default for SystemResponse<T> {
+impl<T> Default for SystemResponse<T>
+    where
+        T: Clone + fmt::Debug + PartialEq + JsonSchema,
+{
     fn default() -> Self {
         SystemResponse {
             messages: vec![],

--- a/packages/std/src/results/system.rs
+++ b/packages/std/src/results/system.rs
@@ -11,8 +11,8 @@ use super::cosmos_msg::CosmosMsg;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct SystemResponse<T = Empty>
-    where
-        T: Clone + fmt::Debug + PartialEq + JsonSchema,
+where
+    T: Clone + fmt::Debug + PartialEq + JsonSchema,
 {
     pub messages: Vec<CosmosMsg<T>>,
     /// The attributes that will be emitted as part of a "wasm" event
@@ -20,8 +20,8 @@ pub struct SystemResponse<T = Empty>
     pub data: Option<Binary>,
 }
 impl<T> Default for SystemResponse<T>
-    where
-        T: Clone + fmt::Debug + PartialEq + JsonSchema,
+where
+    T: Clone + fmt::Debug + PartialEq + JsonSchema,
 {
     fn default() -> Self {
         SystemResponse {

--- a/packages/std/src/results/system.rs
+++ b/packages/std/src/results/system.rs
@@ -1,0 +1,31 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+use crate::binary::Binary;
+use crate::errors::StdError;
+use crate::types::Empty;
+
+use super::attribute::Attribute;
+use super::cosmos_msg::CosmosMsg;
+
+pub struct SystemResponse<T = Empty>
+    where
+        T: Clone + fmt::Debug + PartialEq + JsonSchema,
+{
+    pub messages: Vec<CosmosMsg<T>>,
+    /// The attributes that will be emitted as part of a "wasm" event
+    pub attributes: Vec<Attribute>,
+    pub data: Option<Binary>,
+}
+impl<T> Default for SystemResponse {
+    fn default() -> Self {
+        SystemResponse {
+            messages: vec![],
+            attributes: vec![],
+            data: None,
+        }
+    }
+}
+
+pub type SystemResult<U = Empty> = Result<SystemResponse<U>, StdError>;


### PR DESCRIPTION
issue: #674 

- This is a Pull request with respect to issue: #674. Added system functionality along with the migrate. So that both old and new models can use the migrate functionality. 
- Did not remove the `_info: MessageInfo` parameter for `pub fn system()`. Changed the `SystemMsg` from `InitMsg` like `struct` to `HandleMsg` like `enum`. 
- using `match` While assigning the `MigrateMsg.verifier` to `config.verifier` in `pub fn system`. 
- Created a new file called `system.rs` in `packages/src/results/` mod in order to provide return value. `StdResult<SystemResponse>`. 

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see CONTRIBUTING.md)
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the module structure standards.
- [ ] Wrote unit and integration tests
- [ ] Updated relevant documentation (docs/) or specification (x/<module>/spec/)
- [ ] Added relevant godoc comments.
- [ ] Added a relevant changelog entry to the Unreleased section in CHANGELOG.md
- [ ] Re-reviewed Files changed in the Github PR explorer
- [ ] Review Codecov Report in the comment section below once CI passes
Please review this PR @ethanfrey 

