### PR TITLE
Improve module versioning code

### DIFF
--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -135,6 +135,10 @@ where
         }
 
         // Re-compile module from wasm
+        //
+        // This is needed for chains that upgrade their node software in a way that changes the module
+        // serialization format. If you do not replay all transactions, previous calls of `save_wasm`
+        // stored the old module format.
         let wasm = self.load_wasm(checksum)?;
         self.stats.misses += 1;
         let module = compile_and_use(&wasm, options.memory_limit)?;


### PR DESCRIPTION
Closes #684

No functional change, but makes the code a bit more auditable.

In CosmWasm 0.12 the "./modules/v1" path component did not exist. Instead there was a backend sub-folder, i.e. "./modules/singlpass".