### PR TITLE
Add #[entry_point] macro attribute to generate entry points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## 0.13.1 (unreleased)
+
+**cosmwasm-std**
+
+- Add the new `#[entry_point]` macro attribute that serves as an alternative
+  implementation to `cosmwasm_std::create_entry_points!(contract)` and
+  `cosmwasm_std::create_entry_points_with_migration!(contract)`. Both ways are
+  supported in the 0.13 series.
+
 ## 0.13.0 (2020-01-06)
 
 **all**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,6 +165,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826"
 
 [[package]]
+name = "cosmwasm-derive"
+version = "0.13.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "cosmwasm-schema"
 version = "0.13.0"
 dependencies = [
@@ -178,6 +187,7 @@ version = "0.13.0"
 dependencies = [
  "base64",
  "chrono",
+ "cosmwasm-derive",
  "cosmwasm-schema",
  "schemars",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,6 +168,7 @@ checksum = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826"
 name = "cosmwasm-derive"
 version = "0.13.0"
 dependencies = [
+ "cosmwasm-std",
  "syn",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,6 @@ checksum = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826"
 name = "cosmwasm-derive"
 version = "0.13.0"
 dependencies = [
- "proc-macro2",
  "quote",
  "syn",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,6 @@ checksum = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826"
 name = "cosmwasm-derive"
 version = "0.13.0"
 dependencies = [
- "quote",
  "syn",
 ]
 

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -4,6 +4,79 @@ This guide explains what is needed to upgrade contracts when migrating over
 major releases of `cosmwasm`. Note that you can also view the
 [complete CHANGELOG](./CHANGELOG.md) to understand the differences.
 
+## 0.13 -> 0.14 (unreleased)
+
+- Update CosmWasm dependencies in Cargo.toml (skip the ones you don't use):
+
+  ```
+  [dependencies]
+  cosmwasm-std = "0.14.0"
+  cosmwasm-storage = "0.14.0"
+  # ...
+
+  [dev-dependencies]
+  cosmwasm-schema = "0.14.0"
+  cosmwasm-vm = "0.14.0"
+  # ...
+  ```
+
+- Use the new entry point system. From `lib.rs` remove
+
+  ```rust
+  #[cfg(target_arch = "wasm32")]
+  cosmwasm_std::create_entry_points!(contract);
+
+  // or
+
+  #[cfg(target_arch = "wasm32")]
+  cosmwasm_std::create_entry_points_with_migration!(contract);
+  ```
+
+  Then add the macro attribute `#[entry_point]` to your `contract.rs` as
+  follows:
+
+  ```rust
+  use cosmwasm_std::{entry_point, … };
+
+  // …
+
+  #[entry_point]
+  pub fn init(
+      _deps: DepsMut,
+      _env: Env,
+      _info: MessageInfo,
+      _msg: InitMsg,
+  ) -> StdResult<InitResponse> {
+      // …
+  }
+
+  #[entry_point]
+  pub fn handle(
+      _deps: DepsMut,
+      _env: Env,
+      _info: MessageInfo,
+      _msg: HandleMsg,
+  ) -> StdResult<HandleResponse> {
+      // …
+  }
+
+  // only if you have migrate
+  #[entry_point]
+  pub fn migrate(
+      deps: DepsMut,
+      env: Env,
+      _info: MessageInfo,
+      msg: MigrateMsg,
+  ) -> StdResult<MigrateResponse> {
+      // …
+  }
+
+  #[entry_point]
+  pub fn query(_deps: Deps, _env: Env, _msg: QueryMsg) -> StdResult<QueryResponse> {
+      // …
+  }
+  ```
+
 ## 0.12 -> 0.13
 
 - The minimum Rust supported version for 0.13 is 1.47.0.

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -41,3 +41,23 @@ docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
   cosmwasm/rust-optimizer:0.10.5 ./contracts/staking
 ```
+
+## Entry points
+
+The development contracts in this folder contain a variety of different entry
+points in order to demonstrate and test the flexibility we have.
+
+| Contract | Macro                                         | Has `query` | Has `migrate` |
+| -------- | --------------------------------------------- | ----------- | ------------- |
+| burner   | `#[entry_point]`                              | yes         | yes           |
+| hackatom | [`create_entry_points_with_migration!`][cepm] | yes         | yes           |
+| queue    | mixed<sup>1</sup>                             | yes         | yes           |
+| reflect  | [`create_entry_points!`][cep]                 | yes         | no            |
+| staking  | `#[entry_point]`                              | yes         | no            |
+
+<sup>1</sup> Because we can. Don't try this at home.
+
+[cepm]:
+  https://docs.rs/cosmwasm-std/0.13.0/cosmwasm_std/macro.create_entry_points_with_migration.html
+[cep]:
+  https://docs.rs/cosmwasm-std/0.13.0/cosmwasm_std/macro.create_entry_points.html

--- a/contracts/burner/Cargo.lock
+++ b/contracts/burner/Cargo.lock
@@ -114,6 +114,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826"
 
 [[package]]
+name = "cosmwasm-derive"
+version = "0.13.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "cosmwasm-schema"
 version = "0.13.0"
 dependencies = [
@@ -126,6 +135,7 @@ name = "cosmwasm-std"
 version = "0.13.0"
 dependencies = [
  "base64",
+ "cosmwasm-derive",
  "schemars",
  "serde",
  "serde-json-wasm",

--- a/contracts/burner/Cargo.lock
+++ b/contracts/burner/Cargo.lock
@@ -117,7 +117,6 @@ checksum = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826"
 name = "cosmwasm-derive"
 version = "0.13.0"
 dependencies = [
- "quote",
  "syn",
 ]
 

--- a/contracts/burner/Cargo.lock
+++ b/contracts/burner/Cargo.lock
@@ -117,7 +117,6 @@ checksum = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826"
 name = "cosmwasm-derive"
 version = "0.13.0"
 dependencies = [
- "proc-macro2",
  "quote",
  "syn",
 ]

--- a/contracts/burner/src/contract.rs
+++ b/contracts/burner/src/contract.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{
-    attr, BankMsg, Deps, DepsMut, Env, HandleResponse, InitResponse, MessageInfo, MigrateResponse,
-    Order, QueryResponse, StdError, StdResult,
+    attr, entry_point, BankMsg, Deps, DepsMut, Env, HandleResponse, InitResponse, MessageInfo,
+    MigrateResponse, Order, QueryResponse, StdError, StdResult,
 };
 
 use crate::msg::{HandleMsg, InitMsg, MigrateMsg, QueryMsg};
@@ -27,6 +27,7 @@ pub fn handle(
     ))
 }
 
+#[entry_point]
 pub fn migrate(
     deps: DepsMut,
     env: Env,

--- a/contracts/burner/src/contract.rs
+++ b/contracts/burner/src/contract.rs
@@ -5,6 +5,7 @@ use cosmwasm_std::{
 
 use crate::msg::{HandleMsg, InitMsg, MigrateMsg, QueryMsg};
 
+#[entry_point]
 pub fn init(
     _deps: DepsMut,
     _env: Env,
@@ -16,6 +17,7 @@ pub fn init(
     ))
 }
 
+#[entry_point]
 pub fn handle(
     _deps: DepsMut,
     _env: Env,
@@ -62,6 +64,7 @@ pub fn migrate(
     })
 }
 
+#[entry_point]
 pub fn query(_deps: Deps, _env: Env, _msg: QueryMsg) -> StdResult<QueryResponse> {
     Err(StdError::generic_err(
         "You can only use this contract for migrations",

--- a/contracts/burner/src/lib.rs
+++ b/contracts/burner/src/lib.rs
@@ -2,4 +2,4 @@ pub mod contract;
 pub mod msg;
 
 #[cfg(target_arch = "wasm32")]
-cosmwasm_std::create_entry_points_with_migration!(contract);
+cosmwasm_std::create_entry_points!(contract);

--- a/contracts/burner/src/lib.rs
+++ b/contracts/burner/src/lib.rs
@@ -1,5 +1,2 @@
 pub mod contract;
 pub mod msg;
-
-#[cfg(target_arch = "wasm32")]
-cosmwasm_std::create_entry_points!(contract);

--- a/contracts/hackatom/Cargo.lock
+++ b/contracts/hackatom/Cargo.lock
@@ -103,6 +103,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826"
 
 [[package]]
+name = "cosmwasm-derive"
+version = "0.13.0"
+dependencies = [
+ "syn",
+]
+
+[[package]]
 name = "cosmwasm-schema"
 version = "0.13.0"
 dependencies = [
@@ -115,6 +122,7 @@ name = "cosmwasm-std"
 version = "0.13.0"
 dependencies = [
  "base64",
+ "cosmwasm-derive",
  "schemars",
  "serde",
  "serde-json-wasm",

--- a/contracts/queue/Cargo.lock
+++ b/contracts/queue/Cargo.lock
@@ -103,6 +103,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826"
 
 [[package]]
+name = "cosmwasm-derive"
+version = "0.13.0"
+dependencies = [
+ "syn",
+]
+
+[[package]]
 name = "cosmwasm-schema"
 version = "0.13.0"
 dependencies = [
@@ -115,6 +122,7 @@ name = "cosmwasm-std"
 version = "0.13.0"
 dependencies = [
  "base64",
+ "cosmwasm-derive",
  "schemars",
  "serde",
  "serde-json-wasm",

--- a/contracts/queue/Cargo.toml
+++ b/contracts/queue/Cargo.toml
@@ -28,6 +28,8 @@ default = ["cranelift"]
 cranelift = ["cosmwasm-vm/cranelift"]
 # For quicker tests, cargo test --lib. for more explicit tests, cargo test --features=backtraces
 backtraces = ["cosmwasm-std/backtraces", "cosmwasm-vm/backtraces"]
+# this is to demonstrate conditional entry-points for cosmwasm-plus style
+library = []
 
 [dependencies]
 cosmwasm-std = { path = "../../packages/std", features = ["iterator"] }

--- a/contracts/queue/examples/schema.rs
+++ b/contracts/queue/examples/schema.rs
@@ -3,9 +3,8 @@ use std::fs::create_dir_all;
 
 use cosmwasm_schema::{export_schema, remove_schemas, schema_for};
 
-use queue::contract::{
-    CountResponse, HandleMsg, InitMsg, Item, ListResponse, QueryMsg, SumResponse,
-};
+use queue::contract::{CountResponse, HandleMsg, Item, ListResponse, QueryMsg, SumResponse};
+use queue::msg::{InitMsg, MigrateMsg};
 
 fn main() {
     let mut out_dir = current_dir().unwrap();
@@ -15,6 +14,7 @@ fn main() {
 
     export_schema(&schema_for!(InitMsg), &out_dir);
     export_schema(&schema_for!(HandleMsg), &out_dir);
+    export_schema(&schema_for!(MigrateMsg), &out_dir);
     export_schema(&schema_for!(QueryMsg), &out_dir);
     export_schema(&schema_for!(Item), &out_dir);
     export_schema(&schema_for!(CountResponse), &out_dir);

--- a/contracts/queue/schema/migrate_msg.json
+++ b/contracts/queue/schema/migrate_msg.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "MigrateMsg",
+  "type": "object"
+}

--- a/contracts/queue/src/contract.rs
+++ b/contracts/queue/src/contract.rs
@@ -124,7 +124,7 @@ fn handle_dequeue(deps: DepsMut) -> StdResult<HandleResponse> {
     }
 }
 
-#[entry_point]
+#[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(
     deps: DepsMut,
     _env: Env,

--- a/contracts/queue/src/contract.rs
+++ b/contracts/queue/src/contract.rs
@@ -4,8 +4,8 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use cosmwasm_std::{
-    from_slice, to_binary, to_vec, Binary, Deps, DepsMut, Env, HandleResponse, InitResponse,
-    MessageInfo, MigrateResponse, Order, QueryResponse, StdResult, Storage,
+    entry_point, from_slice, to_binary, to_vec, Binary, Deps, DepsMut, Env, HandleResponse,
+    InitResponse, MessageInfo, MigrateResponse, Order, QueryResponse, StdResult, Storage,
 };
 
 use crate::msg::{InitMsg, MigrateMsg};
@@ -124,6 +124,7 @@ fn handle_dequeue(deps: DepsMut) -> StdResult<HandleResponse> {
     }
 }
 
+#[entry_point]
 pub fn migrate(
     deps: DepsMut,
     _env: Env,

--- a/contracts/queue/src/lib.rs
+++ b/contracts/queue/src/lib.rs
@@ -2,4 +2,4 @@ pub mod contract;
 pub mod msg;
 
 #[cfg(target_arch = "wasm32")]
-cosmwasm_std::create_entry_points_with_migration!(contract);
+cosmwasm_std::create_entry_points!(contract);

--- a/contracts/queue/src/lib.rs
+++ b/contracts/queue/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod contract;
+pub mod msg;
 
 #[cfg(target_arch = "wasm32")]
-cosmwasm_std::create_entry_points!(contract);
+cosmwasm_std::create_entry_points_with_migration!(contract);

--- a/contracts/queue/src/msg.rs
+++ b/contracts/queue/src/msg.rs
@@ -1,0 +1,10 @@
+#![allow(clippy::field_reassign_with_default)] // see https://github.com/CosmWasm/cosmwasm/issues/685
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct InitMsg {}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct MigrateMsg {}

--- a/contracts/reflect/Cargo.lock
+++ b/contracts/reflect/Cargo.lock
@@ -103,6 +103,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826"
 
 [[package]]
+name = "cosmwasm-derive"
+version = "0.13.0"
+dependencies = [
+ "syn",
+]
+
+[[package]]
 name = "cosmwasm-schema"
 version = "0.13.0"
 dependencies = [
@@ -115,6 +122,7 @@ name = "cosmwasm-std"
 version = "0.13.0"
 dependencies = [
  "base64",
+ "cosmwasm-derive",
  "schemars",
  "serde",
  "serde-json-wasm",

--- a/contracts/staking/Cargo.lock
+++ b/contracts/staking/Cargo.lock
@@ -103,6 +103,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826"
 
 [[package]]
+name = "cosmwasm-derive"
+version = "0.13.0"
+dependencies = [
+ "syn",
+]
+
+[[package]]
 name = "cosmwasm-schema"
 version = "0.13.0"
 dependencies = [
@@ -115,6 +122,7 @@ name = "cosmwasm-std"
 version = "0.13.0"
 dependencies = [
  "base64",
+ "cosmwasm-derive",
  "schemars",
  "serde",
  "serde-json-wasm",

--- a/contracts/staking/src/contract.rs
+++ b/contracts/staking/src/contract.rs
@@ -1,7 +1,7 @@
 use cosmwasm_std::{
-    attr, coin, to_binary, BankMsg, Decimal, Deps, DepsMut, Env, HandleResponse, HumanAddr,
-    InitResponse, MessageInfo, QuerierWrapper, QueryResponse, StakingMsg, StdError, StdResult,
-    Uint128, WasmMsg,
+    attr, coin, entry_point, to_binary, BankMsg, Decimal, Deps, DepsMut, Env, HandleResponse,
+    HumanAddr, InitResponse, MessageInfo, QuerierWrapper, QueryResponse, StakingMsg, StdError,
+    StdResult, Uint128, WasmMsg,
 };
 
 use crate::errors::{StakingError, Unauthorized};
@@ -16,6 +16,7 @@ use crate::state::{
 
 const FALLBACK_RATIO: Decimal = Decimal::one();
 
+#[entry_point]
 pub fn init(deps: DepsMut, _env: Env, info: MessageInfo, msg: InitMsg) -> StdResult<InitResponse> {
     // ensure the validator is registered
     let vals = deps.querier.query_validators()?;
@@ -50,6 +51,7 @@ pub fn init(deps: DepsMut, _env: Env, info: MessageInfo, msg: InitMsg) -> StdRes
     Ok(InitResponse::default())
 }
 
+#[entry_point]
 pub fn handle(
     deps: DepsMut,
     env: Env,
@@ -372,6 +374,7 @@ pub fn _bond_all_tokens(
     Ok(res)
 }
 
+#[entry_point]
 pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<QueryResponse> {
     match msg {
         QueryMsg::TokenInfo {} => to_binary(&query_token_info(deps)?),

--- a/contracts/staking/src/lib.rs
+++ b/contracts/staking/src/lib.rs
@@ -2,6 +2,3 @@ pub mod contract;
 mod errors;
 pub mod msg;
 pub mod state;
-
-#[cfg(target_arch = "wasm32")]
-cosmwasm_std::create_entry_points!(contract);

--- a/packages/derive/Cargo.toml
+++ b/packages/derive/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "cosmwasm-derive"
+version = "0.13.0"
+authors = ["Simon Warta <webmaster128@users.noreply.github.com>"]
+edition = "2018"
+description = "Standard library for Wasm based smart contracts on Cosmos blockchains"
+repository = "https://github.com/CosmWasm/cosmwasm/tree/master/packages/std"
+license = "Apache-2.0"
+readme = "README.md"
+
+[lib]
+proc-macro = true
+
+[features]
+default = []
+
+[dependencies]
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = { version = "1.0", features = ["extra-traits"] }
+
+[dev-dependencies]

--- a/packages/derive/Cargo.toml
+++ b/packages/derive/Cargo.toml
@@ -18,3 +18,8 @@ default = []
 syn = { version = "1.0", features = ["full"] }
 
 [dev-dependencies]
+# Needed for testing docs
+# "What's even more fun, Cargo packages actually can have cyclic dependencies.
+# "(a package can have an indirect dev-dependency on itself)"
+# https://users.rust-lang.org/t/does-cargo-support-cyclic-dependencies/35666/3
+cosmwasm-std = { path = "../std" }

--- a/packages/derive/Cargo.toml
+++ b/packages/derive/Cargo.toml
@@ -3,8 +3,8 @@ name = "cosmwasm-derive"
 version = "0.13.0"
 authors = ["Simon Warta <webmaster128@users.noreply.github.com>"]
 edition = "2018"
-description = "Standard library for Wasm based smart contracts on Cosmos blockchains"
-repository = "https://github.com/CosmWasm/cosmwasm/tree/master/packages/std"
+description = "A package for auto-generated code used for CosmWasm contract development. This is shipped as part of cosmwasm-std. Do not use directly."
+repository = "https://github.com/CosmWasm/cosmwasm/tree/master/packages/derive"
 license = "Apache-2.0"
 readme = "README.md"
 

--- a/packages/derive/Cargo.toml
+++ b/packages/derive/Cargo.toml
@@ -15,8 +15,7 @@ proc-macro = true
 default = []
 
 [dependencies]
-proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "1.0", features = ["extra-traits"] }
+syn = { version = "1.0", features = ["full"] }
 
 [dev-dependencies]

--- a/packages/derive/Cargo.toml
+++ b/packages/derive/Cargo.toml
@@ -15,7 +15,6 @@ proc-macro = true
 default = []
 
 [dependencies]
-quote = "1.0"
 syn = { version = "1.0", features = ["full"] }
 
 [dev-dependencies]

--- a/packages/derive/README.md
+++ b/packages/derive/README.md
@@ -1,0 +1,13 @@
+# cosmwasm-derive
+
+[![cosmwasm-derive on crates.io](https://img.shields.io/crates/v/cosmwasm-derive.svg)](https://crates.io/crates/cosmwasm-derive)
+
+A package for auto-generated code used for CosmWasm contract development. This
+is shipped as part of cosmwasm-std. Do not use directly.
+
+## License
+
+This package is part of the cosmwasm repository, licensed under the Apache
+License 2.0 (see
+[NOTICE](https://github.com/CosmWasm/cosmwasm/blob/master/NOTICE) and
+[LICENSE](https://github.com/CosmWasm/cosmwasm/blob/master/LICENSE)).

--- a/packages/derive/src/lib.rs
+++ b/packages/derive/src/lib.rs
@@ -4,6 +4,57 @@ extern crate syn;
 use proc_macro::TokenStream;
 use std::str::FromStr;
 
+/// This attribute macro generates the boilerplate required to call into the
+/// contract-specific logic from the entry-points to the Wasm module.
+///
+/// It should be added to the contract's init, handle, migrate and query implementations
+/// like this:
+/// ```
+/// # use cosmwasm_std::{
+/// #     Storage, Api, Querier, DepsMut, Deps, entry_point, Env, StdError, MessageInfo,
+/// #     InitResponse, HandleResponse, QueryResponse,
+/// # };
+/// #
+/// # type InitMsg = ();
+/// # type HandleMsg = ();
+/// # type QueryMsg = ();
+///
+/// #[entry_point]
+/// pub fn init(
+///     deps: DepsMut,
+///     env: Env,
+///     info: MessageInfo,
+///     msg: InitMsg,
+/// ) -> Result<InitResponse, StdError> {
+/// #   Ok(Default::default())
+/// }
+///
+/// #[entry_point]
+/// pub fn handle(
+///     deps: DepsMut,
+///     env: Env,
+///     info: MessageInfo,
+///     msg: HandleMsg,
+/// ) -> Result<HandleResponse, StdError> {
+/// #   Ok(Default::default())
+/// }
+///
+/// #[entry_point]
+/// pub fn query(
+///     deps: Deps,
+///     env: Env,
+///     msg: QueryMsg,
+/// ) -> Result<QueryResponse, StdError> {
+/// #   Ok(Default::default())
+/// }
+/// ```
+///
+/// where `InitMsg`, `HandleMsg`, and `QueryMsg` are contract defined
+/// types that implement `DeserializeOwned + JsonSchema`.
+///
+/// This is an alternative implementation of `cosmwasm_std::create_entry_points!(contract)`
+/// and `cosmwasm_std::create_entry_points_with_migration!(contract)`
+/// and should not be used together.
 #[proc_macro_attribute]
 pub fn entry_point(_attr: TokenStream, mut item: TokenStream) -> TokenStream {
     let cloned = item.clone();

--- a/packages/derive/src/lib.rs
+++ b/packages/derive/src/lib.rs
@@ -63,10 +63,10 @@ pub fn entry_point(_attr: TokenStream, mut item: TokenStream) -> TokenStream {
     // The first argument is `deps`, the rest is region pointers
     let args = function.sig.inputs.len() - 1;
 
-    // E.g. "ptr0: u32, ptr1: u32, ptr2: u32,"
-    let typed_ptrs = (0..args).fold(String::new(), |acc, i| format!("{}ptr{}: u32,", acc, i));
-    // E.g. "ptr0, ptr1, ptr2,"
-    let ptrs = (0..args).fold(String::new(), |acc, i| format!("{}ptr{},", acc, i));
+    // E.g. "ptr0: u32, ptr1: u32, ptr2: u32, "
+    let typed_ptrs = (0..args).fold(String::new(), |acc, i| format!("{}ptr{}: u32, ", acc, i));
+    // E.g. "ptr0, ptr1, ptr2, "
+    let ptrs = (0..args).fold(String::new(), |acc, i| format!("{}ptr{}, ", acc, i));
 
     let new_code = format!(
         r##"

--- a/packages/derive/src/lib.rs
+++ b/packages/derive/src/lib.rs
@@ -1,6 +1,4 @@
 #[macro_use]
-extern crate quote;
-#[macro_use]
 extern crate syn;
 
 use proc_macro::TokenStream;
@@ -8,11 +6,9 @@ use std::str::FromStr;
 
 #[proc_macro_attribute]
 pub fn entry_point(_attr: TokenStream, mut item: TokenStream) -> TokenStream {
-    //println!("attr: \"{}\"", attr.to_string());    //println!("item: \"{}\"", item.to_string());
     let cloned = item.clone();
     let function = parse_macro_input!(cloned as syn::ItemFn);
-    let name = format_ident!("{}", &function.sig.ident);
-    // println!("name: \"{}\"", &name);
+    let name = function.sig.ident.to_string();
 
     let new_code = format!(
         r##"

--- a/packages/derive/src/lib.rs
+++ b/packages/derive/src/lib.rs
@@ -1,0 +1,27 @@
+#[macro_use]
+extern crate quote;
+#[macro_use]
+extern crate syn;
+
+use proc_macro::TokenStream;
+use proc_macro2;
+
+#[proc_macro_attribute]
+pub fn entry_point(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let cloned = item.clone();
+    let ast = parse_macro_input!(cloned as syn::DeriveInput);
+    let export_name = format_ident!("{}", &ast.ident);
+    let export_impl = format_ident!("{}", &ast.ident);
+
+    let item: proc_macro2::TokenStream = item.into();
+
+    let gen = quote! {
+        #item
+
+        #[no_mangle]
+        extern "C" fn hahaha_#export_name(env_ptr: u32, info_ptr: u32, msg_ptr: u32) -> u32 {
+            do_migrate(&#export_impl, env_ptr, info_ptr, msg_ptr)
+        }
+    };
+    gen.into()
+}

--- a/packages/derive/src/lib.rs
+++ b/packages/derive/src/lib.rs
@@ -9,18 +9,27 @@ pub fn entry_point(_attr: TokenStream, mut item: TokenStream) -> TokenStream {
     let cloned = item.clone();
     let function = parse_macro_input!(cloned as syn::ItemFn);
     let name = function.sig.ident.to_string();
+    // The first argument is `deps`, the rest is region pointers
+    let args = function.sig.inputs.len() - 1;
+
+    // E.g. "ptr0: u32, ptr1: u32, ptr2: u32,"
+    let typed_ptrs = (0..args).fold(String::new(), |acc, i| format!("{}ptr{}: u32,", acc, i));
+    // E.g. "ptr0, ptr1, ptr2,"
+    let ptrs = (0..args).fold(String::new(), |acc, i| format!("{}ptr{},", acc, i));
 
     let new_code = format!(
         r##"
         #[cfg(target_arch = "wasm32")]
         mod __wasm_export_{name} {{ // new module to avoid conflict of function name
             #[no_mangle]
-            extern "C" fn {name}(env_ptr: u32, info_ptr: u32, msg_ptr: u32) -> u32 {{
-                cosmwasm_std::do_{name}(&super::{name}, env_ptr, info_ptr, msg_ptr)
+            extern "C" fn {name}({typed_ptrs}) -> u32 {{
+                cosmwasm_std::do_{name}(&super::{name}, {ptrs})
             }}
         }}
     "##,
         name = name,
+        typed_ptrs = typed_ptrs,
+        ptrs = ptrs
     );
     let entry = TokenStream::from_str(&new_code).unwrap();
     item.extend(entry);

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -30,6 +30,7 @@ backtraces = []
 
 [dependencies]
 base64 = "0.13.0"
+cosmwasm-derive = { path = "../derive", version = "0.13.0" }
 serde-json-wasm = { version = "0.2.1" }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive", "alloc"] }

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -70,3 +70,8 @@ pub mod testing {
         MockStorage, StakingQuerier, MOCK_CONTRACT_ADDR,
     };
 }
+
+// Re-exports
+
+extern crate cosmwasm_derive;
+pub use cosmwasm_derive::entry_point;

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -73,5 +73,4 @@ pub mod testing {
 
 // Re-exports
 
-extern crate cosmwasm_derive;
 pub use cosmwasm_derive::entry_point;


### PR DESCRIPTION
Closes #698

## Generated code before

via `cosmwasm_std::create_entry_points!(contract)`:

```rust
mod wasm {
    use super::contract;
    use cosmwasm_std::{do_handle, do_init, do_migrate, do_query};
    #[no_mangle]
    extern "C" fn init(env_ptr: u32, info_ptr: u32, msg_ptr: u32) -> u32 {
        do_init(&contract::init, env_ptr, info_ptr, msg_ptr)
    }
    #[no_mangle]
    extern "C" fn handle(env_ptr: u32, info_ptr: u32, msg_ptr: u32) -> u32 {
        do_handle(&contract::handle, env_ptr, info_ptr, msg_ptr)
    }
    #[no_mangle]
    extern "C" fn query(env_ptr: u32, msg_ptr: u32) -> u32 {
        do_query(&contract::query, env_ptr, msg_ptr)
    }
}
```

## Generated code after

Via `#[entry_point]`:

```rust

    #[cfg(target_arch = "wasm32")]
    mod __wasm_export_init {
        #[no_mangle]
        extern "C" fn init(ptr0: u32, ptr1: u32, ptr2: u32) -> u32 {
            cosmwasm_std::do_init(&super::init, ptr0, ptr1, ptr2)
        }
    }

    // ...

    #[cfg(target_arch = "wasm32")]
    mod __wasm_export_handle {
        #[no_mangle]
        extern "C" fn handle(ptr0: u32, ptr1: u32, ptr2: u32) -> u32 {
            cosmwasm_std::do_handle(&super::handle, ptr0, ptr1, ptr2)
        }
    }

    // ...
    
    #[cfg(target_arch = "wasm32")]
    mod __wasm_export_query {
        #[no_mangle]
        extern "C" fn query(ptr0: u32, ptr1: u32) -> u32 {
            cosmwasm_std::do_query(&super::query, ptr0, ptr1)
        }
    }
```
