### PR TITLE
Avoid InMemoryCache store/load serialization/deserialization

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,7 @@ workflows:
                 - master
                 - /^[0-9]+\.[0-9]+$/
                 # 👇 Add your branch here if benchmarking matters to your work
+                - memory-cache-avoid-serialization
                 - benchmarking
                 - update-wasmer
                 - metering-restart

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,6 @@ workflows:
                 - master
                 - /^[0-9]+\.[0-9]+$/
                 # 👇 Add your branch here if benchmarking matters to your work
-                - memory-cache-avoid-serialization
                 - benchmarking
                 - update-wasmer
                 - metering-restart

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@
 - Remove `from_address` from `BankMsg::Send`, as it always sends from the
   contract address, and this is consistent with other `CosmosMsg` variants.
 
+**cosmwasm-vm**
+
+- Avoid serialization of Modules in `InMemoryCache`, for performance. (#697)
+
+  Also, remove `memory_limit` from `InstanceOptions`, and define it instead at
+  `Cache` level (same memory limit for all cached instances).
+
 ## 0.13.1 (2020-01-12)
 
 **cosmwasm-std**

--- a/contracts/reflect/tests/integration.rs
+++ b/contracts/reflect/tests/integration.rs
@@ -176,7 +176,8 @@ fn dispatch_custom_query() {
     // stub gives us defaults. Consume it and override...
     let custom = mock_dependencies_with_custom_querier(&[]);
     // we cannot use mock_instance, so we just copy and modify code from cosmwasm_vm::testing
-    let mut deps = Instance::from_code(WASM, custom, mock_instance_options()).unwrap();
+    let (instance_options, memory_limit) = mock_instance_options();
+    let mut deps = Instance::from_code(WASM, custom, instance_options, memory_limit).unwrap();
 
     // we don't even initialize, just trigger a query
     let res = query(

--- a/contracts/staking/tests/integration.rs
+++ b/contracts/staking/tests/integration.rs
@@ -47,7 +47,8 @@ fn initialization_with_missing_validator() {
     backend
         .querier
         .update_staking("ustake", &[sample_validator("john")], &[]);
-    let mut deps = Instance::from_code(WASM, backend, mock_instance_options()).unwrap();
+    let (instance_options, memory_limit) = mock_instance_options();
+    let mut deps = Instance::from_code(WASM, backend, instance_options, memory_limit).unwrap();
 
     let creator = HumanAddr::from("creator");
     let msg = InitMsg {
@@ -82,7 +83,8 @@ fn proper_initialization() {
         ],
         &[],
     );
-    let mut deps = Instance::from_code(WASM, backend, mock_instance_options()).unwrap();
+    let (instance_options, memory_limit) = mock_instance_options();
+    let mut deps = Instance::from_code(WASM, backend, instance_options, memory_limit).unwrap();
     assert_eq!(deps.required_features.len(), 1);
     assert!(deps.required_features.contains("staking"));
 

--- a/packages/vm/benches/main.rs
+++ b/packages/vm/benches/main.rs
@@ -87,7 +87,7 @@ fn bench_cache(c: &mut Criterion) {
         base_dir: TempDir::new().unwrap().into_path(),
         supported_features: features_from_csv("staking"),
         memory_cache_size: MEMORY_CACHE_SIZE,
-        memory_instances_limit: DEFAULT_MEMORY_LIMIT,
+        instance_memory_limit: DEFAULT_MEMORY_LIMIT,
     };
 
     group.bench_function("save wasm", |b| {
@@ -105,7 +105,7 @@ fn bench_cache(c: &mut Criterion) {
             base_dir: TempDir::new().unwrap().into_path(),
             supported_features: features_from_csv("staking"),
             memory_cache_size: Size(0),
-            memory_instances_limit: DEFAULT_MEMORY_LIMIT,
+            instance_memory_limit: DEFAULT_MEMORY_LIMIT,
         };
         let mut cache: Cache<MockApi, MockStorage, MockQuerier> =
             unsafe { Cache::new(non_memcache).unwrap() };

--- a/packages/vm/benches/main.rs
+++ b/packages/vm/benches/main.rs
@@ -17,7 +17,6 @@ const DEFAULT_GAS_LIMIT: u64 = 400_000;
 const DEFAULT_INSTANCE_OPTIONS: InstanceOptions = InstanceOptions {
     gas_limit: DEFAULT_GAS_LIMIT,
     print_debug: false,
-    memory_limit: DEFAULT_MEMORY_LIMIT,
 };
 // Cache
 const MEMORY_CACHE_SIZE: Size = Size::mebi(200);
@@ -30,8 +29,9 @@ fn bench_instance(c: &mut Criterion) {
     group.bench_function("compile and instantiate", |b| {
         b.iter(|| {
             let backend = mock_backend(&[]);
+            let (instance_options, memory_limit) = mock_instance_options();
             let _instance =
-                Instance::from_code(CONTRACT, backend, mock_instance_options()).unwrap();
+                Instance::from_code(CONTRACT, backend, instance_options, memory_limit).unwrap();
         });
     });
 
@@ -41,7 +41,8 @@ fn bench_instance(c: &mut Criterion) {
             gas_limit: 500_000_000_000,
             ..DEFAULT_INSTANCE_OPTIONS
         };
-        let mut instance = Instance::from_code(CONTRACT, backend, much_gas).unwrap();
+        let mut instance =
+            Instance::from_code(CONTRACT, backend, much_gas, DEFAULT_MEMORY_LIMIT).unwrap();
 
         b.iter(|| {
             let info = mock_info("creator", &coins(1000, "earth"));
@@ -58,7 +59,8 @@ fn bench_instance(c: &mut Criterion) {
             gas_limit: 500_000_000_000,
             ..DEFAULT_INSTANCE_OPTIONS
         };
-        let mut instance = Instance::from_code(CONTRACT, backend, much_gas).unwrap();
+        let mut instance =
+            Instance::from_code(CONTRACT, backend, much_gas, DEFAULT_MEMORY_LIMIT).unwrap();
 
         let info = mock_info("creator", &coins(1000, "earth"));
         let msg = br#"{"verifier": "verifies", "beneficiary": "benefits"}"#;
@@ -85,6 +87,7 @@ fn bench_cache(c: &mut Criterion) {
         base_dir: TempDir::new().unwrap().into_path(),
         supported_features: features_from_csv("staking"),
         memory_cache_size: MEMORY_CACHE_SIZE,
+        memory_instances_limit: DEFAULT_MEMORY_LIMIT,
     };
 
     group.bench_function("save wasm", |b| {
@@ -102,6 +105,7 @@ fn bench_cache(c: &mut Criterion) {
             base_dir: TempDir::new().unwrap().into_path(),
             supported_features: features_from_csv("staking"),
             memory_cache_size: Size(0),
+            memory_instances_limit: DEFAULT_MEMORY_LIMIT,
         };
         let mut cache: Cache<MockApi, MockStorage, MockQuerier> =
             unsafe { Cache::new(non_memcache).unwrap() };

--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -28,11 +28,17 @@ pub struct CacheOptions {
     pub base_dir: PathBuf,
     pub supported_features: HashSet<String>,
     pub memory_cache_size: Size,
+    /// Memory limit for instances, in bytes. Use a value that is divisible by the Wasm page size 65536,
+    /// e.g. full MiBs.
+    pub memory_instances_limit: Size,
 }
 
 pub struct Cache<A: Api, S: Storage, Q: Querier> {
     wasm_path: PathBuf,
     supported_features: HashSet<String>,
+    /// Instances memory limit in bytes. Use a value that is divisible by the Wasm page size 65536,
+    /// e.g. full MiBs.
+    instance_memory_limit: Size,
     memory_cache: InMemoryCache,
     fs_cache: FileSystemCache,
     stats: Stats,
@@ -56,12 +62,13 @@ where
     ///
     /// This function is marked unsafe due to `FileSystemCache::new`, which implicitly
     /// assumes the disk contents are correct, and there's no way to ensure the artifacts
-    //  stored in the cache haven't been corrupted or tampered with.
+    /// stored in the cache haven't been corrupted or tampered with.
     pub unsafe fn new(options: CacheOptions) -> VmResult<Self> {
         let CacheOptions {
             base_dir,
             supported_features,
             memory_cache_size,
+            memory_instances_limit: instance_memory_limit,
         } = options;
         let wasm_path = base_dir.join(WASM_DIR);
         create_dir_all(&wasm_path)
@@ -72,6 +79,7 @@ where
         Ok(Cache {
             wasm_path,
             supported_features,
+            instance_memory_limit,
             memory_cache: InMemoryCache::new(memory_cache_size),
             fs_cache,
             stats: Stats::default(),
@@ -125,7 +133,7 @@ where
         }
 
         // Get module from file system cache
-        let store = make_runtime_store(options.memory_limit);
+        let store = make_runtime_store(self.instance_memory_limit);
         if let Some(module) = self.fs_cache.load(checksum, &store)? {
             self.stats.hits_fs_cache += 1;
             let instance =
@@ -141,7 +149,7 @@ where
         // stored the old module format.
         let wasm = self.load_wasm(checksum)?;
         self.stats.misses += 1;
-        let module = compile_and_use(&wasm, options.memory_limit)?;
+        let module = compile_and_use(&wasm, self.instance_memory_limit)?;
         let instance =
             Instance::from_module(&module, backend, options.gas_limit, options.print_debug)?;
         self.fs_cache.store(checksum, &module)?;
@@ -201,7 +209,6 @@ mod tests {
     const TESTING_MEMORY_LIMIT: Size = Size::mebi(16);
     const TESTING_OPTIONS: InstanceOptions = InstanceOptions {
         gas_limit: TESTING_GAS_LIMIT,
-        memory_limit: TESTING_MEMORY_LIMIT,
         print_debug: false,
     };
     const TESTING_MEMORY_CACHE_SIZE: Size = Size::mebi(200);
@@ -217,6 +224,7 @@ mod tests {
             base_dir: TempDir::new().unwrap().into_path(),
             supported_features: default_features(),
             memory_cache_size: TESTING_MEMORY_CACHE_SIZE,
+            memory_instances_limit: TESTING_MEMORY_LIMIT,
         }
     }
 
@@ -298,6 +306,7 @@ mod tests {
                 base_dir: tmp_dir.path().to_path_buf(),
                 supported_features: default_features(),
                 memory_cache_size: TESTING_MEMORY_CACHE_SIZE,
+                memory_instances_limit: TESTING_MEMORY_LIMIT,
             };
             let mut cache1: Cache<MockApi, MockStorage, MockQuerier> =
                 unsafe { Cache::new(options1).unwrap() };
@@ -309,6 +318,7 @@ mod tests {
                 base_dir: tmp_dir.path().to_path_buf(),
                 supported_features: default_features(),
                 memory_cache_size: TESTING_MEMORY_CACHE_SIZE,
+                memory_instances_limit: TESTING_MEMORY_LIMIT,
             };
             let cache2: Cache<MockApi, MockStorage, MockQuerier> =
                 unsafe { Cache::new(options2).unwrap() };
@@ -342,6 +352,7 @@ mod tests {
             base_dir: tmp_dir.path().to_path_buf(),
             supported_features: default_features(),
             memory_cache_size: TESTING_MEMORY_CACHE_SIZE,
+            memory_instances_limit: TESTING_MEMORY_LIMIT,
         };
         let mut cache: Cache<MockApi, MockStorage, MockQuerier> =
             unsafe { Cache::new(options).unwrap() };
@@ -582,7 +593,6 @@ mod tests {
         // Init from module cache
         let options = InstanceOptions {
             gas_limit: 10,
-            memory_limit: TESTING_MEMORY_LIMIT,
             print_debug: false,
         };
         let mut instance1 = cache.get_instance(&id, backend1, options).unwrap();
@@ -601,7 +611,6 @@ mod tests {
         // Init from memory cache
         let options = InstanceOptions {
             gas_limit: TESTING_GAS_LIMIT,
-            memory_limit: TESTING_MEMORY_LIMIT,
             print_debug: false,
         };
         let mut instance2 = cache.get_instance(&id, backend2, options).unwrap();

--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -30,7 +30,7 @@ pub struct CacheOptions {
     pub memory_cache_size: Size,
     /// Memory limit for instances, in bytes. Use a value that is divisible by the Wasm page size 65536,
     /// e.g. full MiBs.
-    pub memory_instances_limit: Size,
+    pub instance_memory_limit: Size,
 }
 
 pub struct Cache<A: Api, S: Storage, Q: Querier> {
@@ -68,7 +68,7 @@ where
             base_dir,
             supported_features,
             memory_cache_size,
-            memory_instances_limit: instance_memory_limit,
+            instance_memory_limit,
         } = options;
         let wasm_path = base_dir.join(WASM_DIR);
         create_dir_all(&wasm_path)
@@ -224,7 +224,7 @@ mod tests {
             base_dir: TempDir::new().unwrap().into_path(),
             supported_features: default_features(),
             memory_cache_size: TESTING_MEMORY_CACHE_SIZE,
-            memory_instances_limit: TESTING_MEMORY_LIMIT,
+            instance_memory_limit: TESTING_MEMORY_LIMIT,
         }
     }
 
@@ -306,7 +306,7 @@ mod tests {
                 base_dir: tmp_dir.path().to_path_buf(),
                 supported_features: default_features(),
                 memory_cache_size: TESTING_MEMORY_CACHE_SIZE,
-                memory_instances_limit: TESTING_MEMORY_LIMIT,
+                instance_memory_limit: TESTING_MEMORY_LIMIT,
             };
             let mut cache1: Cache<MockApi, MockStorage, MockQuerier> =
                 unsafe { Cache::new(options1).unwrap() };
@@ -318,7 +318,7 @@ mod tests {
                 base_dir: tmp_dir.path().to_path_buf(),
                 supported_features: default_features(),
                 memory_cache_size: TESTING_MEMORY_CACHE_SIZE,
-                memory_instances_limit: TESTING_MEMORY_LIMIT,
+                instance_memory_limit: TESTING_MEMORY_LIMIT,
             };
             let cache2: Cache<MockApi, MockStorage, MockQuerier> =
                 unsafe { Cache::new(options2).unwrap() };
@@ -352,7 +352,7 @@ mod tests {
             base_dir: tmp_dir.path().to_path_buf(),
             supported_features: default_features(),
             memory_cache_size: TESTING_MEMORY_CACHE_SIZE,
-            memory_instances_limit: TESTING_MEMORY_LIMIT,
+            instance_memory_limit: TESTING_MEMORY_LIMIT,
         };
         let mut cache: Cache<MockApi, MockStorage, MockQuerier> =
             unsafe { Cache::new(options).unwrap() };

--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -116,9 +116,8 @@ where
         backend: Backend<A, S, Q>,
         options: InstanceOptions,
     ) -> VmResult<Instance<A, S, Q>> {
-        let store = make_runtime_store(options.memory_limit);
         // Get module from memory cache
-        if let Some(module) = self.memory_cache.load(checksum, &store)? {
+        if let Some(module) = self.memory_cache.load(checksum)? {
             self.stats.hits_memory_cache += 1;
             let instance =
                 Instance::from_module(&module, backend, options.gas_limit, options.print_debug)?;
@@ -126,6 +125,7 @@ where
         }
 
         // Get module from file system cache
+        let store = make_runtime_store(options.memory_limit);
         if let Some(module) = self.fs_cache.load(checksum, &store)? {
             self.stats.hits_fs_cache += 1;
             let instance =

--- a/packages/vm/src/modules/in_memory_cache.rs
+++ b/packages/vm/src/modules/in_memory_cache.rs
@@ -7,7 +7,7 @@ const ESTIMATED_MODULE_SIZE: Size = Size::mebi(10);
 
 /// An in-memory module cache
 pub struct InMemoryCache {
-    artifacts: CLruCache<Checksum, Module>,
+    modules: CLruCache<Checksum, Module>,
 }
 
 impl InMemoryCache {
@@ -15,19 +15,19 @@ impl InMemoryCache {
     pub fn new(size: Size) -> Self {
         let max_entries = size.0 / ESTIMATED_MODULE_SIZE.0;
         InMemoryCache {
-            artifacts: CLruCache::new(max_entries),
+            modules: CLruCache::new(max_entries),
         }
     }
 
     pub fn store(&mut self, checksum: &Checksum, module: Module) -> VmResult<()> {
-        self.artifacts.put(*checksum, module);
+        self.modules.put(*checksum, module);
         Ok(())
     }
 
     /// Looks up a module in the cache and takes its artifact and
     /// creates a new module from store and artifact.
     pub fn load(&mut self, checksum: &Checksum) -> VmResult<Option<Module>> {
-        match self.artifacts.get(checksum) {
+        match self.modules.get(checksum) {
             Some(module) => Ok(Some(module.clone())),
             None => Ok(None),
         }

--- a/packages/vm/src/testing/instance.rs
+++ b/packages/vm/src/testing/instance.rs
@@ -137,21 +137,23 @@ pub fn mock_instance_with_options(
         storage: MockStorage::default(),
         querier: MockQuerier::new(&balances),
     };
+    let memory_limit = options.memory_limit;
     let options = InstanceOptions {
         gas_limit: options.gas_limit,
-        memory_limit: options.memory_limit,
         print_debug: options.print_debug,
     };
-    Instance::from_code(wasm, backend, options).unwrap()
+    Instance::from_code(wasm, backend, options, memory_limit).unwrap()
 }
 
 /// Creates InstanceOptions for testing
-pub fn mock_instance_options() -> InstanceOptions {
-    InstanceOptions {
-        gas_limit: DEFAULT_GAS_LIMIT,
-        memory_limit: DEFAULT_MEMORY_LIMIT,
-        print_debug: DEFAULT_PRINT_DEBUG,
-    }
+pub fn mock_instance_options() -> (InstanceOptions, Size) {
+    (
+        InstanceOptions {
+            gas_limit: DEFAULT_GAS_LIMIT,
+            print_debug: DEFAULT_PRINT_DEBUG,
+        },
+        DEFAULT_MEMORY_LIMIT,
+    )
 }
 
 /// Runs a series of IO tests, hammering especially on allocate and deallocate.


### PR DESCRIPTION
Closes #697.

Simply storing the `Module` in the cache, and cloning it when loading.

@webmaster128, would this be enough? A `Module` is composed of a `Store` and an `Artifact`. All of these are ultimately wrapped into `Arc`s; so, I assume this simple strategy works.

~~Creating as Draft in case some modifications / extensions are needed.~~