### PR TITLE
Demo feature-flagging entry points as per cosmwasm-plus

### DIFF
--- a/contracts/queue/Cargo.toml
+++ b/contracts/queue/Cargo.toml
@@ -28,6 +28,8 @@ default = ["cranelift"]
 cranelift = ["cosmwasm-vm/cranelift"]
 # For quicker tests, cargo test --lib. for more explicit tests, cargo test --features=backtraces
 backtraces = ["cosmwasm-std/backtraces", "cosmwasm-vm/backtraces"]
+# this is to demonstrate conditional entry-points for cosmwasm-plus style
+library = []
 
 [dependencies]
 cosmwasm-std = { path = "../../packages/std", features = ["iterator"] }

--- a/contracts/queue/src/contract.rs
+++ b/contracts/queue/src/contract.rs
@@ -124,7 +124,7 @@ fn handle_dequeue(deps: DepsMut) -> StdResult<HandleResponse> {
     }
 }
 
-#[entry_point]
+#[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(
     deps: DepsMut,
     _env: Env,


### PR DESCRIPTION
Scratching my own itch here. This is how to allow a feature ("library") to disable the wasm entry_point generation. We use this heavily in cosmwasm-plus to allow one contract to import another.

Go to `contracts/queue` and run:

`cargo wasm && cargo test` and it will pass

`cargo wasm --features=library && cargo test` and it will fail one test as there is no migrate entry point

I am happy for a cleaner solution, but this works for now. Let's keep some approach documented in the code.