### PR TITLE
Clarify send msg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,7 @@
 **cosmwasm-std**
 
 - Remove `from_address` from `BankMsg::Send`, as it always sends from the
-  contract.
-- Create `BankMsg::SendFrom` with the `from_address` field to be used if the
-  underlying blockchain supports this with native tokens.
+  contract address, and this is consistent with other `CosmosMsg` variants.
 
 ## 0.13.0 (2020-01-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+**cosmwasm-std**
+
+- Remove `from_address` from `BankMsg::Send`, as it always sends from the
+  contract.
+- Create `BankMsg::SendFrom` with the `from_address` field to be used if the
+  underlying blockchain supports this with native tokens.
+
 ## 0.13.0 (2020-01-06)
 
 **all**

--- a/contracts/burner/src/contract.rs
+++ b/contracts/burner/src/contract.rs
@@ -47,7 +47,6 @@ pub fn migrate(
     // get balance and send all to recipient
     let balance = deps.querier.query_all_balances(&env.contract.address)?;
     let send = BankMsg::Send {
-        from_address: env.contract.address,
         to_address: msg.payout.clone(),
         amount: balance,
     };
@@ -70,7 +69,7 @@ pub fn query(_deps: Deps, _env: Env, _msg: QueryMsg) -> StdResult<QueryResponse>
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info, MOCK_CONTRACT_ADDR};
+    use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
     use cosmwasm_std::{coins, HumanAddr, StdError, Storage};
 
     #[test]
@@ -113,7 +112,6 @@ mod tests {
         assert_eq!(
             msg,
             &BankMsg::Send {
-                from_address: HumanAddr::from(MOCK_CONTRACT_ADDR),
                 to_address: payout,
                 amount: coins(123456, "gold"),
             }

--- a/contracts/burner/tests/integration.rs
+++ b/contracts/burner/tests/integration.rs
@@ -20,7 +20,7 @@
 use cosmwasm_std::{
     coins, BankMsg, ContractResult, HumanAddr, InitResponse, MigrateResponse, Order,
 };
-use cosmwasm_vm::testing::{init, migrate, mock_env, mock_info, mock_instance, MOCK_CONTRACT_ADDR};
+use cosmwasm_vm::testing::{init, migrate, mock_env, mock_info, mock_instance};
 
 use burner::msg::{InitMsg, MigrateMsg};
 use cosmwasm_vm::Storage;
@@ -74,7 +74,6 @@ fn migrate_cleans_up_data() {
     assert_eq!(
         msg,
         &BankMsg::Send {
-            from_address: HumanAddr::from(MOCK_CONTRACT_ADDR),
             to_address: payout,
             amount: coins(123456, "gold"),
         }

--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -160,7 +160,6 @@ fn do_release(deps: DepsMut, env: Env, info: MessageInfo) -> Result<HandleRespon
         ctx.add_attribute("action", "release");
         ctx.add_attribute("destination", &to_addr);
         ctx.add_message(BankMsg::Send {
-            from_address: env.contract.address,
             to_address: to_addr,
             amount: balance,
         });
@@ -491,7 +490,6 @@ mod tests {
         assert_eq!(
             msg,
             &BankMsg::Send {
-                from_address: HumanAddr::from(MOCK_CONTRACT_ADDR),
                 to_address: beneficiary,
                 amount: coins(1000, "earth"),
             }

--- a/contracts/hackatom/tests/integration.rs
+++ b/contracts/hackatom/tests/integration.rs
@@ -212,7 +212,6 @@ fn handle_release_works() {
     assert_eq!(
         msg,
         &BankMsg::Send {
-            from_address: HumanAddr::from(MOCK_CONTRACT_ADDR),
             to_address: beneficiary,
             amount: coins(1000, "earth"),
         }

--- a/contracts/reflect/schema/handle_msg.json
+++ b/contracts/reflect/schema/handle_msg.json
@@ -72,36 +72,6 @@
               }
             }
           }
-        },
-        {
-          "type": "object",
-          "required": [
-            "send_from"
-          ],
-          "properties": {
-            "send_from": {
-              "type": "object",
-              "required": [
-                "amount",
-                "from_address",
-                "to_address"
-              ],
-              "properties": {
-                "amount": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/Coin"
-                  }
-                },
-                "from_address": {
-                  "$ref": "#/definitions/HumanAddr"
-                },
-                "to_address": {
-                  "$ref": "#/definitions/HumanAddr"
-                }
-              }
-            }
-          }
         }
       ]
     },

--- a/contracts/reflect/schema/handle_msg.json
+++ b/contracts/reflect/schema/handle_msg.json
@@ -57,6 +57,32 @@
               "type": "object",
               "required": [
                 "amount",
+                "to_address"
+              ],
+              "properties": {
+                "amount": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Coin"
+                  }
+                },
+                "to_address": {
+                  "$ref": "#/definitions/HumanAddr"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "send_from"
+          ],
+          "properties": {
+            "send_from": {
+              "type": "object",
+              "required": [
+                "amount",
                 "from_address",
                 "to_address"
               ],

--- a/contracts/reflect/schema/handle_response_for__custom_msg.json
+++ b/contracts/reflect/schema/handle_response_for__custom_msg.json
@@ -75,36 +75,6 @@
               }
             }
           }
-        },
-        {
-          "type": "object",
-          "required": [
-            "send_from"
-          ],
-          "properties": {
-            "send_from": {
-              "type": "object",
-              "required": [
-                "amount",
-                "from_address",
-                "to_address"
-              ],
-              "properties": {
-                "amount": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/Coin"
-                  }
-                },
-                "from_address": {
-                  "$ref": "#/definitions/HumanAddr"
-                },
-                "to_address": {
-                  "$ref": "#/definitions/HumanAddr"
-                }
-              }
-            }
-          }
         }
       ]
     },

--- a/contracts/reflect/schema/handle_response_for__custom_msg.json
+++ b/contracts/reflect/schema/handle_response_for__custom_msg.json
@@ -60,6 +60,32 @@
               "type": "object",
               "required": [
                 "amount",
+                "to_address"
+              ],
+              "properties": {
+                "amount": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Coin"
+                  }
+                },
+                "to_address": {
+                  "$ref": "#/definitions/HumanAddr"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "send_from"
+          ],
+          "properties": {
+            "send_from": {
+              "type": "object",
+              "required": [
+                "amount",
                 "from_address",
                 "to_address"
               ],

--- a/contracts/reflect/src/contract.rs
+++ b/contracts/reflect/src/contract.rs
@@ -170,7 +170,6 @@ mod tests {
         let _res = init(deps.as_mut(), mock_env(), info, msg).unwrap();
 
         let payload = vec![BankMsg::Send {
-            from_address: HumanAddr::from(MOCK_CONTRACT_ADDR),
             to_address: HumanAddr::from("friend"),
             amount: coins(1, "token"),
         }
@@ -194,7 +193,6 @@ mod tests {
 
         // signer is not owner
         let payload = vec![BankMsg::Send {
-            from_address: HumanAddr::from(MOCK_CONTRACT_ADDR),
             to_address: HumanAddr::from("friend"),
             amount: coins(1, "token"),
         }
@@ -239,7 +237,6 @@ mod tests {
 
         let payload = vec![
             BankMsg::Send {
-                from_address: HumanAddr::from(MOCK_CONTRACT_ADDR),
                 to_address: HumanAddr::from("friend"),
                 amount: coins(1, "token"),
             }

--- a/contracts/reflect/tests/integration.rs
+++ b/contracts/reflect/tests/integration.rs
@@ -83,7 +83,6 @@ fn reflect() {
 
     let payload = vec![
         BankMsg::Send {
-            from_address: HumanAddr::from(MOCK_CONTRACT_ADDR),
             to_address: HumanAddr::from("friend"),
             amount: coins(1, "token"),
         }
@@ -117,7 +116,6 @@ fn reflect_requires_owner() {
 
     // signer is not owner
     let payload = vec![BankMsg::Send {
-        from_address: HumanAddr::from(MOCK_CONTRACT_ADDR),
         to_address: HumanAddr::from("friend"),
         amount: coins(1, "token"),
     }

--- a/contracts/staking/src/contract.rs
+++ b/contracts/staking/src/contract.rs
@@ -284,7 +284,6 @@ pub fn claim(deps: DepsMut, env: Env, info: MessageInfo) -> StdResult<HandleResp
     balance.amount = to_send;
     let res = HandleResponse {
         messages: vec![BankMsg::Send {
-            from_address: env.contract.address,
             to_address: info.sender.clone(),
             amount: vec![balance],
         }

--- a/packages/std/schema/cosmos_msg.json
+++ b/packages/std/schema/cosmos_msg.json
@@ -75,36 +75,6 @@
               }
             }
           }
-        },
-        {
-          "type": "object",
-          "required": [
-            "send_from"
-          ],
-          "properties": {
-            "send_from": {
-              "type": "object",
-              "required": [
-                "amount",
-                "from_address",
-                "to_address"
-              ],
-              "properties": {
-                "amount": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/Coin"
-                  }
-                },
-                "from_address": {
-                  "$ref": "#/definitions/HumanAddr"
-                },
-                "to_address": {
-                  "$ref": "#/definitions/HumanAddr"
-                }
-              }
-            }
-          }
         }
       ]
     },

--- a/packages/std/schema/cosmos_msg.json
+++ b/packages/std/schema/cosmos_msg.json
@@ -60,6 +60,32 @@
               "type": "object",
               "required": [
                 "amount",
+                "to_address"
+              ],
+              "properties": {
+                "amount": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Coin"
+                  }
+                },
+                "to_address": {
+                  "$ref": "#/definitions/HumanAddr"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "send_from"
+          ],
+          "properties": {
+            "send_from": {
+              "type": "object",
+              "required": [
+                "amount",
                 "from_address",
                 "to_address"
               ],

--- a/packages/std/src/coins.rs
+++ b/packages/std/src/coins.rs
@@ -31,7 +31,6 @@ impl Coin {
 ///
 /// let mut response: HandleResponse = Default::default();
 /// response.messages = vec![CosmosMsg::Bank(BankMsg::Send {
-///   from_address: env.contract.address,
 ///   to_address: info.sender,
 ///   amount: tip,
 /// })];
@@ -56,7 +55,6 @@ pub fn coins<S: Into<String>>(amount: u128, denom: S) -> Vec<Coin> {
 ///
 /// let mut response: HandleResponse = Default::default();
 /// response.messages = vec![CosmosMsg::Bank(BankMsg::Send {
-///     from_address: env.contract.address,
 ///     to_address: info.sender,
 ///     amount: tip,
 /// })];

--- a/packages/std/src/results/context.rs
+++ b/packages/std/src/results/context.rs
@@ -134,14 +134,12 @@ mod tests {
         ctx.add_attribute("sender", &HumanAddr::from("john"));
         ctx.add_attribute("action", "test");
         ctx.add_message(BankMsg::Send {
-            from_address: HumanAddr::from("goo"),
             to_address: HumanAddr::from("foo"),
             amount: coins(128, "uint"),
         });
 
         // and this is what is should return
         let expected_msgs = vec![CosmosMsg::Bank(BankMsg::Send {
-            from_address: HumanAddr::from("goo"),
             to_address: HumanAddr::from("foo"),
             amount: coins(128, "uint"),
         })];

--- a/packages/std/src/results/cosmos_msg.rs
+++ b/packages/std/src/results/cosmos_msg.rs
@@ -25,8 +25,13 @@ where
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum BankMsg {
-    // this moves tokens in the underlying sdk
+    // sends tokens from the contract in the underlying sdk
     Send {
+        to_address: HumanAddr,
+        amount: Vec<Coin>,
+    },
+    // contract sends tokens from another account in the underlying sdk
+    SendFrom {
         from_address: HumanAddr,
         to_address: HumanAddr,
         amount: Vec<Coin>,
@@ -108,14 +113,9 @@ mod tests {
 
     #[test]
     fn from_bank_msg_works() {
-        let from_address = HumanAddr::from("me");
         let to_address = HumanAddr::from("you");
         let amount = coins(1015, "earth");
-        let bank = BankMsg::Send {
-            from_address,
-            to_address,
-            amount,
-        };
+        let bank = BankMsg::Send { to_address, amount };
         let msg: CosmosMsg = bank.clone().into();
         match msg {
             CosmosMsg::Bank(msg) => assert_eq!(bank, msg),

--- a/packages/std/src/results/cosmos_msg.rs
+++ b/packages/std/src/results/cosmos_msg.rs
@@ -30,12 +30,6 @@ pub enum BankMsg {
         to_address: HumanAddr,
         amount: Vec<Coin>,
     },
-    // contract sends tokens from another account in the underlying sdk
-    SendFrom {
-        from_address: HumanAddr,
-        to_address: HumanAddr,
-        amount: Vec<Coin>,
-    },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/packages/std/src/results/init.rs
+++ b/packages/std/src/results/init.rs
@@ -48,7 +48,6 @@ mod tests {
     fn can_serialize_and_deserialize_init_response() {
         let original = InitResponse {
             messages: vec![BankMsg::Send {
-                from_address: HumanAddr::from("me"),
                 to_address: HumanAddr::from("you"),
                 amount: coins(1015, "earth"),
             }


### PR DESCRIPTION
A cleaner solution to #483 

The SDK team is working to add "subkeys", which will allow a "send from" like functionality, where we can send tokens from a different account than the contract. However, that will be a different message type.

Let's make this clear distinction in the CosmosMsg type.