### PR TITLE
Add stargate msg

### DIFF
--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -27,6 +27,9 @@ staking = []
 # at the cost of a bit of code size and performance.
 # This feature requires Rust nightly because it depends on the unstable backtrace feature.
 backtraces = []
+# stargate enables stargate-dependent messages and queries, like raw protobuf messages
+# as well as ibc-related functionality
+stargate = []
 
 [dependencies]
 base64 = "0.13.0"

--- a/packages/std/src/exports.rs
+++ b/packages/std/src/exports.rs
@@ -25,6 +25,10 @@ use crate::{Deps, DepsMut, MessageInfo};
 #[no_mangle]
 extern "C" fn requires_staking() -> () {}
 
+#[cfg(feature = "stargate")]
+#[no_mangle]
+extern "C" fn requires_stargate() -> () {}
+
 /// cosmwasm_vm_version_* exports mark which Wasm VM interface level this contract is compiled for.
 /// They can be checked by cosmwasm_vm.
 /// Update this whenever the Wasm VM interface breaks.

--- a/packages/std/src/query.rs
+++ b/packages/std/src/query.rs
@@ -13,8 +13,9 @@ pub enum QueryRequest<C: CustomQuery> {
     Bank(BankQuery),
     Custom(C),
     Staking(StakingQuery),
-    /// A Stargate message encoded the same way as a protobof [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto).
+    /// A Stargate query encoded the same way as abci_query, with path and protobuf encoded Data.
     /// The format is defined in [ADR-21](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-021-protobuf-query-encoding.md)
+    /// The response is also protobuf encoded. The caller is responsible for compiling the proper protobuf definitions
     #[cfg(feature = "stargate")]
     Stargate {
         /// this is the fully qualified service path used for routing,

--- a/packages/std/src/query.rs
+++ b/packages/std/src/query.rs
@@ -13,6 +13,16 @@ pub enum QueryRequest<C: CustomQuery> {
     Bank(BankQuery),
     Custom(C),
     Staking(StakingQuery),
+    /// A Stargate message encoded the same way as a protobof [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto).
+    /// The format is defined in [ADR-21](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-021-protobuf-query-encoding.md)
+    #[cfg(feature = "stargate")]
+    Stargate {
+        /// this is the fully qualified service path used for routing,
+        /// eg. custom/cosmos_sdk.x.bank.v1.Query/QueryBalance
+        path: String,
+        /// this is the expected protobuf message type (not any), binary encoded
+        data: Binary,
+    },
     Wasm(WasmQuery),
 }
 

--- a/packages/std/src/results/cosmos_msg.rs
+++ b/packages/std/src/results/cosmos_msg.rs
@@ -19,6 +19,15 @@ where
     // to call into more app-specific code (whatever they define)
     Custom(T),
     Staking(StakingMsg),
+    /// A Stargate message encoded the same way as a protobof [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto).
+    /// This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)
+    #[cfg(feature = "stargate")]
+    Stargate {
+        /// 'type' is a reserved keyword, so we need to use a serde rename
+        #[serde(rename = "type")]
+        kind: String,
+        data: Binary,
+    },
     Wasm(WasmMsg),
 }
 

--- a/packages/std/src/results/cosmos_msg.rs
+++ b/packages/std/src/results/cosmos_msg.rs
@@ -23,9 +23,7 @@ where
     /// This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)
     #[cfg(feature = "stargate")]
     Stargate {
-        /// 'type' is a reserved keyword, so we need to use a serde rename
-        #[serde(rename = "type")]
-        kind: String,
+        type_url: String,
         data: Binary,
     },
     Wasm(WasmMsg),


### PR DESCRIPTION
Closes #694 

Adds the message and the query types under a feature flag. And also add the proper requires export.

Contracts have it off by default and `cargo test --features stargate` passes in `cosmwasm-std`.

This is really just to pass info up to wasmd, and doesn't need test mocks (they would be too hard to build)