### PR TITLE
Document omitted "sender" fields for all message types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 0.14.0 (unreleased)
+
+**cosmwasm-std**
+
+- Remove `from_address` from `BankMsg::Send`, as it always sends from the
+  contract address, and this is consistent with other `CosmosMsg` variants.
+
 ## 0.13.1 (2020-01-12)
 
 **cosmwasm-std**

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -20,6 +20,24 @@ major releases of `cosmwasm`. Note that you can also view the
   # ...
   ```
 
+- Remove `from_address` from `BankMsg::Send`, which is now automatically filled
+  with the contract address:
+
+  ```rust
+  // before
+  ctx.add_message(BankMsg::Send {
+      from_address: env.contract.address,
+      to_address: to_addr,
+      amount: balance,
+  });
+
+  // after
+  ctx.add_message(BankMsg::Send {
+      to_address: to_addr,
+      amount: balance,
+  });
+  ```
+
 - Use the new entry point system. From `lib.rs` remove
 
   ```rust

--- a/contracts/burner/src/contract.rs
+++ b/contracts/burner/src/contract.rs
@@ -50,7 +50,6 @@ pub fn migrate(
     // get balance and send all to recipient
     let balance = deps.querier.query_all_balances(&env.contract.address)?;
     let send = BankMsg::Send {
-        from_address: env.contract.address,
         to_address: msg.payout.clone(),
         amount: balance,
     };
@@ -74,7 +73,7 @@ pub fn query(_deps: Deps, _env: Env, _msg: QueryMsg) -> StdResult<QueryResponse>
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info, MOCK_CONTRACT_ADDR};
+    use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
     use cosmwasm_std::{coins, HumanAddr, StdError, Storage};
 
     #[test]
@@ -117,7 +116,6 @@ mod tests {
         assert_eq!(
             msg,
             &BankMsg::Send {
-                from_address: HumanAddr::from(MOCK_CONTRACT_ADDR),
                 to_address: payout,
                 amount: coins(123456, "gold"),
             }

--- a/contracts/burner/tests/integration.rs
+++ b/contracts/burner/tests/integration.rs
@@ -20,7 +20,7 @@
 use cosmwasm_std::{
     coins, BankMsg, ContractResult, HumanAddr, InitResponse, MigrateResponse, Order,
 };
-use cosmwasm_vm::testing::{init, migrate, mock_env, mock_info, mock_instance, MOCK_CONTRACT_ADDR};
+use cosmwasm_vm::testing::{init, migrate, mock_env, mock_info, mock_instance};
 
 use burner::msg::{InitMsg, MigrateMsg};
 use cosmwasm_vm::Storage;
@@ -74,7 +74,6 @@ fn migrate_cleans_up_data() {
     assert_eq!(
         msg,
         &BankMsg::Send {
-            from_address: HumanAddr::from(MOCK_CONTRACT_ADDR),
             to_address: payout,
             amount: coins(123456, "gold"),
         }

--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -160,7 +160,6 @@ fn do_release(deps: DepsMut, env: Env, info: MessageInfo) -> Result<HandleRespon
         ctx.add_attribute("action", "release");
         ctx.add_attribute("destination", &to_addr);
         ctx.add_message(BankMsg::Send {
-            from_address: env.contract.address,
             to_address: to_addr,
             amount: balance,
         });
@@ -491,7 +490,6 @@ mod tests {
         assert_eq!(
             msg,
             &BankMsg::Send {
-                from_address: HumanAddr::from(MOCK_CONTRACT_ADDR),
                 to_address: beneficiary,
                 amount: coins(1000, "earth"),
             }

--- a/contracts/hackatom/tests/integration.rs
+++ b/contracts/hackatom/tests/integration.rs
@@ -212,7 +212,6 @@ fn handle_release_works() {
     assert_eq!(
         msg,
         &BankMsg::Send {
-            from_address: HumanAddr::from(MOCK_CONTRACT_ADDR),
             to_address: beneficiary,
             amount: coins(1000, "earth"),
         }

--- a/contracts/reflect/schema/handle_msg.json
+++ b/contracts/reflect/schema/handle_msg.json
@@ -46,8 +46,10 @@
   ],
   "definitions": {
     "BankMsg": {
+      "description": "The message types of the bank module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto",
       "anyOf": [
         {
+          "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "send"
@@ -173,8 +175,10 @@
       "type": "string"
     },
     "StakingMsg": {
+      "description": "The message types of the staking module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto",
       "anyOf": [
         {
+          "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "delegate"
@@ -198,6 +202,7 @@
           }
         },
         {
+          "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "undelegate"
@@ -221,6 +226,7 @@
           }
         },
         {
+          "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37) followed by a [MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "withdraw"
@@ -251,6 +257,7 @@
           }
         },
         {
+          "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "redelegate"
@@ -283,9 +290,10 @@
       "type": "string"
     },
     "WasmMsg": {
+      "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",
       "anyOf": [
         {
-          "description": "this dispatches a call to another contract at a known address (with known ABI)",
+          "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "execute"
@@ -321,7 +329,7 @@
           }
         },
         {
-          "description": "this instantiates a new contracts from previously uploaded wasm code",
+          "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L47-L61). `sender` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "instantiate"

--- a/contracts/reflect/schema/handle_msg.json
+++ b/contracts/reflect/schema/handle_msg.json
@@ -57,7 +57,6 @@
               "type": "object",
               "required": [
                 "amount",
-                "from_address",
                 "to_address"
               ],
               "properties": {
@@ -66,9 +65,6 @@
                   "items": {
                     "$ref": "#/definitions/Coin"
                   }
-                },
-                "from_address": {
-                  "$ref": "#/definitions/HumanAddr"
                 },
                 "to_address": {
                   "$ref": "#/definitions/HumanAddr"

--- a/contracts/reflect/schema/handle_response_for__custom_msg.json
+++ b/contracts/reflect/schema/handle_response_for__custom_msg.json
@@ -49,8 +49,10 @@
       }
     },
     "BankMsg": {
+      "description": "The message types of the bank module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto",
       "anyOf": [
         {
+          "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "send"
@@ -176,8 +178,10 @@
       "type": "string"
     },
     "StakingMsg": {
+      "description": "The message types of the staking module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto",
       "anyOf": [
         {
+          "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "delegate"
@@ -201,6 +205,7 @@
           }
         },
         {
+          "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "undelegate"
@@ -224,6 +229,7 @@
           }
         },
         {
+          "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37) followed by a [MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "withdraw"
@@ -254,6 +260,7 @@
           }
         },
         {
+          "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "redelegate"
@@ -286,9 +293,10 @@
       "type": "string"
     },
     "WasmMsg": {
+      "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",
       "anyOf": [
         {
-          "description": "this dispatches a call to another contract at a known address (with known ABI)",
+          "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "execute"
@@ -324,7 +332,7 @@
           }
         },
         {
-          "description": "this instantiates a new contracts from previously uploaded wasm code",
+          "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L47-L61). `sender` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "instantiate"

--- a/contracts/reflect/schema/handle_response_for__custom_msg.json
+++ b/contracts/reflect/schema/handle_response_for__custom_msg.json
@@ -60,7 +60,6 @@
               "type": "object",
               "required": [
                 "amount",
-                "from_address",
                 "to_address"
               ],
               "properties": {
@@ -69,9 +68,6 @@
                   "items": {
                     "$ref": "#/definitions/Coin"
                   }
-                },
-                "from_address": {
-                  "$ref": "#/definitions/HumanAddr"
                 },
                 "to_address": {
                   "$ref": "#/definitions/HumanAddr"

--- a/contracts/reflect/src/contract.rs
+++ b/contracts/reflect/src/contract.rs
@@ -170,7 +170,6 @@ mod tests {
         let _res = init(deps.as_mut(), mock_env(), info, msg).unwrap();
 
         let payload = vec![BankMsg::Send {
-            from_address: HumanAddr::from(MOCK_CONTRACT_ADDR),
             to_address: HumanAddr::from("friend"),
             amount: coins(1, "token"),
         }
@@ -194,7 +193,6 @@ mod tests {
 
         // signer is not owner
         let payload = vec![BankMsg::Send {
-            from_address: HumanAddr::from(MOCK_CONTRACT_ADDR),
             to_address: HumanAddr::from("friend"),
             amount: coins(1, "token"),
         }
@@ -239,7 +237,6 @@ mod tests {
 
         let payload = vec![
             BankMsg::Send {
-                from_address: HumanAddr::from(MOCK_CONTRACT_ADDR),
                 to_address: HumanAddr::from("friend"),
                 amount: coins(1, "token"),
             }

--- a/contracts/reflect/tests/integration.rs
+++ b/contracts/reflect/tests/integration.rs
@@ -83,7 +83,6 @@ fn reflect() {
 
     let payload = vec![
         BankMsg::Send {
-            from_address: HumanAddr::from(MOCK_CONTRACT_ADDR),
             to_address: HumanAddr::from("friend"),
             amount: coins(1, "token"),
         }
@@ -117,7 +116,6 @@ fn reflect_requires_owner() {
 
     // signer is not owner
     let payload = vec![BankMsg::Send {
-        from_address: HumanAddr::from(MOCK_CONTRACT_ADDR),
         to_address: HumanAddr::from("friend"),
         amount: coins(1, "token"),
     }

--- a/contracts/staking/src/contract.rs
+++ b/contracts/staking/src/contract.rs
@@ -286,7 +286,6 @@ pub fn claim(deps: DepsMut, env: Env, info: MessageInfo) -> StdResult<HandleResp
     balance.amount = to_send;
     let res = HandleResponse {
         messages: vec![BankMsg::Send {
-            from_address: env.contract.address,
             to_address: info.sender.clone(),
             amount: vec![balance],
         }

--- a/packages/std/schema/cosmos_msg.json
+++ b/packages/std/schema/cosmos_msg.json
@@ -49,8 +49,10 @@
   ],
   "definitions": {
     "BankMsg": {
+      "description": "The message types of the bank module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto",
       "anyOf": [
         {
+          "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "send"
@@ -105,8 +107,10 @@
       "type": "string"
     },
     "StakingMsg": {
+      "description": "The message types of the staking module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto",
       "anyOf": [
         {
+          "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "delegate"
@@ -130,6 +134,7 @@
           }
         },
         {
+          "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "undelegate"
@@ -153,6 +158,7 @@
           }
         },
         {
+          "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37) followed by a [MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "withdraw"
@@ -183,6 +189,7 @@
           }
         },
         {
+          "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "redelegate"
@@ -215,9 +222,10 @@
       "type": "string"
     },
     "WasmMsg": {
+      "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",
       "anyOf": [
         {
-          "description": "this dispatches a call to another contract at a known address (with known ABI)",
+          "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "execute"
@@ -253,7 +261,7 @@
           }
         },
         {
-          "description": "this instantiates a new contracts from previously uploaded wasm code",
+          "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L47-L61). `sender` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "instantiate"

--- a/packages/std/schema/cosmos_msg.json
+++ b/packages/std/schema/cosmos_msg.json
@@ -60,7 +60,6 @@
               "type": "object",
               "required": [
                 "amount",
-                "from_address",
                 "to_address"
               ],
               "properties": {
@@ -69,9 +68,6 @@
                   "items": {
                     "$ref": "#/definitions/Coin"
                   }
-                },
-                "from_address": {
-                  "$ref": "#/definitions/HumanAddr"
                 },
                 "to_address": {
                   "$ref": "#/definitions/HumanAddr"

--- a/packages/std/src/coins.rs
+++ b/packages/std/src/coins.rs
@@ -31,7 +31,6 @@ impl Coin {
 ///
 /// let mut response: HandleResponse = Default::default();
 /// response.messages = vec![CosmosMsg::Bank(BankMsg::Send {
-///   from_address: env.contract.address,
 ///   to_address: info.sender,
 ///   amount: tip,
 /// })];
@@ -56,7 +55,6 @@ pub fn coins<S: Into<String>>(amount: u128, denom: S) -> Vec<Coin> {
 ///
 /// let mut response: HandleResponse = Default::default();
 /// response.messages = vec![CosmosMsg::Bank(BankMsg::Send {
-///     from_address: env.contract.address,
 ///     to_address: info.sender,
 ///     amount: tip,
 /// })];

--- a/packages/std/src/results/context.rs
+++ b/packages/std/src/results/context.rs
@@ -134,14 +134,12 @@ mod tests {
         ctx.add_attribute("sender", &HumanAddr::from("john"));
         ctx.add_attribute("action", "test");
         ctx.add_message(BankMsg::Send {
-            from_address: HumanAddr::from("goo"),
             to_address: HumanAddr::from("foo"),
             amount: coins(128, "uint"),
         });
 
         // and this is what is should return
         let expected_msgs = vec![CosmosMsg::Bank(BankMsg::Send {
-            from_address: HumanAddr::from("goo"),
             to_address: HumanAddr::from("foo"),
             amount: coins(128, "uint"),
         })];

--- a/packages/std/src/results/cosmos_msg.rs
+++ b/packages/std/src/results/cosmos_msg.rs
@@ -25,9 +25,8 @@ where
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum BankMsg {
-    // this moves tokens in the underlying sdk
+    // sends tokens from the contract in the underlying sdk
     Send {
-        from_address: HumanAddr,
         to_address: HumanAddr,
         amount: Vec<Coin>,
     },
@@ -108,14 +107,9 @@ mod tests {
 
     #[test]
     fn from_bank_msg_works() {
-        let from_address = HumanAddr::from("me");
         let to_address = HumanAddr::from("you");
         let amount = coins(1015, "earth");
-        let bank = BankMsg::Send {
-            from_address,
-            to_address,
-            amount,
-        };
+        let bank = BankMsg::Send { to_address, amount };
         let msg: CosmosMsg = bank.clone().into();
         match msg {
             CosmosMsg::Bank(msg) => assert_eq!(bank, msg),

--- a/packages/std/src/results/cosmos_msg.rs
+++ b/packages/std/src/results/cosmos_msg.rs
@@ -22,55 +22,72 @@ where
     Wasm(WasmMsg),
 }
 
+/// The message types of the bank module.
+///
+/// See https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum BankMsg {
-    // sends tokens from the contract in the underlying sdk
+    /// Sends native tokens from the contract to the given address.
+    ///
+    /// This is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28).
+    /// `from_address` is automatically filled with the current contract's address.
     Send {
         to_address: HumanAddr,
         amount: Vec<Coin>,
     },
 }
 
+/// The message types of the staking module.
+///
+/// See https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum StakingMsg {
-    Delegate {
-        // delegator is automatically set to address of the calling contract
-        validator: HumanAddr,
-        amount: Coin,
-    },
-    Undelegate {
-        // delegator is automatically set to address of the calling contract
-        validator: HumanAddr,
-        amount: Coin,
-    },
+    /// This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90).
+    /// `delegator_address` is automatically filled with the current contract's address.
+    Delegate { validator: HumanAddr, amount: Coin },
+    /// This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121).
+    /// `delegator_address` is automatically filled with the current contract's address.
+    Undelegate { validator: HumanAddr, amount: Coin },
+    /// This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37)
+    /// followed by a [MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50).
+    /// `delegator_address` is automatically filled with the current contract's address.
     Withdraw {
-        // delegator is automatically set to address of the calling contract
         validator: HumanAddr,
         /// this is the "withdraw address", the one that should receive the rewards
         /// if None, then use delegator address
         recipient: Option<HumanAddr>,
     },
+    /// This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105).
+    /// `delegator_address` is automatically filled with the current contract's address.
     Redelegate {
-        // delegator is automatically set to address of the calling contract
         src_validator: HumanAddr,
         dst_validator: HumanAddr,
         amount: Coin,
     },
 }
 
+/// The message types of the wasm module.
+///
+/// See https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum WasmMsg {
-    /// this dispatches a call to another contract at a known address (with known ABI)
+    /// Dispatches a call to another contract at a known address (with known ABI).
+    ///
+    /// This is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78).
+    /// `sender` is automatically filled with the current contract's address.
     Execute {
         contract_addr: HumanAddr,
         /// msg is the json-encoded HandleMsg struct (as raw Binary)
         msg: Binary,
         send: Vec<Coin>,
     },
-    /// this instantiates a new contracts from previously uploaded wasm code
+    /// Instantiates a new contracts from previously uploaded Wasm code.
+    ///
+    /// This is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L47-L61).
+    /// `sender` is automatically filled with the current contract's address.
     Instantiate {
         code_id: u64,
         /// msg is the json-encoded InitMsg struct (as raw Binary)

--- a/packages/std/src/results/init.rs
+++ b/packages/std/src/results/init.rs
@@ -48,7 +48,6 @@ mod tests {
     fn can_serialize_and_deserialize_init_response() {
         let original = InitResponse {
             messages: vec![BankMsg::Send {
-                from_address: HumanAddr::from("me"),
                 to_address: HumanAddr::from("you"),
                 amount: coins(1015, "earth"),
             }


### PR DESCRIPTION
Closes #705

When looking into this, I'd also like to propose the following changes:

- Move `::Withdraw` into a new `DistributionMsg`
- Rename `send: Vec<Coin>` to `funds: Vec<Coin>` in execute and instantiate