### PR TITLE
Add Ibc entry points for ibc-enabled contracts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,15 +96,15 @@ jobs:
       - run:
           name: Build library for native target (all features)
           working_directory: ~/project/packages/std
-          command: cargo build --locked --features iterator,staking
+          command: cargo build --locked --features iterator,staking,stargate
       - run:
           name: Build library for wasm target (all features)
           working_directory: ~/project/packages/std
-          command: cargo wasm --locked --features iterator,staking
+          command: cargo wasm --locked --features iterator,staking,stargate
       - run:
           name: Run unit tests (all features)
           working_directory: ~/project/packages/std
-          command: cargo test --locked --features iterator,staking
+          command: cargo test --locked --features iterator,staking,stargate
       - run:
           name: Build and run schema generator
           working_directory: ~/project/packages/std

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1071,9 +1071,9 @@ dependencies = [
 
 [[package]]
 name = "serde-json-wasm"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7294d94d390f1d2334697c065ea591d7074c676e2d20aa6f1df752fced29823f"
+checksum = "0584333eb679085166085b536f2aa378297647618c99f27fd9e9066e9b80c752"
 dependencies = [
  "serde",
 ]

--- a/contracts/burner/Cargo.lock
+++ b/contracts/burner/Cargo.lock
@@ -857,9 +857,9 @@ dependencies = [
 
 [[package]]
 name = "serde-json-wasm"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7294d94d390f1d2334697c065ea591d7074c676e2d20aa6f1df752fced29823f"
+checksum = "0584333eb679085166085b536f2aa378297647618c99f27fd9e9066e9b80c752"
 dependencies = [
  "serde",
 ]

--- a/contracts/hackatom/Cargo.lock
+++ b/contracts/hackatom/Cargo.lock
@@ -868,9 +868,9 @@ dependencies = [
 
 [[package]]
 name = "serde-json-wasm"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7294d94d390f1d2334697c065ea591d7074c676e2d20aa6f1df752fced29823f"
+checksum = "0584333eb679085166085b536f2aa378297647618c99f27fd9e9066e9b80c752"
 dependencies = [
  "serde",
 ]

--- a/contracts/queue/Cargo.lock
+++ b/contracts/queue/Cargo.lock
@@ -857,9 +857,9 @@ dependencies = [
 
 [[package]]
 name = "serde-json-wasm"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7294d94d390f1d2334697c065ea591d7074c676e2d20aa6f1df752fced29823f"
+checksum = "0584333eb679085166085b536f2aa378297647618c99f27fd9e9066e9b80c752"
 dependencies = [
  "serde",
 ]

--- a/contracts/reflect/Cargo.lock
+++ b/contracts/reflect/Cargo.lock
@@ -867,9 +867,9 @@ dependencies = [
 
 [[package]]
 name = "serde-json-wasm"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7294d94d390f1d2334697c065ea591d7074c676e2d20aa6f1df752fced29823f"
+checksum = "0584333eb679085166085b536f2aa378297647618c99f27fd9e9066e9b80c752"
 dependencies = [
  "serde",
 ]

--- a/contracts/staking/Cargo.lock
+++ b/contracts/staking/Cargo.lock
@@ -860,9 +860,9 @@ dependencies = [
 
 [[package]]
 name = "serde-json-wasm"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7294d94d390f1d2334697c065ea591d7074c676e2d20aa6f1df752fced29823f"
+checksum = "0584333eb679085166085b536f2aa378297647618c99f27fd9e9066e9b80c752"
 dependencies = [
  "serde",
 ]

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -34,7 +34,7 @@ stargate = []
 [dependencies]
 base64 = "0.13.0"
 cosmwasm-derive = { path = "../derive", version = "0.13.1" }
-serde-json-wasm = { version = "0.2.1" }
+serde-json-wasm = { version = "0.2.2" }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive", "alloc"] }
 thiserror = "1.0"

--- a/packages/std/src/exports.rs
+++ b/packages/std/src/exports.rs
@@ -251,7 +251,7 @@ where
 }
 
 /// Makes all bridges to external dependencies (i.e. Wasm imports) that are injected by the VM
-fn make_dependencies() -> OwnedDeps<ExternalStorage, ExternalApi, ExternalQuerier> {
+pub(crate) fn make_dependencies() -> OwnedDeps<ExternalStorage, ExternalApi, ExternalQuerier> {
     OwnedDeps {
         storage: ExternalStorage::new(),
         api: ExternalApi::new(),

--- a/packages/std/src/ibc.rs
+++ b/packages/std/src/ibc.rs
@@ -1,0 +1,36 @@
+#![cfg(feature = "stargate")]
+// The CosmosMsg variants are defined in results/cosmos_msg.rs
+// The rest of the IBC related functionality is defined here
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// These are queries to the various IBC modules to see the state of the contract's
+/// IBC connection. These will return errors if the contract is not "ibc enabled"
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum IbcQuery {
+    /// Gets the Port ID the current contract is bound to.
+    /// Returns PortIdResponse
+    PortId {},
+    /// Lists all (portID, channelID) pairs that are bound to a given port
+    /// If port_id is omitted, list all channels bound to the contract's port.
+    ListChannels { port_id: Option<String> },
+    // TODO: Add more
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct PortIdResponse {
+    pub port_id: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct ListChannelsResponse {
+    pub channels: Vec<ChannelPair>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct ChannelPair {
+    pub port_id: String,
+    pub channel_id: String,
+}

--- a/packages/std/src/ibc.rs
+++ b/packages/std/src/ibc.rs
@@ -138,8 +138,15 @@ pub struct IbcAcknowledgement {
     pub original_packet: IbcPacket,
 }
 
+/// This is the return value for the majority of the ibc handlers.
+/// That are able to dispatch messages / events on their own,
+/// but have no meaningful return value to the calling code.
+///
+/// Callbacks that have return values (like receive_packet)
+/// or that cannot redispatch messages (like the handshake callbacks)
+/// will use other Response types
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct IbcConnectResponse<T = Empty>
+pub struct IbcBasicResponse<T = Empty>
 where
     T: Clone + fmt::Debug + PartialEq + JsonSchema,
 {
@@ -148,50 +155,47 @@ where
     pub attributes: Vec<Attribute>,
 }
 
-impl<T> Default for IbcConnectResponse<T>
+impl<T> Default for IbcBasicResponse<T>
 where
     T: Clone + fmt::Debug + PartialEq + JsonSchema,
 {
     fn default() -> Self {
-        IbcConnectResponse {
+        IbcBasicResponse {
             messages: vec![],
             attributes: vec![],
         }
     }
 }
 
-// type IBCPacketReceiveResponse struct {
-//     // Acknowledgement contains the data to acknowledge the ibc packet execution
-//     Acknowledgement []byte `json:"acknowledgement"`
-//     // Messages comes directly from the contract and is it's request for action
-//     Messages []CosmosMsg `json:"messages,omitempty"`
-//     // log message to return over abci interface
-//     Attributes []cosmwasmv1.EventAttribute `json:"attributes"`
-// }
-//
-// type IBCPacketAcknowledgementResponse struct {
-//     Messages   []CosmosMsg                 `json:"messages"`
-//     Attributes []cosmwasmv1.EventAttribute `json:"attributes"`
-// }
-//
-// type IBCPacketTimeoutResponse struct {
-//     Messages   []CosmosMsg                 `json:"messages"`
-//     Attributes []cosmwasmv1.EventAttribute `json:"attributes"`
-// }
-//
-// type IBCChannelOpenResponse struct {
-//     // Success contains a boolean if the channel would be accepted
-//     Success bool `json:"result"`
-//     // Reason optional description why it was not accepted
-//     Reason string `json:"reason"`
-// }
-//
-// type IBCChannelConnectResponse struct {
-//     Messages   []CosmosMsg                 `json:"messages"`
-//     Attributes []cosmwasmv1.EventAttribute `json:"attributes"`
-// }
-//
-// type IBCChannelCloseResponse struct {
-//     Messages   []CosmosMsg                 `json:"messages"`
-//     Attributes []cosmwasmv1.EventAttribute `json:"attributes"`
-// }
+/// This is the return value for the majority of the ibc handlers.
+/// That are able to dispatch messages / events on their own,
+/// but have no meaningful return value to the calling code.
+///
+/// Callbacks that have return values (like receive_packet)
+/// or that cannot redispatch messages (like the handshake callbacks)
+/// will use other Response types
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct IbcReceiveResponse<T = Empty>
+where
+    T: Clone + fmt::Debug + PartialEq + JsonSchema,
+{
+    /// The bytes we return to the contract that sent the packet.
+    /// This may represent a success or error of exection
+    pub acknowledgement: Binary,
+    pub messages: Vec<CosmosMsg<T>>,
+    /// The attributes that will be emitted as part of a "wasm" event
+    pub attributes: Vec<Attribute>,
+}
+
+impl<T> Default for IbcReceiveResponse<T>
+where
+    T: Clone + fmt::Debug + PartialEq + JsonSchema,
+{
+    fn default() -> Self {
+        IbcReceiveResponse {
+            acknowledgement: Binary(vec![]),
+            messages: vec![],
+            attributes: vec![],
+        }
+    }
+}

--- a/packages/std/src/ibc.rs
+++ b/packages/std/src/ibc.rs
@@ -93,7 +93,7 @@ pub struct IbcChannel {
 
 // TODO: check what representation we want here for encoding - string or number
 /// IbcOrder defines if a channel is ORDERED or UNORDERED
-#[repr(u8)]
+/// Values come from https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/ibc/core/channel/v1/channel.proto#L69-L80
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub enum IbcOrder {
     Unordered = 1,

--- a/packages/std/src/ibc.rs
+++ b/packages/std/src/ibc.rs
@@ -15,7 +15,16 @@ pub enum IbcQuery {
     PortId {},
     /// Lists all (portID, channelID) pairs that are bound to a given port
     /// If port_id is omitted, list all channels bound to the contract's port.
+    /// Returns ListChannelsResponse.
     ListChannels { port_id: Option<String> },
+    /// Lists all information for a (portID, channelID) pair.
+    /// If port_id is omitted, it will default to the contract's own channel.
+    /// (To save a PortId{} call)
+    /// Returns ChannelResponse.
+    Channel {
+        channel_id: String,
+        port_id: Option<String>,
+    },
     // TODO: Add more
 }
 
@@ -26,11 +35,93 @@ pub struct PortIdResponse {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct ListChannelsResponse {
-    pub channels: Vec<ChannelPair>,
+    pub channels: Vec<IbcEndpoint>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct ChannelPair {
+pub struct ChannelResponse {
+    pub channel: IbcChannel,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct IbcEndpoint {
     pub port_id: String,
     pub channel_id: String,
 }
+
+// These are various messages used in the callbacks
+
+/// IbcChannel defines all information on a channel.
+/// This is generally used in the hand-shake process, but can be queried directly.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct IbcChannel {
+    pub endpoint: IbcEndpoint,
+    pub counterparty_endpoint: IbcEndpoint,
+    pub order: Order,
+    pub version: String,
+    /// CounterpartyVersion can be None when not known this context, yet
+    pub counterparty_version: Option<String>,
+    /// The connection upon which this channel was created. If this is a multi-hop
+    /// channel, we only expose the first hop.
+    pub connection_id: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct IbcPacket {
+    /// The raw data send from the other side in the packet
+    pub data: Binary,
+    /// identifies the channel and port on the sending chain.
+    pub src: IbcEndpoint,
+    /// identifies the channel and port on the receiving chain.
+    pub dest: IbcEndpoint,
+    /// The sequence number of the packet on the given channel
+    pub sequence: u64,
+    /// block height after which the packet times out
+    pub timeout_height: u64,
+    /// block timestamp (in nanoseconds) after which the packet times out
+    pub timeout_timestamp: u64,
+    // the version that the client is currently on
+    pub version: u64,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct IbcAcknowledgement {
+    pub acknowledgement: Binary,
+    pub original_packet: IbcPacket,
+}
+
+// type IBCPacketReceiveResponse struct {
+//     // Acknowledgement contains the data to acknowledge the ibc packet execution
+//     Acknowledgement []byte `json:"acknowledgement"`
+//     // Messages comes directly from the contract and is it's request for action
+//     Messages []CosmosMsg `json:"messages,omitempty"`
+//     // log message to return over abci interface
+//     Attributes []cosmwasmv1.EventAttribute `json:"attributes"`
+// }
+//
+// type IBCPacketAcknowledgementResponse struct {
+//     Messages   []CosmosMsg                 `json:"messages"`
+//     Attributes []cosmwasmv1.EventAttribute `json:"attributes"`
+// }
+//
+// type IBCPacketTimeoutResponse struct {
+//     Messages   []CosmosMsg                 `json:"messages"`
+//     Attributes []cosmwasmv1.EventAttribute `json:"attributes"`
+// }
+//
+// type IBCChannelOpenResponse struct {
+//     // Success contains a boolean if the channel would be accepted
+//     Success bool `json:"result"`
+//     // Reason optional description why it was not accepted
+//     Reason string `json:"reason"`
+// }
+//
+// type IBCChannelConnectResponse struct {
+//     Messages   []CosmosMsg                 `json:"messages"`
+//     Attributes []cosmwasmv1.EventAttribute `json:"attributes"`
+// }
+//
+// type IBCChannelCloseResponse struct {
+//     Messages   []CosmosMsg                 `json:"messages"`
+//     Attributes []cosmwasmv1.EventAttribute `json:"attributes"`
+// }

--- a/packages/std/src/ibc.rs
+++ b/packages/std/src/ibc.rs
@@ -6,7 +6,9 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+use crate::addresses::HumanAddr;
 use crate::binary::Binary;
+use crate::coins::Coin;
 use crate::results::{Attribute, CosmosMsg};
 use crate::types::Empty;
 
@@ -15,6 +17,20 @@ use crate::types::Empty;
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum IbcMsg {
+    /// Sends bank tokens owned by the contract to the given address on another chain.
+    /// The channel must already be established between the ibctransfer module on this chain
+    /// and a matching module on the remote chain.
+    /// We cannot select the port_id, this is whatever the local chain has bound the ibctransfer
+    /// module to.
+    Ics20Transfer {
+        /// exisiting channel to send the tokens over
+        channel_id: String,
+        /// address on the remote chain to receive these tokens
+        to_address: HumanAddr,
+        /// packet data only supports one coin
+        /// https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/ibc/applications/transfer/v1/transfer.proto#L11-L20
+        amount: Coin,
+    },
     /// Sends an IBC packet with given data over the existing channel.
     /// Data should be encoded in a format defined by the channel version,
     /// and the module on the other side should know how to parse this.

--- a/packages/std/src/ibc.rs
+++ b/packages/std/src/ibc.rs
@@ -110,10 +110,13 @@ pub struct IbcChannel {
 // TODO: check what representation we want here for encoding - string or number
 /// IbcOrder defines if a channel is ORDERED or UNORDERED
 /// Values come from https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/ibc/core/channel/v1/channel.proto#L69-L80
+/// Naming comes from the protobuf files and go translations.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub enum IbcOrder {
-    Unordered = 1,
-    Ordered = 2,
+    #[serde(rename = "ORDER_UNORDERED")]
+    Unordered,
+    #[serde(rename = "ORDER_ORDERED")]
+    Ordered,
 }
 
 // IBCTimeoutHeight Height is a monotonically increasing data type

--- a/packages/std/src/ibc_exports.rs
+++ b/packages/std/src/ibc_exports.rs
@@ -7,11 +7,12 @@ use serde::Serialize;
 
 use crate::deps::DepsMut;
 use crate::exports::make_dependencies;
-use crate::ibc::{IbcChannel, IbcConnectResponse};
+use crate::ibc::{IbcBasicResponse, IbcChannel};
 use crate::memory::{consume_region, release_buffer, Region};
 use crate::results::ContractResult;
 use crate::serde::{from_slice, to_vec};
 use crate::types::Env;
+use crate::{IbcAcknowledgement, IbcPacket, IbcReceiveResponse};
 
 // TODO: replace with https://doc.rust-lang.org/std/ops/trait.Try.html once stabilized
 macro_rules! r#try_into_contract_result {
@@ -69,7 +70,7 @@ where
 ///
 /// ibc_connect_fn is a callback when a IBC channel is established (after both sides agree in open)
 pub fn do_ibc_channel_connect<C, E>(
-    ibc_connect_fn: &dyn Fn(DepsMut, Env, IbcChannel) -> Result<IbcConnectResponse<C>, E>,
+    ibc_connect_fn: &dyn Fn(DepsMut, Env, IbcChannel) -> Result<IbcBasicResponse<C>, E>,
     env_ptr: u32,
     msg_ptr: u32,
 ) -> u32
@@ -87,10 +88,10 @@ where
 }
 
 fn _do_ibc_channel_connect<C, E>(
-    ibc_connect_fn: &dyn Fn(DepsMut, Env, IbcChannel) -> Result<IbcConnectResponse<C>, E>,
+    ibc_connect_fn: &dyn Fn(DepsMut, Env, IbcChannel) -> Result<IbcBasicResponse<C>, E>,
     env_ptr: *mut Region,
     msg_ptr: *mut Region,
-) -> ContractResult<IbcConnectResponse<C>>
+) -> ContractResult<IbcBasicResponse<C>>
 where
     C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
     E: ToString,
@@ -105,138 +106,158 @@ where
     ibc_connect_fn(deps.as_mut(), env, msg).into()
 }
 
-// /// do_handle should be wrapped in an external "C" export, containing a contract-specific function as arg
-// ///
-// /// - `M`: message type for request
-// /// - `C`: custom response message type (see CosmosMsg)
-// /// - `E`: error type for responses
-// pub fn do_handle<M, C, E>(
-//     handle_fn: &dyn Fn(DepsMut, Env, MessageInfo, M) -> Result<HandleResponse<C>, E>,
-//     env_ptr: u32,
-//     info_ptr: u32,
-//     msg_ptr: u32,
-// ) -> u32
-// where
-//     M: DeserializeOwned + JsonSchema,
-//     C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
-//     E: ToString,
-// {
-//     let res = _do_handle(
-//         handle_fn,
-//         env_ptr as *mut Region,
-//         info_ptr as *mut Region,
-//         msg_ptr as *mut Region,
-//     );
-//     let v = to_vec(&res).unwrap();
-//     release_buffer(v) as u32
-// }
-//
-// /// do_migrate should be wrapped in an external "C" export, containing a contract-specific function as arg
-// ///
-// /// - `M`: message type for request
-// /// - `C`: custom response message type (see CosmosMsg)
-// /// - `E`: error type for responses
-// pub fn do_migrate<M, C, E>(
-//     migrate_fn: &dyn Fn(DepsMut, Env, MessageInfo, M) -> Result<MigrateResponse<C>, E>,
-//     env_ptr: u32,
-//     info_ptr: u32,
-//     msg_ptr: u32,
-// ) -> u32
-// where
-//     M: DeserializeOwned + JsonSchema,
-//     C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
-//     E: ToString,
-// {
-//     let res = _do_migrate(
-//         migrate_fn,
-//         env_ptr as *mut Region,
-//         info_ptr as *mut Region,
-//         msg_ptr as *mut Region,
-//     );
-//     let v = to_vec(&res).unwrap();
-//     release_buffer(v) as u32
-// }
-//
-// /// do_query should be wrapped in an external "C" export, containing a contract-specific function as arg
-// ///
-// /// - `M`: message type for request
-// /// - `E`: error type for responses
-// pub fn do_query<M, E>(
-//     query_fn: &dyn Fn(Deps, Env, M) -> Result<QueryResponse, E>,
-//     env_ptr: u32,
-//     msg_ptr: u32,
-// ) -> u32
-// where
-//     M: DeserializeOwned + JsonSchema,
-//     E: ToString,
-// {
-//     let res = _do_query(query_fn, env_ptr as *mut Region, msg_ptr as *mut Region);
-//     let v = to_vec(&res).unwrap();
-//     release_buffer(v) as u32
-// }
-//
-//
-// fn _do_handle<M, C, E>(
-//     handle_fn: &dyn Fn(DepsMut, Env, MessageInfo, M) -> Result<HandleResponse<C>, E>,
-//     env_ptr: *mut Region,
-//     info_ptr: *mut Region,
-//     msg_ptr: *mut Region,
-// ) -> ContractResult<HandleResponse<C>>
-// where
-//     M: DeserializeOwned + JsonSchema,
-//     C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
-//     E: ToString,
-// {
-//     let env: Vec<u8> = unsafe { consume_region(env_ptr) };
-//     let info: Vec<u8> = unsafe { consume_region(info_ptr) };
-//     let msg: Vec<u8> = unsafe { consume_region(msg_ptr) };
-//
-//     let env: Env = try_into_contract_result!(from_slice(&env));
-//     let info: MessageInfo = try_into_contract_result!(from_slice(&info));
-//     let msg: M = try_into_contract_result!(from_slice(&msg));
-//
-//     let mut deps = make_dependencies();
-//     handle_fn(deps.as_mut(), env, info, msg).into()
-// }
-//
-// fn _do_migrate<M, C, E>(
-//     migrate_fn: &dyn Fn(DepsMut, Env, MessageInfo, M) -> Result<MigrateResponse<C>, E>,
-//     env_ptr: *mut Region,
-//     info_ptr: *mut Region,
-//     msg_ptr: *mut Region,
-// ) -> ContractResult<MigrateResponse<C>>
-// where
-//     M: DeserializeOwned + JsonSchema,
-//     C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
-//     E: ToString,
-// {
-//     let env: Vec<u8> = unsafe { consume_region(env_ptr) };
-//     let info: Vec<u8> = unsafe { consume_region(info_ptr) };
-//     let msg: Vec<u8> = unsafe { consume_region(msg_ptr) };
-//
-//     let env: Env = try_into_contract_result!(from_slice(&env));
-//     let info: MessageInfo = try_into_contract_result!(from_slice(&info));
-//     let msg: M = try_into_contract_result!(from_slice(&msg));
-//
-//     let mut deps = make_dependencies();
-//     migrate_fn(deps.as_mut(), env, info, msg).into()
-// }
-//
-// fn _do_query<M, E>(
-//     query_fn: &dyn Fn(Deps, Env, M) -> Result<QueryResponse, E>,
-//     env_ptr: *mut Region,
-//     msg_ptr: *mut Region,
-// ) -> ContractResult<QueryResponse>
-// where
-//     M: DeserializeOwned + JsonSchema,
-//     E: ToString,
-// {
-//     let env: Vec<u8> = unsafe { consume_region(env_ptr) };
-//     let msg: Vec<u8> = unsafe { consume_region(msg_ptr) };
-//
-//     let env: Env = try_into_contract_result!(from_slice(&env));
-//     let msg: M = try_into_contract_result!(from_slice(&msg));
-//
-//     let deps = make_dependencies();
-//     query_fn(deps.as_ref(), env, msg).into()
-// }
+/// do_ibc_channel_close is designed for use with #[entry_point] to make a "C" extern
+///
+/// ibc_close_fn is a callback when a IBC channel belonging to this contract is closed
+pub fn do_ibc_channel_close<C, E>(
+    ibc_close_fn: &dyn Fn(DepsMut, Env, IbcChannel) -> Result<IbcBasicResponse<C>, E>,
+    env_ptr: u32,
+    msg_ptr: u32,
+) -> u32
+where
+    C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
+    E: ToString,
+{
+    let res = _do_ibc_channel_close(ibc_close_fn, env_ptr as *mut Region, msg_ptr as *mut Region);
+    let v = to_vec(&res).unwrap();
+    release_buffer(v) as u32
+}
+
+fn _do_ibc_channel_close<C, E>(
+    ibc_close_fn: &dyn Fn(DepsMut, Env, IbcChannel) -> Result<IbcBasicResponse<C>, E>,
+    env_ptr: *mut Region,
+    msg_ptr: *mut Region,
+) -> ContractResult<IbcBasicResponse<C>>
+where
+    C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
+    E: ToString,
+{
+    let env: Vec<u8> = unsafe { consume_region(env_ptr) };
+    let msg: Vec<u8> = unsafe { consume_region(msg_ptr) };
+
+    let env: Env = try_into_contract_result!(from_slice(&env));
+    let msg: IbcChannel = try_into_contract_result!(from_slice(&msg));
+
+    let mut deps = make_dependencies();
+    ibc_close_fn(deps.as_mut(), env, msg).into()
+}
+
+/// do_ibc_packet_receive is designed for use with #[entry_point] to make a "C" extern
+///
+/// ibc_receive_fn is called when this chain receives an IBC Packet on a channel belonging
+/// to this contract
+pub fn do_ibc_packet_receive<C, E>(
+    ibc_receive_fn: &dyn Fn(DepsMut, Env, IbcPacket) -> Result<IbcReceiveResponse<C>, E>,
+    env_ptr: u32,
+    msg_ptr: u32,
+) -> u32
+where
+    C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
+    E: ToString,
+{
+    let res = _do_ibc_packet_receive(
+        ibc_receive_fn,
+        env_ptr as *mut Region,
+        msg_ptr as *mut Region,
+    );
+    let v = to_vec(&res).unwrap();
+    release_buffer(v) as u32
+}
+
+fn _do_ibc_packet_receive<C, E>(
+    ibc_receive_fn: &dyn Fn(DepsMut, Env, IbcPacket) -> Result<IbcReceiveResponse<C>, E>,
+    env_ptr: *mut Region,
+    msg_ptr: *mut Region,
+) -> ContractResult<IbcReceiveResponse<C>>
+where
+    C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
+    E: ToString,
+{
+    let env: Vec<u8> = unsafe { consume_region(env_ptr) };
+    let msg: Vec<u8> = unsafe { consume_region(msg_ptr) };
+
+    let env: Env = try_into_contract_result!(from_slice(&env));
+    let msg: IbcPacket = try_into_contract_result!(from_slice(&msg));
+
+    let mut deps = make_dependencies();
+    ibc_receive_fn(deps.as_mut(), env, msg).into()
+}
+
+/// do_ibc_packet_ack is designed for use with #[entry_point] to make a "C" extern
+///
+/// ibc_ack_fn is called when this chain receives an IBC Acknowledgement for a packet
+/// that this contract previously sent
+pub fn do_ibc_packet_ack<C, E>(
+    ibc_ack_fn: &dyn Fn(DepsMut, Env, IbcAcknowledgement) -> Result<IbcBasicResponse<C>, E>,
+    env_ptr: u32,
+    msg_ptr: u32,
+) -> u32
+where
+    C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
+    E: ToString,
+{
+    let res = _do_ibc_packet_ack(ibc_ack_fn, env_ptr as *mut Region, msg_ptr as *mut Region);
+    let v = to_vec(&res).unwrap();
+    release_buffer(v) as u32
+}
+
+fn _do_ibc_packet_ack<C, E>(
+    ibc_ack_fn: &dyn Fn(DepsMut, Env, IbcAcknowledgement) -> Result<IbcBasicResponse<C>, E>,
+    env_ptr: *mut Region,
+    msg_ptr: *mut Region,
+) -> ContractResult<IbcBasicResponse<C>>
+where
+    C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
+    E: ToString,
+{
+    let env: Vec<u8> = unsafe { consume_region(env_ptr) };
+    let msg: Vec<u8> = unsafe { consume_region(msg_ptr) };
+
+    let env: Env = try_into_contract_result!(from_slice(&env));
+    let msg: IbcAcknowledgement = try_into_contract_result!(from_slice(&msg));
+
+    let mut deps = make_dependencies();
+    ibc_ack_fn(deps.as_mut(), env, msg).into()
+}
+
+/// do_ibc_packet_timeout is designed for use with #[entry_point] to make a "C" extern
+///
+/// ibc_timeout_fn is called when a packet that this contract previously sent has provably
+/// timedout and will never be relayed to the calling chain. This generally behaves
+/// like ick_ack_fn upon an acknowledgement containing an error.
+pub fn do_ibc_packet_timeout<C, E>(
+    ibc_timeout_fn: &dyn Fn(DepsMut, Env, IbcPacket) -> Result<IbcBasicResponse<C>, E>,
+    env_ptr: u32,
+    msg_ptr: u32,
+) -> u32
+where
+    C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
+    E: ToString,
+{
+    let res = _do_ibc_packet_timeout(
+        ibc_timeout_fn,
+        env_ptr as *mut Region,
+        msg_ptr as *mut Region,
+    );
+    let v = to_vec(&res).unwrap();
+    release_buffer(v) as u32
+}
+
+fn _do_ibc_packet_timeout<C, E>(
+    ibc_timeout_fn: &dyn Fn(DepsMut, Env, IbcPacket) -> Result<IbcBasicResponse<C>, E>,
+    env_ptr: *mut Region,
+    msg_ptr: *mut Region,
+) -> ContractResult<IbcBasicResponse<C>>
+where
+    C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
+    E: ToString,
+{
+    let env: Vec<u8> = unsafe { consume_region(env_ptr) };
+    let msg: Vec<u8> = unsafe { consume_region(msg_ptr) };
+
+    let env: Env = try_into_contract_result!(from_slice(&env));
+    let msg: IbcPacket = try_into_contract_result!(from_slice(&msg));
+
+    let mut deps = make_dependencies();
+    ibc_timeout_fn(deps.as_mut(), env, msg).into()
+}

--- a/packages/std/src/ibc_exports.rs
+++ b/packages/std/src/ibc_exports.rs
@@ -5,8 +5,8 @@ use std::vec::Vec;
 use schemars::JsonSchema;
 use serde::Serialize;
 
-use crate::exports::make_dependencies;
 use crate::deps::DepsMut;
+use crate::exports::make_dependencies;
 use crate::ibc::{IbcChannel, IbcConnectResponse};
 use crate::memory::{consume_region, release_buffer, Region};
 use crate::results::ContractResult;

--- a/packages/std/src/ibc_exports.rs
+++ b/packages/std/src/ibc_exports.rs
@@ -49,7 +49,7 @@ fn _do_ibc_channel_open<E>(
     contract_fn: &dyn Fn(DepsMut, Env, IbcChannel) -> Result<(), E>,
     env_ptr: *mut Region,
     msg_ptr: *mut Region,
-) -> ContractResult<bool>
+) -> ContractResult<()>
 where
     E: ToString,
 {
@@ -60,10 +60,7 @@ where
     let msg: IbcChannel = try_into_contract_result!(from_slice(&msg));
 
     let mut deps = make_dependencies();
-    match contract_fn(deps.as_mut(), env, msg) {
-        Ok(_) => ContractResult::Ok(true),
-        Err(e) => ContractResult::Err(e.to_string()),
-    }
+    contract_fn(deps.as_mut(), env, msg).into()
 }
 
 /// do_ibc_channel_connect is designed for use with #[entry_point] to make a "C" extern

--- a/packages/std/src/ibc_exports.rs
+++ b/packages/std/src/ibc_exports.rs
@@ -1,0 +1,215 @@
+#![cfg(feature = "stargate")]
+use std::fmt;
+use std::vec::Vec;
+
+use schemars::JsonSchema;
+use serde::{de::DeserializeOwned, Serialize};
+
+use crate::deps::OwnedDeps;
+use crate::imports::{ExternalApi, ExternalQuerier, ExternalStorage};
+use crate::memory::{alloc, consume_region, release_buffer, Region};
+use crate::results::{
+    ContractResult, HandleResponse, InitResponse, MigrateResponse, QueryResponse,
+};
+use crate::serde::{from_slice, to_vec};
+use crate::types::Env;
+use crate::{Deps, DepsMut, MessageInfo};
+
+// TODO: replace with https://doc.rust-lang.org/std/ops/trait.Try.html once stabilized
+macro_rules! r#try_into_contract_result {
+    ($expr:expr) => {
+        match $expr {
+            Ok(val) => val,
+            Err(err) => {
+                return ContractResult::Err(err.to_string());
+            }
+        }
+    };
+    ($expr:expr,) => {
+        $crate::try_into_contract_result!($expr)
+    };
+}
+
+/// do_init should be wrapped in an external "C" export, containing a contract-specific function as arg
+///
+/// - `M`: message type for request
+/// - `C`: custom response message type (see CosmosMsg)
+/// - `E`: error type for responses
+pub fn do_init<M, C, E>(
+    init_fn: &dyn Fn(DepsMut, Env, MessageInfo, M) -> Result<InitResponse<C>, E>,
+    env_ptr: u32,
+    info_ptr: u32,
+    msg_ptr: u32,
+) -> u32
+where
+    M: DeserializeOwned + JsonSchema,
+    C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
+    E: ToString,
+{
+    let res = _do_init(
+        init_fn,
+        env_ptr as *mut Region,
+        info_ptr as *mut Region,
+        msg_ptr as *mut Region,
+    );
+    let v = to_vec(&res).unwrap();
+    release_buffer(v) as u32
+}
+
+/// do_handle should be wrapped in an external "C" export, containing a contract-specific function as arg
+///
+/// - `M`: message type for request
+/// - `C`: custom response message type (see CosmosMsg)
+/// - `E`: error type for responses
+pub fn do_handle<M, C, E>(
+    handle_fn: &dyn Fn(DepsMut, Env, MessageInfo, M) -> Result<HandleResponse<C>, E>,
+    env_ptr: u32,
+    info_ptr: u32,
+    msg_ptr: u32,
+) -> u32
+where
+    M: DeserializeOwned + JsonSchema,
+    C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
+    E: ToString,
+{
+    let res = _do_handle(
+        handle_fn,
+        env_ptr as *mut Region,
+        info_ptr as *mut Region,
+        msg_ptr as *mut Region,
+    );
+    let v = to_vec(&res).unwrap();
+    release_buffer(v) as u32
+}
+
+/// do_migrate should be wrapped in an external "C" export, containing a contract-specific function as arg
+///
+/// - `M`: message type for request
+/// - `C`: custom response message type (see CosmosMsg)
+/// - `E`: error type for responses
+pub fn do_migrate<M, C, E>(
+    migrate_fn: &dyn Fn(DepsMut, Env, MessageInfo, M) -> Result<MigrateResponse<C>, E>,
+    env_ptr: u32,
+    info_ptr: u32,
+    msg_ptr: u32,
+) -> u32
+where
+    M: DeserializeOwned + JsonSchema,
+    C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
+    E: ToString,
+{
+    let res = _do_migrate(
+        migrate_fn,
+        env_ptr as *mut Region,
+        info_ptr as *mut Region,
+        msg_ptr as *mut Region,
+    );
+    let v = to_vec(&res).unwrap();
+    release_buffer(v) as u32
+}
+
+/// do_query should be wrapped in an external "C" export, containing a contract-specific function as arg
+///
+/// - `M`: message type for request
+/// - `E`: error type for responses
+pub fn do_query<M, E>(
+    query_fn: &dyn Fn(Deps, Env, M) -> Result<QueryResponse, E>,
+    env_ptr: u32,
+    msg_ptr: u32,
+) -> u32
+where
+    M: DeserializeOwned + JsonSchema,
+    E: ToString,
+{
+    let res = _do_query(query_fn, env_ptr as *mut Region, msg_ptr as *mut Region);
+    let v = to_vec(&res).unwrap();
+    release_buffer(v) as u32
+}
+
+fn _do_init<M, C, E>(
+    init_fn: &dyn Fn(DepsMut, Env, MessageInfo, M) -> Result<InitResponse<C>, E>,
+    env_ptr: *mut Region,
+    info_ptr: *mut Region,
+    msg_ptr: *mut Region,
+) -> ContractResult<InitResponse<C>>
+where
+    M: DeserializeOwned + JsonSchema,
+    C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
+    E: ToString,
+{
+    let env: Vec<u8> = unsafe { consume_region(env_ptr) };
+    let info: Vec<u8> = unsafe { consume_region(info_ptr) };
+    let msg: Vec<u8> = unsafe { consume_region(msg_ptr) };
+
+    let env: Env = try_into_contract_result!(from_slice(&env));
+    let info: MessageInfo = try_into_contract_result!(from_slice(&info));
+    let msg: M = try_into_contract_result!(from_slice(&msg));
+
+    let mut deps = make_dependencies();
+    init_fn(deps.as_mut(), env, info, msg).into()
+}
+
+fn _do_handle<M, C, E>(
+    handle_fn: &dyn Fn(DepsMut, Env, MessageInfo, M) -> Result<HandleResponse<C>, E>,
+    env_ptr: *mut Region,
+    info_ptr: *mut Region,
+    msg_ptr: *mut Region,
+) -> ContractResult<HandleResponse<C>>
+where
+    M: DeserializeOwned + JsonSchema,
+    C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
+    E: ToString,
+{
+    let env: Vec<u8> = unsafe { consume_region(env_ptr) };
+    let info: Vec<u8> = unsafe { consume_region(info_ptr) };
+    let msg: Vec<u8> = unsafe { consume_region(msg_ptr) };
+
+    let env: Env = try_into_contract_result!(from_slice(&env));
+    let info: MessageInfo = try_into_contract_result!(from_slice(&info));
+    let msg: M = try_into_contract_result!(from_slice(&msg));
+
+    let mut deps = make_dependencies();
+    handle_fn(deps.as_mut(), env, info, msg).into()
+}
+
+fn _do_migrate<M, C, E>(
+    migrate_fn: &dyn Fn(DepsMut, Env, MessageInfo, M) -> Result<MigrateResponse<C>, E>,
+    env_ptr: *mut Region,
+    info_ptr: *mut Region,
+    msg_ptr: *mut Region,
+) -> ContractResult<MigrateResponse<C>>
+where
+    M: DeserializeOwned + JsonSchema,
+    C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
+    E: ToString,
+{
+    let env: Vec<u8> = unsafe { consume_region(env_ptr) };
+    let info: Vec<u8> = unsafe { consume_region(info_ptr) };
+    let msg: Vec<u8> = unsafe { consume_region(msg_ptr) };
+
+    let env: Env = try_into_contract_result!(from_slice(&env));
+    let info: MessageInfo = try_into_contract_result!(from_slice(&info));
+    let msg: M = try_into_contract_result!(from_slice(&msg));
+
+    let mut deps = make_dependencies();
+    migrate_fn(deps.as_mut(), env, info, msg).into()
+}
+
+fn _do_query<M, E>(
+    query_fn: &dyn Fn(Deps, Env, M) -> Result<QueryResponse, E>,
+    env_ptr: *mut Region,
+    msg_ptr: *mut Region,
+) -> ContractResult<QueryResponse>
+where
+    M: DeserializeOwned + JsonSchema,
+    E: ToString,
+{
+    let env: Vec<u8> = unsafe { consume_region(env_ptr) };
+    let msg: Vec<u8> = unsafe { consume_region(msg_ptr) };
+
+    let env: Env = try_into_contract_result!(from_slice(&env));
+    let msg: M = try_into_contract_result!(from_slice(&msg));
+
+    let deps = make_dependencies();
+    query_fn(deps.as_ref(), env, msg).into()
+}

--- a/packages/std/src/ibc_exports.rs
+++ b/packages/std/src/ibc_exports.rs
@@ -1,19 +1,17 @@
-#![cfg(feature = "stargate")]
+#![cfg(all(feature = "stargate", target_arch = "wasm32"))]
 use std::fmt;
 use std::vec::Vec;
 
 use schemars::JsonSchema;
-use serde::{de::DeserializeOwned, Serialize};
+use serde::Serialize;
 
-use crate::deps::OwnedDeps;
-use crate::imports::{ExternalApi, ExternalQuerier, ExternalStorage};
-use crate::memory::{alloc, consume_region, release_buffer, Region};
-use crate::results::{
-    ContractResult, HandleResponse, InitResponse, MigrateResponse, QueryResponse,
-};
+use crate::exports::make_dependencies;
+use crate::deps::DepsMut;
+use crate::ibc::{IbcChannel, IbcConnectResponse};
+use crate::memory::{consume_region, release_buffer, Region};
+use crate::results::ContractResult;
 use crate::serde::{from_slice, to_vec};
 use crate::types::Env;
-use crate::{Deps, DepsMut, MessageInfo};
 
 // TODO: replace with https://doc.rust-lang.org/std/ops/trait.Try.html once stabilized
 macro_rules! r#try_into_contract_result {
@@ -30,186 +28,215 @@ macro_rules! r#try_into_contract_result {
     };
 }
 
-/// do_init should be wrapped in an external "C" export, containing a contract-specific function as arg
+/// do_ibc_channel_open is designed for use with #[entry_point] to make a "C" extern
 ///
-/// - `M`: message type for request
-/// - `C`: custom response message type (see CosmosMsg)
-/// - `E`: error type for responses
-pub fn do_init<M, C, E>(
-    init_fn: &dyn Fn(DepsMut, Env, MessageInfo, M) -> Result<InitResponse<C>, E>,
+/// ibc_open_fn does the protocol version negotiation during channel handshake phase
+pub fn do_ibc_channel_open<E>(
+    ibc_open_fn: &dyn Fn(DepsMut, Env, IbcChannel) -> Result<(), E>,
     env_ptr: u32,
-    info_ptr: u32,
     msg_ptr: u32,
 ) -> u32
 where
-    M: DeserializeOwned + JsonSchema,
+    E: ToString,
+{
+    let res = _do_ibc_channel_open(ibc_open_fn, env_ptr as *mut Region, msg_ptr as *mut Region);
+    let v = to_vec(&res).unwrap();
+    release_buffer(v) as u32
+}
+
+fn _do_ibc_channel_open<E>(
+    ibc_open_fn: &dyn Fn(DepsMut, Env, IbcChannel) -> Result<(), E>,
+    env_ptr: *mut Region,
+    msg_ptr: *mut Region,
+) -> ContractResult<bool>
+where
+    E: ToString,
+{
+    let env: Vec<u8> = unsafe { consume_region(env_ptr) };
+    let msg: Vec<u8> = unsafe { consume_region(msg_ptr) };
+
+    let env: Env = try_into_contract_result!(from_slice(&env));
+    let msg: IbcChannel = try_into_contract_result!(from_slice(&msg));
+
+    let mut deps = make_dependencies();
+    match ibc_open_fn(deps.as_mut(), env, msg) {
+        Ok(_) => ContractResult::Ok(true),
+        Err(e) => ContractResult::Err(e.to_string()),
+    }
+}
+
+/// do_ibc_channel_connect is designed for use with #[entry_point] to make a "C" extern
+///
+/// ibc_connect_fn is a callback when a IBC channel is established (after both sides agree in open)
+pub fn do_ibc_channel_connect<C, E>(
+    ibc_connect_fn: &dyn Fn(DepsMut, Env, IbcChannel) -> Result<IbcConnectResponse<C>, E>,
+    env_ptr: u32,
+    msg_ptr: u32,
+) -> u32
+where
     C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
     E: ToString,
 {
-    let res = _do_init(
-        init_fn,
+    let res = _do_ibc_channel_connect(
+        ibc_connect_fn,
         env_ptr as *mut Region,
-        info_ptr as *mut Region,
         msg_ptr as *mut Region,
     );
     let v = to_vec(&res).unwrap();
     release_buffer(v) as u32
 }
 
-/// do_handle should be wrapped in an external "C" export, containing a contract-specific function as arg
-///
-/// - `M`: message type for request
-/// - `C`: custom response message type (see CosmosMsg)
-/// - `E`: error type for responses
-pub fn do_handle<M, C, E>(
-    handle_fn: &dyn Fn(DepsMut, Env, MessageInfo, M) -> Result<HandleResponse<C>, E>,
-    env_ptr: u32,
-    info_ptr: u32,
-    msg_ptr: u32,
-) -> u32
-where
-    M: DeserializeOwned + JsonSchema,
-    C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
-    E: ToString,
-{
-    let res = _do_handle(
-        handle_fn,
-        env_ptr as *mut Region,
-        info_ptr as *mut Region,
-        msg_ptr as *mut Region,
-    );
-    let v = to_vec(&res).unwrap();
-    release_buffer(v) as u32
-}
-
-/// do_migrate should be wrapped in an external "C" export, containing a contract-specific function as arg
-///
-/// - `M`: message type for request
-/// - `C`: custom response message type (see CosmosMsg)
-/// - `E`: error type for responses
-pub fn do_migrate<M, C, E>(
-    migrate_fn: &dyn Fn(DepsMut, Env, MessageInfo, M) -> Result<MigrateResponse<C>, E>,
-    env_ptr: u32,
-    info_ptr: u32,
-    msg_ptr: u32,
-) -> u32
-where
-    M: DeserializeOwned + JsonSchema,
-    C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
-    E: ToString,
-{
-    let res = _do_migrate(
-        migrate_fn,
-        env_ptr as *mut Region,
-        info_ptr as *mut Region,
-        msg_ptr as *mut Region,
-    );
-    let v = to_vec(&res).unwrap();
-    release_buffer(v) as u32
-}
-
-/// do_query should be wrapped in an external "C" export, containing a contract-specific function as arg
-///
-/// - `M`: message type for request
-/// - `E`: error type for responses
-pub fn do_query<M, E>(
-    query_fn: &dyn Fn(Deps, Env, M) -> Result<QueryResponse, E>,
-    env_ptr: u32,
-    msg_ptr: u32,
-) -> u32
-where
-    M: DeserializeOwned + JsonSchema,
-    E: ToString,
-{
-    let res = _do_query(query_fn, env_ptr as *mut Region, msg_ptr as *mut Region);
-    let v = to_vec(&res).unwrap();
-    release_buffer(v) as u32
-}
-
-fn _do_init<M, C, E>(
-    init_fn: &dyn Fn(DepsMut, Env, MessageInfo, M) -> Result<InitResponse<C>, E>,
+fn _do_ibc_channel_connect<C, E>(
+    ibc_connect_fn: &dyn Fn(DepsMut, Env, IbcChannel) -> Result<IbcConnectResponse<C>, E>,
     env_ptr: *mut Region,
-    info_ptr: *mut Region,
     msg_ptr: *mut Region,
-) -> ContractResult<InitResponse<C>>
+) -> ContractResult<IbcConnectResponse<C>>
 where
-    M: DeserializeOwned + JsonSchema,
     C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
     E: ToString,
 {
     let env: Vec<u8> = unsafe { consume_region(env_ptr) };
-    let info: Vec<u8> = unsafe { consume_region(info_ptr) };
     let msg: Vec<u8> = unsafe { consume_region(msg_ptr) };
 
     let env: Env = try_into_contract_result!(from_slice(&env));
-    let info: MessageInfo = try_into_contract_result!(from_slice(&info));
-    let msg: M = try_into_contract_result!(from_slice(&msg));
+    let msg: IbcChannel = try_into_contract_result!(from_slice(&msg));
 
     let mut deps = make_dependencies();
-    init_fn(deps.as_mut(), env, info, msg).into()
+    ibc_connect_fn(deps.as_mut(), env, msg).into()
 }
 
-fn _do_handle<M, C, E>(
-    handle_fn: &dyn Fn(DepsMut, Env, MessageInfo, M) -> Result<HandleResponse<C>, E>,
-    env_ptr: *mut Region,
-    info_ptr: *mut Region,
-    msg_ptr: *mut Region,
-) -> ContractResult<HandleResponse<C>>
-where
-    M: DeserializeOwned + JsonSchema,
-    C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
-    E: ToString,
-{
-    let env: Vec<u8> = unsafe { consume_region(env_ptr) };
-    let info: Vec<u8> = unsafe { consume_region(info_ptr) };
-    let msg: Vec<u8> = unsafe { consume_region(msg_ptr) };
-
-    let env: Env = try_into_contract_result!(from_slice(&env));
-    let info: MessageInfo = try_into_contract_result!(from_slice(&info));
-    let msg: M = try_into_contract_result!(from_slice(&msg));
-
-    let mut deps = make_dependencies();
-    handle_fn(deps.as_mut(), env, info, msg).into()
-}
-
-fn _do_migrate<M, C, E>(
-    migrate_fn: &dyn Fn(DepsMut, Env, MessageInfo, M) -> Result<MigrateResponse<C>, E>,
-    env_ptr: *mut Region,
-    info_ptr: *mut Region,
-    msg_ptr: *mut Region,
-) -> ContractResult<MigrateResponse<C>>
-where
-    M: DeserializeOwned + JsonSchema,
-    C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
-    E: ToString,
-{
-    let env: Vec<u8> = unsafe { consume_region(env_ptr) };
-    let info: Vec<u8> = unsafe { consume_region(info_ptr) };
-    let msg: Vec<u8> = unsafe { consume_region(msg_ptr) };
-
-    let env: Env = try_into_contract_result!(from_slice(&env));
-    let info: MessageInfo = try_into_contract_result!(from_slice(&info));
-    let msg: M = try_into_contract_result!(from_slice(&msg));
-
-    let mut deps = make_dependencies();
-    migrate_fn(deps.as_mut(), env, info, msg).into()
-}
-
-fn _do_query<M, E>(
-    query_fn: &dyn Fn(Deps, Env, M) -> Result<QueryResponse, E>,
-    env_ptr: *mut Region,
-    msg_ptr: *mut Region,
-) -> ContractResult<QueryResponse>
-where
-    M: DeserializeOwned + JsonSchema,
-    E: ToString,
-{
-    let env: Vec<u8> = unsafe { consume_region(env_ptr) };
-    let msg: Vec<u8> = unsafe { consume_region(msg_ptr) };
-
-    let env: Env = try_into_contract_result!(from_slice(&env));
-    let msg: M = try_into_contract_result!(from_slice(&msg));
-
-    let deps = make_dependencies();
-    query_fn(deps.as_ref(), env, msg).into()
-}
+// /// do_handle should be wrapped in an external "C" export, containing a contract-specific function as arg
+// ///
+// /// - `M`: message type for request
+// /// - `C`: custom response message type (see CosmosMsg)
+// /// - `E`: error type for responses
+// pub fn do_handle<M, C, E>(
+//     handle_fn: &dyn Fn(DepsMut, Env, MessageInfo, M) -> Result<HandleResponse<C>, E>,
+//     env_ptr: u32,
+//     info_ptr: u32,
+//     msg_ptr: u32,
+// ) -> u32
+// where
+//     M: DeserializeOwned + JsonSchema,
+//     C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
+//     E: ToString,
+// {
+//     let res = _do_handle(
+//         handle_fn,
+//         env_ptr as *mut Region,
+//         info_ptr as *mut Region,
+//         msg_ptr as *mut Region,
+//     );
+//     let v = to_vec(&res).unwrap();
+//     release_buffer(v) as u32
+// }
+//
+// /// do_migrate should be wrapped in an external "C" export, containing a contract-specific function as arg
+// ///
+// /// - `M`: message type for request
+// /// - `C`: custom response message type (see CosmosMsg)
+// /// - `E`: error type for responses
+// pub fn do_migrate<M, C, E>(
+//     migrate_fn: &dyn Fn(DepsMut, Env, MessageInfo, M) -> Result<MigrateResponse<C>, E>,
+//     env_ptr: u32,
+//     info_ptr: u32,
+//     msg_ptr: u32,
+// ) -> u32
+// where
+//     M: DeserializeOwned + JsonSchema,
+//     C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
+//     E: ToString,
+// {
+//     let res = _do_migrate(
+//         migrate_fn,
+//         env_ptr as *mut Region,
+//         info_ptr as *mut Region,
+//         msg_ptr as *mut Region,
+//     );
+//     let v = to_vec(&res).unwrap();
+//     release_buffer(v) as u32
+// }
+//
+// /// do_query should be wrapped in an external "C" export, containing a contract-specific function as arg
+// ///
+// /// - `M`: message type for request
+// /// - `E`: error type for responses
+// pub fn do_query<M, E>(
+//     query_fn: &dyn Fn(Deps, Env, M) -> Result<QueryResponse, E>,
+//     env_ptr: u32,
+//     msg_ptr: u32,
+// ) -> u32
+// where
+//     M: DeserializeOwned + JsonSchema,
+//     E: ToString,
+// {
+//     let res = _do_query(query_fn, env_ptr as *mut Region, msg_ptr as *mut Region);
+//     let v = to_vec(&res).unwrap();
+//     release_buffer(v) as u32
+// }
+//
+//
+// fn _do_handle<M, C, E>(
+//     handle_fn: &dyn Fn(DepsMut, Env, MessageInfo, M) -> Result<HandleResponse<C>, E>,
+//     env_ptr: *mut Region,
+//     info_ptr: *mut Region,
+//     msg_ptr: *mut Region,
+// ) -> ContractResult<HandleResponse<C>>
+// where
+//     M: DeserializeOwned + JsonSchema,
+//     C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
+//     E: ToString,
+// {
+//     let env: Vec<u8> = unsafe { consume_region(env_ptr) };
+//     let info: Vec<u8> = unsafe { consume_region(info_ptr) };
+//     let msg: Vec<u8> = unsafe { consume_region(msg_ptr) };
+//
+//     let env: Env = try_into_contract_result!(from_slice(&env));
+//     let info: MessageInfo = try_into_contract_result!(from_slice(&info));
+//     let msg: M = try_into_contract_result!(from_slice(&msg));
+//
+//     let mut deps = make_dependencies();
+//     handle_fn(deps.as_mut(), env, info, msg).into()
+// }
+//
+// fn _do_migrate<M, C, E>(
+//     migrate_fn: &dyn Fn(DepsMut, Env, MessageInfo, M) -> Result<MigrateResponse<C>, E>,
+//     env_ptr: *mut Region,
+//     info_ptr: *mut Region,
+//     msg_ptr: *mut Region,
+// ) -> ContractResult<MigrateResponse<C>>
+// where
+//     M: DeserializeOwned + JsonSchema,
+//     C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
+//     E: ToString,
+// {
+//     let env: Vec<u8> = unsafe { consume_region(env_ptr) };
+//     let info: Vec<u8> = unsafe { consume_region(info_ptr) };
+//     let msg: Vec<u8> = unsafe { consume_region(msg_ptr) };
+//
+//     let env: Env = try_into_contract_result!(from_slice(&env));
+//     let info: MessageInfo = try_into_contract_result!(from_slice(&info));
+//     let msg: M = try_into_contract_result!(from_slice(&msg));
+//
+//     let mut deps = make_dependencies();
+//     migrate_fn(deps.as_mut(), env, info, msg).into()
+// }
+//
+// fn _do_query<M, E>(
+//     query_fn: &dyn Fn(Deps, Env, M) -> Result<QueryResponse, E>,
+//     env_ptr: *mut Region,
+//     msg_ptr: *mut Region,
+// ) -> ContractResult<QueryResponse>
+// where
+//     M: DeserializeOwned + JsonSchema,
+//     E: ToString,
+// {
+//     let env: Vec<u8> = unsafe { consume_region(env_ptr) };
+//     let msg: Vec<u8> = unsafe { consume_region(msg_ptr) };
+//
+//     let env: Env = try_into_contract_result!(from_slice(&env));
+//     let msg: M = try_into_contract_result!(from_slice(&msg));
+//
+//     let deps = make_dependencies();
+//     query_fn(deps.as_ref(), env, msg).into()
+// }

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -25,6 +25,8 @@ pub use crate::binary::{Binary, ByteArray};
 pub use crate::coins::{coin, coins, has_coins, Coin};
 pub use crate::deps::{Deps, DepsMut, OwnedDeps};
 pub use crate::errors::{StdError, StdResult, SystemError};
+#[cfg(feature = "stargate")]
+pub use crate::ibc::*;
 #[cfg(feature = "iterator")]
 pub use crate::iterator::{Order, KV};
 pub use crate::math::{Decimal, Uint128};
@@ -57,6 +59,11 @@ mod memory; // Used by exports and imports only. This assumes pointers are 32 bi
 pub use crate::exports::{do_handle, do_init, do_migrate, do_query};
 #[cfg(target_arch = "wasm32")]
 pub use crate::imports::{ExternalApi, ExternalQuerier, ExternalStorage};
+
+#[cfg(all(feature = "stargate", target_arch = "wasm32"))]
+mod ibc_exports;
+#[cfg(all(feature = "stargate", target_arch = "wasm32"))]
+pub use crate::ibc_exports::*;
 
 // Exposed for testing only
 // Both unit tests and integration tests are compiled to native code, so everything in here does not need to compile to Wasm.

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -26,7 +26,11 @@ pub use crate::coins::{coin, coins, has_coins, Coin};
 pub use crate::deps::{Deps, DepsMut, OwnedDeps};
 pub use crate::errors::{StdError, StdResult, SystemError};
 #[cfg(feature = "stargate")]
-pub use crate::ibc::*;
+pub use crate::ibc::{
+    ChannelResponse, IbcAcknowledgement, IbcBasicResponse, IbcChannel, IbcEndpoint, IbcMsg,
+    IbcOrder, IbcPacket, IbcQuery, IbcReceiveResponse, IbcTimeoutHeight, ListChannelsResponse,
+    PortIdResponse,
+};
 #[cfg(feature = "iterator")]
 pub use crate::iterator::{Order, KV};
 pub use crate::math::{Decimal, Uint128};
@@ -63,7 +67,10 @@ pub use crate::imports::{ExternalApi, ExternalQuerier, ExternalStorage};
 #[cfg(all(feature = "stargate", target_arch = "wasm32"))]
 mod ibc_exports;
 #[cfg(all(feature = "stargate", target_arch = "wasm32"))]
-pub use crate::ibc_exports::*;
+pub use crate::ibc_exports::{
+    do_ibc_channel_close, do_ibc_channel_connect, do_ibc_channel_open, do_ibc_packet_ack,
+    do_ibc_packet_receive, do_ibc_packet_timeout,
+};
 
 // Exposed for testing only
 // Both unit tests and integration tests are compiled to native code, so everything in here does not need to compile to Wasm.

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -9,6 +9,7 @@ mod coins;
 mod deps;
 mod entry_points;
 mod errors;
+mod ibc;
 #[cfg(feature = "iterator")]
 mod iterator;
 mod math;

--- a/packages/std/src/mock.rs
+++ b/packages/std/src/mock.rs
@@ -236,6 +236,10 @@ impl<C: CustomQuery + DeserializeOwned> MockQuerier<C> {
             QueryRequest::Stargate { .. } => SystemResult::Err(SystemError::UnsupportedRequest {
                 kind: "Stargate".to_string(),
             }),
+            #[cfg(feature = "stargate")]
+            QueryRequest::Ibc(_) => SystemResult::Err(SystemError::UnsupportedRequest {
+                kind: "Ibc".to_string(),
+            }),
         }
     }
 }

--- a/packages/std/src/mock.rs
+++ b/packages/std/src/mock.rs
@@ -232,6 +232,10 @@ impl<C: CustomQuery + DeserializeOwned> MockQuerier<C> {
             QueryRequest::Custom(custom_query) => (*self.custom_handler)(custom_query),
             QueryRequest::Staking(staking_query) => self.staking.query(staking_query),
             QueryRequest::Wasm(msg) => self.wasm.query(msg),
+            #[cfg(feature = "stargate")]
+            QueryRequest::Stargate { .. } => SystemResult::Err(SystemError::UnsupportedRequest {
+                kind: "Stargate".to_string(),
+            }),
         }
     }
 }

--- a/packages/std/src/query.rs
+++ b/packages/std/src/query.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 use crate::addresses::HumanAddr;
 use crate::binary::Binary;
 use crate::coins::Coin;
+#[cfg(feature = "stargate")]
+use crate::ibc::IbcQuery;
 use crate::math::Decimal;
 use crate::types::Empty;
 
@@ -24,6 +26,8 @@ pub enum QueryRequest<C: CustomQuery> {
         /// this is the expected protobuf message type (not any), binary encoded
         data: Binary,
     },
+    #[cfg(feature = "stargate")]
+    Ibc(IbcQuery),
     Wasm(WasmQuery),
 }
 
@@ -103,6 +107,13 @@ impl<C: CustomQuery> From<StakingQuery> for QueryRequest<C> {
 impl<C: CustomQuery> From<WasmQuery> for QueryRequest<C> {
     fn from(msg: WasmQuery) -> Self {
         QueryRequest::Wasm(msg)
+    }
+}
+
+#[cfg(feature = "stargate")]
+impl<C: CustomQuery> From<IbcQuery> for QueryRequest<C> {
+    fn from(msg: IbcQuery) -> Self {
+        QueryRequest::Ibc(msg)
     }
 }
 

--- a/packages/std/src/results/cosmos_msg.rs
+++ b/packages/std/src/results/cosmos_msg.rs
@@ -5,6 +5,8 @@ use std::fmt;
 use crate::addresses::HumanAddr;
 use crate::binary::Binary;
 use crate::coins::Coin;
+#[cfg(feature = "stargate")]
+use crate::ibc::IbcMsg;
 use crate::types::Empty;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -105,28 +107,6 @@ pub enum WasmMsg {
         /// optional human-readbale label for the contract
         label: Option<String>,
     },
-}
-
-/// These are messages in the IBC lifecycle. Only usable by IBC-enabled contracts
-/// (contracts that directly speak the IBC protocol via 6 entry points)
-#[cfg(feature = "stargate")]
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-#[serde(rename_all = "snake_case")]
-pub enum IbcMsg {
-    /// Sends an IBC packet with given data over the existing channel.
-    /// Data should be encoded in a format defined by the channel version,
-    /// and the module on the other side should know how to parse this.
-    SendPacket {
-        channel_id: String,
-        data: Binary,
-        timeout_height: u64,
-        // TODO: does the cosmos sdk support timestamp based timeouts?
-        timeout_timestamp: u64,
-        version: u64,
-    },
-    /// This will close an existing channel that is owned by this contract.
-    /// Port is auto-assigned to the contracts' ibc port
-    CloseChannel { channel_id: String },
 }
 
 impl<T: Clone + fmt::Debug + PartialEq + JsonSchema> From<BankMsg> for CosmosMsg<T> {

--- a/packages/std/src/results/cosmos_msg.rs
+++ b/packages/std/src/results/cosmos_msg.rs
@@ -124,9 +124,7 @@ pub enum IbcMsg {
     },
     /// This will close an existing channel that is owned by this contract.
     /// Port is auto-assigned to the contracts' ibc port
-    CloseChannel {
-        channel_id: String,
-    }
+    CloseChannel { channel_id: String },
 }
 
 impl<T: Clone + fmt::Debug + PartialEq + JsonSchema> From<BankMsg> for CosmosMsg<T> {

--- a/packages/std/src/results/cosmos_msg.rs
+++ b/packages/std/src/results/cosmos_msg.rs
@@ -120,6 +120,8 @@ pub enum IbcMsg {
         channel_id: String,
         data: Binary,
         timeout_height: u64,
+        // TODO: does the cosmos sdk support timestamp based timeouts?
+        timeout_timestamp: u64,
         version: u64,
     },
     /// This will close an existing channel that is owned by this contract.


### PR DESCRIPTION
This allows contracts to implement their own application-protocol on top of IBC and participate in both the channel handshake phase as well as sending and receiving packets

@alpe Nice for you to have a look at it sometime, especially the ibc.rs types and ibc_exports.rs entry points