### PR TITLE
refactor: Change to copy function in read_region

### DIFF
--- a/packages/vm/src/memory.rs
+++ b/packages/vm/src/memory.rs
@@ -1,5 +1,5 @@
-use wasmer::{Array, ValueType, WasmPtr};
 use std::ptr;
+use wasmer::{Array, ValueType, WasmPtr};
 
 use crate::conversion::to_u32;
 use crate::errors::{
@@ -41,7 +41,6 @@ pub fn read_region(memory: &wasmer::Memory, ptr: u32, max_length: usize) -> VmRe
     match WasmPtr::<u8, Array>::new(region.offset).deref(memory, 0, region.length) {
         Some(cells) => {
             let raw_cells = cells as *const [_] as *const u8;
-            
             let len = region.length as usize;
             let mut result = vec![0u8; len];
             unsafe{


### PR DESCRIPTION
# Motivation
Due to wasmer's memory type patch, dynamic memory type was changed to static memory type, resulting in high performance improvement. https://github.com/wasmerio/wasmer/pull/1299
As a result, there are fewer bound check assemblies for dynamic memory types, which reduces code size and improves performance. It works for all backends.


However, after applied, when measured with erc20 in cosmwasm, the improved performance range was not consistently recorded.
(at least 30% to up to 200%. i.e: when singlepass, 418txs -> 532 ~ 870txs)
So, I had to find out where the difference occurred.

The log below is the measurement result when a JIT compiled function is called from wasmer.
For each transfer, A difference of about 50us occurs irregularly.

<details>
address 3608BA37 is handle

> debug: func "deallocate" | func:360B5DE8 | elapsed:4.838µs
> debug: func "allocate" | func:360B5709 | elapsed:15.843µs
> debug: func "allocate" | func:360B5709 | elapsed:4.115µs
> debug: func "handle" | func:360B5709 | elapsed:5.189µs
> func:3608BA37 | elapsed:199.764µs
> debug: func "deallocate" | func:360B5DE8 | elapsed:4.826µs
> debug: func "allocate" | func:360B5709 | elapsed:18.979µs
> debug: func "allocate" | func:360B5709 | elapsed:3.872µs
> debug: func "handle" | func:360B5709 | elapsed:5.222µs
> func:3608BA37 | elapsed:207.639µs
> debug: func "deallocate" | func:360B5DE8 | elapsed:4.667µs
> debug: func "allocate" | func:360B5709 | elapsed:21.81µs
> debug: func "allocate" | func:360B5709 | elapsed:4.543µs
> debug: func "handle" | func:360B5709 | elapsed:5.699µs
> func:3608BA37 | elapsed:236.879µs
> debug: func "deallocate" | func:360B5DE8 | elapsed:5.159µs
> debug: func "allocate" | func:360B5709 | elapsed:21.678µs
> debug: func "allocate" | func:360B5709 | elapsed:4.599µs
> debug: func "handle" | func:360B5709 | elapsed:6.005µs
> func:3608BA37 | elapsed:297.624µs
> debug: func "deallocate" | func:360B5DE8 | elapsed:6.274µs
> debug: func "allocate" | func:360B5709 | elapsed:19.402µs
> debug: func "allocate" | func:360B5709 | elapsed:4.457µs
> debug: func "handle" | func:360B5709 | elapsed:5.347µs
> func:3608BA37 | elapsed:213.839µs
> debug: func "deallocate" | func:360B5DE8 | elapsed:5.012µs
> debug: func "allocate" | func:360B5709 | elapsed:15.524µs
> debug: func "allocate" | func:360B5709 | elapsed:4.157µs
> debug: func "handle" | func:360B5709 | elapsed:5.215µs
> func:3608BA37 | elapsed:197.728µs
> debug: func "deallocate" | func:360B5DE8 | elapsed:4.924µs
> debug: func "allocate" | func:360B5709 | elapsed:28.02µs
> debug: func "allocate" | func:360B5709 | elapsed:5.18µs
> debug: func "handle" | func:360B5709 | elapsed:8.691µs
> func:3608BA37 | elapsed:360.173µs
> debug: func "deallocate" | func:360B5DE8 | elapsed:7.916µs
> debug: func "allocate" | func:360B5709 | elapsed:20.315µs
> debug: func "allocate" | func:360B5709 | elapsed:4.221µs
> debug: func "handle" | func:360B5709 | elapsed:5.81µs
> func:3608BA37 | elapsed:244.343µs
> debug: func "deallocate" | func:360B5DE8 | elapsed:5.193µs
> debug: func "allocate" | func:360B5709 | elapsed:21.005µs
> debug: func "allocate" | func:360B5709 | elapsed:4.536µs
> debug: func "handle" | func:360B5709 | elapsed:5.448µs
> func:3608BA37 | elapsed:236.151µs
> debug: func "deallocate" | func:360B5DE8 | elapsed:5.057µs
> debug: func "allocate" | func:360B5709 | elapsed:21.288µs
> debug: func "allocate" | func:360B5709 | elapsed:4.263µs
> debug: func "handle" | func:360B5709 | elapsed:5.594µs
> func:3608BA37 | elapsed:238.434µs
> debug: func "deallocate" | func:360B5DE8 | elapsed:5.078µs

</details>

This is by no means small compared to the total execution time.
However, it is difficult to know from this information alone which part of the handle function is causing the cause.

As a result of analyzing using the profiler tool, I found that every time the execution was slow, read_region took up time.
due to the low resolution of the profiler, read_region was only captured when it was slow and not when it was fast.
(I'd like to write more details about the profiling process, but it will take a long time, so I skip it.)

![image](https://user-images.githubusercontent.com/6722671/105012059-0f5d8400-5a81-11eb-8acb-31f8553095c0.png)
![image](https://user-images.githubusercontent.com/6722671/105012108-1d130980-5a81-11eb-9e3a-e43a13486800.png)

# Proposed Solution
As you know well, optimization is difficult if you copy it repeatedly with a for statement.
Using a method like memcpy, you can lead to optimizations such as SIMD copying.
It is effective even if the memory size is not necessarily large.

As a result of patching the read_region,
- recorded stable performance
- and maximum performance improvement 10%
(when singlepass, 532 ~ 870txs -> 876 ~ 913txs)

In the comment, I found that already had this kind of issue.
So, for some reason, I'd like to hear your opinion on the change back to the for statement method.