### PR TITLE
Update to serde json wasm 0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1049,9 +1049,9 @@ dependencies = [
 
 [[package]]
 name = "serde-json-wasm"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ebf73928683472b82f01683968f4f3e8979fb9443e28f0f4d5e5f308901123e"
+checksum = "50eef3672ec8fa45f3457fd423ba131117786784a895548021976117c1ded449"
 dependencies = [
  "serde",
 ]

--- a/contracts/burner/Cargo.lock
+++ b/contracts/burner/Cargo.lock
@@ -835,9 +835,9 @@ dependencies = [
 
 [[package]]
 name = "serde-json-wasm"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ebf73928683472b82f01683968f4f3e8979fb9443e28f0f4d5e5f308901123e"
+checksum = "50eef3672ec8fa45f3457fd423ba131117786784a895548021976117c1ded449"
 dependencies = [
  "serde",
 ]

--- a/contracts/hackatom/Cargo.lock
+++ b/contracts/hackatom/Cargo.lock
@@ -846,9 +846,9 @@ dependencies = [
 
 [[package]]
 name = "serde-json-wasm"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ebf73928683472b82f01683968f4f3e8979fb9443e28f0f4d5e5f308901123e"
+checksum = "50eef3672ec8fa45f3457fd423ba131117786784a895548021976117c1ded449"
 dependencies = [
  "serde",
 ]

--- a/contracts/ibc-reflect/Cargo.lock
+++ b/contracts/ibc-reflect/Cargo.lock
@@ -844,9 +844,9 @@ dependencies = [
 
 [[package]]
 name = "serde-json-wasm"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ebf73928683472b82f01683968f4f3e8979fb9443e28f0f4d5e5f308901123e"
+checksum = "50eef3672ec8fa45f3457fd423ba131117786784a895548021976117c1ded449"
 dependencies = [
  "serde",
 ]

--- a/contracts/ibc-reflect/src/contract.rs
+++ b/contracts/ibc-reflect/src/contract.rs
@@ -438,11 +438,9 @@ mod tests {
         let packet = mock_ibc_packet_recv(channel_id, &ibc_msg).unwrap();
         let res = ibc_packet_receive(deps.as_mut(), mock_env(), packet.clone()).unwrap();
 
-        // TODO: blocked on serde-json-wasm fix
-        // see: https://github.com/CosmWasm/serde-json-wasm/issues/27
         // assert app-level success
-        // let ack: AcknowledgementMsg = from_slice(&res.acknowledgement).unwrap();
-        // ack.unwrap();
+        let ack: AcknowledgementMsg<()> = from_slice(&res.acknowledgement).unwrap();
+        ack.unwrap();
 
         // and we dispatch the BankMsg
         assert_eq!(1, res.messages.len());

--- a/contracts/queue/Cargo.lock
+++ b/contracts/queue/Cargo.lock
@@ -835,9 +835,9 @@ dependencies = [
 
 [[package]]
 name = "serde-json-wasm"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ebf73928683472b82f01683968f4f3e8979fb9443e28f0f4d5e5f308901123e"
+checksum = "50eef3672ec8fa45f3457fd423ba131117786784a895548021976117c1ded449"
 dependencies = [
  "serde",
 ]

--- a/contracts/reflect/Cargo.lock
+++ b/contracts/reflect/Cargo.lock
@@ -845,9 +845,9 @@ dependencies = [
 
 [[package]]
 name = "serde-json-wasm"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ebf73928683472b82f01683968f4f3e8979fb9443e28f0f4d5e5f308901123e"
+checksum = "50eef3672ec8fa45f3457fd423ba131117786784a895548021976117c1ded449"
 dependencies = [
  "serde",
 ]

--- a/contracts/staking/Cargo.lock
+++ b/contracts/staking/Cargo.lock
@@ -838,9 +838,9 @@ dependencies = [
 
 [[package]]
 name = "serde-json-wasm"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ebf73928683472b82f01683968f4f3e8979fb9443e28f0f4d5e5f308901123e"
+checksum = "50eef3672ec8fa45f3457fd423ba131117786784a895548021976117c1ded449"
 dependencies = [
  "serde",
 ]

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -34,7 +34,7 @@ stargate = []
 [dependencies]
 base64 = "0.13.0"
 cosmwasm-derive = { path = "../derive", version = "0.13.2" }
-serde-json-wasm = { version = "0.3.0" }
+serde-json-wasm = { version = "0.3.1" }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive", "alloc"] }
 thiserror = "1.0"


### PR DESCRIPTION
Enabling this check now that `serde-json-wasm` implements the required functionality.

See [serde-json-wasm #27](https://github.com/CosmWasm/serde-json-wasm/issues/27) / [serde-json-wasm #28](https://github.com/CosmWasm/serde-json-wasm/pull/28)