### PR TITLE
Add a data field to InitResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ and this project adheres to
 - cosmwasm-std: Remove the previously deprecated `InitResult`, `HandleResult`,
   `MigrateResult` and `QueryResult` in order to make error type explicit and
   encourage migration to custom errors.
+- cosmwasm-std: Add a `data` field to `InitResponse` the same way as in
+  `MigrateResponse` and `HandleResponse`.
 - cosmwasm-vm: Avoid serialization of Modules in `InMemoryCache`, for
   performance. Also, remove `memory_limit` from `InstanceOptions`, and define it
   instead at `Cache` level (same memory limit for all cached instances).

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -95,6 +95,27 @@ major releases of `cosmwasm`. Note that you can also view the
   }
   ```
 
+- Since `InitResponse` now contains a `data` field like `HandleResponse` and
+  `MigrateResponse`, converting `Context` into `InitResponse` always succeeds.
+
+  ```rust
+  // before
+  pub fn init(deps: DepsMut, env: Env, info: MessageInfo, msg: InitMsg) -> Result<InitResponse, HackError> {
+      // …
+      let mut ctx = Context::new();
+      ctx.add_attribute("Let the", "hacking begin");
+      Ok(ctx.try_into()?)
+  }
+
+  // after
+  pub fn init(deps: DepsMut, env: Env, info: MessageInfo, msg: InitMsg) -> Result<InitResponse, HackError> {
+      // …
+      let mut ctx = Context::new();
+      ctx.add_attribute("Let the", "hacking begin");
+      Ok(ctx.into())
+  }
+  ```
+
 ## 0.12 -> 0.13
 
 - The minimum Rust supported version for 0.13 is 1.47.0.

--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -3,7 +3,6 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::convert::TryInto;
 
 use cosmwasm_std::{
     from_slice, to_binary, to_vec, AllBalanceResponse, Api, BankMsg, Binary, CanonicalAddr,
@@ -108,7 +107,7 @@ pub fn init(
     // This adds some unrelated event attribute for testing purposes
     let mut ctx = Context::new();
     ctx.add_attribute("Let the", "hacking begin");
-    Ok(ctx.try_into()?)
+    Ok(ctx.into())
 }
 
 pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> Result<MigrateResponse, HackError> {

--- a/contracts/ibc-reflect/src/contract.rs
+++ b/contracts/ibc-reflect/src/contract.rs
@@ -25,6 +25,7 @@ pub fn init(deps: DepsMut, _env: Env, _info: MessageInfo, msg: InitMsg) -> StdRe
     Ok(InitResponse {
         messages: vec![],
         attributes: vec![attr("action", "init")],
+        data: None,
     })
 }
 

--- a/contracts/reflect/src/contract.rs
+++ b/contracts/reflect/src/contract.rs
@@ -10,7 +10,6 @@ use crate::msg::{
     QueryMsg, RawResponse, SpecialQuery, SpecialResponse,
 };
 use crate::state::{config, config_read, State};
-use std::convert::TryInto;
 
 pub fn init(
     deps: DepsMut,
@@ -36,7 +35,7 @@ pub fn init(
         };
         ctx.add_message(msg);
     }
-    ctx.try_into()
+    Ok(ctx.into())
 }
 
 pub fn handle(

--- a/packages/std/src/results/init.rs
+++ b/packages/std/src/results/init.rs
@@ -2,7 +2,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-use crate::types::Empty;
+use crate::{Binary, Empty};
 
 use super::attribute::Attribute;
 use super::cosmos_msg::CosmosMsg;
@@ -15,6 +15,7 @@ where
     pub messages: Vec<CosmosMsg<T>>,
     /// The attributes that will be emitted as part of a "wasm" event
     pub attributes: Vec<Attribute>,
+    pub data: Option<Binary>,
 }
 
 impl<T> Default for InitResponse<T>
@@ -25,6 +26,7 @@ where
         InitResponse {
             messages: vec![],
             attributes: vec![],
+            data: None,
         }
     }
 }
@@ -48,6 +50,7 @@ mod tests {
                 key: "action".to_string(),
                 value: "release".to_string(),
             }],
+            data: Some(Binary::from([0xAA, 0xBB])),
         };
         let serialized = to_vec(&original).expect("encode contract result");
         let deserialized: InitResponse = from_slice(&serialized).expect("decode contract result");


### PR DESCRIPTION
This increases consistency between InitResponse, MigrateResponse and HandleResponse. The corresponding wasmd change is in https://github.com/CosmWasm/wasmd/issues/385.

Note: conflicts with #740, so one must be updated after the other is merged.