### PR TITLE
Show how to verify Ethereum signatures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ workflows:
 jobs:
   package_schema:
     docker:
-      - image: rust:1.47.0
+      - image: rust:1.49.0
     steps:
       - checkout
       - run:
@@ -55,7 +55,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-package_schema-rust:1.47.0-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-package_schema-rust:1.49.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Build
           working_directory: ~/project/packages/schema
@@ -70,11 +70,11 @@ jobs:
             - target/debug/.fingerprint
             - target/debug/build
             - target/debug/deps
-          key: cargocache-v2-package_schema-rust:1.47.0-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-package_schema-rust:1.49.0-{{ checksum "Cargo.lock" }}
 
   package_std:
     docker:
-      - image: rust:1.47.0
+      - image: rust:1.49.0
     steps:
       - checkout
       - run:
@@ -82,7 +82,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-package_std-rust:1.47.0-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-package_std-rust:1.49.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Add wasm32 target
           command: rustup target add wasm32-unknown-unknown && rustup target list --installed
@@ -129,11 +129,11 @@ jobs:
             - target/debug/.fingerprint
             - target/debug/build
             - target/debug/deps
-          key: cargocache-v2-package_std-rust:1.47.0-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-package_std-rust:1.49.0-{{ checksum "Cargo.lock" }}
 
   package_storage:
     docker:
-      - image: rust:1.47.0
+      - image: rust:1.49.0
     steps:
       - checkout
       - run:
@@ -141,7 +141,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-package_storage-rust:1.47.0-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-package_storage-rust:1.49.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Build library for native target
           working_directory: ~/project/packages/storage
@@ -160,11 +160,11 @@ jobs:
             - target/debug/.fingerprint
             - target/debug/build
             - target/debug/deps
-          key: cargocache-v2-package_storage-rust:1.47.0-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-package_storage-rust:1.49.0-{{ checksum "Cargo.lock" }}
 
   package_vm:
     docker:
-      - image: rust:1.47.0
+      - image: rust:1.49.0
     steps:
       - checkout
       - run:
@@ -172,7 +172,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-package_vm-rust:1.47.0-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-package_vm-rust:1.49.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Build
           working_directory: ~/project/packages/vm
@@ -195,11 +195,11 @@ jobs:
             - target/debug/.fingerprint
             - target/debug/build
             - target/debug/deps
-          key: cargocache-v2-package_vm-rust:1.47.0-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-package_vm-rust:1.49.0-{{ checksum "Cargo.lock" }}
 
   package_vm_cranelift:
     docker:
-      - image: rust:1.47.0
+      - image: rust:1.49.0
     steps:
       - checkout
       - run:
@@ -207,7 +207,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-package_vm_cranelift-rust:1.47.0-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-package_vm_cranelift-rust:1.49.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Build
           working_directory: ~/project/packages/vm
@@ -230,11 +230,11 @@ jobs:
             - target/debug/.fingerprint
             - target/debug/build
             - target/debug/deps
-          key: cargocache-v2-package_vm_cranelift-rust:1.47.0-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-package_vm_cranelift-rust:1.49.0-{{ checksum "Cargo.lock" }}
 
   contract_burner:
     docker:
-      - image: rust:1.47.0
+      - image: rust:1.49.0
     environment:
       RUST_BACKTRACE: 1
     working_directory: ~/cosmwasm/contracts/burner
@@ -246,7 +246,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-v2-contract_burner-rust:1.47.0-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-contract_burner-rust:1.49.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Add wasm32 target
           command: rustup target add wasm32-unknown-unknown && rustup target list --installed
@@ -283,11 +283,11 @@ jobs:
             - target/wasm32-unknown-unknown/release/.fingerprint
             - target/wasm32-unknown-unknown/release/build
             - target/wasm32-unknown-unknown/release/deps
-          key: cargocache-v2-contract_burner-rust:1.47.0-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-contract_burner-rust:1.49.0-{{ checksum "Cargo.lock" }}
 
   contract_crypto_verify:
     docker:
-      - image: rust:1.47.0
+      - image: rust:1.49.0
     environment:
       RUST_BACKTRACE: 1
     working_directory: ~/cosmwasm/contracts/crypto-verify
@@ -299,7 +299,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-v2-contract_crypto_verify-rust:1.47.0-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-contract_crypto_verify-rust:1.49.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Add wasm32 target
           command: rustup target add wasm32-unknown-unknown && rustup target list --installed
@@ -336,11 +336,11 @@ jobs:
             - target/wasm32-unknown-unknown/release/.fingerprint
             - target/wasm32-unknown-unknown/release/build
             - target/wasm32-unknown-unknown/release/deps
-          key: cargocache-v2-contract_crypto_verify-rust:1.47.0-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-contract_crypto_verify-rust:1.49.0-{{ checksum "Cargo.lock" }}
 
   contract_hackatom:
     docker:
-      - image: rust:1.47.0
+      - image: rust:1.49.0
     environment:
       RUST_BACKTRACE: 1
     working_directory: ~/cosmwasm/contracts/hackatom
@@ -352,7 +352,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-v2-contract_hackatom-rust:1.47.0-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-contract_hackatom-rust:1.49.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Add wasm32 target
           command: rustup target add wasm32-unknown-unknown && rustup target list --installed
@@ -389,11 +389,11 @@ jobs:
             - target/wasm32-unknown-unknown/release/.fingerprint
             - target/wasm32-unknown-unknown/release/build
             - target/wasm32-unknown-unknown/release/deps
-          key: cargocache-v2-contract_hackatom-rust:1.47.0-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-contract_hackatom-rust:1.49.0-{{ checksum "Cargo.lock" }}
 
   contract_ibc_reflect:
     docker:
-      - image: rust:1.47.0
+      - image: rust:1.49.0
     environment:
       RUST_BACKTRACE: 1
     working_directory: ~/cosmwasm/contracts/ibc-reflect
@@ -405,7 +405,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-v2-contract_ibc_reflect-rust:1.47.0-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-contract_ibc_reflect-rust:1.49.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Add wasm32 target
           command: rustup target add wasm32-unknown-unknown && rustup target list --installed
@@ -442,12 +442,12 @@ jobs:
             - target/wasm32-unknown-unknown/release/.fingerprint
             - target/wasm32-unknown-unknown/release/build
             - target/wasm32-unknown-unknown/release/deps
-          key: cargocache-v2-contract_ibc_reflect-rust:1.47.0-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-contract_ibc_reflect-rust:1.49.0-{{ checksum "Cargo.lock" }}
 
 
   contract_ibc_reflect_send:
     docker:
-      - image: rust:1.47.0
+      - image: rust:1.49.0
     environment:
       RUST_BACKTRACE: 1
     working_directory: ~/cosmwasm/contracts/ibc-reflect-send
@@ -459,7 +459,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-v2-contract_ibc_reflect_send-rust:1.47.0-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-contract_ibc_reflect_send-rust:1.49.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Add wasm32 target
           command: rustup target add wasm32-unknown-unknown && rustup target list --installed
@@ -496,11 +496,11 @@ jobs:
             - target/wasm32-unknown-unknown/release/.fingerprint
             - target/wasm32-unknown-unknown/release/build
             - target/wasm32-unknown-unknown/release/deps
-          key: cargocache-v2-contract_ibc_reflect_send-rust:1.47.0-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-contract_ibc_reflect_send-rust:1.49.0-{{ checksum "Cargo.lock" }}
 
   contract_queue:
     docker:
-      - image: rust:1.47.0
+      - image: rust:1.49.0
     environment:
       RUST_BACKTRACE: 1
     working_directory: ~/cosmwasm/contracts/queue
@@ -512,7 +512,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-v2-contract_queue-rust:1.47.0-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-contract_queue-rust:1.49.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Add wasm32 target
           command: rustup target add wasm32-unknown-unknown && rustup target list --installed
@@ -549,11 +549,11 @@ jobs:
             - target/wasm32-unknown-unknown/release/.fingerprint
             - target/wasm32-unknown-unknown/release/build
             - target/wasm32-unknown-unknown/release/deps
-          key: cargocache-v2-contract_queue-rust:1.47.0-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-contract_queue-rust:1.49.0-{{ checksum "Cargo.lock" }}
 
   contract_reflect:
     docker:
-      - image: rust:1.47.0
+      - image: rust:1.49.0
     environment:
       RUST_BACKTRACE: 1
     working_directory: ~/cosmwasm/contracts/reflect
@@ -565,7 +565,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-v2-contract_reflect-rust:1.47.0-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-contract_reflect-rust:1.49.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Add wasm32 target
           command: rustup target add wasm32-unknown-unknown && rustup target list --installed
@@ -602,11 +602,11 @@ jobs:
             - target/wasm32-unknown-unknown/release/.fingerprint
             - target/wasm32-unknown-unknown/release/build
             - target/wasm32-unknown-unknown/release/deps
-          key: cargocache-v2-contract_reflect-rust:1.47.0-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-contract_reflect-rust:1.49.0-{{ checksum "Cargo.lock" }}
 
   contract_staking:
     docker:
-      - image: rust:1.47.0
+      - image: rust:1.49.0
     environment:
       RUST_BACKTRACE: 1
     working_directory: ~/cosmwasm/contracts/staking
@@ -618,7 +618,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-v2-contract_staking-rust:1.47.0-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-contract_staking-rust:1.49.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Add wasm32 target
           command: rustup target add wasm32-unknown-unknown && rustup target list --installed
@@ -655,11 +655,11 @@ jobs:
             - target/wasm32-unknown-unknown/release/.fingerprint
             - target/wasm32-unknown-unknown/release/build
             - target/wasm32-unknown-unknown/release/deps
-          key: cargocache-v2-contract_staking-rust:1.47.0-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-contract_staking-rust:1.49.0-{{ checksum "Cargo.lock" }}
 
   fmt:
     docker:
-      - image: rust:1.47.0
+      - image: rust:1.49.0
     steps:
       - checkout
       - run:
@@ -667,7 +667,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-fmt-rust:1.47.0-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-fmt-rust:1.49.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Add rustfmt component
           command: rustup component add rustfmt
@@ -704,7 +704,7 @@ jobs:
             - target/debug/.fingerprint
             - target/debug/build
             - target/debug/deps
-          key: cargocache-v2-fmt-rust:1.47.0-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-fmt-rust:1.49.0-{{ checksum "Cargo.lock" }}
 
   clippy:
     docker:
@@ -846,7 +846,7 @@ jobs:
 
   benchmarking:
     docker:
-      - image: rust:1.47.0
+      - image: rust:1.49.0
     environment:
       RUST_BACKTRACE: 1
     steps:
@@ -856,7 +856,7 @@ jobs:
           command: rustc --version && cargo --version
       - restore_cache:
           keys:
-            - cargocache-v2-benchmarking-rust:1.47.0-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-benchmarking-rust:1.49.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Run benchmarks (Singlepass)
           working_directory: ~/project/packages/vm
@@ -874,7 +874,7 @@ jobs:
             - target/release/.fingerprint
             - target/release/build
             - target/release/deps
-          key: cargocache-v2-benchmarking-rust:1.47.0-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-benchmarking-rust:1.49.0-{{ checksum "Cargo.lock" }}
 
   # This job roughly follows the instructions from https://circleci.com/blog/publishing-to-github-releases-via-circleci/
   build_and_upload_devcontracts:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.47.0
+          toolchain: 1.49.0
           target: wasm32-unknown-unknown
           profile: minimal
           override: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to
 ### Added
 
 - cosmwasm-crypto: Add `ed25519_batch_verify`, EdDSA ed25519 batch signature
-  verification scheme for Tendermint signatures and public keys formats. ([#788])
+  verification scheme for Tendermint signatures and public keys formats.
+  ([#788])
 - cosmwasm-crypto: Add `ed25519_verify`, EdDSA ed25519 signature verification
   scheme for Tendermint signature and public key formats. ([#771])
 - cosmwasm-crypto: New crypto-related crate. Add `secp256k1_verify`, ECDSA
@@ -55,6 +56,7 @@ and this project adheres to
 
 ### Changed
 
+- all: Drop support for Rust versions lower than 1.49.0.
 - all: The `query` enpoint is now optional. It is still highly recommended to
   expose it an almost any use case though.
 - all: Change the encoding of the key/value region of the `db_next` import to a

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -6,6 +6,9 @@ major releases of `cosmwasm`. Note that you can also view the
 
 ## 0.13 -> 0.14 (unreleased)
 
+- The minimum Rust supported version for 0.14 is 1.49.0. Verify your Rust
+  version is >= 1.49.0 with: `rustc --version`
+
 - Update CosmWasm dependencies in Cargo.toml (skip the ones you don't use):
 
   ```
@@ -199,13 +202,8 @@ major releases of `cosmwasm`. Note that you can also view the
 
 ## 0.12 -> 0.13
 
-- The minimum Rust supported version for 0.13 is 1.47.0.
-
-  Verify your Rust version is >= 1.47.0:
-
-  ```
-  rustc -V
-  ```
+- The minimum Rust supported version for 0.13 is 1.47.0. Verify your Rust
+  version is >= 1.47.0 with: `rustc --version`
 
 - Update CosmWasm dependencies in Cargo.toml (skip the ones you don't use):
 

--- a/contracts/crypto-verify/Cargo.lock
+++ b/contracts/crypto-verify/Cargo.lock
@@ -16,6 +16,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -64,7 +70,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d2838fdd79e8776dbe07a106c784b0f8dda571a21b2750a092cc4cbaa653c8e"
 dependencies = [
  "funty",
- "radium",
+ "radium 0.4.1",
+ "wyz",
+]
+
+[[package]]
+name = "bitvec"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5011ffc90248764d7005b0e10c7294f5aa1bd87d9dd7248f4ad475b347c294d"
+dependencies = [
+ "funty",
+ "radium 0.6.2",
+ "tap",
  "wyz",
 ]
 
@@ -85,10 +103,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
+name = "byte-slice-cast"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c1bf4a04a88c54f589125563643d773f3254b5c38571395e2b591c693bbc81"
+
+[[package]]
 name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+
+[[package]]
+name = "bytes"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cc"
@@ -135,7 +165,7 @@ dependencies = [
  "digest",
  "ed25519-zebra",
  "k256",
- "rand_core",
+ "rand_core 0.5.1",
  "thiserror",
 ]
 
@@ -320,6 +350,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
 name = "crypto-mac"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,7 +373,9 @@ dependencies = [
  "cosmwasm-std",
  "cosmwasm-storage",
  "cosmwasm-vm",
+ "ethereum-transaction",
  "hex",
+ "hex-literal",
  "schemars",
  "serde",
  "sha2",
@@ -352,7 +390,7 @@ checksum = "f627126b946c25a4638eec0ea634fc52506dea98db118aae985118ce7c3d723f"
 dependencies = [
  "byteorder",
  "digest",
- "rand_core",
+ "rand_core 0.5.1",
  "subtle",
  "zeroize",
 ]
@@ -455,7 +493,7 @@ checksum = "0a128b76af6dd4b427e34a6fd43dc78dbfe73672ec41ff615a2414c1a0ad0409"
 dependencies = [
  "curve25519-dalek",
  "hex",
- "rand_core",
+ "rand_core 0.5.1",
  "serde",
  "sha2",
  "thiserror",
@@ -473,13 +511,13 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "592b1c857559479c056b73a3053c717108a70e4dce320ad28c79c63f5c2e62ba"
 dependencies = [
- "bitvec",
+ "bitvec 0.18.4",
  "digest",
  "ff",
  "generic-array",
  "group",
  "pkcs8",
- "rand_core",
+ "rand_core 0.5.1",
  "subtle",
  "zeroize",
 ]
@@ -506,6 +544,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethbloom"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "779864b9c7f7ead1f092972c3257496c6a84b46dba2ce131dd8a282cb2cc5972"
+dependencies = [
+ "crunchy",
+ "fixed-hash",
+ "impl-rlp",
+ "impl-serde",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "ethereum-transaction"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e30cf7b703d4cff17586f1cbe479ff996a12ca49b0dcb5a986e3a57de5461c1"
+dependencies = [
+ "ethereum-types",
+ "impl-serde",
+ "log",
+ "rlp",
+ "serde",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64b5df66a228d85e4b17e5d6c6aa43b0310898ffe8a85988c4c032357aaabfd"
+dependencies = [
+ "ethbloom",
+ "fixed-hash",
+ "impl-rlp",
+ "impl-serde",
+ "primitive-types",
+ "uint",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -517,9 +596,21 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01646e077d4ebda82b73f1bca002ea1e91561a77df2431a9e79729bcc31950ef"
 dependencies = [
- "bitvec",
- "rand_core",
+ "bitvec 0.18.4",
+ "rand_core 0.5.1",
  "subtle",
+]
+
+[[package]]
+name = "fixed-hash"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
+dependencies = [
+ "byteorder",
+ "rand 0.8.3",
+ "rustc-hex",
+ "static_assertions",
 ]
 
 [[package]]
@@ -552,7 +643,18 @@ checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -579,7 +681,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc11f9f5fbf1943b48ae7c2bf6846e7d827a512d1be4f23af708f5ca5d01dde1"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.5.1",
  "subtle",
 ]
 
@@ -605,6 +707,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
 
 [[package]]
+name = "hex-literal"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5af1f635ef1bc545d78392b136bfe1c9809e029023c84a3638a864a10b8819c8"
+
+[[package]]
 name = "hmac"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -619,6 +727,33 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "impl-codec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df170efa359aebdd5cb7fe78edcc67107748e4737bdca8a8fb40d15ea7a877ed"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-rlp"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
+dependencies = [
+ "rlp",
+]
+
+[[package]]
+name = "impl-serde"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47ca4d2b6931707a55fce5cf66aff80e2178c8b63bbb4ecb5695cbc870ddf6f"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "indexmap"
@@ -771,6 +906,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "parity-scale-codec"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75c823fdae1bb5ff5708ee61a62697e6296175dc671710876871c853f48592b3"
+dependencies = [
+ "arrayvec",
+ "bitvec 0.20.1",
+ "byte-slice-cast",
+ "serde",
+]
+
+[[package]]
 name = "parity-wasm"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -796,6 +943,19 @@ name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "primitive-types"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2415937401cb030a2a0a4d922483f945fa068f52a7dbb22ce0fe5f2b6f6adace"
+dependencies = [
+ "fixed-hash",
+ "impl-codec",
+ "impl-rlp",
+ "impl-serde",
+ "uint",
+]
 
 [[package]]
 name = "proc-macro-error"
@@ -846,16 +1006,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64de9a0c5361e034f1aefc9f71a86871ec870e766fe31a009734a989b329286a"
 
 [[package]]
+name = "radium"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
+
+[[package]]
 name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
  "rand_hc",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.0",
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -865,7 +1042,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -874,7 +1061,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+dependencies = [
+ "getrandom 0.2.2",
 ]
 
 [[package]]
@@ -883,7 +1079,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -950,6 +1146,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rlp"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e54369147e3e7796c9b885c7304db87ca3d09a0a98f72843d532868675bbfba8"
+dependencies = [
+ "bytes",
+ "rustc-hex",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -960,6 +1166,12 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "ryu"
@@ -1088,7 +1300,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1102,6 +1314,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -1127,6 +1345,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "target-lexicon"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1140,7 +1364,7 @@ checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
- "rand",
+ "rand 0.7.3",
  "redox_syscall",
  "remove_dir_all",
  "winapi",
@@ -1164,6 +1388,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -1205,6 +1438,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 
 [[package]]
+name = "uint"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e11fe9a9348741cf134085ad57c249508345fe16411b3d7fb4ff2da2f1d6382e"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1221,6 +1466,12 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasmer"

--- a/contracts/crypto-verify/Cargo.lock
+++ b/contracts/crypto-verify/Cargo.lock
@@ -16,12 +16,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
-name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -70,19 +64,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d2838fdd79e8776dbe07a106c784b0f8dda571a21b2750a092cc4cbaa653c8e"
 dependencies = [
  "funty",
- "radium 0.4.1",
- "wyz",
-]
-
-[[package]]
-name = "bitvec"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5011ffc90248764d7005b0e10c7294f5aa1bd87d9dd7248f4ad475b347c294d"
-dependencies = [
- "funty",
- "radium 0.6.2",
- "tap",
+ "radium",
  "wyz",
 ]
 
@@ -101,12 +83,6 @@ name = "block-padding"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
-
-[[package]]
-name = "byte-slice-cast"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65c1bf4a04a88c54f589125563643d773f3254b5c38571395e2b591c693bbc81"
 
 [[package]]
 name = "byteorder"
@@ -165,7 +141,7 @@ dependencies = [
  "digest",
  "ed25519-zebra",
  "k256",
- "rand_core 0.5.1",
+ "rand_core",
  "thiserror",
 ]
 
@@ -350,12 +326,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crunchy"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
-
-[[package]]
 name = "crypto-mac"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,9 +343,9 @@ dependencies = [
  "cosmwasm-std",
  "cosmwasm-storage",
  "cosmwasm-vm",
- "ethereum-transaction",
  "hex",
  "hex-literal",
+ "rlp",
  "schemars",
  "serde",
  "sha2",
@@ -390,7 +360,7 @@ checksum = "f627126b946c25a4638eec0ea634fc52506dea98db118aae985118ce7c3d723f"
 dependencies = [
  "byteorder",
  "digest",
- "rand_core 0.5.1",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -493,7 +463,7 @@ checksum = "0a128b76af6dd4b427e34a6fd43dc78dbfe73672ec41ff615a2414c1a0ad0409"
 dependencies = [
  "curve25519-dalek",
  "hex",
- "rand_core 0.5.1",
+ "rand_core",
  "serde",
  "sha2",
  "thiserror",
@@ -511,13 +481,13 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "592b1c857559479c056b73a3053c717108a70e4dce320ad28c79c63f5c2e62ba"
 dependencies = [
- "bitvec 0.18.4",
+ "bitvec",
  "digest",
  "ff",
  "generic-array",
  "group",
  "pkcs8",
- "rand_core 0.5.1",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -544,47 +514,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ethbloom"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779864b9c7f7ead1f092972c3257496c6a84b46dba2ce131dd8a282cb2cc5972"
-dependencies = [
- "crunchy",
- "fixed-hash",
- "impl-rlp",
- "impl-serde",
- "tiny-keccak",
-]
-
-[[package]]
-name = "ethereum-transaction"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e30cf7b703d4cff17586f1cbe479ff996a12ca49b0dcb5a986e3a57de5461c1"
-dependencies = [
- "ethereum-types",
- "impl-serde",
- "log",
- "rlp",
- "serde",
- "tiny-keccak",
-]
-
-[[package]]
-name = "ethereum-types"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f64b5df66a228d85e4b17e5d6c6aa43b0310898ffe8a85988c4c032357aaabfd"
-dependencies = [
- "ethbloom",
- "fixed-hash",
- "impl-rlp",
- "impl-serde",
- "primitive-types",
- "uint",
-]
-
-[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,21 +525,9 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01646e077d4ebda82b73f1bca002ea1e91561a77df2431a9e79729bcc31950ef"
 dependencies = [
- "bitvec 0.18.4",
- "rand_core 0.5.1",
+ "bitvec",
+ "rand_core",
  "subtle",
-]
-
-[[package]]
-name = "fixed-hash"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
-dependencies = [
- "byteorder",
- "rand 0.8.3",
- "rustc-hex",
- "static_assertions",
 ]
 
 [[package]]
@@ -643,18 +560,7 @@ checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -681,7 +587,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc11f9f5fbf1943b48ae7c2bf6846e7d827a512d1be4f23af708f5ca5d01dde1"
 dependencies = [
  "ff",
- "rand_core 0.5.1",
+ "rand_core",
  "subtle",
 ]
 
@@ -727,33 +633,6 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
-name = "impl-codec"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df170efa359aebdd5cb7fe78edcc67107748e4737bdca8a8fb40d15ea7a877ed"
-dependencies = [
- "parity-scale-codec",
-]
-
-[[package]]
-name = "impl-rlp"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
-dependencies = [
- "rlp",
-]
-
-[[package]]
-name = "impl-serde"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47ca4d2b6931707a55fce5cf66aff80e2178c8b63bbb4ecb5695cbc870ddf6f"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "indexmap"
@@ -906,18 +785,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
-name = "parity-scale-codec"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75c823fdae1bb5ff5708ee61a62697e6296175dc671710876871c853f48592b3"
-dependencies = [
- "arrayvec",
- "bitvec 0.20.1",
- "byte-slice-cast",
- "serde",
-]
-
-[[package]]
 name = "parity-wasm"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -943,19 +810,6 @@ name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
-
-[[package]]
-name = "primitive-types"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2415937401cb030a2a0a4d922483f945fa068f52a7dbb22ce0fe5f2b6f6adace"
-dependencies = [
- "fixed-hash",
- "impl-codec",
- "impl-rlp",
- "impl-serde",
- "uint",
-]
 
 [[package]]
 name = "proc-macro-error"
@@ -1006,33 +860,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64de9a0c5361e034f1aefc9f71a86871ec870e766fe31a009734a989b329286a"
 
 [[package]]
-name = "radium"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
-
-[[package]]
 name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom 0.1.16",
+ "getrandom",
  "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
+ "rand_chacha",
+ "rand_core",
  "rand_hc",
-]
-
-[[package]]
-name = "rand"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
-dependencies = [
- "libc",
- "rand_chacha 0.3.0",
- "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -1042,17 +879,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.2",
+ "rand_core",
 ]
 
 [[package]]
@@ -1061,16 +888,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom 0.1.16",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
-dependencies = [
- "getrandom 0.2.2",
+ "getrandom",
 ]
 
 [[package]]
@@ -1079,7 +897,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core 0.5.1",
+ "rand_core",
 ]
 
 [[package]]
@@ -1300,7 +1118,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
 dependencies = [
  "digest",
- "rand_core 0.5.1",
+ "rand_core",
 ]
 
 [[package]]
@@ -1314,12 +1132,6 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -1345,12 +1157,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
 name = "target-lexicon"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1364,7 +1170,7 @@ checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
- "rand 0.7.3",
+ "rand",
  "redox_syscall",
  "remove_dir_all",
  "winapi",
@@ -1388,15 +1194,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
 ]
 
 [[package]]
@@ -1438,18 +1235,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 
 [[package]]
-name = "uint"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11fe9a9348741cf134085ad57c249508345fe16411b3d7fb4ff2da2f1d6382e"
-dependencies = [
- "byteorder",
- "crunchy",
- "hex",
- "static_assertions",
-]
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1466,12 +1251,6 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasmer"

--- a/contracts/crypto-verify/Cargo.toml
+++ b/contracts/crypto-verify/Cargo.toml
@@ -34,8 +34,8 @@ backtraces = ["cosmwasm-std/backtraces", "cosmwasm-vm/backtraces"]
 [dependencies]
 cosmwasm-std = { path = "../../packages/std", features = ["iterator"] }
 cosmwasm-storage = { path = "../../packages/storage", features = ["iterator"] }
-ethereum-transaction = "0.6"
 hex = "0.4"
+rlp = "0.5"
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 sha2 = "0.9"

--- a/contracts/crypto-verify/Cargo.toml
+++ b/contracts/crypto-verify/Cargo.toml
@@ -34,6 +34,7 @@ backtraces = ["cosmwasm-std/backtraces", "cosmwasm-vm/backtraces"]
 [dependencies]
 cosmwasm-std = { path = "../../packages/std", features = ["iterator"] }
 cosmwasm-storage = { path = "../../packages/storage", features = ["iterator"] }
+ethereum-transaction = "0.6"
 hex = "0.4"
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
@@ -43,3 +44,4 @@ sha3 = "0.9"
 [dev-dependencies]
 cosmwasm-vm = { path = "../../packages/vm", default-features = false, features = ["iterator"] }
 cosmwasm-schema = { path = "../../packages/schema" }
+hex-literal = "0.3.1"

--- a/contracts/crypto-verify/schema/query_msg.json
+++ b/contracts/crypto-verify/schema/query_msg.json
@@ -81,6 +81,73 @@
       }
     },
     {
+      "type": "object",
+      "required": [
+        "verify_ethereum_transaction"
+      ],
+      "properties": {
+        "verify_ethereum_transaction": {
+          "type": "object",
+          "required": [
+            "chain_id",
+            "data",
+            "from",
+            "gas_limit",
+            "gas_price",
+            "nonce",
+            "r",
+            "s",
+            "to",
+            "v",
+            "value"
+          ],
+          "properties": {
+            "chain_id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "data": {
+              "$ref": "#/definitions/Binary"
+            },
+            "from": {
+              "description": "Ethereum address in hex format (42 characters, starting with 0x)",
+              "type": "string"
+            },
+            "gas_limit": {
+              "$ref": "#/definitions/Uint128"
+            },
+            "gas_price": {
+              "$ref": "#/definitions/Uint128"
+            },
+            "nonce": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "r": {
+              "$ref": "#/definitions/Binary"
+            },
+            "s": {
+              "$ref": "#/definitions/Binary"
+            },
+            "to": {
+              "description": "Ethereum address in hex format (42 characters, starting with 0x)",
+              "type": "string"
+            },
+            "v": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "value": {
+              "$ref": "#/definitions/Uint128"
+            }
+          }
+        }
+      }
+    },
+    {
       "description": "Tendermint format (ed25519 verification scheme).",
       "type": "object",
       "required": [
@@ -179,6 +246,9 @@
   "definitions": {
     "Binary": {
       "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>",
+      "type": "string"
+    },
+    "Uint128": {
       "type": "string"
     }
   }

--- a/contracts/crypto-verify/src/contract.rs
+++ b/contracts/crypto-verify/src/contract.rs
@@ -143,6 +143,7 @@ pub fn query_verify_ethereum_text(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn query_verify_ethereum_transaction(
     deps: Deps,
     from: String,

--- a/contracts/crypto-verify/src/contract.rs
+++ b/contracts/crypto-verify/src/contract.rs
@@ -4,11 +4,12 @@ use cosmwasm_std::{
 };
 use sha2::{Digest, Sha256};
 use sha3::Keccak256;
+use std::ops::Deref;
 
+use crate::ethereum::ethereum_address;
 use crate::msg::{
     list_verifications, HandleMsg, InitMsg, ListVerificationsResponse, QueryMsg, VerifyResponse,
 };
-use std::ops::Deref;
 
 pub const VERSION: &str = "crypto-verify-v2";
 
@@ -159,25 +160,6 @@ pub fn query_list_verifications(deps: Deps) -> StdResult<ListVerificationsRespon
     Ok(ListVerificationsResponse {
         verification_schemes,
     })
-}
-
-fn ethereum_address(pubkey: &[u8]) -> StdResult<String> {
-    let (tag, data) = match pubkey.split_first() {
-        Some(pair) => pair,
-        None => return Err(StdError::generic_err("Public key must not be empty")),
-    };
-    if *tag != 0x04 {
-        return Err(StdError::generic_err("Public key start with 0x04"));
-    }
-    if data.len() != 64 {
-        return Err(StdError::generic_err("Public key must be 65 bytes long"));
-    }
-
-    let hash = Keccak256::digest(data);
-    let mut out = String::with_capacity(42);
-    out.push_str("0x");
-    out.push_str(&hex::encode(&hash[hash.len() - 20..]));
-    Ok(out)
 }
 
 fn get_recovery_param(v: u8) -> StdResult<u8> {

--- a/contracts/crypto-verify/src/contract.rs
+++ b/contracts/crypto-verify/src/contract.rs
@@ -6,7 +6,7 @@ use sha2::{Digest, Sha256};
 use sha3::Keccak256;
 use std::ops::Deref;
 
-use crate::ethereum::{ethereum_address, to_20bytes, verify_transaction};
+use crate::ethereum::{decode_address, ethereum_address, verify_transaction};
 use crate::msg::{
     list_verifications, HandleMsg, InitMsg, ListVerificationsResponse, QueryMsg, VerifyResponse,
 };
@@ -143,8 +143,8 @@ pub fn query_verify_ethereum_text(
 
 pub fn query_verify_ethereum_transaction(
     deps: Deps,
-    from: Binary,
-    to: Binary,
+    from: String,
+    to: String,
     nonce: u64,
     gas_limit: Uint128,
     gas_price: Uint128,
@@ -155,8 +155,8 @@ pub fn query_verify_ethereum_transaction(
     s: Binary,
     v: u64,
 ) -> StdResult<VerifyResponse> {
-    let from = to_20bytes(&from)?;
-    let to = to_20bytes(&to)?;
+    let from = decode_address(&from)?;
+    let to = decode_address(&to)?;
 
     let verifies = verify_transaction(
         deps.api,
@@ -433,8 +433,8 @@ mod tests {
         // }
         let nonce = 0xe1;
         let chain_id = 4; // Rinkeby, see https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md#list-of-chain-ids
-        let from = hex!("0a65766695a712af41b5cfecaad217b1a11cb22a");
-        let to = hex!("e137f5264b6b528244e1643a2d570b37660b7f14");
+        let from = "0x0a65766695a712af41b5cfecaad217b1a11cb22a";
+        let to = "0xe137f5264b6b528244e1643a2d570b37660b7f14";
         let gas_limit = Uint128(0x226c8);
         let gas_price = Uint128(0x3b9aca00);
         let value = Uint128(0x53177c);

--- a/contracts/crypto-verify/src/contract.rs
+++ b/contracts/crypto-verify/src/contract.rs
@@ -6,7 +6,9 @@ use sha2::{Digest, Sha256};
 use sha3::Keccak256;
 use std::ops::Deref;
 
-use crate::ethereum::{decode_address, ethereum_address_raw, verify_transaction};
+use crate::ethereum::{
+    decode_address, ethereum_address_raw, get_recovery_param, verify_transaction,
+};
 use crate::msg::{
     list_verifications, HandleMsg, InitMsg, ListVerificationsResponse, QueryMsg, VerifyResponse,
 };
@@ -212,16 +214,6 @@ pub fn query_list_verifications(deps: Deps) -> StdResult<ListVerificationsRespon
     Ok(ListVerificationsResponse {
         verification_schemes,
     })
-}
-
-fn get_recovery_param(v: u8) -> StdResult<u8> {
-    // See https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md
-    // for how `v` is composed.
-    match v {
-        27 => Ok(0),
-        28 => Ok(1),
-        _ => Err(StdError::generic_err("Values of v other than 27 and 28 not supported. Replay protection (EIP-155) cannot be used here."))
-    }
 }
 
 #[cfg(test)]

--- a/contracts/crypto-verify/src/ethereum.rs
+++ b/contracts/crypto-verify/src/ethereum.rs
@@ -45,6 +45,8 @@ fn serialize_unsigned_transaction(
     data: &[u8],
     chain_id: u64,
 ) -> Vec<u8> {
+    // See https://ethereum.stackexchange.com/a/2097/54581 and
+    // https://github.com/tomusdrw/jsonrpc-proxy/blob/7855dec/ethereum-proxy/plugins/accounts/transaction/src/lib.rs#L132-L144.
     let mut stream = RlpStream::new();
     stream.begin_list(9);
     stream.append(&nonce);

--- a/contracts/crypto-verify/src/ethereum.rs
+++ b/contracts/crypto-verify/src/ethereum.rs
@@ -1,8 +1,45 @@
 use std::borrow::Cow;
 
+use cosmwasm_std::{Api, StdError, StdResult};
 use ethereum_transaction::{SignedTransaction, Transaction};
+use sha3::{Digest, Keccak256};
 
-pub fn serialize_unsigned_transaction(
+#[allow(clippy::too_many_arguments)]
+pub fn verify_transaction<A: Api>(
+    api: A,
+    from: [u8; 20],
+    to: [u8; 20],
+    nonce: u128,
+    gas: u128,
+    gas_price: u128,
+    value: u128,
+    data: Vec<u8>,
+    chain_id: u64,
+    r: &[u8],
+    s: &[u8],
+    v: u64,
+) -> StdResult<bool> {
+    let sign_bytes =
+        serialize_unsigned_transaction(from, to, nonce, gas, gas_price, value, data, chain_id);
+    let hash = Keccak256::digest(&sign_bytes);
+    let mut rs: Vec<u8> = Vec::with_capacity(64);
+    rs.resize(32 - r.len(), 0); // Left pad r to 32 bytes
+    rs.extend_from_slice(r);
+    rs.resize(32 + (32 - s.len()), 0); // Left pad s to 32 bytes
+    rs.extend_from_slice(s);
+
+    let recovery = get_recovery_param(v, chain_id)?;
+    let calculated_pubkey = api.secp256k1_recover_pubkey(&hash, &rs, recovery)?;
+    let calculated_address = ethereum_address_raw(&calculated_pubkey)?;
+    if from.as_ref() != calculated_address {
+        return Ok(false);
+    }
+    let valid = api.secp256k1_verify(&hash, &rs, &calculated_pubkey)?;
+    Ok(valid)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn serialize_unsigned_transaction(
     from: [u8; 20],
     to: [u8; 20],
     nonce: u128,
@@ -31,10 +68,90 @@ pub fn serialize_unsigned_transaction(
     .to_rlp()
 }
 
+pub fn get_recovery_param(v: u64, chain_id: u64) -> StdResult<u8> {
+    // See https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md
+    // for how `v` is composed.
+    let recovery = v - chain_id * 2 - 35;
+    match recovery {
+        0 | 1 => Ok(recovery as u8),
+        _ => Err(StdError::generic_err(format!(
+            "Calculated recovery parameter must be 0 or 1 but is {}.",
+            recovery
+        ))),
+    }
+}
+
+fn ethereum_address_raw(pubkey: &[u8]) -> StdResult<Vec<u8>> {
+    let (tag, data) = match pubkey.split_first() {
+        Some(pair) => pair,
+        None => return Err(StdError::generic_err("Public key must not be empty")),
+    };
+    if *tag != 0x04 {
+        return Err(StdError::generic_err("Public key start with 0x04"));
+    }
+    if data.len() != 64 {
+        return Err(StdError::generic_err("Public key must be 65 bytes long"));
+    }
+
+    let hash = Keccak256::digest(data);
+    Ok(hash[hash.len() - 20..].into())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cosmwasm_std::testing::MockApi;
     use hex_literal::hex;
+
+    #[test]
+    fn verify_transaction_works() {
+        // curl -sS -X POST --data '{"jsonrpc":"2.0","method":"eth_getTransactionByHash","params":["0x3b87faa3410f33284124a6898fac1001673f0f7c3682d18f55bdff0031cce9ce"],"id":1}' -H "Content-type: application/json" https://rinkeby-light.eth.linkpool.io | jq .result
+        // {
+        //   "blockHash": "0x05ebd1bd99956537f49cfa1104682b3b3f9ff9249fa41a09931ce93368606c21",
+        //   "blockNumber": "0x37ef3e",
+        //   "from": "0x0a65766695a712af41b5cfecaad217b1a11cb22a",
+        //   "gas": "0x226c8",
+        //   "gasPrice": "0x3b9aca00",
+        //   "hash": "0x3b87faa3410f33284124a6898fac1001673f0f7c3682d18f55bdff0031cce9ce",
+        //   "input": "0x536561726368207478207465737420302e36353930383639313733393634333335",
+        //   "nonce": "0xe1",
+        //   "to": "0xe137f5264b6b528244e1643a2d570b37660b7f14",
+        //   "transactionIndex": "0xb",
+        //   "value": "0x53177c",
+        //   "v": "0x2b",
+        //   "r": "0xb9299dab50b3cddcaecd64b29bfbd5cd30fac1a1adea1b359a13c4e5171492a6",
+        //   "s": "0x573059c66d894684488f92e7ce1f91b158ca57b0235485625b576a3b98c480ac"
+        // }
+        let nonce = 0xe1;
+        let chain_id = 4; // Rinkeby, see https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md#list-of-chain-ids
+        let from = hex!("0a65766695a712af41b5cfecaad217b1a11cb22a");
+        let to = hex!("e137f5264b6b528244e1643a2d570b37660b7f14");
+        let gas_limit = 0x226c8;
+        let gas_price = 0x3b9aca00;
+        let value = 0x53177c;
+        let data = hex!("536561726368207478207465737420302e36353930383639313733393634333335");
+        let r = hex!("b9299dab50b3cddcaecd64b29bfbd5cd30fac1a1adea1b359a13c4e5171492a6");
+        let s = hex!("573059c66d894684488f92e7ce1f91b158ca57b0235485625b576a3b98c480ac");
+        let v = 0x2b;
+
+        let api = MockApi::default();
+        let valid = verify_transaction(
+            api,
+            from,
+            to,
+            nonce,
+            gas_limit,
+            gas_price,
+            value,
+            data.to_vec(),
+            chain_id,
+            &r,
+            &s,
+            v,
+        )
+        .unwrap();
+        assert_eq!(valid, true);
+    }
 
     #[test]
     fn serialize_unsigned_transaction_works() {

--- a/contracts/crypto-verify/src/ethereum.rs
+++ b/contracts/crypto-verify/src/ethereum.rs
@@ -72,17 +72,8 @@ pub fn get_recovery_param(v: u64, chain_id: u64) -> StdResult<u8> {
     }
 }
 
-/// Returns a hex-encoded Ethereum address (lower case hex)
-pub fn ethereum_address(pubkey: &[u8]) -> StdResult<String> {
-    let data = ethereum_address_raw(pubkey)?;
-    let mut out = String::with_capacity(42);
-    out.push_str("0x");
-    out.push_str(&hex::encode(data));
-    Ok(out)
-}
-
 /// Returns a raw 20 byte Ethereum address
-fn ethereum_address_raw(pubkey: &[u8]) -> StdResult<[u8; 20]> {
+pub fn ethereum_address_raw(pubkey: &[u8]) -> StdResult<[u8; 20]> {
     let (tag, data) = match pubkey.split_first() {
         Some(pair) => pair,
         None => return Err(StdError::generic_err("Public key must not be empty")),

--- a/contracts/crypto-verify/src/ethereum.rs
+++ b/contracts/crypto-verify/src/ethereum.rs
@@ -3,8 +3,8 @@ use rlp::RlpStream;
 use sha3::{Digest, Keccak256};
 
 #[allow(clippy::too_many_arguments)]
-pub fn verify_transaction<A: Api>(
-    api: A,
+pub fn verify_transaction(
+    api: &dyn Api,
     from: [u8; 20],
     to: [u8; 20],
     nonce: u64,
@@ -139,7 +139,7 @@ mod tests {
 
         let api = MockApi::default();
         let valid = verify_transaction(
-            api, from, to, nonce, gas_limit, gas_price, value, &data, chain_id, &r, &s, v,
+            &api, from, to, nonce, gas_limit, gas_price, value, &data, chain_id, &r, &s, v,
         )
         .unwrap();
         assert_eq!(valid, true);

--- a/contracts/crypto-verify/src/ethereum.rs
+++ b/contracts/crypto-verify/src/ethereum.rs
@@ -100,12 +100,19 @@ fn ethereum_address_raw(pubkey: &[u8]) -> StdResult<[u8; 20]> {
     Ok(out)
 }
 
-pub fn to_20bytes(input: &[u8]) -> StdResult<[u8; 20]> {
-    if input.len() != 20 {
-        return Err(StdError::generic_err("Input not 20 bytes"));
+pub fn decode_address(input: &str) -> StdResult<[u8; 20]> {
+    if input.len() != 42 {
+        return Err(StdError::generic_err(
+            "Ethereum adddress must be 42 characters long",
+        ));
     }
+    if !input.starts_with("0x") {
+        return Err(StdError::generic_err("Ethereum adddress must start wit 0x"));
+    }
+    let data = hex::decode(&input[2..]).map_err(|_| StdError::generic_err("hex decoding error"))?;
+    debug_assert_eq!(data.len(), 20);
     let mut out = [0u8; 20];
-    out[..].clone_from_slice(input);
+    out[..].copy_from_slice(&data);
     Ok(out)
 }
 

--- a/contracts/crypto-verify/src/ethereum.rs
+++ b/contracts/crypto-verify/src/ethereum.rs
@@ -7,7 +7,7 @@ pub fn verify_transaction<A: Api>(
     api: A,
     from: [u8; 20],
     to: [u8; 20],
-    nonce: u128,
+    nonce: u64,
     gas: u128,
     gas_price: u128,
     value: u128,
@@ -38,7 +38,7 @@ pub fn verify_transaction<A: Api>(
 
 fn serialize_unsigned_transaction(
     to: [u8; 20],
-    nonce: u128,
+    nonce: u64,
     gas_limit: u128,
     gas_price: u128,
     value: u128,

--- a/contracts/crypto-verify/src/ethereum.rs
+++ b/contracts/crypto-verify/src/ethereum.rs
@@ -1,6 +1,7 @@
 use cosmwasm_std::{Api, StdError, StdResult};
 use rlp::RlpStream;
 use sha3::{Digest, Keccak256};
+use std::convert::TryInto;
 
 #[allow(clippy::too_many_arguments)]
 pub fn verify_transaction(
@@ -108,9 +109,7 @@ pub fn ethereum_address_raw(pubkey: &[u8]) -> StdResult<[u8; 20]> {
     }
 
     let hash = Keccak256::digest(data);
-    let mut out = [0u8; 20];
-    out[..].copy_from_slice(&hash[hash.len() - 20..]);
-    Ok(out)
+    Ok(hash[hash.len() - 20..].try_into().unwrap())
 }
 
 pub fn decode_address(input: &str) -> StdResult<[u8; 20]> {
@@ -123,10 +122,7 @@ pub fn decode_address(input: &str) -> StdResult<[u8; 20]> {
         return Err(StdError::generic_err("Ethereum address must start wit 0x"));
     }
     let data = hex::decode(&input[2..]).map_err(|_| StdError::generic_err("hex decoding error"))?;
-    debug_assert_eq!(data.len(), 20);
-    let mut out = [0u8; 20];
-    out[..].copy_from_slice(&data);
-    Ok(out)
+    Ok(data.try_into().unwrap())
 }
 
 #[cfg(test)]

--- a/contracts/crypto-verify/src/ethereum.rs
+++ b/contracts/crypto-verify/src/ethereum.rs
@@ -96,7 +96,7 @@ fn ethereum_address_raw(pubkey: &[u8]) -> StdResult<[u8; 20]> {
 
     let hash = Keccak256::digest(data);
     let mut out = [0u8; 20];
-    out[..].clone_from_slice(&hash[hash.len() - 20..]);
+    out[..].copy_from_slice(&hash[hash.len() - 20..]);
     Ok(out)
 }
 

--- a/contracts/crypto-verify/src/ethereum.rs
+++ b/contracts/crypto-verify/src/ethereum.rs
@@ -1,0 +1,55 @@
+use std::borrow::Cow;
+
+use ethereum_transaction::{SignedTransaction, Transaction};
+
+pub fn serialize_unsigned_transaction(
+    from: [u8; 20],
+    to: [u8; 20],
+    nonce: u128,
+    gas: u128,
+    gas_price: u128,
+    value: u128,
+    data: Vec<u8>,
+    chain_id: u64,
+) -> Vec<u8> {
+    let unsigned = Transaction {
+        from: from.into(),
+        to: Some(to.into()),
+        nonce: nonce.into(),
+        gas: gas.into(),
+        gas_price: gas_price.into(),
+        value: value.into(),
+        data: data.into(),
+    };
+
+    SignedTransaction {
+        transaction: Cow::Owned(unsigned),
+        v: chain_id,
+        r: 0.into(),
+        s: 0.into(),
+    }
+    .to_rlp()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hex_literal::hex;
+
+    #[test]
+    fn serialize_unsigned_transaction_works() {
+        // Test data from https://github.com/iov-one/iov-core/blob/v2.5.0/packages/iov-ethereum/src/serialization.spec.ts#L78-L93
+        let nonce = 26;
+        let chain_id = 5777;
+        let from = hex!("9d8a62f656a8d1615c1294fd71e9cfb3e4855a4f");
+        let to = hex!("43aa18faae961c23715735682dc75662d90f4dde");
+        let gas_limit = 21000;
+        let gas_price = 20000000000;
+        let value = 20000000000000000000;
+        let data = Vec::default();
+        let bytes_to_sign = serialize_unsigned_transaction(
+            from, to, nonce, gas_limit, gas_price, value, data, chain_id,
+        );
+        assert_eq!(hex::encode(bytes_to_sign), "ef1a8504a817c8008252089443aa18faae961c23715735682dc75662d90f4dde8901158e460913d00000808216918080");
+    }
+}

--- a/contracts/crypto-verify/src/ethereum.rs
+++ b/contracts/crypto-verify/src/ethereum.rs
@@ -79,7 +79,7 @@ pub fn ethereum_address_raw(pubkey: &[u8]) -> StdResult<[u8; 20]> {
         None => return Err(StdError::generic_err("Public key must not be empty")),
     };
     if *tag != 0x04 {
-        return Err(StdError::generic_err("Public key start with 0x04"));
+        return Err(StdError::generic_err("Public key must start with 0x04"));
     }
     if data.len() != 64 {
         return Err(StdError::generic_err("Public key must be 65 bytes long"));
@@ -94,11 +94,11 @@ pub fn ethereum_address_raw(pubkey: &[u8]) -> StdResult<[u8; 20]> {
 pub fn decode_address(input: &str) -> StdResult<[u8; 20]> {
     if input.len() != 42 {
         return Err(StdError::generic_err(
-            "Ethereum adddress must be 42 characters long",
+            "Ethereum address must be 42 characters long",
         ));
     }
     if !input.starts_with("0x") {
-        return Err(StdError::generic_err("Ethereum adddress must start wit 0x"));
+        return Err(StdError::generic_err("Ethereum address must start wit 0x"));
     }
     let data = hex::decode(&input[2..]).map_err(|_| StdError::generic_err("hex decoding error"))?;
     debug_assert_eq!(data.len(), 20);

--- a/contracts/crypto-verify/src/ethereum.rs
+++ b/contracts/crypto-verify/src/ethereum.rs
@@ -100,6 +100,15 @@ fn ethereum_address_raw(pubkey: &[u8]) -> StdResult<[u8; 20]> {
     Ok(out)
 }
 
+pub fn to_20bytes(input: &[u8]) -> StdResult<[u8; 20]> {
+    if input.len() != 20 {
+        return Err(StdError::generic_err("Input not 20 bytes"));
+    }
+    let mut out = [0u8; 20];
+    out[..].clone_from_slice(input);
+    Ok(out)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/contracts/crypto-verify/src/lib.rs
+++ b/contracts/crypto-verify/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod contract;
+mod ethereum;
 pub mod msg;

--- a/contracts/crypto-verify/src/msg.rs
+++ b/contracts/crypto-verify/src/msg.rs
@@ -38,8 +38,10 @@ pub enum QueryMsg {
         signer_address: String,
     },
     VerifyEthereumTransaction {
-        from: Binary,
-        to: Binary,
+        /// Ethereum address in hex format (42 characters, starting with 0x)
+        from: String,
+        /// Ethereum address in hex format (42 characters, starting with 0x)
+        to: String,
         nonce: u64,
         gas_limit: Uint128,
         gas_price: Uint128,

--- a/contracts/crypto-verify/src/msg.rs
+++ b/contracts/crypto-verify/src/msg.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::field_reassign_with_default)] // see https://github.com/CosmWasm/cosmwasm/issues/685
 
-use cosmwasm_std::{Binary, Deps, StdResult};
+use cosmwasm_std::{Binary, Deps, StdResult, Uint128};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -36,6 +36,19 @@ pub enum QueryMsg {
         /// Signer address.
         /// This is matched case insensitive, so you can provide checksummed and non-checksummed addresses. Checksums are not validated.
         signer_address: String,
+    },
+    VerifyEthereumTransaction {
+        from: Binary,
+        to: Binary,
+        nonce: u64,
+        gas_limit: Uint128,
+        gas_price: Uint128,
+        value: Uint128,
+        data: Binary,
+        chain_id: u64,
+        r: Binary,
+        s: Binary,
+        v: u64,
     },
     /// Tendermint format (ed25519 verification scheme).
     VerifyTendermintSignature {

--- a/contracts/crypto-verify/tests/integration.rs
+++ b/contracts/crypto-verify/tests/integration.rs
@@ -220,8 +220,8 @@ fn verify_ethereum_transaction_works() {
     // }
     let nonce = 0xe1;
     let chain_id = 4; // Rinkeby, see https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md#list-of-chain-ids
-    let from = hex!("0a65766695a712af41b5cfecaad217b1a11cb22a");
-    let to = hex!("e137f5264b6b528244e1643a2d570b37660b7f14");
+    let from = "0x0a65766695a712af41b5cfecaad217b1a11cb22a";
+    let to = "0xe137f5264b6b528244e1643a2d570b37660b7f14";
     let gas_limit = Uint128(0x226c8);
     let gas_price = Uint128(0x3b9aca00);
     let value = Uint128(0x53177c);

--- a/contracts/crypto-verify/tests/integration.rs
+++ b/contracts/crypto-verify/tests/integration.rs
@@ -19,12 +19,12 @@
 //! 5. Anywhere you see query(deps.as_ref(), ...) you must replace it with query(&mut deps, ...)
 //! (Use cosmwasm_vm::testing::{init, handle, query}, instead of the contract variants).
 
+use cosmwasm_std::{Binary, Response, Uint128};
 use cosmwasm_vm::testing::{
     init, mock_env, mock_info, mock_instance, query, MockApi, MockQuerier, MockStorage,
 };
 use cosmwasm_vm::{from_slice, Instance};
-
-use cosmwasm_std::{Binary, Response};
+use hex_literal::hex;
 
 use crypto_verify::msg::{InitMsg, ListVerificationsResponse, QueryMsg, VerifyResponse};
 
@@ -195,6 +195,57 @@ fn ethereum_signature_verify_fails_for_corrupted_signature() {
     let result = query(&mut deps, mock_env(), verify_msg);
     let msg = result.unwrap_err();
     assert_eq!(msg, "Recover pubkey error: Unknown error: 10");
+}
+
+#[test]
+fn verify_ethereum_transaction_works() {
+    let mut deps = setup();
+
+    // curl -sS -X POST --data '{"jsonrpc":"2.0","method":"eth_getTransactionByHash","params":["0x3b87faa3410f33284124a6898fac1001673f0f7c3682d18f55bdff0031cce9ce"],"id":1}' -H "Content-type: application/json" https://rinkeby-light.eth.linkpool.io | jq .result
+    // {
+    //   "blockHash": "0x05ebd1bd99956537f49cfa1104682b3b3f9ff9249fa41a09931ce93368606c21",
+    //   "blockNumber": "0x37ef3e",
+    //   "from": "0x0a65766695a712af41b5cfecaad217b1a11cb22a",
+    //   "gas": "0x226c8",
+    //   "gasPrice": "0x3b9aca00",
+    //   "hash": "0x3b87faa3410f33284124a6898fac1001673f0f7c3682d18f55bdff0031cce9ce",
+    //   "input": "0x536561726368207478207465737420302e36353930383639313733393634333335",
+    //   "nonce": "0xe1",
+    //   "to": "0xe137f5264b6b528244e1643a2d570b37660b7f14",
+    //   "transactionIndex": "0xb",
+    //   "value": "0x53177c",
+    //   "v": "0x2b",
+    //   "r": "0xb9299dab50b3cddcaecd64b29bfbd5cd30fac1a1adea1b359a13c4e5171492a6",
+    //   "s": "0x573059c66d894684488f92e7ce1f91b158ca57b0235485625b576a3b98c480ac"
+    // }
+    let nonce = 0xe1;
+    let chain_id = 4; // Rinkeby, see https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md#list-of-chain-ids
+    let from = hex!("0a65766695a712af41b5cfecaad217b1a11cb22a");
+    let to = hex!("e137f5264b6b528244e1643a2d570b37660b7f14");
+    let gas_limit = Uint128(0x226c8);
+    let gas_price = Uint128(0x3b9aca00);
+    let value = Uint128(0x53177c);
+    let data = hex!("536561726368207478207465737420302e36353930383639313733393634333335");
+    let r = hex!("b9299dab50b3cddcaecd64b29bfbd5cd30fac1a1adea1b359a13c4e5171492a6");
+    let s = hex!("573059c66d894684488f92e7ce1f91b158ca57b0235485625b576a3b98c480ac");
+    let v = 0x2b;
+
+    let msg = QueryMsg::VerifyEthereumTransaction {
+        from: from.into(),
+        to: to.into(),
+        nonce,
+        gas_limit,
+        gas_price,
+        value,
+        data: data.into(),
+        chain_id,
+        r: r.into(),
+        s: s.into(),
+        v,
+    };
+    let raw = query(&mut deps, mock_env(), msg).unwrap();
+    let res: VerifyResponse = from_slice(&raw).unwrap();
+    assert_eq!(res, VerifyResponse { verifies: true });
 }
 
 #[test]


### PR DESCRIPTION
This shows how a contract can verify an Ethereum transaction given the information stored on chain. It is feature complete. We just need to expose `verify_transaction` as part of the `HandleMsg`. Opening a draft to allow early review.

It turns out we don't need a DER decoder as the Ethereum nodes provide signatures as three fields (r, s, v) directly.

Closes #753