### PR TITLE
Clru-rs upstream integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ workflows:
                 - metering-restart
                 - load-wasm-speed
                 - cache-analyze
-                - crypto-verify-benchmarks
+                - clru-rs-upstream
   deploy:
     jobs:
       - build_and_upload_devcontracts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,6 @@ workflows:
                 - metering-restart
                 - load-wasm-speed
                 - cache-analyze
-                - clru-rs-upstream
   deploy:
     jobs:
       - build_and_upload_devcontracts:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,11 +178,8 @@ dependencies = [
 
 [[package]]
 name = "clru"
-version = "0.4.0"
-source = "git+https://github.com/maurolacy/clru-rs?rev=88bb2300#88bb23002249c9b74cf99aaa858cfd0b15df6a36"
-dependencies = [
- "thiserror",
-]
+version = "0.3.0"
+source = "git+https://github.com/marmeladema/clru-rs?rev=a1d41d92#a1d41d926cdc9a6e195cde52543ea38e73dffbdc"
 
 [[package]]
 name = "const-oid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,8 +178,9 @@ dependencies = [
 
 [[package]]
 name = "clru"
-version = "0.3.0"
-source = "git+https://github.com/marmeladema/clru-rs?rev=a1d41d92#a1d41d926cdc9a6e195cde52543ea38e73dffbdc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591ff76ca0691bd91c1b0b5b987e5cf93b21ec810ad96665c5a569c60846dd93"
 
 [[package]]
 name = "const-oid"

--- a/contracts/burner/Cargo.lock
+++ b/contracts/burner/Cargo.lock
@@ -114,11 +114,8 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clru"
-version = "0.4.0"
-source = "git+https://github.com/maurolacy/clru-rs?rev=88bb2300#88bb23002249c9b74cf99aaa858cfd0b15df6a36"
-dependencies = [
- "thiserror",
-]
+version = "0.3.0"
+source = "git+https://github.com/marmeladema/clru-rs?rev=a1d41d92#a1d41d926cdc9a6e195cde52543ea38e73dffbdc"
 
 [[package]]
 name = "const-oid"

--- a/contracts/burner/Cargo.lock
+++ b/contracts/burner/Cargo.lock
@@ -114,8 +114,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clru"
-version = "0.3.0"
-source = "git+https://github.com/marmeladema/clru-rs?rev=a1d41d92#a1d41d926cdc9a6e195cde52543ea38e73dffbdc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591ff76ca0691bd91c1b0b5b987e5cf93b21ec810ad96665c5a569c60846dd93"
 
 [[package]]
 name = "const-oid"

--- a/contracts/crypto-verify/Cargo.lock
+++ b/contracts/crypto-verify/Cargo.lock
@@ -116,8 +116,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clru"
-version = "0.3.0"
-source = "git+https://github.com/marmeladema/clru-rs?rev=a1d41d92#a1d41d926cdc9a6e195cde52543ea38e73dffbdc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591ff76ca0691bd91c1b0b5b987e5cf93b21ec810ad96665c5a569c60846dd93"
 
 [[package]]
 name = "const-oid"

--- a/contracts/crypto-verify/Cargo.lock
+++ b/contracts/crypto-verify/Cargo.lock
@@ -116,11 +116,8 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clru"
-version = "0.4.0"
-source = "git+https://github.com/maurolacy/clru-rs?rev=88bb2300#88bb23002249c9b74cf99aaa858cfd0b15df6a36"
-dependencies = [
- "thiserror",
-]
+version = "0.3.0"
+source = "git+https://github.com/marmeladema/clru-rs?rev=a1d41d92#a1d41d926cdc9a6e195cde52543ea38e73dffbdc"
 
 [[package]]
 name = "const-oid"

--- a/contracts/hackatom/Cargo.lock
+++ b/contracts/hackatom/Cargo.lock
@@ -103,8 +103,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clru"
-version = "0.3.0"
-source = "git+https://github.com/marmeladema/clru-rs?rev=a1d41d92#a1d41d926cdc9a6e195cde52543ea38e73dffbdc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591ff76ca0691bd91c1b0b5b987e5cf93b21ec810ad96665c5a569c60846dd93"
 
 [[package]]
 name = "const-oid"

--- a/contracts/hackatom/Cargo.lock
+++ b/contracts/hackatom/Cargo.lock
@@ -103,11 +103,8 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clru"
-version = "0.4.0"
-source = "git+https://github.com/maurolacy/clru-rs?rev=88bb2300#88bb23002249c9b74cf99aaa858cfd0b15df6a36"
-dependencies = [
- "thiserror",
-]
+version = "0.3.0"
+source = "git+https://github.com/marmeladema/clru-rs?rev=a1d41d92#a1d41d926cdc9a6e195cde52543ea38e73dffbdc"
 
 [[package]]
 name = "const-oid"

--- a/contracts/ibc-reflect-send/Cargo.lock
+++ b/contracts/ibc-reflect-send/Cargo.lock
@@ -103,8 +103,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clru"
-version = "0.3.0"
-source = "git+https://github.com/marmeladema/clru-rs?rev=a1d41d92#a1d41d926cdc9a6e195cde52543ea38e73dffbdc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591ff76ca0691bd91c1b0b5b987e5cf93b21ec810ad96665c5a569c60846dd93"
 
 [[package]]
 name = "const-oid"

--- a/contracts/ibc-reflect-send/Cargo.lock
+++ b/contracts/ibc-reflect-send/Cargo.lock
@@ -103,11 +103,8 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clru"
-version = "0.4.0"
-source = "git+https://github.com/maurolacy/clru-rs?rev=88bb2300#88bb23002249c9b74cf99aaa858cfd0b15df6a36"
-dependencies = [
- "thiserror",
-]
+version = "0.3.0"
+source = "git+https://github.com/marmeladema/clru-rs?rev=a1d41d92#a1d41d926cdc9a6e195cde52543ea38e73dffbdc"
 
 [[package]]
 name = "const-oid"

--- a/contracts/ibc-reflect/Cargo.lock
+++ b/contracts/ibc-reflect/Cargo.lock
@@ -103,8 +103,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clru"
-version = "0.3.0"
-source = "git+https://github.com/marmeladema/clru-rs?rev=a1d41d92#a1d41d926cdc9a6e195cde52543ea38e73dffbdc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591ff76ca0691bd91c1b0b5b987e5cf93b21ec810ad96665c5a569c60846dd93"
 
 [[package]]
 name = "const-oid"

--- a/contracts/ibc-reflect/Cargo.lock
+++ b/contracts/ibc-reflect/Cargo.lock
@@ -103,11 +103,8 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clru"
-version = "0.4.0"
-source = "git+https://github.com/maurolacy/clru-rs?rev=88bb2300#88bb23002249c9b74cf99aaa858cfd0b15df6a36"
-dependencies = [
- "thiserror",
-]
+version = "0.3.0"
+source = "git+https://github.com/marmeladema/clru-rs?rev=a1d41d92#a1d41d926cdc9a6e195cde52543ea38e73dffbdc"
 
 [[package]]
 name = "const-oid"

--- a/contracts/queue/Cargo.lock
+++ b/contracts/queue/Cargo.lock
@@ -103,8 +103,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clru"
-version = "0.3.0"
-source = "git+https://github.com/marmeladema/clru-rs?rev=a1d41d92#a1d41d926cdc9a6e195cde52543ea38e73dffbdc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591ff76ca0691bd91c1b0b5b987e5cf93b21ec810ad96665c5a569c60846dd93"
 
 [[package]]
 name = "const-oid"

--- a/contracts/queue/Cargo.lock
+++ b/contracts/queue/Cargo.lock
@@ -103,11 +103,8 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clru"
-version = "0.4.0"
-source = "git+https://github.com/maurolacy/clru-rs?rev=88bb2300#88bb23002249c9b74cf99aaa858cfd0b15df6a36"
-dependencies = [
- "thiserror",
-]
+version = "0.3.0"
+source = "git+https://github.com/marmeladema/clru-rs?rev=a1d41d92#a1d41d926cdc9a6e195cde52543ea38e73dffbdc"
 
 [[package]]
 name = "const-oid"

--- a/contracts/reflect/Cargo.lock
+++ b/contracts/reflect/Cargo.lock
@@ -103,8 +103,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clru"
-version = "0.3.0"
-source = "git+https://github.com/marmeladema/clru-rs?rev=a1d41d92#a1d41d926cdc9a6e195cde52543ea38e73dffbdc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591ff76ca0691bd91c1b0b5b987e5cf93b21ec810ad96665c5a569c60846dd93"
 
 [[package]]
 name = "const-oid"

--- a/contracts/reflect/Cargo.lock
+++ b/contracts/reflect/Cargo.lock
@@ -103,11 +103,8 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clru"
-version = "0.4.0"
-source = "git+https://github.com/maurolacy/clru-rs?rev=88bb2300#88bb23002249c9b74cf99aaa858cfd0b15df6a36"
-dependencies = [
- "thiserror",
-]
+version = "0.3.0"
+source = "git+https://github.com/marmeladema/clru-rs?rev=a1d41d92#a1d41d926cdc9a6e195cde52543ea38e73dffbdc"
 
 [[package]]
 name = "const-oid"

--- a/contracts/staking/Cargo.lock
+++ b/contracts/staking/Cargo.lock
@@ -103,8 +103,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clru"
-version = "0.3.0"
-source = "git+https://github.com/marmeladema/clru-rs?rev=a1d41d92#a1d41d926cdc9a6e195cde52543ea38e73dffbdc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591ff76ca0691bd91c1b0b5b987e5cf93b21ec810ad96665c5a569c60846dd93"
 
 [[package]]
 name = "const-oid"

--- a/contracts/staking/Cargo.lock
+++ b/contracts/staking/Cargo.lock
@@ -103,11 +103,8 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clru"
-version = "0.4.0"
-source = "git+https://github.com/maurolacy/clru-rs?rev=88bb2300#88bb23002249c9b74cf99aaa858cfd0b15df6a36"
-dependencies = [
- "thiserror",
-]
+version = "0.3.0"
+source = "git+https://github.com/marmeladema/clru-rs?rev=a1d41d92#a1d41d926cdc9a6e195cde52543ea38e73dffbdc"
 
 [[package]]
 name = "const-oid"

--- a/packages/vm/Cargo.toml
+++ b/packages/vm/Cargo.toml
@@ -31,7 +31,7 @@ bench = false
 
 [dependencies]
 #clru = "0.4.0"
-clru = { git = "https://github.com/maurolacy/clru-rs", rev="88bb2300" }
+clru = { git = "https://github.com/marmeladema/clru-rs", rev="a1d41d92" }
 # Uses the path when built locally; uses the given version from crates.io when published
 cosmwasm-std = { path = "../std", version = "0.13.2" }
 cosmwasm-crypto = { path = "../crypto", version = "0.13.2" }

--- a/packages/vm/Cargo.toml
+++ b/packages/vm/Cargo.toml
@@ -30,8 +30,7 @@ cranelift = ["wasmer/cranelift"]
 bench = false
 
 [dependencies]
-#clru = "0.4.0"
-clru = { git = "https://github.com/marmeladema/clru-rs", rev="a1d41d92" }
+clru = "0.4.0"
 # Uses the path when built locally; uses the given version from crates.io when published
 cosmwasm-std = { path = "../std", version = "0.13.2" }
 cosmwasm-crypto = { path = "../crypto", version = "0.13.2" }

--- a/packages/vm/src/modules/in_memory_cache.rs
+++ b/packages/vm/src/modules/in_memory_cache.rs
@@ -55,10 +55,8 @@ impl InMemoryCache {
     }
 
     pub fn store(&mut self, checksum: &Checksum, module: Module, size: usize) -> VmResult<()> {
-        if self.modules.is_some() {
-            self.modules
-                .as_mut()
-                .unwrap()
+        if let Some(modules) = &mut self.modules {
+            modules
                 .put_with_weight(*checksum, SizedModule { module, size })
                 .map_err(|e| VmError::cache_err(format!("{:?}", e)))?;
         }
@@ -67,8 +65,8 @@ impl InMemoryCache {
 
     /// Looks up a module in the cache and creates a new module
     pub fn load(&mut self, checksum: &Checksum) -> VmResult<Option<Module>> {
-        if self.modules.is_some() {
-            match self.modules.as_mut().unwrap().get(checksum) {
+        if let Some(modules) = &mut self.modules {
+            match modules.get(checksum) {
                 Some(sized_module) => Ok(Some(sized_module.module.clone())),
                 None => Ok(None),
             }


### PR DESCRIPTION
Integration with the new weighted `clru-rs` (currently [in development](https://github.com/marmeladema/clru-rs/pull/32)).

Creating as draft to track upstream. This will close #749 when `clru-rs` 0.4.0 is published to crates.io.