### PR TITLE
Remove cranelift from CI tests / benchmarks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -716,7 +716,11 @@ jobs:
       - run:
           name: Clippy linting on vm (no feature flags)
           working_directory: ~/project/packages/vm
-          command: cargo clippy -- -D warnings
+          command: cargo clippy --no-default-features -- -D warnings
+      - run:
+          name: Clippy linting on vm (all feature flags)
+          working_directory: ~/project/packages/vm
+          command: cargo clippy --features iterator,staking,stargate -- -D warnings
       #
       # Contracts
       #

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,6 @@ workflows:
       - package_std
       - package_storage
       - package_vm
-      - package_vm_cranelift
       - contract_burner
       - contract_crypto_verify
       - contract_hackatom
@@ -23,7 +22,6 @@ workflows:
       - benchmarking:
           requires:
             - package_vm
-            - package_vm_cranelift
             - package_crypto
           filters:
             branches:
@@ -226,41 +224,6 @@ jobs:
             - target/debug/deps
           key: cargocache-v2-package_vm-rust:1.50.0-{{ checksum "Cargo.lock" }}
 
-  package_vm_cranelift:
-    docker:
-      - image: rust:1.50.0
-    steps:
-      - checkout
-      - run:
-          name: Version information
-          command: rustc --version; cargo --version; rustup --version; rustup target list --installed
-      - restore_cache:
-          keys:
-            - cargocache-v2-package_vm_cranelift-rust:1.50.0-{{ checksum "Cargo.lock" }}
-      - run:
-          name: Build
-          working_directory: ~/project/packages/vm
-          command: cargo build --locked --features cranelift
-      - run:
-          name: Build with all features
-          working_directory: ~/project/packages/vm
-          command: cargo build --locked --features cranelift,iterator,staking,stargate
-      - run:
-          name: Test
-          working_directory: ~/project/packages/vm
-          command: cargo test --locked --features cranelift
-      - run:
-          name: Test with all features
-          working_directory: ~/project/packages/vm
-          command: cargo test --locked --features cranelift,iterator,staking,stargate
-      - save_cache:
-          paths:
-            - /usr/local/cargo/registry
-            - target/debug/.fingerprint
-            - target/debug/build
-            - target/debug/deps
-          key: cargocache-v2-package_vm_cranelift-rust:1.50.0-{{ checksum "Cargo.lock" }}
-
   contract_burner:
     docker:
       - image: rust:1.50.0
@@ -285,9 +248,6 @@ jobs:
       - run:
           name: Unit tests
           command: cargo unit-test --locked
-      - run:
-          name: Integration tests (cranelift backend)
-          command: cargo integration-test --locked
       - run:
           name: Integration tests (singlepass backend)
           command: cargo integration-test --locked --no-default-features
@@ -339,9 +299,6 @@ jobs:
           name: Unit tests
           command: cargo unit-test --locked
       - run:
-          name: Integration tests (cranelift backend)
-          command: cargo integration-test --locked
-      - run:
           name: Integration tests (singlepass backend)
           command: cargo integration-test --locked --no-default-features
       - run:
@@ -392,9 +349,6 @@ jobs:
           name: Unit tests
           command: cargo unit-test --locked
       - run:
-          name: Integration tests (cranelift backend)
-          command: cargo integration-test --locked
-      - run:
           name: Integration tests (singlepass backend)
           command: cargo integration-test --locked --no-default-features
       - run:
@@ -444,9 +398,6 @@ jobs:
       - run:
           name: Unit tests
           command: cargo unit-test --locked
-      - run:
-          name: Integration tests (cranelift backend)
-          command: cargo integration-test --locked
       - run:
           name: Integration tests (singlepass backend)
           command: cargo integration-test --locked --no-default-features
@@ -499,9 +450,6 @@ jobs:
           name: Unit tests
           command: cargo unit-test --locked
       - run:
-          name: Integration tests (cranelift backend)
-          command: cargo integration-test --locked
-      - run:
           name: Integration tests (singlepass backend)
           command: cargo integration-test --locked --no-default-features
       - run:
@@ -551,9 +499,6 @@ jobs:
       - run:
           name: Unit tests
           command: cargo unit-test --locked
-      - run:
-          name: Integration tests (cranelift backend)
-          command: cargo integration-test --locked
       - run:
           name: Integration tests (singlepass backend)
           command: cargo integration-test --locked --no-default-features
@@ -605,9 +550,6 @@ jobs:
           name: Unit tests
           command: cargo unit-test --locked
       - run:
-          name: Integration tests (cranelift backend)
-          command: cargo integration-test --locked
-      - run:
           name: Integration tests (singlepass backend)
           command: cargo integration-test --locked --no-default-features
       - run:
@@ -657,9 +599,6 @@ jobs:
       - run:
           name: Unit tests
           command: cargo unit-test --locked
-      - run:
-          name: Integration tests (cranelift backend)
-          command: cargo integration-test --locked
       - run:
           name: Integration tests (singlepass backend)
           command: cargo integration-test --locked --no-default-features
@@ -778,10 +717,6 @@ jobs:
           name: Clippy linting on vm (no feature flags)
           working_directory: ~/project/packages/vm
           command: cargo clippy -- -D warnings
-      - run:
-          name: Clippy linting on vm (all feature flags)
-          working_directory: ~/project/packages/vm
-          command: cargo clippy --features cranelift,iterator -- -D warnings
       #
       # Contracts
       #
@@ -890,10 +825,6 @@ jobs:
           name: Run vm benchmarks (Singlepass)
           working_directory: ~/project/packages/vm
           command: cargo bench --no-default-features -- --color never --save-baseline singlepass
-      - run:
-          name: Run vm benchmarks (Cranelift)
-          working_directory: ~/project/packages/vm
-          command: cargo bench --no-default-features --features cranelift -- --color never --save-baseline cranelift
       - run:
           name: Run crypto benchmarks
           working_directory: ~/project/packages/crypto


### PR DESCRIPTION
Let's remove cranelift entirely for now. We can always add it again later, and define the stages it will run.