### PR TITLE
Update to 0.14.0 alpha2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,7 @@ checksum = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "base64",
  "criterion",
@@ -216,7 +216,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "cosmwasm-std",
  "syn",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "schemars",
  "serde_json",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "base64",
  "chrono",
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "clap",
  "clru",

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -26,6 +26,10 @@ major releases of `cosmwasm`. Note that you can also view the
 - Rename the `handle` entry point to `execute`.
   Also, rename `HandleMsg` to `ExecuteMsg`.
 
+- Rename `InitResponse`, `HandleResponse` and `MigrateResponse` to `Response`.
+  The old names are still supported (with a deprecation warning), and will be
+  removed in the next version.
+
 - Remove `from_address` from `BankMsg::Send`, which is now automatically filled
   with the contract address:
 
@@ -70,7 +74,7 @@ major releases of `cosmwasm`. Note that you can also view the
       _env: Env,
       _info: MessageInfo,
       _msg: InitMsg,
-  ) -> StdResult<InitResponse> {
+  ) -> StdResult<Response> {
       // …
   }
 
@@ -80,7 +84,7 @@ major releases of `cosmwasm`. Note that you can also view the
       _env: Env,
       _info: MessageInfo,
       _msg: ExecuteMsg,
-  ) -> StdResult<HandleResponse> {
+  ) -> StdResult<Response> {
       // …
   }
 
@@ -91,7 +95,7 @@ major releases of `cosmwasm`. Note that you can also view the
       env: Env,
       _info: MessageInfo,
       msg: MigrateMsg,
-  ) -> StdResult<MigrateResponse> {
+  ) -> StdResult<Response> {
       // …
   }
 
@@ -101,8 +105,8 @@ major releases of `cosmwasm`. Note that you can also view the
   }
   ```
 
-- Since `InitResponse` now contains a `data` field like `HandleResponse` and
-  `MigrateResponse`, converting `Context` into `InitResponse` always succeeds.
+- Since `Response` contains a `data` field, converting `Context` into `Response`
+  always succeeds.
 
   ```rust
   // before
@@ -114,7 +118,7 @@ major releases of `cosmwasm`. Note that you can also view the
   }
 
   // after
-  pub fn init(deps: DepsMut, env: Env, info: MessageInfo, msg: InitMsg) -> Result<InitResponse, HackError> {
+  pub fn init(deps: DepsMut, env: Env, info: MessageInfo, msg: InitMsg) -> Result<Response, HackError> {
       // …
       let mut ctx = Context::new();
       ctx.add_attribute("Let the", "hacking begin");
@@ -136,7 +140,7 @@ major releases of `cosmwasm`. Note that you can also view the
   }
 
   // After
-  pub fn migrate(deps: DepsMut, env: Env, msg: MigrateMsg) -> StdResult<MigrateResponse> {
+  pub fn migrate(deps: DepsMut, env: Env, msg: MigrateMsg) -> StdResult<Response> {
     // ...
   }
   ```
@@ -150,13 +154,12 @@ major releases of `cosmwasm`. Note that you can also view the
   [msgmigratecontract]:
     https://github.com/CosmWasm/wasmd/blob/v0.15.0/x/wasm/internal/types/tx.proto#L86-L96
 
-- Add mutating helper methods to `InitResponse`, `HandleResponse` and
-  `MigrateResponse` that can be used instead of a creating a `Context` that is
-  later converted to a response:
+- Add mutating helper methods to `Response` that can be used instead of
+  creating a `Context` that is later converted to a response:
 
   ```rust
   // before
-  pub fn handle_impl(deps: DepsMut, env: Env, info: MessageInfo) -> Result<HandleResponse, ContractError> {
+  pub fn handle_impl(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response, ContractError> {
       // ...
 
       // release counter_offer to creator
@@ -180,11 +183,11 @@ major releases of `cosmwasm`. Note that you can also view the
 
 
   // after
-  pub fn execute_impl(deps: DepsMut, env: Env, info: MessageInfo) -> Result<HandleResponse, ContractError> {
+  pub fn execute_impl(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response, ContractError> {
       // ...
 
       // release counter_offer to creator
-      let mut resp = HandleResponse::new();
+      let mut resp = Response::new();
       resp.add_message(BankMsg::Send {
           to_address: state.creator,
           amount: state.counter_offer,

--- a/contracts/burner/Cargo.lock
+++ b/contracts/burner/Cargo.lock
@@ -132,7 +132,7 @@ checksum = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "digest",
  "ed25519-zebra",
@@ -143,14 +143,14 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "syn",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "schemars",
  "serde_json",
@@ -158,7 +158,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "clru",
  "cosmwasm-crypto",

--- a/contracts/crypto-verify/Cargo.lock
+++ b/contracts/crypto-verify/Cargo.lock
@@ -134,7 +134,7 @@ checksum = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "digest",
  "ed25519-zebra",
@@ -145,14 +145,14 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "syn",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "schemars",
  "serde_json",
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "clru",
  "cosmwasm-crypto",

--- a/contracts/hackatom/Cargo.lock
+++ b/contracts/hackatom/Cargo.lock
@@ -121,7 +121,7 @@ checksum = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "digest",
  "ed25519-zebra",
@@ -132,14 +132,14 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "syn",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "schemars",
  "serde_json",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -168,7 +168,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "clru",
  "cosmwasm-crypto",

--- a/contracts/ibc-reflect-send/Cargo.lock
+++ b/contracts/ibc-reflect-send/Cargo.lock
@@ -121,7 +121,7 @@ checksum = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "digest",
  "ed25519-zebra",
@@ -132,14 +132,14 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "syn",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "schemars",
  "serde_json",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -168,7 +168,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "clru",
  "cosmwasm-crypto",

--- a/contracts/ibc-reflect/Cargo.lock
+++ b/contracts/ibc-reflect/Cargo.lock
@@ -121,7 +121,7 @@ checksum = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "digest",
  "ed25519-zebra",
@@ -132,14 +132,14 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "syn",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "schemars",
  "serde_json",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -168,7 +168,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "clru",
  "cosmwasm-crypto",

--- a/contracts/queue/Cargo.lock
+++ b/contracts/queue/Cargo.lock
@@ -121,7 +121,7 @@ checksum = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "digest",
  "ed25519-zebra",
@@ -132,14 +132,14 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "syn",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "schemars",
  "serde_json",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "clru",
  "cosmwasm-crypto",

--- a/contracts/reflect/Cargo.lock
+++ b/contracts/reflect/Cargo.lock
@@ -121,7 +121,7 @@ checksum = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "digest",
  "ed25519-zebra",
@@ -132,14 +132,14 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "syn",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "schemars",
  "serde_json",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -168,7 +168,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "clru",
  "cosmwasm-crypto",

--- a/contracts/staking/Cargo.lock
+++ b/contracts/staking/Cargo.lock
@@ -121,7 +121,7 @@ checksum = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "digest",
  "ed25519-zebra",
@@ -132,14 +132,14 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "syn",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "schemars",
  "serde_json",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -168,7 +168,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 dependencies = [
  "clru",
  "cosmwasm-crypto",

--- a/packages/crypto/Cargo.toml
+++ b/packages/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmwasm-crypto"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 authors = ["Mauro Lacy <maurolacy@users.noreply.github.com>"]
 edition = "2018"
 description = "Crypto bindings for cosmwasm contracts"

--- a/packages/derive/Cargo.toml
+++ b/packages/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmwasm-derive"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 authors = ["Simon Warta <webmaster128@users.noreply.github.com>"]
 edition = "2018"
 description = "A package for auto-generated code used for CosmWasm contract development. This is shipped as part of cosmwasm-std. Do not use directly."

--- a/packages/schema/Cargo.toml
+++ b/packages/schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmwasm-schema"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 authors = ["Simon Warta <webmaster128@users.noreply.github.com>", "Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "A dev-dependency for CosmWasm contracts to generate JSON Schema files."

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmwasm-std"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Standard library for Wasm based smart contracts on Cosmos blockchains"
@@ -29,14 +29,14 @@ stargate = []
 
 [dependencies]
 base64 = "0.13.0"
-cosmwasm-derive = { path = "../derive", version = "0.14.0-alpha1" }
+cosmwasm-derive = { path = "../derive", version = "0.14.0-alpha2" }
 serde-json-wasm = { version = "0.3.1" }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive", "alloc"] }
 thiserror = "1.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-cosmwasm-crypto = { path = "../crypto", version = "0.14.0-alpha1" }
+cosmwasm-crypto = { path = "../crypto", version = "0.14.0-alpha2" }
 
 [dev-dependencies]
 cosmwasm-schema = { path = "../schema" }

--- a/packages/storage/Cargo.toml
+++ b/packages/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmwasm-storage"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "CosmWasm library with useful helpers for Storage patterns"
@@ -15,5 +15,5 @@ iterator = ["cosmwasm-std/iterator"]
 
 [dependencies]
 # Uses the path when built locally; uses the given version from crates.io when published
-cosmwasm-std = { path = "../std", version = "0.14.0-alpha1" }
+cosmwasm-std = { path = "../std", version = "0.14.0-alpha2" }
 serde = { version = "1.0.103", default-features = false, features = ["derive", "alloc"] }

--- a/packages/vm/Cargo.toml
+++ b/packages/vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmwasm-vm"
-version = "0.14.0-alpha1"
+version = "0.14.0-alpha2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "VM bindings to run cosmwams contracts"
@@ -32,8 +32,8 @@ bench = false
 [dependencies]
 clru = "0.4.0"
 # Uses the path when built locally; uses the given version from crates.io when published
-cosmwasm-std = { path = "../std", version = "0.14.0-alpha1" }
-cosmwasm-crypto = { path = "../crypto", version = "0.14.0-alpha1" }
+cosmwasm-std = { path = "../std", version = "0.14.0-alpha2" }
+cosmwasm-crypto = { path = "../crypto", version = "0.14.0-alpha2" }
 hex = "0.4"
 parity-wasm = "0.42"
 schemars = "0.7"


### PR DESCRIPTION
Creating this PR to update the version to `0.14.0-alpha2`.

Also, updated the migration guide with instructions to migrate to `Response`.