### PR TITLE
Prepare Uint128 for new Rust 1.51.0 clippy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ and this project adheres to
 - cosmwasm-std: Added `reply` entry point that will receive all callbacks from
   submessages dispatched by this contract. This is only required if contract
   returns "submessages" (above). ([#796])
+- cosmwasm-std: Implement `From<Uint128> for String` and
+  `From<Uint128> for u128`.
 
 [#692]: https://github.com/CosmWasm/cosmwasm/issues/692
 [#706]: https://github.com/CosmWasm/cosmwasm/pull/706

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,8 +50,8 @@ and this project adheres to
 - cosmwasm-std: Added `reply` entry point that will receive all callbacks from
   submessages dispatched by this contract. This is only required if contract
   returns "submessages" (above). ([#796])
-- cosmwasm-std: Implement `From<Uint128> for String` and
-  `From<Uint128> for u128`.
+- cosmwasm-std: Implement `From<Uint128> for String`, `From<Uint128> for u128`
+  as well as `From<u{32,16,8}> for Uint128`.
 
 [#692]: https://github.com/CosmWasm/cosmwasm/issues/692
 [#706]: https://github.com/CosmWasm/cosmwasm/pull/706

--- a/packages/std/src/math.rs
+++ b/packages/std/src/math.rs
@@ -205,15 +205,15 @@ impl TryFrom<&str> for Uint128 {
     }
 }
 
-impl Into<String> for Uint128 {
-    fn into(self) -> String {
-        self.0.to_string()
+impl From<Uint128> for String {
+    fn from(original: Uint128) -> Self {
+        original.to_string()
     }
 }
 
-impl Into<u128> for Uint128 {
-    fn into(self) -> u128 {
-        self.0
+impl From<Uint128> for u128 {
+    fn from(original: Uint128) -> Self {
+        original.0
     }
 }
 
@@ -363,9 +363,8 @@ impl<'a> Sum<&'a Uint128> for Uint128 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::errors::{StdError, StdResult};
+    use crate::errors::StdError;
     use crate::{from_slice, to_vec};
-    use std::convert::TryInto;
 
     #[test]
     fn decimal_one() {
@@ -642,17 +641,37 @@ mod tests {
     }
 
     #[test]
-    fn to_and_from_uint128() {
-        let a: Uint128 = 12345u64.into();
-        assert_eq!(12345, a.u128());
-        assert_eq!("12345", a.to_string());
+    fn uint128_convert_into() {
+        let original = Uint128(12345);
+        let a = u128::from(original);
+        assert_eq!(a, 12345);
 
-        let a: Uint128 = "34567".try_into().unwrap();
-        assert_eq!(34567, a.u128());
-        assert_eq!("34567", a.to_string());
+        let original = Uint128(12345);
+        let a = String::from(original);
+        assert_eq!(a, "12345");
+    }
 
-        let a: StdResult<Uint128> = "1.23".try_into();
-        assert!(a.is_err());
+    #[test]
+    fn uint128_convert_from() {
+        let a = Uint128::from(12345u64);
+        assert_eq!(a.0, 12345);
+
+        let result = Uint128::try_from("34567");
+        assert_eq!(result.unwrap().0, 34567);
+
+        let result = Uint128::try_from("1.23");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn uint128_implements_display() {
+        let a = Uint128(12345);
+        assert_eq!(format!("Embedded: {}", a), "Embedded: 12345");
+        assert_eq!(a.to_string(), "12345");
+
+        let a = Uint128(0);
+        assert_eq!(format!("Embedded: {}", a), "Embedded: 0");
+        assert_eq!(a.to_string(), "0");
     }
 
     #[test]

--- a/packages/std/src/math.rs
+++ b/packages/std/src/math.rs
@@ -182,6 +182,11 @@ impl Uint128 {
     }
 }
 
+// `From<u{128,64,32,16,8}>` is implemented manually instead of
+// using `impl<T: Into<u128>> From<T> for Uint128` because
+// of the conflict with `TryFrom<&str>` as described here
+// https://stackoverflow.com/questions/63136970/how-do-i-work-around-the-upstream-crates-may-add-a-new-impl-of-trait-error
+
 impl From<u128> for Uint128 {
     fn from(val: u128) -> Self {
         Uint128(val)
@@ -190,6 +195,24 @@ impl From<u128> for Uint128 {
 
 impl From<u64> for Uint128 {
     fn from(val: u64) -> Self {
+        Uint128(val.into())
+    }
+}
+
+impl From<u32> for Uint128 {
+    fn from(val: u32) -> Self {
+        Uint128(val.into())
+    }
+}
+
+impl From<u16> for Uint128 {
+    fn from(val: u16) -> Self {
+        Uint128(val.into())
+    }
+}
+
+impl From<u8> for Uint128 {
+    fn from(val: u8) -> Self {
         Uint128(val.into())
     }
 }
@@ -653,8 +676,20 @@ mod tests {
 
     #[test]
     fn uint128_convert_from() {
-        let a = Uint128::from(12345u64);
-        assert_eq!(a.0, 12345);
+        let a = Uint128::from(5u128);
+        assert_eq!(a.0, 5);
+
+        let a = Uint128::from(5u64);
+        assert_eq!(a.0, 5);
+
+        let a = Uint128::from(5u32);
+        assert_eq!(a.0, 5);
+
+        let a = Uint128::from(5u16);
+        assert_eq!(a.0, 5);
+
+        let a = Uint128::from(5u8);
+        assert_eq!(a.0, 5);
 
         let result = Uint128::try_from("34567");
         assert_eq!(result.unwrap().0, 34567);


### PR DESCRIPTION
This implements From instead of Into, which the new 1.51.0 clippy requires (https://rust-lang.github.io/rust-clippy/master/index.html#from_over_into).

The implementation of `From<u{32,16,8}> for Uint128` is unrelated and done because we can and I looked into the tests.