### PR TITLE
Contract sanity check in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -871,6 +871,18 @@ jobs:
             docker run --volumes-from with_code cosmwasm/rust-optimizer:0.10.8 ./contracts/*/
             docker cp with_code:/code/artifacts .
       - run:
+          name: Install check_contract
+          # Uses --debug for compilation speed
+          command: cargo install --debug --features iterator --path ./packages/vm --example check_contract -- cosmwasm-vm
+      - run:
+          name: Check development contracts
+          command: |
+            for W in ./artifacts/*.wasm
+            do
+              echo -n "Checking `basename $W`... "
+              check_contract $W
+            done
+      - run:
           name: Publish artifacts on GitHub
           command: |
             TAG="$CIRCLE_TAG"

--- a/packages/vm/examples/check_contract.rs
+++ b/packages/vm/examples/check_contract.rs
@@ -28,7 +28,7 @@ pub fn main() {
     file.read_to_end(&mut wasm).unwrap();
 
     // Check wasm
-    check_wasm(&wasm, &features_from_csv("staking")).unwrap();
+    check_wasm(&wasm, &features_from_csv("staking,stargate")).unwrap();
 
     // Compile module
     compile(&wasm, None).unwrap();


### PR DESCRIPTION
Adds a contract checking step to the CI deploy stage.

Not yet tested, as this runs on release branches only.