### PR TITLE
Do not set cranelift feature by default for integration testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,8 +249,8 @@ jobs:
           name: Unit tests
           command: cargo unit-test --locked
       - run:
-          name: Integration tests (singlepass backend)
-          command: cargo integration-test --locked --no-default-features
+          name: Integration tests
+          command: cargo integration-test --locked
       - run:
           name: Build and run schema generator
           command: cargo schema --locked
@@ -299,8 +299,8 @@ jobs:
           name: Unit tests
           command: cargo unit-test --locked
       - run:
-          name: Integration tests (singlepass backend)
-          command: cargo integration-test --locked --no-default-features
+          name: Integration tests
+          command: cargo integration-test --locked
       - run:
           name: Build and run schema generator
           command: cargo schema --locked
@@ -349,8 +349,8 @@ jobs:
           name: Unit tests
           command: cargo unit-test --locked
       - run:
-          name: Integration tests (singlepass backend)
-          command: cargo integration-test --locked --no-default-features
+          name: Integration tests
+          command: cargo integration-test --locked
       - run:
           name: Build and run schema generator
           command: cargo schema --locked
@@ -399,8 +399,8 @@ jobs:
           name: Unit tests
           command: cargo unit-test --locked
       - run:
-          name: Integration tests (singlepass backend)
-          command: cargo integration-test --locked --no-default-features
+          name: Integration tests
+          command: cargo integration-test --locked
       - run:
           name: Build and run schema generator
           command: cargo schema --locked
@@ -423,7 +423,6 @@ jobs:
             - target/wasm32-unknown-unknown/release/build
             - target/wasm32-unknown-unknown/release/deps
           key: cargocache-v2-contract_ibc_reflect-rust:1.50.0-{{ checksum "Cargo.lock" }}
-
 
   contract_ibc_reflect_send:
     docker:
@@ -450,8 +449,8 @@ jobs:
           name: Unit tests
           command: cargo unit-test --locked
       - run:
-          name: Integration tests (singlepass backend)
-          command: cargo integration-test --locked --no-default-features
+          name: Integration tests
+          command: cargo integration-test --locked
       - run:
           name: Build and run schema generator
           command: cargo schema --locked
@@ -500,8 +499,8 @@ jobs:
           name: Unit tests
           command: cargo unit-test --locked
       - run:
-          name: Integration tests (singlepass backend)
-          command: cargo integration-test --locked --no-default-features
+          name: Integration tests
+          command: cargo integration-test --locked
       - run:
           name: Build and run schema generator
           command: cargo schema --locked
@@ -550,8 +549,8 @@ jobs:
           name: Unit tests
           command: cargo unit-test --locked
       - run:
-          name: Integration tests (singlepass backend)
-          command: cargo integration-test --locked --no-default-features
+          name: Integration tests
+          command: cargo integration-test --locked
       - run:
           name: Build and run schema generator
           command: cargo schema --locked
@@ -600,8 +599,8 @@ jobs:
           name: Unit tests
           command: cargo unit-test --locked
       - run:
-          name: Integration tests (singlepass backend)
-          command: cargo integration-test --locked --no-default-features
+          name: Integration tests
+          command: cargo integration-test --locked
       - run:
           name: Build and run schema generator
           command: cargo schema --locked

--- a/contracts/burner/Cargo.toml
+++ b/contracts/burner/Cargo.toml
@@ -22,9 +22,9 @@ incremental = false
 overflow-checks = true
 
 [features]
-# Change this to [] if you don't need Windows support and want faster integration tests.
-default = ["cranelift"]
-# Use cranelift backend instead of singlepass. This is required for development on Windows.
+# Add feature "cranelift" to default if you need 32 bit Windows support
+default = []
+# Use cranelift backend instead of singlepass. This is required for development on 32 bit Windows.
 cranelift = ["cosmwasm-vm/cranelift"]
 # for quicker tests, cargo test --lib
 # for more explicit tests, cargo test --features=backtraces

--- a/contracts/crypto-verify/Cargo.toml
+++ b/contracts/crypto-verify/Cargo.toml
@@ -22,10 +22,9 @@ incremental = false
 overflow-checks = true
 
 [features]
-# Change this to [] if you don't need Windows support and want faster integration tests.
-#default = ["cranelift"]
+# Add feature "cranelift" to default if you need 32 bit Windows support
 default = []
-# Use cranelift backend instead of singlepass. This is required for development on Windows.
+# Use cranelift backend instead of singlepass. This is required for development on 32 bit Windows.
 cranelift = ["cosmwasm-vm/cranelift"]
 # for quicker tests, cargo test --lib
 # for more explicit tests, cargo test --features=backtraces

--- a/contracts/hackatom/Cargo.toml
+++ b/contracts/hackatom/Cargo.toml
@@ -22,9 +22,9 @@ incremental = false
 overflow-checks = true
 
 [features]
-# Change this to [] if you don't need Windows support and want faster integration tests.
-default = ["cranelift"]
-# Use cranelift backend instead of singlepass. This is required for development on Windows.
+# Add feature "cranelift" to default if you need 32 bit Windows support
+default = []
+# Use cranelift backend instead of singlepass. This is required for development on 32 bit Windows.
 cranelift = ["cosmwasm-vm/cranelift"]
 # For quicker tests, cargo test --lib. for more explicit tests, cargo test --features=backtraces
 backtraces = ["cosmwasm-std/backtraces", "cosmwasm-vm/backtraces"]

--- a/contracts/ibc-reflect-send/Cargo.toml
+++ b/contracts/ibc-reflect-send/Cargo.toml
@@ -22,9 +22,9 @@ incremental = false
 overflow-checks = true
 
 [features]
-# Change this to [] if you don't need Windows support and want faster integration tests.
-default = ["cranelift"]
-# Use cranelift backend instead of singlepass. This is required for development on Windows.
+# Add feature "cranelift" to default if you need 32 bit Windows support
+default = []
+# Use cranelift backend instead of singlepass. This is required for development on 32 bit Windows.
 cranelift = ["cosmwasm-vm/cranelift"]
 # for quicker tests, cargo test --lib
 # for more explicit tests, cargo test --features=backtraces

--- a/contracts/ibc-reflect/Cargo.toml
+++ b/contracts/ibc-reflect/Cargo.toml
@@ -22,9 +22,9 @@ incremental = false
 overflow-checks = true
 
 [features]
-# Change this to [] if you don't need Windows support and want faster integration tests.
-default = ["cranelift"]
-# Use cranelift backend instead of singlepass. This is required for development on Windows.
+# Add feature "cranelift" to default if you need 32 bit Windows support
+default = []
+# Use cranelift backend instead of singlepass. This is required for development on 32 bit Windows.
 cranelift = ["cosmwasm-vm/cranelift"]
 # for quicker tests, cargo test --lib
 # for more explicit tests, cargo test --features=backtraces

--- a/contracts/queue/Cargo.toml
+++ b/contracts/queue/Cargo.toml
@@ -22,9 +22,9 @@ incremental = false
 overflow-checks = true
 
 [features]
-# Change this to [] if you don't need Windows support and want faster integration tests.
-default = ["cranelift"]
-# Use cranelift backend instead of singlepass. This is required for development on Windows.
+# Add feature "cranelift" to default if you need 32 bit Windows support
+default = []
+# Use cranelift backend instead of singlepass. This is required for development on 32 bit Windows.
 cranelift = ["cosmwasm-vm/cranelift"]
 # For quicker tests, cargo test --lib. for more explicit tests, cargo test --features=backtraces
 backtraces = ["cosmwasm-std/backtraces", "cosmwasm-vm/backtraces"]

--- a/contracts/reflect/Cargo.toml
+++ b/contracts/reflect/Cargo.toml
@@ -24,9 +24,9 @@ incremental = false
 overflow-checks = true
 
 [features]
-# Change this to [] if you don't need Windows support and want faster integration tests.
-default = ["cranelift"]
-# Use cranelift backend instead of singlepass. This is required for development on Windows.
+# Add feature "cranelift" to default if you need 32 bit Windows support
+default = []
+# Use cranelift backend instead of singlepass. This is required for development on 32 bit Windows.
 cranelift = ["cosmwasm-vm/cranelift"]
 # for quicker tests, cargo test --lib
 # for more explicit tests, cargo test --features=backtraces

--- a/contracts/staking/Cargo.toml
+++ b/contracts/staking/Cargo.toml
@@ -22,9 +22,9 @@ incremental = false
 overflow-checks = true
 
 [features]
-# Change this to [] if you don't need Windows support and want faster integration tests.
-default = ["cranelift"]
-# Use cranelift backend instead of singlepass. This is required for development on Windows.
+# Add feature "cranelift" to default if you need 32 bit Windows support
+default = []
+# Use cranelift backend instead of singlepass. This is required for development on 32 bit Windows.
 cranelift = ["cosmwasm-vm/cranelift"]
 # for quicker tests, cargo test --lib
 # for more explicit tests, cargo test --features=backtraces


### PR DESCRIPTION
Singlepass now runs on 64 bit Windows, such that non-singlepass use cases became rare enough to ~ignore~ stop optimizing for them.

Closes #649