### PR TITLE
Change CI build and release image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -848,8 +848,7 @@ jobs:
   # This job roughly follows the instructions from https://circleci.com/blog/publishing-to-github-releases-via-circleci/
   build_and_upload_devcontracts:
     docker:
-      # Image from https://github.com/cibuilds/github, based on alpine
-      - image: cibuilds/github:0.13
+      - image: rust:1.50.0
     steps:
       - run:
           name: Install Docker client


### PR DESCRIPTION
Adds Rust support to the build and release CI job. It's this, or perhaps we can put `check_contract` inside the optimizers.