### PR TITLE
Implement interior mutability consistently and run concurrency tests

### DIFF
--- a/packages/vm/benches/main.rs
+++ b/packages/vm/benches/main.rs
@@ -91,7 +91,7 @@ fn bench_cache(c: &mut Criterion) {
     };
 
     group.bench_function("save wasm", |b| {
-        let mut cache: Cache<MockApi, MockStorage, MockQuerier> =
+        let cache: Cache<MockApi, MockStorage, MockQuerier> =
             unsafe { Cache::new(options.clone()).unwrap() };
 
         b.iter(|| {
@@ -101,7 +101,7 @@ fn bench_cache(c: &mut Criterion) {
     });
 
     group.bench_function("load wasm", |b| {
-        let mut cache: Cache<MockApi, MockStorage, MockQuerier> =
+        let cache: Cache<MockApi, MockStorage, MockQuerier> =
             unsafe { Cache::new(options.clone()).unwrap() };
         let checksum = cache.save_wasm(CONTRACT).unwrap();
 
@@ -112,7 +112,7 @@ fn bench_cache(c: &mut Criterion) {
     });
 
     group.bench_function("analyze", |b| {
-        let mut cache: Cache<MockApi, MockStorage, MockQuerier> =
+        let cache: Cache<MockApi, MockStorage, MockQuerier> =
             unsafe { Cache::new(options.clone()).unwrap() };
         let checksum = cache.save_wasm(CONTRACT).unwrap();
 
@@ -129,7 +129,7 @@ fn bench_cache(c: &mut Criterion) {
             memory_cache_size: Size(0),
             instance_memory_limit: DEFAULT_MEMORY_LIMIT,
         };
-        let mut cache: Cache<MockApi, MockStorage, MockQuerier> =
+        let cache: Cache<MockApi, MockStorage, MockQuerier> =
             unsafe { Cache::new(non_memcache).unwrap() };
         let checksum = cache.save_wasm(CONTRACT).unwrap();
 
@@ -146,7 +146,7 @@ fn bench_cache(c: &mut Criterion) {
 
     group.bench_function("instantiate from memory", |b| {
         let checksum = Checksum::generate(CONTRACT);
-        let mut cache: Cache<MockApi, MockStorage, MockQuerier> =
+        let cache: Cache<MockApi, MockStorage, MockQuerier> =
             unsafe { Cache::new(options.clone()).unwrap() };
         // Load into memory
         cache
@@ -167,7 +167,7 @@ fn bench_cache(c: &mut Criterion) {
 
     group.bench_function("instantiate from pinned memory", |b| {
         let checksum = Checksum::generate(CONTRACT);
-        let mut cache: Cache<MockApi, MockStorage, MockQuerier> =
+        let cache: Cache<MockApi, MockStorage, MockQuerier> =
             unsafe { Cache::new(options.clone()).unwrap() };
         // Load into pinned memory
         cache.pin(&checksum).unwrap();

--- a/packages/vm/examples/multi_threaded_cache.rs
+++ b/packages/vm/examples/multi_threaded_cache.rs
@@ -1,0 +1,73 @@
+use std::sync::Arc;
+use std::thread;
+use tempfile::TempDir;
+
+use cosmwasm_std::{coins, Empty};
+use cosmwasm_vm::testing::{mock_backend, mock_env, mock_info, MockApi, MockQuerier, MockStorage};
+use cosmwasm_vm::{
+    call_execute, call_instantiate, features_from_csv, Cache, CacheOptions, InstanceOptions, Size,
+};
+
+// Instance
+const DEFAULT_MEMORY_LIMIT: Size = Size::mebi(64);
+const DEFAULT_GAS_LIMIT: u64 = 400_000;
+const DEFAULT_INSTANCE_OPTIONS: InstanceOptions = InstanceOptions {
+    gas_limit: DEFAULT_GAS_LIMIT,
+    print_debug: false,
+};
+// Cache
+const MEMORY_CACHE_SIZE: Size = Size::mebi(200);
+
+static CONTRACT: &[u8] = include_bytes!("../testdata/hackatom.wasm");
+
+const THREAD_COUNT: usize = 32;
+
+pub fn main() {
+    let options = CacheOptions {
+        base_dir: TempDir::new().unwrap().into_path(),
+        supported_features: features_from_csv("staking"),
+        memory_cache_size: MEMORY_CACHE_SIZE,
+        instance_memory_limit: DEFAULT_MEMORY_LIMIT,
+    };
+
+    let cache: Cache<MockApi, MockStorage, MockQuerier> =
+        unsafe { Cache::new(options.clone()).unwrap() };
+    let cache = Arc::new(cache);
+
+    let checksum = cache.save_wasm(CONTRACT).unwrap();
+
+    let mut threads = Vec::with_capacity(THREAD_COUNT);
+    (0..THREAD_COUNT).for_each(|_| {
+        let cache = Arc::clone(&cache);
+
+        threads.push(thread::spawn(move || {
+            let checksum = checksum.clone();
+            let mut instance = cache
+                .get_instance(&checksum, mock_backend(&[]), DEFAULT_INSTANCE_OPTIONS)
+                .unwrap();
+
+            let info = mock_info("creator", &coins(1000, "earth"));
+            let msg = br#"{"verifier": "verifies", "beneficiary": "benefits"}"#;
+            let contract_result =
+                call_instantiate::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg).unwrap();
+            assert!(contract_result.into_result().is_ok());
+
+            let info = mock_info("verifies", &coins(15, "earth"));
+            let msg = br#"{"release":{}}"#;
+            let contract_result =
+                call_execute::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg).unwrap();
+            assert!(contract_result.into_result().is_ok());
+        }));
+    });
+
+    threads.into_iter().for_each(|thread| {
+        thread
+            .join()
+            .expect("The thread creating or execution failed !")
+    });
+
+    assert_eq!(cache.stats().misses, 0);
+    assert_eq!(cache.stats().hits_pinned_memory_cache, 0);
+    assert_eq!(cache.stats().hits_memory_cache, THREAD_COUNT as u32 - 1);
+    assert_eq!(cache.stats().hits_fs_cache, 1);
+}

--- a/packages/vm/examples/multi_threaded_cache.rs
+++ b/packages/vm/examples/multi_threaded_cache.rs
@@ -21,8 +21,8 @@ const MEMORY_CACHE_SIZE: Size = Size::mebi(200);
 static CONTRACT: &[u8] = include_bytes!("../testdata/hackatom.wasm");
 
 const SAVE_WASM_THREADS: usize = 32;
-const INSTANTION_THREADS: usize = 2048;
-const THREADS: usize = SAVE_WASM_THREADS + INSTANTION_THREADS;
+const INSTANTIATION_THREADS: usize = 2048;
+const THREADS: usize = SAVE_WASM_THREADS + INSTANTIATION_THREADS;
 
 pub fn main() {
     let options = CacheOptions {
@@ -47,7 +47,7 @@ pub fn main() {
             println!("Done saving Wasm {}", checksum);
         }));
     }
-    for _ in 0..INSTANTION_THREADS {
+    for _ in 0..INSTANTIATION_THREADS {
         let cache = Arc::clone(&cache);
 
         threads.push(thread::spawn(move || {
@@ -81,7 +81,7 @@ pub fn main() {
     assert_eq!(cache.stats().hits_pinned_memory_cache, 0);
     assert_eq!(
         cache.stats().hits_memory_cache,
-        INSTANTION_THREADS as u32 - 1
+        INSTANTIATION_THREADS as u32 - 1
     );
     assert_eq!(cache.stats().hits_fs_cache, 1);
 }

--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -108,7 +108,7 @@ where
         self.inner.lock().unwrap().stats
     }
 
-    pub fn save_wasm(&mut self, wasm: &[u8]) -> VmResult<Checksum> {
+    pub fn save_wasm(&self, wasm: &[u8]) -> VmResult<Checksum> {
         let mut cache = self.inner.lock().unwrap();
         check_wasm(wasm, &cache.supported_features)?;
         let checksum = save_wasm_to_disk(&cache.wasm_path, wasm)?;
@@ -155,7 +155,7 @@ where
     /// If not found, the code is loaded from the file system, compiled, and stored into the
     /// pinned cache.
     /// If the given ID is not found, or the content does not match the hash (=ID), an error is returned.
-    pub fn pin(&mut self, checksum: &Checksum) -> VmResult<()> {
+    pub fn pin(&self, checksum: &Checksum) -> VmResult<()> {
         let mut cache = self.inner.lock().unwrap();
         if cache.pinned_memory_cache.has(checksum) {
             return Ok(());
@@ -186,7 +186,7 @@ where
     ///
     /// Not found IDs are silently ignored, and no integrity check (checksum validation) is done
     /// on the removed value.
-    pub fn unpin(&mut self, checksum: &Checksum) -> VmResult<()> {
+    pub fn unpin(&self, checksum: &Checksum) -> VmResult<()> {
         self.inner
             .lock()
             .unwrap()
@@ -197,7 +197,7 @@ where
     /// Returns an Instance tied to a previously saved Wasm.
     /// Depending on availability, this is either generated from a cached instance, a cached module or Wasm code.
     pub fn get_instance(
-        &mut self,
+        &self,
         checksum: &Checksum,
         backend: Backend<A, S, Q>,
         options: InstanceOptions,
@@ -325,7 +325,7 @@ mod tests {
 
     #[test]
     fn save_wasm_works() {
-        let mut cache: Cache<MockApi, MockStorage, MockQuerier> =
+        let cache: Cache<MockApi, MockStorage, MockQuerier> =
             unsafe { Cache::new(make_testing_options()).unwrap() };
         cache.save_wasm(CONTRACT).unwrap();
     }
@@ -333,7 +333,7 @@ mod tests {
     #[test]
     // This property is required when the same bytecode is uploaded multiple times
     fn save_wasm_allows_saving_multiple_times() {
-        let mut cache: Cache<MockApi, MockStorage, MockQuerier> =
+        let cache: Cache<MockApi, MockStorage, MockQuerier> =
             unsafe { Cache::new(make_testing_options()).unwrap() };
         cache.save_wasm(CONTRACT).unwrap();
         cache.save_wasm(CONTRACT).unwrap();
@@ -353,7 +353,7 @@ mod tests {
         )
         .unwrap();
 
-        let mut cache: Cache<MockApi, MockStorage, MockQuerier> =
+        let cache: Cache<MockApi, MockStorage, MockQuerier> =
             unsafe { Cache::new(make_testing_options()).unwrap() };
         let save_result = cache.save_wasm(&wasm);
         match save_result.unwrap_err() {
@@ -369,7 +369,7 @@ mod tests {
         // Who knows if and when the uploaded contract will be executed. Don't pollute
         // memory cache before the init call.
 
-        let mut cache = unsafe { Cache::new(make_testing_options()).unwrap() };
+        let cache = unsafe { Cache::new(make_testing_options()).unwrap() };
         let checksum = cache.save_wasm(CONTRACT).unwrap();
 
         let backend = mock_backend(&[]);
@@ -384,7 +384,7 @@ mod tests {
 
     #[test]
     fn load_wasm_works() {
-        let mut cache: Cache<MockApi, MockStorage, MockQuerier> =
+        let cache: Cache<MockApi, MockStorage, MockQuerier> =
             unsafe { Cache::new(make_testing_options()).unwrap() };
         let id = cache.save_wasm(CONTRACT).unwrap();
 
@@ -404,7 +404,7 @@ mod tests {
                 memory_cache_size: TESTING_MEMORY_CACHE_SIZE,
                 instance_memory_limit: TESTING_MEMORY_LIMIT,
             };
-            let mut cache1: Cache<MockApi, MockStorage, MockQuerier> =
+            let cache1: Cache<MockApi, MockStorage, MockQuerier> =
                 unsafe { Cache::new(options1).unwrap() };
             id = cache1.save_wasm(CONTRACT).unwrap();
         }
@@ -450,7 +450,7 @@ mod tests {
             memory_cache_size: TESTING_MEMORY_CACHE_SIZE,
             instance_memory_limit: TESTING_MEMORY_LIMIT,
         };
-        let mut cache: Cache<MockApi, MockStorage, MockQuerier> =
+        let cache: Cache<MockApi, MockStorage, MockQuerier> =
             unsafe { Cache::new(options).unwrap() };
         let checksum = cache.save_wasm(CONTRACT).unwrap();
 
@@ -469,7 +469,7 @@ mod tests {
 
     #[test]
     fn get_instance_finds_cached_module() {
-        let mut cache = unsafe { Cache::new(make_testing_options()).unwrap() };
+        let cache = unsafe { Cache::new(make_testing_options()).unwrap() };
         let id = cache.save_wasm(CONTRACT).unwrap();
         let backend = mock_backend(&[]);
         let _instance = cache.get_instance(&id, backend, TESTING_OPTIONS).unwrap();
@@ -481,7 +481,7 @@ mod tests {
 
     #[test]
     fn get_instance_finds_cached_modules_and_stores_to_memory() {
-        let mut cache = unsafe { Cache::new(make_testing_options()).unwrap() };
+        let cache = unsafe { Cache::new(make_testing_options()).unwrap() };
         let id = cache.save_wasm(CONTRACT).unwrap();
         let backend1 = mock_backend(&[]);
         let backend2 = mock_backend(&[]);
@@ -534,7 +534,7 @@ mod tests {
 
     #[test]
     fn call_instantiate_on_cached_contract() {
-        let mut cache = unsafe { Cache::new(make_testing_options()).unwrap() };
+        let cache = unsafe { Cache::new(make_testing_options()).unwrap() };
         let checksum = cache.save_wasm(CONTRACT).unwrap();
 
         // from file system
@@ -599,7 +599,7 @@ mod tests {
 
     #[test]
     fn call_execute_on_cached_contract() {
-        let mut cache = unsafe { Cache::new(make_testing_options()).unwrap() };
+        let cache = unsafe { Cache::new(make_testing_options()).unwrap() };
         let checksum = cache.save_wasm(CONTRACT).unwrap();
 
         // from file system
@@ -691,7 +691,7 @@ mod tests {
 
     #[test]
     fn use_multiple_cached_instances_of_same_contract() {
-        let mut cache = unsafe { Cache::new(make_testing_options()).unwrap() };
+        let cache = unsafe { Cache::new(make_testing_options()).unwrap() };
         let id = cache.save_wasm(CONTRACT).unwrap();
 
         // these differentiate the two instances of the same contract
@@ -737,7 +737,7 @@ mod tests {
 
     #[test]
     fn resets_gas_when_reusing_instance() {
-        let mut cache = unsafe { Cache::new(make_testing_options()).unwrap() };
+        let cache = unsafe { Cache::new(make_testing_options()).unwrap() };
         let id = cache.save_wasm(CONTRACT).unwrap();
 
         let backend1 = mock_backend(&[]);
@@ -770,7 +770,7 @@ mod tests {
 
     #[test]
     fn recovers_from_out_of_gas() {
-        let mut cache = unsafe { Cache::new(make_testing_options()).unwrap() };
+        let cache = unsafe { Cache::new(make_testing_options()).unwrap() };
         let id = cache.save_wasm(CONTRACT).unwrap();
 
         let backend1 = mock_backend(&[]);
@@ -860,7 +860,7 @@ mod tests {
 
     #[test]
     fn pin_unpin_works() {
-        let mut cache = unsafe { Cache::new(make_testing_options()).unwrap() };
+        let cache = unsafe { Cache::new(make_testing_options()).unwrap() };
         let id = cache.save_wasm(CONTRACT).unwrap();
 
         // check not pinned

--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -68,9 +68,7 @@ where
     S: Storage + 'static,    // 'static is needed by `impl<…> Instance`
     Q: Querier + 'static,    // 'static is needed by `impl<…> Instance`
 {
-    /// new stores the data for cache under base_dir
-    ///
-    /// Instance caching is disabled since 0.8.1 and any cache size value will be treated as 0.
+    /// Creates a new cache that stores data in `base_dir`.
     ///
     /// # Safety
     ///

--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -253,6 +253,14 @@ where
 {
 }
 
+unsafe impl<A, S, Q> Send for Cache<A, S, Q>
+where
+    A: BackendApi + 'static,
+    S: Storage + 'static,
+    Q: Querier + 'static,
+{
+}
+
 /// save stores the wasm code in the given directory and returns an ID for lookup.
 /// It will create the directory if it doesn't exist.
 /// Saving the same byte code multiple times is allowed.

--- a/packages/vm/src/checksum.rs
+++ b/packages/vm/src/checksum.rs
@@ -1,4 +1,5 @@
 use std::convert::TryFrom;
+use std::fmt;
 
 use sha2::{Digest, Sha256};
 
@@ -19,7 +20,16 @@ impl Checksum {
 
     /// Creates a lowercase hex encoded copy of this checksum
     pub fn to_hex(&self) -> String {
-        hex::encode(self.0)
+        self.to_string()
+    }
+}
+
+impl fmt::Display for Checksum {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for byte in self.0.iter() {
+            write!(f, "{:02x}", byte)?;
+        }
+        Ok(())
     }
 }
 
@@ -65,6 +75,22 @@ mod tests {
             0x84, 0x22, 0x71, 0x04,
         ];
         assert_eq!(checksum.0, expected);
+    }
+
+    #[test]
+    fn implemented_display() {
+        let wasm = vec![0x68, 0x69, 0x6a];
+        let checksum = Checksum::generate(&wasm);
+        // echo -n "hij" | sha256sum
+        let embedded = format!("Check: {}", checksum);
+        assert_eq!(
+            embedded,
+            "Check: 722c8c993fd75a7627d69ed941344fe2a1423a3e75efd3e6778a142884227104"
+        );
+        assert_eq!(
+            checksum.to_string(),
+            "722c8c993fd75a7627d69ed941344fe2a1423a3e75efd3e6778a142884227104"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Turns out the use of mutex is exactly what we need to implement the interior mutability pattern. A readable reference to the mutex is enough to get exclusive access by locking.

This also adds a concurrency example and does some more cleanup.