### PR TITLE
Run clippy on all tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -695,33 +695,37 @@ jobs:
       # Workspace packages
       #
       - run:
+          name: Clippy linting on crypto
+          working_directory: ~/project/packages/crypto
+          command: cargo clippy --tests -- -D warnings
+      - run:
           name: Clippy linting on schema
           working_directory: ~/project/packages/schema
-          command: cargo clippy -- -D warnings
+          command: cargo clippy --tests -- -D warnings
       - run:
           name: Clippy linting on std (no feature flags)
           working_directory: ~/project/packages/std
-          command: cargo clippy -- -D warnings
+          command: cargo clippy --tests -- -D warnings
       - run:
           name: Clippy linting on std (all feature flags)
           working_directory: ~/project/packages/std
-          command: cargo clippy --features iterator,staking -- -D warnings
+          command: cargo clippy --tests --features iterator,staking -- -D warnings
       - run:
           name: Clippy linting on storage (no feature flags)
           working_directory: ~/project/packages/storage
-          command: cargo clippy -- -D warnings
+          command: cargo clippy --tests -- -D warnings
       - run:
           name: Clippy linting on storage (all feature flags)
           working_directory: ~/project/packages/storage
-          command: cargo clippy --features iterator -- -D warnings
+          command: cargo clippy --tests --features iterator -- -D warnings
       - run:
           name: Clippy linting on vm (no feature flags)
           working_directory: ~/project/packages/vm
-          command: cargo clippy --no-default-features -- -D warnings
+          command: cargo clippy --tests --no-default-features -- -D warnings
       - run:
           name: Clippy linting on vm (all feature flags)
           working_directory: ~/project/packages/vm
-          command: cargo clippy --features iterator,staking,stargate -- -D warnings
+          command: cargo clippy --tests --features iterator,staking,stargate -- -D warnings
       #
       # Contracts
       #

--- a/packages/std/src/addresses.rs
+++ b/packages/std/src/addresses.rs
@@ -251,7 +251,7 @@ mod tests {
         assert_eq!(set.len(), 2);
 
         let set1 = HashSet::<HumanAddr>::from_iter(vec![bob.clone(), alice1.clone()]);
-        let set2 = HashSet::from_iter(vec![alice1.clone(), alice2.clone(), bob.clone()]);
+        let set2 = HashSet::from_iter(vec![alice1, alice2, bob]);
         assert_eq!(set1, set2);
     }
 
@@ -399,7 +399,7 @@ mod tests {
         assert_eq!(set.len(), 2);
 
         let set1 = HashSet::<CanonicalAddr>::from_iter(vec![bob.clone(), alice1.clone()]);
-        let set2 = HashSet::from_iter(vec![alice1.clone(), alice2.clone(), bob.clone()]);
+        let set2 = HashSet::from_iter(vec![alice1, alice2, bob]);
         assert_eq!(set1, set2);
     }
 }

--- a/packages/std/src/binary.rs
+++ b/packages/std/src/binary.rs
@@ -541,7 +541,7 @@ mod tests {
         assert_eq!(set.len(), 2);
 
         let set1 = HashSet::<Binary>::from_iter(vec![b.clone(), a1.clone()]);
-        let set2 = HashSet::from_iter(vec![a1.clone(), a2.clone(), b.clone()]);
+        let set2 = HashSet::from_iter(vec![a1, a2, b]);
         assert_eq!(set1, set2);
     }
 

--- a/packages/std/src/deps.rs
+++ b/packages/std/src/deps.rs
@@ -74,8 +74,8 @@ mod tests {
     fn execute2(_deps: DepsMut) {}
 
     fn query(deps: Deps) {
-        query2(deps.clone());
-        query2(deps.clone());
+        query2(deps);
+        query2(deps);
     }
     fn query2(_deps: Deps) {}
 

--- a/packages/std/src/math.rs
+++ b/packages/std/src/math.rs
@@ -432,13 +432,13 @@ mod tests {
         // 1/3 (result floored)
         assert_eq!(
             Decimal::from_ratio(1u64, 3u64),
-            Decimal(0_333_333_333_333_333_333)
+            Decimal(333_333_333_333_333_333)
         );
 
         // 2/3 (result floored)
         assert_eq!(
             Decimal::from_ratio(2u64, 3u64),
-            Decimal(0_666_666_666_666_666_666)
+            Decimal(666_666_666_666_666_666)
         );
     }
 
@@ -467,9 +467,9 @@ mod tests {
         assert_eq!(Decimal::from_str("0.123").unwrap(), Decimal::permille(123));
 
         assert_eq!(Decimal::from_str("40.00").unwrap(), Decimal::percent(4000));
-        assert_eq!(Decimal::from_str("04.00").unwrap(), Decimal::percent(0400));
-        assert_eq!(Decimal::from_str("00.40").unwrap(), Decimal::percent(0040));
-        assert_eq!(Decimal::from_str("00.04").unwrap(), Decimal::percent(0004));
+        assert_eq!(Decimal::from_str("04.00").unwrap(), Decimal::percent(400));
+        assert_eq!(Decimal::from_str("00.40").unwrap(), Decimal::percent(40));
+        assert_eq!(Decimal::from_str("00.04").unwrap(), Decimal::percent(4));
 
         // Can handle 18 fractional digits
         assert_eq!(
@@ -738,6 +738,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::op_ref)]
     fn uint128_math() {
         let a = Uint128(12345);
         let b = Uint128(23456);

--- a/packages/std/src/mock.rs
+++ b/packages/std/src/mock.rs
@@ -664,7 +664,7 @@ mod tests {
         let expected = hex!("044a071e8a6e10aada2b8cf39fa3b5fb3400b04e99ea8ae64ceea1a977dbeaf5d5f8c8fbd10b71ab14cd561f7df8eb6da50f8a8d81ba564342244d26d1d4211595");
 
         // Wrong hash
-        let mut corrupted_hash = hash.clone();
+        let mut corrupted_hash = hash;
         corrupted_hash[0] ^= 0x01;
         let pubkey = api
             .secp256k1_recover_pubkey(&corrupted_hash, &signature, recovery_param)
@@ -784,9 +784,7 @@ mod tests {
 
         // all
         let all = bank
-            .query(&BankQuery::AllBalances {
-                address: addr.clone(),
-            })
+            .query(&BankQuery::AllBalances { address: addr })
             .unwrap()
             .unwrap();
         let res: AllBalanceResponse = from_binary(&all).unwrap();
@@ -813,7 +811,7 @@ mod tests {
         // missing denom
         let miss = bank
             .query(&BankQuery::Balance {
-                address: addr.clone(),
+                address: addr,
                 denom: "MISS".to_string(),
             })
             .unwrap()
@@ -970,21 +968,21 @@ mod tests {
 
         // filter a by validator (1 and 1)
         let dels = get_delegator(&staking, user_a.clone(), val1.clone());
-        assert_eq!(dels, Some(del1a.clone()));
-        let dels = get_delegator(&staking, user_a.clone(), val2.clone());
-        assert_eq!(dels, Some(del2a.clone()));
+        assert_eq!(dels, Some(del1a));
+        let dels = get_delegator(&staking, user_a, val2.clone());
+        assert_eq!(dels, Some(del2a));
 
         // filter b by validator (2 and 0)
         let dels = get_delegator(&staking, user_b.clone(), val1.clone());
-        assert_eq!(dels, Some(del1b.clone()));
-        let dels = get_delegator(&staking, user_b.clone(), val2.clone());
+        assert_eq!(dels, Some(del1b));
+        let dels = get_delegator(&staking, user_b, val2.clone());
         assert_eq!(dels, None);
 
         // filter c by validator (0 and 1)
-        let dels = get_delegator(&staking, user_c.clone(), val1.clone());
+        let dels = get_delegator(&staking, user_c.clone(), val1);
         assert_eq!(dels, None);
-        let dels = get_delegator(&staking, user_c.clone(), val2.clone());
-        assert_eq!(dels, Some(del2c.clone()));
+        let dels = get_delegator(&staking, user_c, val2);
+        assert_eq!(dels, Some(del2c));
     }
 
     #[test]

--- a/packages/std/src/results/context.rs
+++ b/packages/std/src/results/context.rs
@@ -80,7 +80,7 @@ mod tests {
     fn empty_context() {
         let ctx = Context::new();
 
-        let init: Response = ctx.clone().into();
+        let init: Response = ctx.into();
         assert_eq!(init, Response::default());
     }
 
@@ -105,7 +105,7 @@ mod tests {
         let expected_attributes = vec![attr("sender", "john"), attr("action", "test")];
         let expected_data = Some(Binary::from(b"banana"));
 
-        let response: Response = ctx.clone().into();
+        let response: Response = ctx.into();
         assert_eq!(&response.messages, &expected_msgs);
         assert_eq!(&response.attributes, &expected_attributes);
         assert_eq!(&response.data, &expected_data);

--- a/packages/storage/src/bucket.rs
+++ b/packages/storage/src/bucket.rs
@@ -230,7 +230,7 @@ mod tests {
         };
         bucket.save(b"maria", &data).unwrap();
 
-        let reader = bucket_read::<Data>(&mut store, b"data");
+        let reader = bucket_read::<Data>(&store, b"data");
 
         // check empty data handling
         assert!(reader.load(b"john").is_err());
@@ -291,7 +291,7 @@ mod tests {
 
         // it's my birthday
         let birthday = |mayd: Option<Data>| -> StdResult<Data> {
-            let mut d = mayd.ok_or(StdError::not_found("Data"))?;
+            let mut d = mayd.ok_or_else(|| StdError::not_found("Data"))?;
             d.age += 1;
             Ok(d)
         };
@@ -321,7 +321,7 @@ mod tests {
         let mut old_age = 0i32;
         bucket
             .update(b"maria", |mayd: Option<Data>| -> StdResult<_> {
-                let mut d = mayd.ok_or(StdError::not_found("Data"))?;
+                let mut d = mayd.ok_or_else(|| StdError::not_found("Data"))?;
                 old_age = d.age;
                 d.age += 1;
                 Ok(d)
@@ -390,7 +390,7 @@ mod tests {
                 data.age += 1;
                 Ok(data)
             } else {
-                return Err(MyError::NotFound);
+                Err(MyError::NotFound)
             }
         });
         match res.unwrap_err() {

--- a/packages/storage/src/prefixed_storage.rs
+++ b/packages/storage/src/prefixed_storage.rs
@@ -115,14 +115,14 @@ mod tests {
         let mut storage = MockStorage::new();
 
         // set
-        let mut foo = PrefixedStorage::new(&mut storage, b"foo");
-        foo.set(b"bar", b"gotcha");
+        let mut s1 = PrefixedStorage::new(&mut storage, b"foo");
+        s1.set(b"bar", b"gotcha");
         assert_eq!(storage.get(b"\x00\x03foobar").unwrap(), b"gotcha".to_vec());
 
         // get
-        let foo = PrefixedStorage::new(&mut storage, b"foo");
-        assert_eq!(foo.get(b"bar"), Some(b"gotcha".to_vec()));
-        assert_eq!(foo.get(b"elsewhere"), None);
+        let s2 = PrefixedStorage::new(&mut storage, b"foo");
+        assert_eq!(s2.get(b"bar"), Some(b"gotcha".to_vec()));
+        assert_eq!(s2.get(b"elsewhere"), None);
     }
 
     #[test]
@@ -149,13 +149,13 @@ mod tests {
         storage.set(b"\x00\x03foobar", b"gotcha");
 
         // try readonly correctly
-        let foo = ReadonlyPrefixedStorage::new(&storage, b"foo");
-        assert_eq!(foo.get(b"bar"), Some(b"gotcha".to_vec()));
-        assert_eq!(foo.get(b"elsewhere"), None);
+        let s1 = ReadonlyPrefixedStorage::new(&storage, b"foo");
+        assert_eq!(s1.get(b"bar"), Some(b"gotcha".to_vec()));
+        assert_eq!(s1.get(b"elsewhere"), None);
 
         // no collisions with other prefixes
-        let fo = ReadonlyPrefixedStorage::new(&storage, b"fo");
-        assert_eq!(fo.get(b"obar"), None);
+        let s2 = ReadonlyPrefixedStorage::new(&storage, b"fo");
+        assert_eq!(s2.get(b"obar"), None);
     }
 
     #[test]

--- a/packages/vm/src/checksum.rs
+++ b/packages/vm/src/checksum.rs
@@ -106,7 +106,7 @@ mod tests {
 
     #[test]
     fn into_vec_works() {
-        let checksum = Checksum::generate(&vec![12u8; 17]);
+        let checksum = Checksum::generate(&[12u8; 17]);
         let as_vec: Vec<u8> = checksum.into();
         assert_eq!(as_vec, checksum.0);
     }

--- a/packages/vm/src/compatibility.rs
+++ b/packages/vm/src/compatibility.rs
@@ -149,14 +149,13 @@ fn check_wasm_features(module: &Module, supported_features: &HashSet<String>) ->
 mod tests {
     use super::*;
     use crate::errors::VmError;
-    use std::iter::FromIterator;
 
     static CONTRACT_0_6: &[u8] = include_bytes!("../testdata/hackatom_0.6.wasm");
     static CONTRACT_0_7: &[u8] = include_bytes!("../testdata/hackatom_0.7.wasm");
     static CONTRACT: &[u8] = include_bytes!("../testdata/hackatom.wasm");
 
     fn default_features() -> HashSet<String> {
-        HashSet::from_iter(["staking".to_string()].iter().cloned())
+        ["staking".to_string()].iter().cloned().collect()
     }
 
     #[test]
@@ -277,7 +276,7 @@ mod tests {
     #[test]
     fn check_wasm_exports_works() {
         // this is invalid, as it doesn't contain all required exports
-        const WAT_MISSING_EXPORTS: &'static str = r#"
+        const WAT_MISSING_EXPORTS: &str = r#"
             (module
               (type $t0 (func (param i32) (result i32)))
               (func $add_one (export "add_one") (type $t0) (param $p0 i32) (result i32)
@@ -417,16 +416,15 @@ mod tests {
         )
         .unwrap();
         let module = deserialize_wasm(&wasm).unwrap();
-        let supported = HashSet::from_iter(
-            [
-                "water".to_string(),
-                "nutrients".to_string(),
-                "sun".to_string(),
-                "freedom".to_string(),
-            ]
-            .iter()
-            .cloned(),
-        );
+        let supported = [
+            "water".to_string(),
+            "nutrients".to_string(),
+            "sun".to_string(),
+            "freedom".to_string(),
+        ]
+        .iter()
+        .cloned()
+        .collect();
         check_wasm_features(&module, &supported).unwrap();
     }
 
@@ -448,15 +446,14 @@ mod tests {
         let module = deserialize_wasm(&wasm).unwrap();
 
         // Support set 1
-        let supported = HashSet::from_iter(
-            [
-                "water".to_string(),
-                "nutrients".to_string(),
-                "freedom".to_string(),
-            ]
-            .iter()
-            .cloned(),
-        );
+        let supported = [
+            "water".to_string(),
+            "nutrients".to_string(),
+            "freedom".to_string(),
+        ]
+        .iter()
+        .cloned()
+        .collect();
         match check_wasm_features(&module, &supported).unwrap_err() {
             VmError::StaticValidationErr { msg, .. } => assert_eq!(
                 msg,
@@ -466,15 +463,14 @@ mod tests {
         }
 
         // Support set 2
-        let supported = HashSet::from_iter(
-            [
-                "nutrients".to_string(),
-                "freedom".to_string(),
-                "Water".to_string(), // features are case sensitive (and lowercase by convention)
-            ]
-            .iter()
-            .cloned(),
-        );
+        let supported = [
+            "nutrients".to_string(),
+            "freedom".to_string(),
+            "Water".to_string(), // features are case sensitive (and lowercase by convention)
+        ]
+        .iter()
+        .cloned()
+        .collect();
         match check_wasm_features(&module, &supported).unwrap_err() {
             VmError::StaticValidationErr { msg, .. } => assert_eq!(
                 msg,
@@ -484,7 +480,7 @@ mod tests {
         }
 
         // Support set 3
-        let supported = HashSet::from_iter(["freedom".to_string()].iter().cloned());
+        let supported = ["freedom".to_string()].iter().cloned().collect();
         match check_wasm_features(&module, &supported).unwrap_err() {
             VmError::StaticValidationErr { msg, .. } => assert_eq!(
                 msg,
@@ -494,7 +490,7 @@ mod tests {
         }
 
         // Support set 4
-        let supported = HashSet::from_iter([].iter().cloned());
+        let supported = [].iter().cloned().collect();
         match check_wasm_features(&module, &supported).unwrap_err() {
             VmError::StaticValidationErr { msg, .. } => assert_eq!(
                 msg,

--- a/packages/vm/src/ibc_calls.rs
+++ b/packages/vm/src/ibc_calls.rs
@@ -307,7 +307,7 @@ mod tests {
         let packet = mock_ibc_packet_ack(CHANNEL_ID, br#"{}"#).unwrap();
         let ack = IbcAcknowledgement {
             acknowledgement: br#"{}"#.into(),
-            original_packet: packet.clone(),
+            original_packet: packet,
         };
         call_ibc_packet_ack::<_, _, _, Empty>(&mut instance, &mock_env(), &ack)
             .unwrap()

--- a/packages/vm/src/imports.rs
+++ b/packages/vm/src/imports.rs
@@ -615,8 +615,7 @@ mod tests {
         let result = allocate
             .call(&[capacity.into()])
             .expect("error calling allocate");
-        let region_ptr = ref_to_u32(&result[0]).expect("error converting result");
-        region_ptr
+        ref_to_u32(&result[0]).expect("error converting result")
     }
 
     /// A Region reader that is just good enough for the tests in this file
@@ -968,7 +967,7 @@ mod tests {
         let api = MockApi::default();
         let (env, mut instance) = make_instance(api);
 
-        let source_ptr = write_data(&env, &vec![61; 100]);
+        let source_ptr = write_data(&env, &[61; 100]);
         let dest_ptr = create_empty(&mut instance, 8);
 
         leave_default_data(&env);
@@ -1070,7 +1069,7 @@ mod tests {
         let api = MockApi::default();
         let (env, mut instance) = make_instance(api);
 
-        let source_ptr = write_data(&env, &vec![61; 33]);
+        let source_ptr = write_data(&env, &[61; 33]);
         let dest_ptr = create_empty(&mut instance, 50);
 
         leave_default_data(&env);
@@ -1119,7 +1118,7 @@ mod tests {
     #[test]
     fn do_secp256k1_verify_works() {
         let api = MockApi::default();
-        let (env, mut _instance) = make_instance(api.clone());
+        let (env, mut _instance) = make_instance(api);
 
         let hash = hex::decode(ECDSA_HASH_HEX).unwrap();
         let hash_ptr = write_data(&env, &hash);
@@ -1137,7 +1136,7 @@ mod tests {
     #[test]
     fn do_secp256k1_verify_wrong_hash_verify_fails() {
         let api = MockApi::default();
-        let (env, mut _instance) = make_instance(api.clone());
+        let (env, mut _instance) = make_instance(api);
 
         let mut hash = hex::decode(ECDSA_HASH_HEX).unwrap();
         // alter hash
@@ -1157,7 +1156,7 @@ mod tests {
     #[test]
     fn do_secp256k1_verify_larger_hash_fails() {
         let api = MockApi::default();
-        let (env, mut _instance) = make_instance(api.clone());
+        let (env, mut _instance) = make_instance(api);
 
         let mut hash = hex::decode(ECDSA_HASH_HEX).unwrap();
         // extend / break hash
@@ -1181,7 +1180,7 @@ mod tests {
     #[test]
     fn do_secp256k1_verify_shorter_hash_fails() {
         let api = MockApi::default();
-        let (env, mut _instance) = make_instance(api.clone());
+        let (env, mut _instance) = make_instance(api);
 
         let mut hash = hex::decode(ECDSA_HASH_HEX).unwrap();
         // reduce / break hash
@@ -1201,7 +1200,7 @@ mod tests {
     #[test]
     fn do_secp256k1_verify_wrong_sig_verify_fails() {
         let api = MockApi::default();
-        let (env, mut _instance) = make_instance(api.clone());
+        let (env, mut _instance) = make_instance(api);
 
         let hash = hex::decode(ECDSA_HASH_HEX).unwrap();
         let hash_ptr = write_data(&env, &hash);
@@ -1221,7 +1220,7 @@ mod tests {
     #[test]
     fn do_secp256k1_verify_larger_sig_fails() {
         let api = MockApi::default();
-        let (env, mut _instance) = make_instance(api.clone());
+        let (env, mut _instance) = make_instance(api);
 
         let hash = hex::decode(ECDSA_HASH_HEX).unwrap();
         let hash_ptr = write_data(&env, &hash);
@@ -1245,7 +1244,7 @@ mod tests {
     #[test]
     fn do_secp256k1_verify_shorter_sig_fails() {
         let api = MockApi::default();
-        let (env, mut _instance) = make_instance(api.clone());
+        let (env, mut _instance) = make_instance(api);
 
         let hash = hex::decode(ECDSA_HASH_HEX).unwrap();
         let hash_ptr = write_data(&env, &hash);
@@ -1265,7 +1264,7 @@ mod tests {
     #[test]
     fn do_secp256k1_verify_wrong_pubkey_format_fails() {
         let api = MockApi::default();
-        let (env, mut _instance) = make_instance(api.clone());
+        let (env, mut _instance) = make_instance(api);
 
         let hash = hex::decode(ECDSA_HASH_HEX).unwrap();
         let hash_ptr = write_data(&env, &hash);
@@ -1285,7 +1284,7 @@ mod tests {
     #[test]
     fn do_secp256k1_verify_wrong_pubkey_fails() {
         let api = MockApi::default();
-        let (env, mut _instance) = make_instance(api.clone());
+        let (env, mut _instance) = make_instance(api);
 
         let hash = hex::decode(ECDSA_HASH_HEX).unwrap();
         let hash_ptr = write_data(&env, &hash);
@@ -1305,7 +1304,7 @@ mod tests {
     #[test]
     fn do_secp256k1_verify_larger_pubkey_fails() {
         let api = MockApi::default();
-        let (env, mut _instance) = make_instance(api.clone());
+        let (env, mut _instance) = make_instance(api);
 
         let hash = hex::decode(ECDSA_HASH_HEX).unwrap();
         let hash_ptr = write_data(&env, &hash);
@@ -1329,7 +1328,7 @@ mod tests {
     #[test]
     fn do_secp256k1_verify_shorter_pubkey_fails() {
         let api = MockApi::default();
-        let (env, mut _instance) = make_instance(api.clone());
+        let (env, mut _instance) = make_instance(api);
 
         let hash = hex::decode(ECDSA_HASH_HEX).unwrap();
         let hash_ptr = write_data(&env, &hash);
@@ -1349,7 +1348,7 @@ mod tests {
     #[test]
     fn do_secp256k1_verify_empty_pubkey_fails() {
         let api = MockApi::default();
-        let (env, mut _instance) = make_instance(api.clone());
+        let (env, mut _instance) = make_instance(api);
 
         let hash = hex::decode(ECDSA_HASH_HEX).unwrap();
         let hash_ptr = write_data(&env, &hash);
@@ -1367,7 +1366,7 @@ mod tests {
     #[test]
     fn do_secp256k1_verify_wrong_data_fails() {
         let api = MockApi::default();
-        let (env, mut _instance) = make_instance(api.clone());
+        let (env, mut _instance) = make_instance(api);
 
         let hash = vec![0x22; MESSAGE_HASH_MAX_LEN];
         let hash_ptr = write_data(&env, &hash);
@@ -1385,7 +1384,7 @@ mod tests {
     #[test]
     fn do_secp256k1_recover_pubkey_works() {
         let api = MockApi::default();
-        let (env, mut _instance) = make_instance(api.clone());
+        let (env, mut _instance) = make_instance(api);
 
         // https://gist.github.com/webmaster128/130b628d83621a33579751846699ed15
         let hash = hex!("5ae8317d34d1e595e3fa7247db80c0af4320cce1116de187f8f7e2e099c0d8d0");
@@ -1407,7 +1406,7 @@ mod tests {
     #[test]
     fn do_ed25519_verify_works() {
         let api = MockApi::default();
-        let (env, mut _instance) = make_instance(api.clone());
+        let (env, mut _instance) = make_instance(api);
 
         let msg = hex::decode(EDDSA_MSG_HEX).unwrap();
         let msg_ptr = write_data(&env, &msg);
@@ -1425,7 +1424,7 @@ mod tests {
     #[test]
     fn do_ed25519_verify_wrong_msg_verify_fails() {
         let api = MockApi::default();
-        let (env, mut _instance) = make_instance(api.clone());
+        let (env, mut _instance) = make_instance(api);
 
         let mut msg = hex::decode(EDDSA_MSG_HEX).unwrap();
         // alter msg
@@ -1445,7 +1444,7 @@ mod tests {
     #[test]
     fn do_ed25519_verify_larger_msg_fails() {
         let api = MockApi::default();
-        let (env, mut _instance) = make_instance(api.clone());
+        let (env, mut _instance) = make_instance(api);
 
         let mut msg = hex::decode(EDDSA_MSG_HEX).unwrap();
         // extend / break msg
@@ -1469,7 +1468,7 @@ mod tests {
     #[test]
     fn do_ed25519_verify_wrong_sig_verify_fails() {
         let api = MockApi::default();
-        let (env, mut _instance) = make_instance(api.clone());
+        let (env, mut _instance) = make_instance(api);
 
         let msg = hex::decode(EDDSA_MSG_HEX).unwrap();
         let msg_ptr = write_data(&env, &msg);
@@ -1489,7 +1488,7 @@ mod tests {
     #[test]
     fn do_ed25519_verify_larger_sig_fails() {
         let api = MockApi::default();
-        let (env, mut _instance) = make_instance(api.clone());
+        let (env, mut _instance) = make_instance(api);
 
         let msg = hex::decode(EDDSA_MSG_HEX).unwrap();
         let msg_ptr = write_data(&env, &msg);
@@ -1513,7 +1512,7 @@ mod tests {
     #[test]
     fn do_ed25519_verify_shorter_sig_fails() {
         let api = MockApi::default();
-        let (env, mut _instance) = make_instance(api.clone());
+        let (env, mut _instance) = make_instance(api);
 
         let msg = hex::decode(EDDSA_MSG_HEX).unwrap();
         let msg_ptr = write_data(&env, &msg);
@@ -1533,7 +1532,7 @@ mod tests {
     #[test]
     fn do_ed25519_verify_wrong_pubkey_verify_fails() {
         let api = MockApi::default();
-        let (env, mut _instance) = make_instance(api.clone());
+        let (env, mut _instance) = make_instance(api);
 
         let msg = hex::decode(EDDSA_MSG_HEX).unwrap();
         let msg_ptr = write_data(&env, &msg);
@@ -1553,7 +1552,7 @@ mod tests {
     #[test]
     fn do_ed25519_verify_larger_pubkey_fails() {
         let api = MockApi::default();
-        let (env, mut _instance) = make_instance(api.clone());
+        let (env, mut _instance) = make_instance(api);
 
         let msg = hex::decode(EDDSA_MSG_HEX).unwrap();
         let msg_ptr = write_data(&env, &msg);
@@ -1577,7 +1576,7 @@ mod tests {
     #[test]
     fn do_ed25519_verify_shorter_pubkey_fails() {
         let api = MockApi::default();
-        let (env, mut _instance) = make_instance(api.clone());
+        let (env, mut _instance) = make_instance(api);
 
         let msg = hex::decode(EDDSA_MSG_HEX).unwrap();
         let msg_ptr = write_data(&env, &msg);
@@ -1597,7 +1596,7 @@ mod tests {
     #[test]
     fn do_ed25519_verify_empty_pubkey_fails() {
         let api = MockApi::default();
-        let (env, mut _instance) = make_instance(api.clone());
+        let (env, mut _instance) = make_instance(api);
 
         let msg = hex::decode(EDDSA_MSG_HEX).unwrap();
         let msg_ptr = write_data(&env, &msg);
@@ -1615,7 +1614,7 @@ mod tests {
     #[test]
     fn do_ed25519_verify_wrong_data_fails() {
         let api = MockApi::default();
-        let (env, mut _instance) = make_instance(api.clone());
+        let (env, mut _instance) = make_instance(api);
 
         let msg = vec![0x22; MESSAGE_HASH_MAX_LEN];
         let msg_ptr = write_data(&env, &msg);

--- a/packages/vm/src/limited.rs
+++ b/packages/vm/src/limited.rs
@@ -99,15 +99,14 @@ mod tests {
         assert_eq!(set.to_string_limited(20), "{}");
         assert_eq!(set.to_string_limited(2), "{}");
 
-        let fruits = BTreeSet::from_iter(
-            [
-                "watermelon".to_string(),
-                "apple".to_string(),
-                "banana".to_string(),
-            ]
-            .iter()
-            .cloned(),
-        );
+        let fruits: BTreeSet<String> = [
+            "watermelon".to_string(),
+            "apple".to_string(),
+            "banana".to_string(),
+        ]
+        .iter()
+        .cloned()
+        .collect();
         assert_eq!(
             fruits.to_string_limited(100),
             "{\"apple\", \"banana\", \"watermelon\"}"
@@ -137,15 +136,14 @@ mod tests {
         assert_eq!(set.to_string_limited(20), "{}");
         assert_eq!(set.to_string_limited(2), "{}");
 
-        let fruits = HashSet::from_iter(
-            [
-                "watermelon".to_string(),
-                "apple".to_string(),
-                "banana".to_string(),
-            ]
-            .iter()
-            .cloned(),
-        );
+        let fruits: HashSet<String> = [
+            "watermelon".to_string(),
+            "apple".to_string(),
+            "banana".to_string(),
+        ]
+        .iter()
+        .cloned()
+        .collect();
         assert_eq!(
             fruits.to_string_limited(100),
             "{\"apple\", \"banana\", \"watermelon\"}"
@@ -178,15 +176,14 @@ mod tests {
     #[test]
     #[should_panic(expected = "Cannot remove hide enough elements to fit in length limit.")]
     fn panics_if_limit_is_too_small_nonempty() {
-        let fruits = HashSet::from_iter(
-            [
-                "watermelon".to_string(),
-                "apple".to_string(),
-                "banana".to_string(),
-            ]
-            .iter()
-            .cloned(),
-        );
+        let fruits: HashSet<String> = [
+            "watermelon".to_string(),
+            "apple".to_string(),
+            "banana".to_string(),
+        ]
+        .iter()
+        .cloned()
+        .collect();
         assert_eq!(fruits.to_string_limited(15), "{... 3 elements}");
     }
 

--- a/packages/vm/src/static_analysis.rs
+++ b/packages/vm/src/static_analysis.rs
@@ -60,19 +60,12 @@ mod tests {
         let module = deserialize_wasm(CONTRACT).unwrap();
         assert_eq!(module.version(), 1);
 
-        let exported_functions =
-            module
-                .export_section()
-                .unwrap()
-                .entries()
-                .iter()
-                .filter(|entry| {
-                    if let Internal::Function(_) = entry.internal() {
-                        true
-                    } else {
-                        false
-                    }
-                });
+        let exported_functions = module
+            .export_section()
+            .unwrap()
+            .entries()
+            .iter()
+            .filter(|entry| matches!(entry.internal(), Internal::Function(_)));
         assert_eq!(exported_functions.count(), 8); // 4 required exports plus "execute", "migrate", "query" and "sudo"
 
         let exported_memories = module
@@ -80,13 +73,7 @@ mod tests {
             .unwrap()
             .entries()
             .iter()
-            .filter(|entry| {
-                if let Internal::Memory(_) = entry.internal() {
-                    true
-                } else {
-                    false
-                }
-            });
+            .filter(|entry| matches!(entry.internal(), Internal::Memory(_)));
         assert_eq!(exported_memories.count(), 1);
     }
 

--- a/packages/vm/src/testing/querier.rs
+++ b/packages/vm/src/testing/querier.rs
@@ -134,10 +134,7 @@ mod tests {
         // all
         let all = querier
             .query::<Empty>(
-                &BankQuery::AllBalances {
-                    address: addr.clone(),
-                }
-                .into(),
+                &BankQuery::AllBalances { address: addr }.into(),
                 DEFAULT_QUERY_GAS_LIMIT,
             )
             .0
@@ -175,7 +172,7 @@ mod tests {
         let miss = querier
             .query::<Empty>(
                 &BankQuery::Balance {
-                    address: addr.clone(),
+                    address: addr,
                     denom: "MISS".to_string(),
                 }
                 .into(),


### PR DESCRIPTION
Mostly annoying changes, but good to have the check in place.

Some learnings:
- `matches!` is cool
- I was not aware of slice literals (like `[33; 100]`)