### PR TITLE
Re-enable field_reassign_with_default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,6 +539,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
+
+[[package]]
 name = "dynasm"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1212,10 +1218,11 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be77ed66abed6954aabf6a3e31a84706bedbf93750d267e92ef4a6d90bbd6a61"
+checksum = "8a24475737c47c5a97cd0858d09db5b0c01ade85d671ee569cd1a5a2c0c80a44"
 dependencies = [
+ "dyn-clone",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -1223,9 +1230,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11af7a475c9ee266cfaa9e303a47c830ebe072bf3101ab907a7b7b9d816fa01d"
+checksum = "c5f0ccbfe5a97322d90f8b19604fa5b99dd8223540eb6e36c99a9125303e4c00"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -9,12 +9,14 @@ major releases of `cosmwasm`. Note that you can also view the
 - The minimum Rust supported version for 0.14 is 1.50.0. Verify your Rust
   version is >= 1.50.0 with: `rustc --version`
 
-- Update CosmWasm dependencies in Cargo.toml (skip the ones you don't use):
+- Update CosmWasm and schemars dependencies in Cargo.toml (skip the ones you
+  don't use):
 
   ```
   [dependencies]
   cosmwasm-std = "0.14.0"
   cosmwasm-storage = "0.14.0"
+  schemars = "0.8.1"
   # ...
 
   [dev-dependencies]

--- a/contracts/burner/Cargo.lock
+++ b/contracts/burner/Cargo.lock
@@ -390,6 +390,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
+
+[[package]]
 name = "dynasm"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -942,10 +948,11 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "schemars"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be77ed66abed6954aabf6a3e31a84706bedbf93750d267e92ef4a6d90bbd6a61"
+checksum = "8a24475737c47c5a97cd0858d09db5b0c01ade85d671ee569cd1a5a2c0c80a44"
 dependencies = [
+ "dyn-clone",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -953,9 +960,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11af7a475c9ee266cfaa9e303a47c830ebe072bf3101ab907a7b7b9d816fa01d"
+checksum = "c5f0ccbfe5a97322d90f8b19604fa5b99dd8223540eb6e36c99a9125303e4c00"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/contracts/burner/Cargo.toml
+++ b/contracts/burner/Cargo.toml
@@ -32,7 +32,7 @@ backtraces = ["cosmwasm-std/backtraces", "cosmwasm-vm/backtraces"]
 
 [dependencies]
 cosmwasm-std = { path = "../../packages/std", features = ["iterator"] }
-schemars = "0.7"
+schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 
 [dev-dependencies]

--- a/contracts/burner/src/msg.rs
+++ b/contracts/burner/src/msg.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::field_reassign_with_default)] // see https://github.com/CosmWasm/cosmwasm/issues/685
-
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 

--- a/contracts/crypto-verify/Cargo.lock
+++ b/contracts/crypto-verify/Cargo.lock
@@ -417,6 +417,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
+
+[[package]]
 name = "dynasm"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -997,10 +1003,11 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "schemars"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be77ed66abed6954aabf6a3e31a84706bedbf93750d267e92ef4a6d90bbd6a61"
+checksum = "8a24475737c47c5a97cd0858d09db5b0c01ade85d671ee569cd1a5a2c0c80a44"
 dependencies = [
+ "dyn-clone",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -1008,9 +1015,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11af7a475c9ee266cfaa9e303a47c830ebe072bf3101ab907a7b7b9d816fa01d"
+checksum = "c5f0ccbfe5a97322d90f8b19604fa5b99dd8223540eb6e36c99a9125303e4c00"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/contracts/crypto-verify/Cargo.toml
+++ b/contracts/crypto-verify/Cargo.toml
@@ -36,7 +36,7 @@ cosmwasm-std = { path = "../../packages/std", features = ["iterator"] }
 cosmwasm-storage = { path = "../../packages/storage", features = ["iterator"] }
 hex = "0.4"
 rlp = "0.5"
-schemars = "0.7"
+schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 sha2 = "0.9"
 sha3 = "0.9"

--- a/contracts/crypto-verify/schema/query_msg.json
+++ b/contracts/crypto-verify/schema/query_msg.json
@@ -43,7 +43,8 @@
             }
           }
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "description": "Ethereum text verification (compatible to the eth_sign RPC/web3 enpoint). This cannot be used to verify transaction.\n\nSee https://web3js.readthedocs.io/en/v1.2.0/web3-eth.html#sign",
@@ -78,7 +79,8 @@
             }
           }
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "type": "object",
@@ -145,7 +147,8 @@
             }
           }
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "description": "Tendermint format (ed25519 verification scheme).",
@@ -188,7 +191,8 @@
             }
           }
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "description": "Tendermint format (batch ed25519 verification scheme).",
@@ -228,7 +232,8 @@
             }
           }
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "description": "Returns a list of supported verification schemes. No pagination - this is a short list.",
@@ -240,7 +245,8 @@
         "list_verification_schemes": {
           "type": "object"
         }
-      }
+      },
+      "additionalProperties": false
     }
   ],
   "definitions": {

--- a/contracts/crypto-verify/src/msg.rs
+++ b/contracts/crypto-verify/src/msg.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::field_reassign_with_default)] // see https://github.com/CosmWasm/cosmwasm/issues/685
-
 use cosmwasm_std::{Binary, Deps, Uint128};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};

--- a/contracts/hackatom/Cargo.lock
+++ b/contracts/hackatom/Cargo.lock
@@ -387,6 +387,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
+
+[[package]]
 name = "dynasm"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -953,10 +959,11 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "schemars"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be77ed66abed6954aabf6a3e31a84706bedbf93750d267e92ef4a6d90bbd6a61"
+checksum = "8a24475737c47c5a97cd0858d09db5b0c01ade85d671ee569cd1a5a2c0c80a44"
 dependencies = [
+ "dyn-clone",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -964,9 +971,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11af7a475c9ee266cfaa9e303a47c830ebe072bf3101ab907a7b7b9d816fa01d"
+checksum = "c5f0ccbfe5a97322d90f8b19604fa5b99dd8223540eb6e36c99a9125303e4c00"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/contracts/hackatom/Cargo.toml
+++ b/contracts/hackatom/Cargo.toml
@@ -31,7 +31,7 @@ backtraces = ["cosmwasm-std/backtraces", "cosmwasm-vm/backtraces"]
 
 [dependencies]
 cosmwasm-std = { path = "../../packages/std" }
-schemars = "0.7"
+schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 sha2 = "0.9.1"
 thiserror = "1.0"

--- a/contracts/hackatom/schema/execute_msg.json
+++ b/contracts/hackatom/schema/execute_msg.json
@@ -12,7 +12,8 @@
         "release": {
           "type": "object"
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "description": "Infinite loop to burn cpu cycles (only run when metering is enabled)",
@@ -24,7 +25,8 @@
         "cpu_loop": {
           "type": "object"
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "description": "Infinite loop making storage calls (to test when their limit hits)",
@@ -36,7 +38,8 @@
         "storage_loop": {
           "type": "object"
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "description": "Infinite loop reading and writing memory",
@@ -48,7 +51,8 @@
         "memory_loop": {
           "type": "object"
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "description": "Allocate large amounts of memory without consuming much gas",
@@ -70,7 +74,8 @@
             }
           }
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "description": "Trigger a panic to ensure framework handles gracefully",
@@ -82,7 +87,8 @@
         "panic": {
           "type": "object"
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "description": "Starting with CosmWasm 0.10, some API calls return user errors back to the contract. This triggers such user errors, ensuring the transaction does not fail in the backend.",
@@ -94,7 +100,8 @@
         "user_errors_in_api_calls": {
           "type": "object"
         }
-      }
+      },
+      "additionalProperties": false
     }
   ]
 }

--- a/contracts/hackatom/schema/query_msg.json
+++ b/contracts/hackatom/schema/query_msg.json
@@ -12,7 +12,8 @@
         "verifier": {
           "type": "object"
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "description": "This returns cosmwasm_std::AllBalanceResponse to demo use of the querier",
@@ -32,7 +33,8 @@
             }
           }
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "description": "Recurse will execute a query into itself up to depth-times and return Each step of the recursion may perform some extra work to test gas metering (`work` rounds of sha256 on contract). Now that we have Env, we can auto-calculate the address to recurse into",
@@ -60,7 +62,8 @@
             }
           }
         }
-      }
+      },
+      "additionalProperties": false
     }
   ],
   "definitions": {

--- a/contracts/hackatom/schema/sudo_msg.json
+++ b/contracts/hackatom/schema/sudo_msg.json
@@ -27,7 +27,8 @@
             }
           }
         }
-      }
+      },
+      "additionalProperties": false
     }
   ],
   "definitions": {

--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::field_reassign_with_default)] // see https://github.com/CosmWasm/cosmwasm/issues/685
-
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};

--- a/contracts/ibc-reflect-send/Cargo.lock
+++ b/contracts/ibc-reflect-send/Cargo.lock
@@ -387,6 +387,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
+
+[[package]]
 name = "dynasm"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -951,10 +957,11 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "schemars"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be77ed66abed6954aabf6a3e31a84706bedbf93750d267e92ef4a6d90bbd6a61"
+checksum = "8a24475737c47c5a97cd0858d09db5b0c01ade85d671ee569cd1a5a2c0c80a44"
 dependencies = [
+ "dyn-clone",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -962,9 +969,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11af7a475c9ee266cfaa9e303a47c830ebe072bf3101ab907a7b7b9d816fa01d"
+checksum = "c5f0ccbfe5a97322d90f8b19604fa5b99dd8223540eb6e36c99a9125303e4c00"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/contracts/ibc-reflect-send/Cargo.toml
+++ b/contracts/ibc-reflect-send/Cargo.toml
@@ -33,7 +33,7 @@ backtraces = ["cosmwasm-std/backtraces", "cosmwasm-vm/backtraces"]
 [dependencies]
 cosmwasm-std = { path = "../../packages/std", features = ["iterator", "stargate"] }
 cosmwasm-storage = { path = "../../packages/storage", features = ["iterator"] }
-schemars = "0.7"
+schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 
 [dev-dependencies]

--- a/contracts/ibc-reflect-send/schema/execute_msg.json
+++ b/contracts/ibc-reflect-send/schema/execute_msg.json
@@ -20,7 +20,8 @@
             }
           }
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "type": "object",
@@ -46,7 +47,8 @@
             }
           }
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "type": "object",
@@ -65,7 +67,8 @@
             }
           }
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "description": "If you sent funds to this contract, it will attempt to ibc transfer them to the account on the remote side of this channel. If we don't have the address yet, this fails.",
@@ -91,7 +94,8 @@
             }
           }
         }
-      }
+      },
+      "additionalProperties": false
     }
   ],
   "definitions": {
@@ -123,7 +127,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         }
       ]
     },
@@ -157,7 +162,8 @@
             "bank": {
               "$ref": "#/definitions/BankMsg"
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "type": "object",
@@ -168,7 +174,8 @@
             "custom": {
               "$ref": "#/definitions/Empty"
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "type": "object",
@@ -179,7 +186,8 @@
             "staking": {
               "$ref": "#/definitions/StakingMsg"
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "A Stargate message encoded the same way as a protobof [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto). This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)",
@@ -203,7 +211,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "type": "object",
@@ -214,7 +223,8 @@
             "ibc": {
               "$ref": "#/definitions/IbcMsg"
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "type": "object",
@@ -225,7 +235,8 @@
             "wasm": {
               "$ref": "#/definitions/WasmMsg"
             }
-          }
+          },
+          "additionalProperties": false
         }
       ]
     },
@@ -296,7 +307,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "Sends an IBC packet with given data over the existing channel. Data should be encoded in a format defined by the channel version, and the module on the other side should know how to parse this.",
@@ -340,7 +352,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "This will close an existing channel that is owned by this contract. Port is auto-assigned to the contracts' ibc port",
@@ -360,7 +373,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         }
       ]
     },
@@ -411,7 +425,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
@@ -435,7 +450,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37) followed by a [MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
@@ -466,7 +482,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
@@ -494,7 +511,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         }
       ]
     },
@@ -538,7 +556,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L47-L61). `sender` is automatically filled with the current contract's address.",
@@ -581,7 +600,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
@@ -617,7 +637,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         }
       ]
     }

--- a/contracts/ibc-reflect-send/schema/packet_msg.json
+++ b/contracts/ibc-reflect-send/schema/packet_msg.json
@@ -23,7 +23,8 @@
             }
           }
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "type": "object",
@@ -34,7 +35,8 @@
         "who_am_i": {
           "type": "object"
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "type": "object",
@@ -45,7 +47,8 @@
         "balances": {
           "type": "object"
         }
-      }
+      },
+      "additionalProperties": false
     }
   ],
   "definitions": {
@@ -77,7 +80,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         }
       ]
     },
@@ -111,7 +115,8 @@
             "bank": {
               "$ref": "#/definitions/BankMsg"
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "type": "object",
@@ -122,7 +127,8 @@
             "custom": {
               "$ref": "#/definitions/Empty"
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "type": "object",
@@ -133,7 +139,8 @@
             "staking": {
               "$ref": "#/definitions/StakingMsg"
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "A Stargate message encoded the same way as a protobof [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto). This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)",
@@ -157,7 +164,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "type": "object",
@@ -168,7 +176,8 @@
             "ibc": {
               "$ref": "#/definitions/IbcMsg"
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "type": "object",
@@ -179,7 +188,8 @@
             "wasm": {
               "$ref": "#/definitions/WasmMsg"
             }
-          }
+          },
+          "additionalProperties": false
         }
       ]
     },
@@ -250,7 +260,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "Sends an IBC packet with given data over the existing channel. Data should be encoded in a format defined by the channel version, and the module on the other side should know how to parse this.",
@@ -294,7 +305,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "This will close an existing channel that is owned by this contract. Port is auto-assigned to the contracts' ibc port",
@@ -314,7 +326,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         }
       ]
     },
@@ -365,7 +378,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
@@ -389,7 +403,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37) followed by a [MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
@@ -420,7 +435,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
@@ -448,7 +464,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         }
       ]
     },
@@ -492,7 +509,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L47-L61). `sender` is automatically filled with the current contract's address.",
@@ -535,7 +553,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
@@ -571,7 +590,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         }
       ]
     }

--- a/contracts/ibc-reflect-send/schema/query_msg.json
+++ b/contracts/ibc-reflect-send/schema/query_msg.json
@@ -11,7 +11,8 @@
         "admin": {
           "type": "object"
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "type": "object",
@@ -22,7 +23,8 @@
         "list_accounts": {
           "type": "object"
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "type": "object",
@@ -41,7 +43,8 @@
             }
           }
         }
-      }
+      },
+      "additionalProperties": false
     }
   ]
 }

--- a/contracts/ibc-reflect-send/src/ibc_msg.rs
+++ b/contracts/ibc-reflect-send/src/ibc_msg.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::field_reassign_with_default)] // see https://github.com/CosmWasm/cosmwasm/issues/685
-
 use cosmwasm_std::{Coin, ContractResult, CosmosMsg, HumanAddr};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};

--- a/contracts/ibc-reflect-send/src/msg.rs
+++ b/contracts/ibc-reflect-send/src/msg.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::field_reassign_with_default)] // see https://github.com/CosmWasm/cosmwasm/issues/685
-
 use cosmwasm_std::{Coin, CosmosMsg, Empty, HumanAddr};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};

--- a/contracts/ibc-reflect-send/src/state.rs
+++ b/contracts/ibc-reflect-send/src/state.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::field_reassign_with_default)] // see https://github.com/CosmWasm/cosmwasm/issues/685
-
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 

--- a/contracts/ibc-reflect/Cargo.lock
+++ b/contracts/ibc-reflect/Cargo.lock
@@ -387,6 +387,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
+
+[[package]]
 name = "dynasm"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -951,10 +957,11 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "schemars"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be77ed66abed6954aabf6a3e31a84706bedbf93750d267e92ef4a6d90bbd6a61"
+checksum = "8a24475737c47c5a97cd0858d09db5b0c01ade85d671ee569cd1a5a2c0c80a44"
 dependencies = [
+ "dyn-clone",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -962,9 +969,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11af7a475c9ee266cfaa9e303a47c830ebe072bf3101ab907a7b7b9d816fa01d"
+checksum = "c5f0ccbfe5a97322d90f8b19604fa5b99dd8223540eb6e36c99a9125303e4c00"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/contracts/ibc-reflect/Cargo.toml
+++ b/contracts/ibc-reflect/Cargo.toml
@@ -33,7 +33,7 @@ backtraces = ["cosmwasm-std/backtraces", "cosmwasm-vm/backtraces"]
 [dependencies]
 cosmwasm-std = { path = "../../packages/std", features = ["iterator", "stargate"] }
 cosmwasm-storage = { path = "../../packages/storage", features = ["iterator"] }
-schemars = "0.7"
+schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 
 [dev-dependencies]

--- a/contracts/ibc-reflect/schema/acknowledgement_msg_balances.json
+++ b/contracts/ibc-reflect/schema/acknowledgement_msg_balances.json
@@ -12,7 +12,8 @@
         "ok": {
           "$ref": "#/definitions/BalancesResponse"
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "description": "An error type that every custom error created by contract developers can be converted to. This could potientially have more structure, but String is the easiest.",
@@ -24,7 +25,8 @@
         "error": {
           "type": "string"
         }
-      }
+      },
+      "additionalProperties": false
     }
   ],
   "definitions": {

--- a/contracts/ibc-reflect/schema/acknowledgement_msg_dispatch.json
+++ b/contracts/ibc-reflect/schema/acknowledgement_msg_dispatch.json
@@ -12,7 +12,8 @@
         "ok": {
           "type": "null"
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "description": "An error type that every custom error created by contract developers can be converted to. This could potientially have more structure, but String is the easiest.",
@@ -24,7 +25,8 @@
         "error": {
           "type": "string"
         }
-      }
+      },
+      "additionalProperties": false
     }
   ]
 }

--- a/contracts/ibc-reflect/schema/acknowledgement_msg_who_am_i.json
+++ b/contracts/ibc-reflect/schema/acknowledgement_msg_who_am_i.json
@@ -12,7 +12,8 @@
         "ok": {
           "$ref": "#/definitions/WhoAmIResponse"
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "description": "An error type that every custom error created by contract developers can be converted to. This could potientially have more structure, but String is the easiest.",
@@ -24,7 +25,8 @@
         "error": {
           "type": "string"
         }
-      }
+      },
+      "additionalProperties": false
     }
   ],
   "definitions": {

--- a/contracts/ibc-reflect/schema/execute_msg.json
+++ b/contracts/ibc-reflect/schema/execute_msg.json
@@ -30,7 +30,8 @@
             }
           }
         }
-      }
+      },
+      "additionalProperties": false
     }
   ],
   "definitions": {

--- a/contracts/ibc-reflect/schema/packet_msg.json
+++ b/contracts/ibc-reflect/schema/packet_msg.json
@@ -22,7 +22,8 @@
             }
           }
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "type": "object",
@@ -33,7 +34,8 @@
         "who_am_i": {
           "type": "object"
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "type": "object",
@@ -44,7 +46,8 @@
         "balances": {
           "type": "object"
         }
-      }
+      },
+      "additionalProperties": false
     }
   ],
   "definitions": {
@@ -76,7 +79,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         }
       ]
     },
@@ -110,7 +114,8 @@
             "bank": {
               "$ref": "#/definitions/BankMsg"
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "type": "object",
@@ -121,7 +126,8 @@
             "custom": {
               "$ref": "#/definitions/Empty"
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "type": "object",
@@ -132,7 +138,8 @@
             "staking": {
               "$ref": "#/definitions/StakingMsg"
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "A Stargate message encoded the same way as a protobof [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto). This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)",
@@ -156,7 +163,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "type": "object",
@@ -167,7 +175,8 @@
             "ibc": {
               "$ref": "#/definitions/IbcMsg"
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "type": "object",
@@ -178,7 +187,8 @@
             "wasm": {
               "$ref": "#/definitions/WasmMsg"
             }
-          }
+          },
+          "additionalProperties": false
         }
       ]
     },
@@ -249,7 +259,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "Sends an IBC packet with given data over the existing channel. Data should be encoded in a format defined by the channel version, and the module on the other side should know how to parse this.",
@@ -293,7 +304,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "This will close an existing channel that is owned by this contract. Port is auto-assigned to the contracts' ibc port",
@@ -313,7 +325,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         }
       ]
     },
@@ -364,7 +377,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
@@ -388,7 +402,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37) followed by a [MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
@@ -419,7 +434,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
@@ -447,7 +463,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         }
       ]
     },
@@ -491,7 +508,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L47-L61). `sender` is automatically filled with the current contract's address.",
@@ -534,7 +552,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
@@ -570,7 +589,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         }
       ]
     }

--- a/contracts/ibc-reflect/schema/query_msg.json
+++ b/contracts/ibc-reflect/schema/query_msg.json
@@ -20,7 +20,8 @@
             }
           }
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "description": "Returns all (channel, reflect_account) pairs. No pagination - this is a test contract",
@@ -32,7 +33,8 @@
         "list_accounts": {
           "type": "object"
         }
-      }
+      },
+      "additionalProperties": false
     }
   ]
 }

--- a/contracts/ibc-reflect/src/msg.rs
+++ b/contracts/ibc-reflect/src/msg.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::field_reassign_with_default)] // see https://github.com/CosmWasm/cosmwasm/issues/685
-
 use cosmwasm_std::{Coin, ContractResult, CosmosMsg, HumanAddr};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};

--- a/contracts/ibc-reflect/src/state.rs
+++ b/contracts/ibc-reflect/src/state.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::field_reassign_with_default)] // see https://github.com/CosmWasm/cosmwasm/issues/685
-
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 

--- a/contracts/queue/Cargo.lock
+++ b/contracts/queue/Cargo.lock
@@ -379,6 +379,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
+
+[[package]]
 name = "dynasm"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -942,10 +948,11 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "schemars"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be77ed66abed6954aabf6a3e31a84706bedbf93750d267e92ef4a6d90bbd6a61"
+checksum = "8a24475737c47c5a97cd0858d09db5b0c01ade85d671ee569cd1a5a2c0c80a44"
 dependencies = [
+ "dyn-clone",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -953,9 +960,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11af7a475c9ee266cfaa9e303a47c830ebe072bf3101ab907a7b7b9d816fa01d"
+checksum = "c5f0ccbfe5a97322d90f8b19604fa5b99dd8223540eb6e36c99a9125303e4c00"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/contracts/queue/Cargo.toml
+++ b/contracts/queue/Cargo.toml
@@ -33,7 +33,7 @@ library = []
 
 [dependencies]
 cosmwasm-std = { path = "../../packages/std", features = ["iterator"] }
-schemars = "0.7"
+schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 
 [dev-dependencies]

--- a/contracts/queue/schema/execute_msg.json
+++ b/contracts/queue/schema/execute_msg.json
@@ -20,7 +20,8 @@
             }
           }
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "type": "object",
@@ -31,7 +32,8 @@
         "dequeue": {
           "type": "object"
         }
-      }
+      },
+      "additionalProperties": false
     }
   ]
 }

--- a/contracts/queue/schema/query_msg.json
+++ b/contracts/queue/schema/query_msg.json
@@ -11,7 +11,8 @@
         "count": {
           "type": "object"
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "type": "object",
@@ -22,7 +23,8 @@
         "sum": {
           "type": "object"
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "type": "object",
@@ -33,7 +35,8 @@
         "reducer": {
           "type": "object"
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "type": "object",
@@ -44,7 +47,8 @@
         "list": {
           "type": "object"
         }
-      }
+      },
+      "additionalProperties": false
     }
   ]
 }

--- a/contracts/queue/src/contract.rs
+++ b/contracts/queue/src/contract.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::field_reassign_with_default)] // see https://github.com/CosmWasm/cosmwasm/issues/685
-
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 

--- a/contracts/queue/src/msg.rs
+++ b/contracts/queue/src/msg.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::field_reassign_with_default)] // see https://github.com/CosmWasm/cosmwasm/issues/685
-
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 

--- a/contracts/reflect/Cargo.lock
+++ b/contracts/reflect/Cargo.lock
@@ -387,6 +387,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
+
+[[package]]
 name = "dynasm"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -952,10 +958,11 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "schemars"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be77ed66abed6954aabf6a3e31a84706bedbf93750d267e92ef4a6d90bbd6a61"
+checksum = "8a24475737c47c5a97cd0858d09db5b0c01ade85d671ee569cd1a5a2c0c80a44"
 dependencies = [
+ "dyn-clone",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -963,9 +970,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11af7a475c9ee266cfaa9e303a47c830ebe072bf3101ab907a7b7b9d816fa01d"
+checksum = "c5f0ccbfe5a97322d90f8b19604fa5b99dd8223540eb6e36c99a9125303e4c00"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/contracts/reflect/Cargo.toml
+++ b/contracts/reflect/Cargo.toml
@@ -35,7 +35,7 @@ backtraces = ["cosmwasm-std/backtraces", "cosmwasm-vm/backtraces"]
 [dependencies]
 cosmwasm-std = { path = "../../packages/std", features = ["staking", "stargate"] }
 cosmwasm-storage = { path = "../../packages/storage" }
-schemars = "0.7"
+schemars = "0.8.1"
 serde = { version = "=1.0.103", default-features = false, features = ["derive"] }
 thiserror = "1.0"
 

--- a/contracts/reflect/schema/custom_msg.json
+++ b/contracts/reflect/schema/custom_msg.json
@@ -12,7 +12,8 @@
         "debug": {
           "type": "string"
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "type": "object",
@@ -23,7 +24,8 @@
         "raw": {
           "$ref": "#/definitions/Binary"
         }
-      }
+      },
+      "additionalProperties": false
     }
   ],
   "definitions": {

--- a/contracts/reflect/schema/execute_msg.json
+++ b/contracts/reflect/schema/execute_msg.json
@@ -22,7 +22,8 @@
             }
           }
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "type": "object",
@@ -44,7 +45,8 @@
             }
           }
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "type": "object",
@@ -63,7 +65,8 @@
             }
           }
         }
-      }
+      },
+      "additionalProperties": false
     }
   ],
   "definitions": {
@@ -95,7 +98,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         }
       ]
     },
@@ -129,7 +133,8 @@
             "bank": {
               "$ref": "#/definitions/BankMsg"
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "type": "object",
@@ -140,7 +145,8 @@
             "custom": {
               "$ref": "#/definitions/CustomMsg"
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "type": "object",
@@ -151,7 +157,8 @@
             "staking": {
               "$ref": "#/definitions/StakingMsg"
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "A Stargate message encoded the same way as a protobof [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto). This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)",
@@ -175,7 +182,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "type": "object",
@@ -186,7 +194,8 @@
             "ibc": {
               "$ref": "#/definitions/IbcMsg"
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "type": "object",
@@ -197,7 +206,8 @@
             "wasm": {
               "$ref": "#/definitions/WasmMsg"
             }
-          }
+          },
+          "additionalProperties": false
         }
       ]
     },
@@ -213,7 +223,8 @@
             "debug": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "type": "object",
@@ -224,7 +235,8 @@
             "raw": {
               "$ref": "#/definitions/Binary"
             }
-          }
+          },
+          "additionalProperties": false
         }
       ]
     },
@@ -291,7 +303,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "Sends an IBC packet with given data over the existing channel. Data should be encoded in a format defined by the channel version, and the module on the other side should know how to parse this.",
@@ -335,7 +348,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "This will close an existing channel that is owned by this contract. Port is auto-assigned to the contracts' ibc port",
@@ -355,7 +369,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         }
       ]
     },
@@ -406,7 +421,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
@@ -430,7 +446,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37) followed by a [MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
@@ -461,7 +478,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
@@ -489,7 +507,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         }
       ]
     },
@@ -559,7 +578,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L47-L61). `sender` is automatically filled with the current contract's address.",
@@ -602,7 +622,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
@@ -638,7 +659,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         }
       ]
     }

--- a/contracts/reflect/schema/query_msg.json
+++ b/contracts/reflect/schema/query_msg.json
@@ -11,7 +11,8 @@
         "owner": {
           "type": "object"
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "description": "This will call out to SpecialQuery::Capitalized",
@@ -31,7 +32,8 @@
             }
           }
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "description": "Queries the blockchain and returns the result untouched",
@@ -51,7 +53,8 @@
             }
           }
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "description": "Queries another contract and returns the data",
@@ -75,7 +78,8 @@
             }
           }
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "description": "If there was a previous ReflectSubCall with this ID, returns cosmwasm_std::Reply",
@@ -97,7 +101,8 @@
             }
           }
         }
-      }
+      },
+      "additionalProperties": false
     }
   ],
   "definitions": {
@@ -125,7 +130,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "This calls into the native bank module for all denominations. Note that this may be much more expensive than Balance and should be avoided if possible. Return value is AllBalanceResponse.",
@@ -145,7 +151,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         }
       ]
     },
@@ -169,7 +176,8 @@
             "port_id": {
               "type": "object"
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "Lists all channels that are bound to a given port. If `port_id` is omitted, this list all channels bound to the contract's port. Returns a `ListChannelsResponse`.",
@@ -189,7 +197,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "Lists all information for a (portID, channelID) pair. If port_id is omitted, it will default to the contract's own channel. (To save a PortId{} call) Returns ChannelResponse.",
@@ -215,7 +224,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         }
       ]
     },
@@ -230,7 +240,8 @@
             "bank": {
               "$ref": "#/definitions/BankQuery"
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "type": "object",
@@ -241,7 +252,8 @@
             "custom": {
               "$ref": "#/definitions/SpecialQuery"
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "type": "object",
@@ -252,7 +264,8 @@
             "staking": {
               "$ref": "#/definitions/StakingQuery"
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "A Stargate query encoded the same way as abci_query, with path and protobuf encoded Data. The format is defined in [ADR-21](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-021-protobuf-query-encoding.md) The response is also protobuf encoded. The caller is responsible for compiling the proper protobuf definitions",
@@ -282,7 +295,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "type": "object",
@@ -293,7 +307,8 @@
             "ibc": {
               "$ref": "#/definitions/IbcQuery"
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "type": "object",
@@ -304,7 +319,8 @@
             "wasm": {
               "$ref": "#/definitions/WasmQuery"
             }
-          }
+          },
+          "additionalProperties": false
         }
       ]
     },
@@ -320,7 +336,8 @@
             "ping": {
               "type": "object"
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "type": "object",
@@ -339,7 +356,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         }
       ]
     },
@@ -355,7 +373,8 @@
             "bonded_denom": {
               "type": "object"
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "AllDelegations will return all delegations by the delegator",
@@ -375,7 +394,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "Delegation will return more detailed info on a particular delegation, defined by delegator/validator pair",
@@ -399,7 +419,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "Returns all registered Validators on the system",
@@ -411,7 +432,8 @@
             "validators": {
               "type": "object"
             }
-          }
+          },
+          "additionalProperties": false
         }
       ]
     },
@@ -444,7 +466,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "this queries the raw kv-store of the contract. returns the raw, unparsed data stored at that key, which may be an empty vector if not present",
@@ -473,7 +496,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         }
       ]
     }

--- a/contracts/reflect/schema/response_for__custom_msg.json
+++ b/contracts/reflect/schema/response_for__custom_msg.json
@@ -86,7 +86,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         }
       ]
     },
@@ -120,7 +121,8 @@
             "bank": {
               "$ref": "#/definitions/BankMsg"
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "type": "object",
@@ -131,7 +133,8 @@
             "custom": {
               "$ref": "#/definitions/CustomMsg"
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "type": "object",
@@ -142,7 +145,8 @@
             "staking": {
               "$ref": "#/definitions/StakingMsg"
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "A Stargate message encoded the same way as a protobof [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto). This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)",
@@ -166,7 +170,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "type": "object",
@@ -177,7 +182,8 @@
             "ibc": {
               "$ref": "#/definitions/IbcMsg"
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "type": "object",
@@ -188,7 +194,8 @@
             "wasm": {
               "$ref": "#/definitions/WasmMsg"
             }
-          }
+          },
+          "additionalProperties": false
         }
       ]
     },
@@ -204,7 +211,8 @@
             "debug": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "type": "object",
@@ -215,7 +223,8 @@
             "raw": {
               "$ref": "#/definitions/Binary"
             }
-          }
+          },
+          "additionalProperties": false
         }
       ]
     },
@@ -282,7 +291,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "Sends an IBC packet with given data over the existing channel. Data should be encoded in a format defined by the channel version, and the module on the other side should know how to parse this.",
@@ -326,7 +336,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "This will close an existing channel that is owned by this contract. Port is auto-assigned to the contracts' ibc port",
@@ -346,7 +357,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         }
       ]
     },
@@ -397,7 +409,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
@@ -421,7 +434,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37) followed by a [MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
@@ -452,7 +466,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
@@ -480,7 +495,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         }
       ]
     },
@@ -550,7 +566,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L47-L61). `sender` is automatically filled with the current contract's address.",
@@ -593,7 +610,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
@@ -629,7 +647,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         }
       ]
     }

--- a/contracts/reflect/src/msg.rs
+++ b/contracts/reflect/src/msg.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::field_reassign_with_default)] // see https://github.com/CosmWasm/cosmwasm/issues/685
-
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 

--- a/contracts/reflect/src/state.rs
+++ b/contracts/reflect/src/state.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::field_reassign_with_default)] // see https://github.com/CosmWasm/cosmwasm/issues/685
-
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 

--- a/contracts/staking/Cargo.lock
+++ b/contracts/staking/Cargo.lock
@@ -393,6 +393,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
+
+[[package]]
 name = "dynasm"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -945,10 +951,11 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "schemars"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be77ed66abed6954aabf6a3e31a84706bedbf93750d267e92ef4a6d90bbd6a61"
+checksum = "8a24475737c47c5a97cd0858d09db5b0c01ade85d671ee569cd1a5a2c0c80a44"
 dependencies = [
+ "dyn-clone",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -956,9 +963,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11af7a475c9ee266cfaa9e303a47c830ebe072bf3101ab907a7b7b9d816fa01d"
+checksum = "c5f0ccbfe5a97322d90f8b19604fa5b99dd8223540eb6e36c99a9125303e4c00"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/contracts/staking/Cargo.toml
+++ b/contracts/staking/Cargo.toml
@@ -33,7 +33,7 @@ backtraces = ["cosmwasm-std/backtraces", "cosmwasm-vm/backtraces"]
 [dependencies]
 cosmwasm-std = { path = "../../packages/std", features = ["staking"] }
 cosmwasm-storage = { path = "../../packages/storage" }
-schemars = "0.7"
+schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 snafu = "0.6"
 

--- a/contracts/staking/schema/execute_msg.json
+++ b/contracts/staking/schema/execute_msg.json
@@ -24,7 +24,8 @@
             }
           }
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "description": "Bond will bond all staking tokens sent with the message and release derivative tokens",
@@ -36,7 +37,8 @@
         "bond": {
           "type": "object"
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "description": "Unbond will \"burn\" the given amount of derivative tokens and send the unbonded staking tokens to the message sender (after exit tax is deducted)",
@@ -56,7 +58,8 @@
             }
           }
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "description": "Claim is used to claim your native tokens that you previously \"unbonded\" after the chain-defined waiting period (eg. 3 weeks)",
@@ -68,7 +71,8 @@
         "claim": {
           "type": "object"
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "description": "Reinvest will check for all accumulated rewards, withdraw them, and re-bond them to the same validator. Anyone can call this, which updates the value of the token (how much under custody).",
@@ -80,7 +84,8 @@
         "reinvest": {
           "type": "object"
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "description": "_BondAllTokens can only be called by the contract itself, after all rewards have been withdrawn. This is an example of using \"callbacks\" in message flows. This can only be invoked by the contract itself as a return from Reinvest",
@@ -92,7 +97,8 @@
         "__bond_all_tokens": {
           "type": "object"
         }
-      }
+      },
+      "additionalProperties": false
     }
   ],
   "definitions": {

--- a/contracts/staking/schema/query_msg.json
+++ b/contracts/staking/schema/query_msg.json
@@ -20,7 +20,8 @@
             }
           }
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "description": "Claims shows the number of tokens this address can access when they are done unbonding",
@@ -40,7 +41,8 @@
             }
           }
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "description": "TokenInfo shows the metadata of the token for UIs",
@@ -52,7 +54,8 @@
         "token_info": {
           "type": "object"
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "description": "Investment shows info on total staking tokens under custody, with which validator, as well as how many derivative tokens are lists. It also shows with the exit tax.",
@@ -64,7 +67,8 @@
         "investment": {
           "type": "object"
         }
-      }
+      },
+      "additionalProperties": false
     }
   ],
   "definitions": {

--- a/contracts/staking/src/msg.rs
+++ b/contracts/staking/src/msg.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::field_reassign_with_default)] // see https://github.com/CosmWasm/cosmwasm/issues/685
-
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 

--- a/contracts/staking/src/state.rs
+++ b/contracts/staking/src/state.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::field_reassign_with_default)] // see https://github.com/CosmWasm/cosmwasm/issues/685
-
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 

--- a/packages/schema/Cargo.toml
+++ b/packages/schema/Cargo.toml
@@ -8,5 +8,5 @@ repository = "https://github.com/CosmWasm/cosmwasm/tree/main/packages/schema"
 license = "Apache-2.0"
 
 [dependencies]
-schemars = "0.7"
+schemars = "0.8.1"
 serde_json = "1.0"

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -31,7 +31,7 @@ stargate = []
 base64 = "0.13.0"
 cosmwasm-derive = { path = "../derive", version = "0.14.0-beta1" }
 serde-json-wasm = { version = "0.3.1" }
-schemars = "0.7"
+schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive", "alloc"] }
 thiserror = "1.0"
 

--- a/packages/std/schema/cosmos_msg.json
+++ b/packages/std/schema/cosmos_msg.json
@@ -11,7 +11,8 @@
         "bank": {
           "$ref": "#/definitions/BankMsg"
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "type": "object",
@@ -22,7 +23,8 @@
         "custom": {
           "$ref": "#/definitions/Empty"
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "type": "object",
@@ -33,7 +35,8 @@
         "staking": {
           "$ref": "#/definitions/StakingMsg"
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "type": "object",
@@ -44,7 +47,8 @@
         "wasm": {
           "$ref": "#/definitions/WasmMsg"
         }
-      }
+      },
+      "additionalProperties": false
     }
   ],
   "definitions": {
@@ -76,7 +80,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         }
       ]
     },
@@ -131,7 +136,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
@@ -155,7 +161,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37) followed by a [MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
@@ -186,7 +193,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
@@ -214,7 +222,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         }
       ]
     },
@@ -258,7 +267,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L47-L61). `sender` is automatically filled with the current contract's address.",
@@ -301,7 +311,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
@@ -337,7 +348,8 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         }
       ]
     }

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(feature = "backtraces", feature(backtrace))]
-#![allow(clippy::field_reassign_with_default)] // see https://github.com/CosmWasm/cosmwasm/issues/685
 
 // Exposed on all platforms
 

--- a/packages/vm/Cargo.toml
+++ b/packages/vm/Cargo.toml
@@ -40,7 +40,7 @@ cosmwasm-std = { path = "../std", version = "0.14.0-beta1" }
 cosmwasm-crypto = { path = "../crypto", version = "0.14.0-beta1" }
 hex = "0.4"
 parity-wasm = "0.42"
-schemars = "0.7"
+schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive", "alloc"] }
 serde_json = "1.0"
 sha2 = "0.9.1"


### PR DESCRIPTION
Closes #685

@orkunkl this will require users to upgrade schemars from 0.7 to 0.8 because the contract needs to use the same version as cosmwasm-derive. When do we release this? After Hackatom RU and before Riddlethon as 0.14.0-beta2?