### PR TITLE
Move backtraces from OverflowError/DivideByZeroError into StdError

### DIFF
--- a/contracts/staking/src/contract.rs
+++ b/contracts/staking/src/contract.rs
@@ -361,7 +361,7 @@ pub fn _bond_all_tokens(
     }) {
         Ok(_) => {}
         // if it is below the minimum, we do a no-op (do not revert other state from withdrawal)
-        Err(StdError::Overflow(_)) => return Ok(Response::default()),
+        Err(StdError::Overflow { .. }) => return Ok(Response::default()),
         Err(e) => return Err(e.into()),
     }
 
@@ -739,7 +739,7 @@ mod tests {
         let res = execute(deps.as_mut(), mock_env(), info, unbond_msg);
         match res.unwrap_err() {
             StakingError::Std {
-                original: StdError::Overflow(_),
+                original: StdError::Overflow { .. },
             } => {}
             err => panic!("Unexpected error: {:?}", err),
         }

--- a/packages/storage/src/singleton.rs
+++ b/packages/storage/src/singleton.rs
@@ -259,7 +259,7 @@ mod tests {
             )))
         });
         match output.unwrap_err() {
-            StdError::Overflow(_) => {}
+            StdError::Overflow { .. } => {}
             err => panic!("Unexpected error: {:?}", err),
         }
         assert_eq!(writer.load().unwrap(), cfg);


### PR DESCRIPTION
Let's keep `OverflowError`/`DivideByZeroError` simple and only create the backtrace when the conversion to `StdError` happens.

This fixes the `PartialEq` implementation of `OverflowError` and `DivideByZeroError` which otherwise returns false when the backtrace is different.