### PR TITLE
Make Addr::unchecked a const fn

### DIFF
--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -92,7 +92,7 @@ fn do_release(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response, Ha
 
         let mut resp = Response::new();
         resp.add_attribute("action", "release");
-        resp.add_attribute("destination", to_addr.clone());
+        resp.add_attribute("destination", to_addr);
         resp.add_message(BankMsg::Send {
             to_address: to_addr.into(),
             amount: balance,
@@ -496,9 +496,9 @@ mod tests {
         assert_eq!(
             state,
             State {
-                verifier: Addr::unchecked(verifier),
-                beneficiary: Addr::unchecked(beneficiary),
-                funder: Addr::unchecked(creator),
+                verifier: Addr::unchecked(&verifier),
+                beneficiary: Addr::unchecked(&beneficiary),
+                funder: Addr::unchecked(&creator),
             }
         );
     }
@@ -563,7 +563,7 @@ mod tests {
         let bin_contract: &[u8] = b"my-contract";
 
         // return the unhashed value here
-        let no_work_query = query_recurse(deps.as_ref(), 0, 0, contract.clone()).unwrap();
+        let no_work_query = query_recurse(deps.as_ref(), 0, 0, contract).unwrap();
         assert_eq!(no_work_query.hashed, Binary::from(bin_contract));
 
         // let's see if 5 hashes are done right

--- a/contracts/reflect/src/contract.rs
+++ b/contracts/reflect/src/contract.rs
@@ -17,9 +17,7 @@ pub fn instantiate(
     info: MessageInfo,
     msg: InstantiateMsg,
 ) -> StdResult<Response<CustomMsg>> {
-    let state = State {
-        owner: info.sender.clone(),
-    };
+    let state = State { owner: info.sender };
     config(deps.storage).save(&state)?;
 
     let mut resp = Response::new();

--- a/contracts/reflect/src/testing.rs
+++ b/contracts/reflect/src/testing.rs
@@ -9,7 +9,7 @@ pub fn mock_dependencies_with_custom_querier(
     contract_balance: &[Coin],
 ) -> OwnedDeps<MockStorage, MockApi, MockQuerier<SpecialQuery>> {
     let custom_querier: MockQuerier<SpecialQuery> =
-        MockQuerier::new(&[(MOCK_CONTRACT_ADDR, contract_balance)])
+        MockQuerier::new(&[(MOCK_CONTRACT_ADDR.as_str(), contract_balance)])
             .with_custom_handler(|query| SystemResult::Ok(custom_query_execute(&query)));
     OwnedDeps {
         storage: MockStorage::default(),

--- a/contracts/reflect/tests/integration.rs
+++ b/contracts/reflect/tests/integration.rs
@@ -46,7 +46,7 @@ pub fn mock_dependencies_with_custom_querier(
     contract_balance: &[Coin],
 ) -> Backend<MockApi, MockStorage, MockQuerier<SpecialQuery>> {
     let custom_querier: MockQuerier<SpecialQuery> =
-        MockQuerier::new(&[(MOCK_CONTRACT_ADDR, contract_balance)])
+        MockQuerier::new(&[(MOCK_CONTRACT_ADDR.as_str(), contract_balance)])
             .with_custom_handler(|query| SystemResult::Ok(custom_query_execute(query)));
 
     Backend {

--- a/contracts/staking/src/contract.rs
+++ b/contracts/staking/src/contract.rs
@@ -462,7 +462,7 @@ mod tests {
         let can_redelegate = amount.clone();
         FullDelegation {
             validator: Addr::unchecked(validator_addr),
-            delegator: Addr::unchecked(MOCK_CONTRACT_ADDR),
+            delegator: MOCK_CONTRACT_ADDR,
             amount,
             can_redelegate,
             accumulated_rewards: Vec::new(),

--- a/packages/std/src/imports.rs
+++ b/packages/std/src/imports.rs
@@ -205,7 +205,7 @@ impl Api for ExternalApi {
         }
 
         let address = unsafe { consume_string_region_written_by_vm(human) };
-        Ok(Addr::unchecked(address))
+        Ok(Addr::unchecked(&address))
     }
 
     fn secp256k1_verify(

--- a/packages/std/src/mock.rs
+++ b/packages/std/src/mock.rs
@@ -21,7 +21,7 @@ use crate::storage::MemoryStorage;
 use crate::traits::{Api, Querier, QuerierResult};
 use crate::types::{BlockInfo, ContractInfo, Env, MessageInfo};
 
-pub const MOCK_CONTRACT_ADDR: &str = "cosmos2contract";
+pub const MOCK_CONTRACT_ADDR: Addr = Addr::unchecked("cosmos2contract");
 
 /// All external requirements that can be injected for unit tests.
 /// It sets the given balance for the contract itself, nothing else
@@ -31,7 +31,7 @@ pub fn mock_dependencies(
     OwnedDeps {
         storage: MockStorage::default(),
         api: MockApi::default(),
-        querier: MockQuerier::new(&[(MOCK_CONTRACT_ADDR, contract_balance)]),
+        querier: MockQuerier::new(&[(MOCK_CONTRACT_ADDR.as_str(), contract_balance)]),
     }
 }
 
@@ -121,7 +121,7 @@ impl Api for MockApi {
         let trimmed = tmp.into_iter().filter(|&x| x != 0x00).collect();
         // decode UTF-8 bytes into string
         let human = String::from_utf8(trimmed)?;
-        Ok(Addr::unchecked(human))
+        Ok(Addr::unchecked(&human))
     }
 
     fn secp256k1_verify(
@@ -191,16 +191,16 @@ pub fn mock_env() -> Env {
             chain_id: "cosmos-testnet-14002".to_string(),
         },
         contract: ContractInfo {
-            address: Addr::unchecked(MOCK_CONTRACT_ADDR),
+            address: MOCK_CONTRACT_ADDR,
         },
     }
 }
 
 /// Just set sender and funds for the message.
 /// This is intended for use in test code only.
-pub fn mock_info(sender: &str, funds: &[Coin]) -> MessageInfo {
+pub fn mock_info<S: AsRef<str>>(sender: S, funds: &[Coin]) -> MessageInfo {
     MessageInfo {
-        sender: Addr::unchecked(sender),
+        sender: Addr::unchecked(sender.as_ref()),
         funds: funds.to_vec(),
     }
 }

--- a/packages/vm/src/testing/instance.rs
+++ b/packages/vm/src/testing/instance.rs
@@ -135,7 +135,7 @@ pub fn mock_instance_with_options(
         if let Some(pos) = balances.iter().position(|item| item.0 == contract_address) {
             balances.remove(pos);
         }
-        balances.push((contract_address, contract_balance));
+        balances.push((contract_address.as_str(), contract_balance));
     }
 
     let api = if let Some(backend_error) = options.backend_error {

--- a/packages/vm/src/testing/mock.rs
+++ b/packages/vm/src/testing/mock.rs
@@ -5,7 +5,7 @@ use super::querier::MockQuerier;
 use super::storage::MockStorage;
 use crate::{Backend, BackendApi, BackendError, BackendResult, GasInfo};
 
-pub const MOCK_CONTRACT_ADDR: &str = "cosmos2contract";
+pub const MOCK_CONTRACT_ADDR: Addr = Addr::unchecked("cosmos2contract");
 const GAS_COST_HUMANIZE: u64 = 44;
 const GAS_COST_CANONICALIZE: u64 = 55;
 
@@ -15,7 +15,7 @@ pub fn mock_backend(contract_balance: &[Coin]) -> Backend<MockApi, MockStorage, 
     Backend {
         api: MockApi::default(),
         storage: MockStorage::default(),
-        querier: MockQuerier::new(&[(MOCK_CONTRACT_ADDR, contract_balance)]),
+        querier: MockQuerier::new(&[(MOCK_CONTRACT_ADDR.as_str(), contract_balance)]),
     }
 }
 
@@ -149,16 +149,16 @@ pub fn mock_env() -> Env {
             chain_id: "cosmos-testnet-14002".to_string(),
         },
         contract: ContractInfo {
-            address: Addr::unchecked(MOCK_CONTRACT_ADDR),
+            address: MOCK_CONTRACT_ADDR,
         },
     }
 }
 
 /// Just set sender and funds for the message.
 /// This is intended for use in test code only.
-pub fn mock_info(sender: &str, funds: &[Coin]) -> MessageInfo {
+pub fn mock_info<S: AsRef<str>>(sender: S, funds: &[Coin]) -> MessageInfo {
     MessageInfo {
-        sender: Addr::unchecked(sender),
+        sender: Addr::unchecked(sender.as_ref()),
         funds: funds.to_vec(),
     }
 }


### PR DESCRIPTION
This allows you to use `Addr::unchecked("foo")` in all the places where you can use "foo", specially `const VARIABLES`. This uses the facts that:
1. We have a known max size and `Addr` can have a constant size. The memory layout can safely be copied.
2. In contract to String, `Addr` is immutable. So it does not matter if we move or copy.