### PR TITLE
Addr ref helper

### DIFF
--- a/packages/std/src/addresses.rs
+++ b/packages/std/src/addresses.rs
@@ -103,18 +103,6 @@ impl From<&Addr> for String {
     }
 }
 
-impl From<Addr> for HumanAddr {
-    fn from(addr: Addr) -> Self {
-        HumanAddr(addr.0)
-    }
-}
-
-impl From<&Addr> for HumanAddr {
-    fn from(addr: &Addr) -> Self {
-        HumanAddr(addr.0.clone())
-    }
-}
-
 #[deprecated(
     since = "0.14.0",
     note = "HumanAddr is not much more than an alias to String and it does not provide significant safety advantages. With CosmWasm 0.14, we now use String when there was HumanAddr before. There is also the new Addr, which holds a validated immutable human readable address."
@@ -320,20 +308,6 @@ mod tests {
         let addr_ref = &addr;
         let string: String = addr_ref.into();
         assert_eq!(string, "cos934gh9034hg04g0h134");
-    }
-
-    #[test]
-    fn addr_implements_into_human_address() {
-        // owned Addr
-        let addr = Addr::unchecked("cos934gh9034hg04g0h134");
-        let human: HumanAddr = addr.into();
-        assert_eq!(human, "cos934gh9034hg04g0h134");
-
-        // &Addr
-        let addr = Addr::unchecked("cos934gh9034hg04g0h134");
-        let addr_ref = &addr;
-        let human: HumanAddr = addr_ref.into();
-        assert_eq!(human, "cos934gh9034hg04g0h134");
     }
 
     // Test HumanAddr as_str() for each HumanAddr::from input type

--- a/packages/std/src/addresses.rs
+++ b/packages/std/src/addresses.rs
@@ -45,6 +45,11 @@ impl Addr {
     pub fn unchecked<T: Into<String>>(input: T) -> Addr {
         Addr(input.into())
     }
+
+    #[inline]
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
 }
 
 impl fmt::Display for Addr {
@@ -56,7 +61,7 @@ impl fmt::Display for Addr {
 impl AsRef<str> for Addr {
     #[inline]
     fn as_ref(&self) -> &str {
-        &self.0
+        self.as_str()
     }
 }
 
@@ -274,6 +279,12 @@ mod tests {
     fn addr_implements_as_ref_for_str() {
         let addr = Addr::unchecked("literal-string");
         assert_eq!(addr.as_ref(), "literal-string");
+    }
+
+    #[test]
+    fn addr_as_str() {
+        let addr = Addr::unchecked("literal-string");
+        assert_eq!(addr.as_str(), "literal-string");
     }
 
     #[test]


### PR DESCRIPTION
Closes #868 
Alternative to #869 (close that if we take this)

This solves the AddrRef need for use in cosmwasm-plus contracts and includes nice helpers for conversion between Addr and AddrRef.

`AddrRef::unchecked` is a `const fn`, so we can use like:

```rust
const foo = AddrRef::unchecked("foo");
call_with_addr(foo.into());
```

