### PR TITLE
Add Timestamp type

### DIFF
--- a/contracts/ibc-reflect-send/src/contract.rs
+++ b/contracts/ibc-reflect-send/src/contract.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{
-    attr, entry_point, to_binary, CosmosMsg, Deps, DepsMut, Env, IbcMsg, IbcTimeout, MessageInfo,
-    Order, QueryResponse, Response, StdError, StdResult,
+    attr, entry_point, to_binary, CosmosMsg, Deps, DepsMut, Env, IbcMsg, MessageInfo, Order,
+    QueryResponse, Response, StdError, StdResult,
 };
 
 use crate::ibc::PACKET_LIFETIME;
@@ -91,7 +91,7 @@ pub fn handle_send_msgs(
     let msg = IbcMsg::SendPacket {
         channel_id,
         data: to_binary(&packet)?,
-        timeout: IbcTimeout::in_secs(&env.block, PACKET_LIFETIME),
+        timeout: env.block.timestamp().plus_seconds(PACKET_LIFETIME).into(),
     };
 
     Ok(Response {
@@ -121,7 +121,7 @@ pub fn handle_check_remote_balance(
     let msg = IbcMsg::SendPacket {
         channel_id,
         data: to_binary(&packet)?,
-        timeout: IbcTimeout::in_secs(&env.block, PACKET_LIFETIME),
+        timeout: env.block.timestamp().plus_seconds(PACKET_LIFETIME).into(),
     };
 
     Ok(Response {
@@ -171,7 +171,7 @@ pub fn handle_send_funds(
         channel_id: transfer_channel_id,
         to_address: remote_addr,
         amount,
-        timeout: IbcTimeout::in_secs(&env.block, PACKET_LIFETIME),
+        timeout: env.block.timestamp().plus_seconds(PACKET_LIFETIME).into(),
     };
 
     Ok(Response {

--- a/contracts/ibc-reflect-send/src/ibc.rs
+++ b/contracts/ibc-reflect-send/src/ibc.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{
     attr, entry_point, from_slice, to_binary, DepsMut, Env, IbcAcknowledgement, IbcBasicResponse,
-    IbcChannel, IbcMsg, IbcOrder, IbcPacket, IbcReceiveResponse, IbcTimeout, StdError, StdResult,
+    IbcChannel, IbcMsg, IbcOrder, IbcPacket, IbcReceiveResponse, StdError, StdResult,
 };
 
 use crate::ibc_msg::{
@@ -58,7 +58,7 @@ pub fn ibc_channel_connect(
     let msg = IbcMsg::SendPacket {
         channel_id: channel_id.clone(),
         data: to_binary(&packet)?,
-        timeout: IbcTimeout::in_secs(&env.block, PACKET_LIFETIME),
+        timeout: env.block.timestamp().plus_seconds(PACKET_LIFETIME).into(),
     };
 
     Ok(IbcBasicResponse {
@@ -255,7 +255,7 @@ mod tests {
         mock_dependencies, mock_env, mock_ibc_channel, mock_ibc_packet_ack, mock_info, MockApi,
         MockQuerier, MockStorage,
     };
-    use cosmwasm_std::{coin, coins, BankMsg, CosmosMsg, OwnedDeps};
+    use cosmwasm_std::{coin, coins, BankMsg, CosmosMsg, IbcTimeout, OwnedDeps};
 
     const CREATOR: &str = "creator";
 

--- a/packages/std/src/ibc.rs
+++ b/packages/std/src/ibc.rs
@@ -10,7 +10,7 @@ use std::fmt;
 use crate::binary::Binary;
 use crate::coins::Coin;
 use crate::results::{Attribute, CosmosMsg, Empty, SubMsg};
-use crate::types::BlockInfo;
+use crate::timestamp::Timestamp;
 
 /// These are messages in the IBC lifecycle. Only usable by IBC-enabled contracts
 /// (contracts that directly speak the IBC protocol via 6 entry points)
@@ -69,11 +69,9 @@ pub enum IbcTimeout {
     },
 }
 
-impl IbcTimeout {
-    pub fn in_secs(block: &BlockInfo, secs: u64) -> Self {
-        let secs = block.time + secs;
-        let nanos = secs * 1_000_000_000 + block.time_nanos;
-        IbcTimeout::TimestampNanos(nanos)
+impl From<Timestamp> for IbcTimeout {
+    fn from(time: Timestamp) -> IbcTimeout {
+        IbcTimeout::TimestampNanos(time.seconds * 1_000_000_000 + time.nanos)
     }
 }
 

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -19,6 +19,7 @@ mod results;
 mod sections;
 mod serde;
 mod storage;
+mod timestamp;
 mod traits;
 mod types;
 
@@ -60,6 +61,7 @@ pub use crate::results::{Context, HandleResponse, InitResponse, MigrateResponse}
 pub use crate::results::{DistributionMsg, StakingMsg};
 pub use crate::serde::{from_binary, from_slice, to_binary, to_vec};
 pub use crate::storage::MemoryStorage;
+pub use crate::timestamp::Timestamp;
 pub use crate::traits::{Api, Querier, QuerierResult, QuerierWrapper, Storage};
 pub use crate::types::{BlockInfo, ContractInfo, Env, MessageInfo};
 

--- a/packages/std/src/timestamp.rs
+++ b/packages/std/src/timestamp.rs
@@ -1,0 +1,18 @@
+/// A point in time in nanosecond precision.
+///
+/// This type cannot represent any time before the UNIX epoch because both fields are unsigned.
+pub struct Timestamp {
+    /// Absolute time in seconds since the UNIX epoch (00:00:00 on 1970-01-01 UTC).
+    pub seconds: u64,
+    /// The fractional part time in nanoseconds since `time` (0 to 999999999).
+    pub nanos: u64,
+}
+
+impl Timestamp {
+    pub fn plus_seconds(&self, addition: u64) -> Timestamp {
+        Timestamp {
+            seconds: self.seconds + addition,
+            nanos: self.nanos,
+        }
+    }
+}

--- a/packages/std/src/types.rs
+++ b/packages/std/src/types.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::addresses::Addr;
 use crate::coins::Coin;
+use crate::timestamp::Timestamp;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct Env {
@@ -61,6 +62,16 @@ pub struct BlockInfo {
     /// ```
     pub time_nanos: u64,
     pub chain_id: String,
+}
+
+impl BlockInfo {
+    /// Returns the block creation time as a Timestamp in nanosecond precision
+    pub fn timestamp(&self) -> Timestamp {
+        Timestamp {
+            seconds: self.time,
+            nanos: self.time_nanos,
+        }
+    }
 }
 
 /// Additional information from [MsgInstantiateContract] and [MsgExecuteContract], which is passed


### PR DESCRIPTION
This adds a timestamp type with nanosecond precision. Using this type `IbcTimeout` can easily be created from an arbitrary time source, including `BlockInfo`.

We could extens this to cover  all kind of math

- [x] `Timestamp::plus_seconds`
- [ ] `Timestamp::minus_seconds`
- [ ] `Timestamp::plus_nanos` (needs wrapping functionality)
- [ ] `Timestamp::minus_nanos` (needs wrapping functionality)
- [ ] Difference between two `Timestamp`s (signed or absolute)
- [ ] …