### PR TITLE
Rename TimestampNanos to Timestamp and improve IbcTimeout docs

### DIFF
--- a/IBC.md
+++ b/IBC.md
@@ -37,21 +37,26 @@ pub enum IbcMsg {
     }
 }
 
+/// In IBC each package must set at least one type of timeout:
+/// the timestamp or the block height. Using this rather complex enum instead of
+/// two timeout fields we ensure that at least one timeout is set.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum IbcTimeout {
-    /// block timestamp (nanoseconds since UNIX epoch) after which the packet times out
-    /// (measured on the remote chain)
+    /// Block timestamp (nanoseconds since UNIX epoch) after which the packet times out
+    /// (measured on the remote chain).
+    ///
     /// See https://golang.org/pkg/time/#Time.UnixNano
-    TimestampNanos(u64),
+    Timestamp(u64),
     /// block after which the packet times out (measured on remote chain)
     Block(IbcTimeoutBlock),
+    /// Use this to set both timestamp and block timeout. The package then times out once
+    /// the first of both timeouts is hit.
     Both {
-        timestamp_nanos: u64,
+        timestamp: u64,
         block: IbcTimeoutBlock,
     },
 }
-
 ```
 
 Note the `to_address` is likely not a valid `Addr`, as it uses the bech32 prefix

--- a/contracts/ibc-reflect-send/schema/execute_msg.json
+++ b/contracts/ibc-reflect-send/schema/execute_msg.json
@@ -435,15 +435,16 @@
       ]
     },
     "IbcTimeout": {
+      "description": "In IBC each package must set at least one type of timeout: the timestamp or the block height. Using this rather complex enum instead of two timeout fields we ensure that at least one timeout is set.",
       "anyOf": [
         {
-          "description": "block timestamp (nanoseconds since UNIX epoch) after which the packet times out (measured on the remote chain) See https://golang.org/pkg/time/#Time.UnixNano",
+          "description": "Block timestamp (nanoseconds since UNIX epoch) after which the packet times out (measured on the remote chain).\n\nSee https://golang.org/pkg/time/#Time.UnixNano",
           "type": "object",
           "required": [
-            "timestamp_nanos"
+            "timestamp"
           ],
           "properties": {
-            "timestamp_nanos": {
+            "timestamp": {
               "type": "integer",
               "format": "uint64",
               "minimum": 0.0
@@ -465,6 +466,7 @@
           "additionalProperties": false
         },
         {
+          "description": "Use this to set both timestamp and block timeout. The package then times out once the first of both timeouts is hit.",
           "type": "object",
           "required": [
             "both"
@@ -474,13 +476,13 @@
               "type": "object",
               "required": [
                 "block",
-                "timestamp_nanos"
+                "timestamp"
               ],
               "properties": {
                 "block": {
                   "$ref": "#/definitions/IbcTimeoutBlock"
                 },
-                "timestamp_nanos": {
+                "timestamp": {
                   "type": "integer",
                   "format": "uint64",
                   "minimum": 0.0

--- a/contracts/ibc-reflect-send/schema/packet_msg.json
+++ b/contracts/ibc-reflect-send/schema/packet_msg.json
@@ -388,15 +388,16 @@
       ]
     },
     "IbcTimeout": {
+      "description": "In IBC each package must set at least one type of timeout: the timestamp or the block height. Using this rather complex enum instead of two timeout fields we ensure that at least one timeout is set.",
       "anyOf": [
         {
-          "description": "block timestamp (nanoseconds since UNIX epoch) after which the packet times out (measured on the remote chain) See https://golang.org/pkg/time/#Time.UnixNano",
+          "description": "Block timestamp (nanoseconds since UNIX epoch) after which the packet times out (measured on the remote chain).\n\nSee https://golang.org/pkg/time/#Time.UnixNano",
           "type": "object",
           "required": [
-            "timestamp_nanos"
+            "timestamp"
           ],
           "properties": {
-            "timestamp_nanos": {
+            "timestamp": {
               "type": "integer",
               "format": "uint64",
               "minimum": 0.0
@@ -418,6 +419,7 @@
           "additionalProperties": false
         },
         {
+          "description": "Use this to set both timestamp and block timeout. The package then times out once the first of both timeouts is hit.",
           "type": "object",
           "required": [
             "both"
@@ -427,13 +429,13 @@
               "type": "object",
               "required": [
                 "block",
-                "timestamp_nanos"
+                "timestamp"
               ],
               "properties": {
                 "block": {
                   "$ref": "#/definitions/IbcTimeoutBlock"
                 },
-                "timestamp_nanos": {
+                "timestamp": {
                   "type": "integer",
                   "format": "uint64",
                   "minimum": 0.0

--- a/contracts/ibc-reflect-send/src/ibc.rs
+++ b/contracts/ibc-reflect-send/src/ibc.rs
@@ -445,7 +445,7 @@ mod tests {
                 assert_eq!(transfer_channel_id, channel_id.as_str());
                 assert_eq!(remote_addr, to_address.as_str());
                 assert_eq!(&coin(12344, "utrgd"), amount);
-                assert!(matches!(timeout, IbcTimeout::TimestampNanos { .. }));
+                assert!(matches!(timeout, IbcTimeout::Timestamp { .. }));
             }
             o => panic!("unexpected message: {:?}", o),
         }

--- a/contracts/ibc-reflect-send/tests/integration.rs
+++ b/contracts/ibc-reflect-send/tests/integration.rs
@@ -239,7 +239,7 @@ fn send_remote_funds() {
             assert_eq!(transfer_channel_id, channel_id.as_str());
             assert_eq!(remote_addr, to_address.as_str());
             assert_eq!(&coin(12344, "utrgd"), amount);
-            assert!(matches!(timeout, IbcTimeout::TimestampNanos { .. }));
+            assert!(matches!(timeout, IbcTimeout::Timestamp { .. }));
         }
         o => panic!("unexpected message: {:?}", o),
     }

--- a/contracts/ibc-reflect/schema/packet_msg.json
+++ b/contracts/ibc-reflect/schema/packet_msg.json
@@ -387,15 +387,16 @@
       ]
     },
     "IbcTimeout": {
+      "description": "In IBC each package must set at least one type of timeout: the timestamp or the block height. Using this rather complex enum instead of two timeout fields we ensure that at least one timeout is set.",
       "anyOf": [
         {
-          "description": "block timestamp (nanoseconds since UNIX epoch) after which the packet times out (measured on the remote chain) See https://golang.org/pkg/time/#Time.UnixNano",
+          "description": "Block timestamp (nanoseconds since UNIX epoch) after which the packet times out (measured on the remote chain).\n\nSee https://golang.org/pkg/time/#Time.UnixNano",
           "type": "object",
           "required": [
-            "timestamp_nanos"
+            "timestamp"
           ],
           "properties": {
-            "timestamp_nanos": {
+            "timestamp": {
               "type": "integer",
               "format": "uint64",
               "minimum": 0.0
@@ -417,6 +418,7 @@
           "additionalProperties": false
         },
         {
+          "description": "Use this to set both timestamp and block timeout. The package then times out once the first of both timeouts is hit.",
           "type": "object",
           "required": [
             "both"
@@ -426,13 +428,13 @@
               "type": "object",
               "required": [
                 "block",
-                "timestamp_nanos"
+                "timestamp"
               ],
               "properties": {
                 "block": {
                   "$ref": "#/definitions/IbcTimeoutBlock"
                 },
-                "timestamp_nanos": {
+                "timestamp": {
                   "type": "integer",
                   "format": "uint64",
                   "minimum": 0.0

--- a/contracts/reflect/schema/execute_msg.json
+++ b/contracts/reflect/schema/execute_msg.json
@@ -431,15 +431,16 @@
       ]
     },
     "IbcTimeout": {
+      "description": "In IBC each package must set at least one type of timeout: the timestamp or the block height. Using this rather complex enum instead of two timeout fields we ensure that at least one timeout is set.",
       "anyOf": [
         {
-          "description": "block timestamp (nanoseconds since UNIX epoch) after which the packet times out (measured on the remote chain) See https://golang.org/pkg/time/#Time.UnixNano",
+          "description": "Block timestamp (nanoseconds since UNIX epoch) after which the packet times out (measured on the remote chain).\n\nSee https://golang.org/pkg/time/#Time.UnixNano",
           "type": "object",
           "required": [
-            "timestamp_nanos"
+            "timestamp"
           ],
           "properties": {
-            "timestamp_nanos": {
+            "timestamp": {
               "type": "integer",
               "format": "uint64",
               "minimum": 0.0
@@ -461,6 +462,7 @@
           "additionalProperties": false
         },
         {
+          "description": "Use this to set both timestamp and block timeout. The package then times out once the first of both timeouts is hit.",
           "type": "object",
           "required": [
             "both"
@@ -470,13 +472,13 @@
               "type": "object",
               "required": [
                 "block",
-                "timestamp_nanos"
+                "timestamp"
               ],
               "properties": {
                 "block": {
                   "$ref": "#/definitions/IbcTimeoutBlock"
                 },
-                "timestamp_nanos": {
+                "timestamp": {
                   "type": "integer",
                   "format": "uint64",
                   "minimum": 0.0

--- a/contracts/reflect/schema/response_for__custom_msg.json
+++ b/contracts/reflect/schema/response_for__custom_msg.json
@@ -419,15 +419,16 @@
       ]
     },
     "IbcTimeout": {
+      "description": "In IBC each package must set at least one type of timeout: the timestamp or the block height. Using this rather complex enum instead of two timeout fields we ensure that at least one timeout is set.",
       "anyOf": [
         {
-          "description": "block timestamp (nanoseconds since UNIX epoch) after which the packet times out (measured on the remote chain) See https://golang.org/pkg/time/#Time.UnixNano",
+          "description": "Block timestamp (nanoseconds since UNIX epoch) after which the packet times out (measured on the remote chain).\n\nSee https://golang.org/pkg/time/#Time.UnixNano",
           "type": "object",
           "required": [
-            "timestamp_nanos"
+            "timestamp"
           ],
           "properties": {
-            "timestamp_nanos": {
+            "timestamp": {
               "type": "integer",
               "format": "uint64",
               "minimum": 0.0
@@ -449,6 +450,7 @@
           "additionalProperties": false
         },
         {
+          "description": "Use this to set both timestamp and block timeout. The package then times out once the first of both timeouts is hit.",
           "type": "object",
           "required": [
             "both"
@@ -458,13 +460,13 @@
               "type": "object",
               "required": [
                 "block",
-                "timestamp_nanos"
+                "timestamp"
               ],
               "properties": {
                 "block": {
                   "$ref": "#/definitions/IbcTimeoutBlock"
                 },
-                "timestamp_nanos": {
+                "timestamp": {
                   "type": "integer",
                   "format": "uint64",
                   "minimum": 0.0

--- a/packages/std/src/ibc.rs
+++ b/packages/std/src/ibc.rs
@@ -54,24 +54,31 @@ pub struct IbcEndpoint {
     pub channel_id: String,
 }
 
+/// In IBC each package must set at least one type of timeout:
+/// the timestamp or the block height. Using this rather complex enum instead of
+/// two timeout fields we ensure that at least one timeout is set.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum IbcTimeout {
-    /// block timestamp (nanoseconds since UNIX epoch) after which the packet times out
-    /// (measured on the remote chain)
+    /// Block timestamp (nanoseconds since UNIX epoch) after which the packet times out
+    /// (measured on the remote chain).
+    ///
     /// See https://golang.org/pkg/time/#Time.UnixNano
-    TimestampNanos(u64),
+    Timestamp(u64),
     /// block after which the packet times out (measured on remote chain)
     Block(IbcTimeoutBlock),
+    /// Use this to set both timestamp and block timeout. The package then times out once
+    /// the first of both timeouts is hit.
     Both {
-        timestamp_nanos: u64,
+        timestamp: u64,
         block: IbcTimeoutBlock,
     },
 }
 
 impl From<Timestamp> for IbcTimeout {
     fn from(time: Timestamp) -> IbcTimeout {
-        IbcTimeout::TimestampNanos(time.seconds * 1_000_000_000 + time.nanos)
+        let nanos = time.seconds * 1_000_000_000 + time.nanos;
+        IbcTimeout::Timestamp(nanos)
     }
 }
 
@@ -253,10 +260,10 @@ mod tests {
             channel_id: "channel-123".to_string(),
             to_address: "my-special-addr".into(),
             amount: Coin::new(12345678, "uatom"),
-            timeout: IbcTimeout::TimestampNanos(1234567890),
+            timeout: IbcTimeout::Timestamp(1234567890),
         };
         let encoded = to_string(&msg).unwrap();
-        let expected = r#"{"transfer":{"channel_id":"channel-123","to_address":"my-special-addr","amount":{"denom":"uatom","amount":"12345678"},"timeout":{"timestamp_nanos":1234567890}}}"#;
+        let expected = r#"{"transfer":{"channel_id":"channel-123","to_address":"my-special-addr","amount":{"denom":"uatom","amount":"12345678"},"timeout":{"timestamp":1234567890}}}"#;
         assert_eq!(encoded.as_str(), expected);
     }
 


### PR DESCRIPTION
Simply the case name by avoiding type information in the variable name