### PR TITLE
Remove unneeded callback

### DIFF
--- a/contracts/ibc-reflect/src/contract.rs
+++ b/contracts/ibc-reflect/src/contract.rs
@@ -1,8 +1,8 @@
 use cosmwasm_std::{
-    attr, entry_point, from_slice, to_binary, wasm_execute, wasm_instantiate, BankMsg, Binary,
-    ContractResult, CosmosMsg, Deps, DepsMut, Empty, Env, Event, IbcAcknowledgement,
-    IbcBasicResponse, IbcChannel, IbcOrder, IbcPacket, IbcReceiveResponse, MessageInfo, Order,
-    QueryResponse, Reply, ReplyOn, Response, StdError, StdResult, SubMsg, SubcallResponse,
+    attr, entry_point, from_slice, to_binary, wasm_execute, BankMsg, Binary, ContractResult,
+    CosmosMsg, Deps, DepsMut, Empty, Env, Event, IbcAcknowledgement, IbcBasicResponse, IbcChannel,
+    IbcOrder, IbcPacket, IbcReceiveResponse, MessageInfo, Order, QueryResponse, Reply, ReplyOn,
+    Response, StdError, StdResult, SubMsg, SubcallResponse, WasmMsg,
 };
 
 use crate::msg::{
@@ -160,9 +160,13 @@ pub fn ibc_channel_connect(
     let cfg = config(deps.storage).load()?;
     let chan_id = channel.endpoint.channel_id;
 
-    let label = format!("ibc-reflect-{}", &chan_id);
-    let msg = wasm_instantiate(cfg.reflect_code_id, b"{}", vec![], label)?;
-
+    let msg = WasmMsg::Instantiate {
+        admin: None,
+        code_id: cfg.reflect_code_id,
+        msg: b"{}".into(),
+        send: vec![],
+        label: format!("ibc-reflect-{}", &chan_id),
+    };
     let sub_msg = SubMsg {
         id: INIT_CALLBACK_ID,
         msg: msg.into(),

--- a/contracts/ibc-reflect/src/contract.rs
+++ b/contracts/ibc-reflect/src/contract.rs
@@ -7,8 +7,7 @@ use cosmwasm_std::{
 
 use crate::msg::{
     AccountInfo, AccountResponse, AcknowledgementMsg, BalancesResponse, DispatchResponse,
-    InstantiateMsg, ListAccountsResponse, PacketMsg, QueryMsg, ReflectExecuteMsg,
-    ReflectInstantiateMsg, WhoAmIResponse,
+    InstantiateMsg, ListAccountsResponse, PacketMsg, QueryMsg, ReflectExecuteMsg, WhoAmIResponse,
 };
 use crate::state::{accounts, accounts_read, config, pending_channel, Config};
 
@@ -162,10 +161,7 @@ pub fn ibc_channel_connect(
     let chan_id = channel.endpoint.channel_id;
 
     let label = format!("ibc-reflect-{}", &chan_id);
-    let payload = ReflectInstantiateMsg {
-        callback_id: Some(chan_id.clone()),
-    };
-    let msg = wasm_instantiate(cfg.reflect_code_id, &payload, vec![], label)?;
+    let msg = wasm_instantiate(cfg.reflect_code_id, b"{}", vec![], label)?;
 
     let sub_msg = SubMsg {
         id: INIT_CALLBACK_ID,
@@ -476,7 +472,7 @@ mod tests {
         if let CosmosMsg::Wasm(WasmMsg::Instantiate {
             admin,
             code_id,
-            msg,
+            msg: _,
             send,
             label,
         }) = &res.submessages[0].msg
@@ -485,9 +481,6 @@ mod tests {
             assert_eq!(*code_id, REFLECT_ID);
             assert_eq!(send.len(), 0);
             assert!(label.contains(channel_id));
-            // parse the message - should callback with proper channel_id
-            let rmsg: ReflectInstantiateMsg = from_slice(&msg).unwrap();
-            assert_eq!(rmsg.callback_id, Some(channel_id.to_string()));
         } else {
             panic!("invalid return message: {:?}", res.messages[0]);
         }

--- a/contracts/ibc-reflect/src/msg.rs
+++ b/contracts/ibc-reflect/src/msg.rs
@@ -35,12 +35,6 @@ pub struct AccountInfo {
     pub channel_id: String,
 }
 
-/// This is the message we send to the reflect contract to initialize it
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct ReflectInstantiateMsg {
-    pub callback_id: Option<String>,
-}
-
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ReflectExecuteMsg {

--- a/contracts/ibc-reflect/tests/integration.rs
+++ b/contracts/ibc-reflect/tests/integration.rs
@@ -31,7 +31,7 @@ use cosmwasm_vm::{from_slice, Instance};
 use ibc_reflect::contract::{IBC_VERSION, RECEIVE_DISPATCH_ID};
 use ibc_reflect::msg::{
     AccountInfo, AccountResponse, AcknowledgementMsg, DispatchResponse, InstantiateMsg,
-    ListAccountsResponse, PacketMsg, QueryMsg, ReflectExecuteMsg, ReflectInstantiateMsg,
+    ListAccountsResponse, PacketMsg, QueryMsg, ReflectExecuteMsg,
 };
 
 // This line will test the output of cargo wasm
@@ -144,7 +144,7 @@ fn proper_handshake_flow() {
     if let CosmosMsg::Wasm(WasmMsg::Instantiate {
         admin,
         code_id,
-        msg,
+        msg: _,
         send,
         label,
     }) = &res.submessages[0].msg
@@ -153,9 +153,6 @@ fn proper_handshake_flow() {
         assert_eq!(*code_id, REFLECT_ID);
         assert_eq!(send.len(), 0);
         assert!(label.contains(channel_id));
-        // parse the message - should callback with proper channel_id
-        let rmsg: ReflectInstantiateMsg = from_slice(&msg).unwrap();
-        assert_eq!(rmsg.callback_id, Some(channel_id.to_string()));
     } else {
         panic!("invalid return message: {:?}", res.messages[0]);
     }

--- a/contracts/reflect/schema/instantiate_msg.json
+++ b/contracts/reflect/schema/instantiate_msg.json
@@ -1,14 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "InstantiateMsg",
-  "type": "object",
-  "properties": {
-    "callback_id": {
-      "description": "if set, returns CallbackMsg::InstantiateCallback{} to the caller with this contract's address and this id",
-      "type": [
-        "string",
-        "null"
-      ]
-    }
-  }
+  "type": "object"
 }

--- a/contracts/reflect/src/contract.rs
+++ b/contracts/reflect/src/contract.rs
@@ -17,9 +17,7 @@ pub fn instantiate(
     info: MessageInfo,
     _msg: InstantiateMsg,
 ) -> StdResult<Response<CustomMsg>> {
-    let state = State {
-        owner: info.sender.clone(),
-    };
+    let state = State { owner: info.sender };
     config(deps.storage).save(&state)?;
     Ok(Response::default())
 }

--- a/contracts/reflect/src/msg.rs
+++ b/contracts/reflect/src/msg.rs
@@ -4,24 +4,7 @@ use serde::{Deserialize, Serialize};
 use cosmwasm_std::{Binary, CosmosMsg, CustomQuery, QueryRequest, SubMsg};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct InstantiateMsg {
-    /// if set, returns CallbackMsg::InstantiateCallback{} to the caller with this contract's address
-    /// and this id
-    pub callback_id: Option<String>,
-}
-
-/// This is what we return upon init if callback is set
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-#[serde(rename_all = "snake_case")]
-pub enum CallbackMsg {
-    /// This type must match [ExecuteMsg::InitCallback from ibc-reflect](https://github.com/CosmWasm/cosmwasm/blob/9fd06ea/contracts/ibc-reflect/src/msg.rs#L17-L22).
-    InitCallback {
-        /// Callback ID provided in the InstantiateMsg
-        id: String,
-        /// contract_addr is the address of this contract
-        contract_addr: String,
-    },
-}
+pub struct InstantiateMsg {}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]

--- a/contracts/reflect/tests/integration.rs
+++ b/contracts/reflect/tests/integration.rs
@@ -60,7 +60,7 @@ pub fn mock_dependencies_with_custom_querier(
 fn proper_initialization() {
     let mut deps = mock_instance(WASM, &[]);
 
-    let msg = InstantiateMsg { callback_id: None };
+    let msg = InstantiateMsg {};
     let info = mock_info("creator", &coins(1000, "earth"));
 
     // we can just call .unwrap() to assert this was a success
@@ -77,7 +77,7 @@ fn proper_initialization() {
 fn reflect() {
     let mut deps = mock_instance(WASM, &[]);
 
-    let msg = InstantiateMsg { callback_id: None };
+    let msg = InstantiateMsg {};
     let info = mock_info("creator", &coins(2, "token"));
     let _res: Response<CustomMsg> = instantiate(&mut deps, mock_env(), info, msg).unwrap();
 
@@ -110,7 +110,7 @@ fn reflect() {
 fn reflect_requires_owner() {
     let mut deps = mock_instance(WASM, &[]);
 
-    let msg = InstantiateMsg { callback_id: None };
+    let msg = InstantiateMsg {};
     let info = mock_info("creator", &coins(2, "token"));
     let _res: Response<CustomMsg> = instantiate(&mut deps, mock_env(), info, msg).unwrap();
 
@@ -132,7 +132,7 @@ fn reflect_requires_owner() {
 fn transfer() {
     let mut deps = mock_instance(WASM, &[]);
 
-    let msg = InstantiateMsg { callback_id: None };
+    let msg = InstantiateMsg {};
     let info = mock_info("creator", &coins(2, "token"));
     let _res: Response<CustomMsg> = instantiate(&mut deps, mock_env(), info, msg).unwrap();
 
@@ -152,7 +152,7 @@ fn transfer() {
 fn transfer_requires_owner() {
     let mut deps = mock_instance(WASM, &[]);
 
-    let msg = InstantiateMsg { callback_id: None };
+    let msg = InstantiateMsg {};
     let info = mock_info("creator", &coins(2, "token"));
     let _res: Response<CustomMsg> = instantiate(&mut deps, mock_env(), info, msg).unwrap();
 
@@ -190,7 +190,7 @@ fn dispatch_custom_query() {
 fn reflect_subcall() {
     let mut deps = mock_instance(WASM, &[]);
 
-    let msg = InstantiateMsg { callback_id: None };
+    let msg = InstantiateMsg {};
     let info = mock_info("creator", &coins(2, "token"));
     let _res: Response = instantiate(&mut deps, mock_env(), info, msg).unwrap();
 
@@ -222,7 +222,7 @@ fn reflect_subcall() {
 fn reply_and_query() {
     let mut deps = mock_instance(WASM, &[]);
 
-    let msg = InstantiateMsg { callback_id: None };
+    let msg = InstantiateMsg {};
     let info = mock_info("creator", &coins(2, "token"));
     let _res: Response = instantiate(&mut deps, mock_env(), info, msg).unwrap();
 


### PR DESCRIPTION
In #885  `ibc-reflect` stopped using `reflect` "execute callback" on `instantiate` and uses submessages. But I kept the logic and it got an unhandled `execute` callback.

Remove this flow completely.

 