### PR TITLE
Add seconds() method to Timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 - cosmwasm-std: Add `Timestamp::minus_seconds` and `::minus_nanos`.
 - cosmwasm-std: Add `Addr::as_bytes`
 - cosmwasm-std: Implement `std::ops::Sub` for `math::Decimal`
+- cosmwasm-std: Add `Timestamp::seconds` and `Timestamp::subsec_nanos`.
 
 ## [0.14.0] - 2021-05-03
 

--- a/contracts/ibc-reflect-send/schema/account_response.json
+++ b/contracts/ibc-reflect-send/schema/account_response.json
@@ -46,7 +46,7 @@
       }
     },
     "Timestamp": {
-      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.",
+      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
       "allOf": [
         {
           "$ref": "#/definitions/Uint64"

--- a/contracts/ibc-reflect-send/schema/execute_msg.json
+++ b/contracts/ibc-reflect-send/schema/execute_msg.json
@@ -567,7 +567,7 @@
       ]
     },
     "Timestamp": {
-      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.",
+      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
       "allOf": [
         {
           "$ref": "#/definitions/Uint64"

--- a/contracts/ibc-reflect-send/schema/list_accounts_response.json
+++ b/contracts/ibc-reflect-send/schema/list_accounts_response.json
@@ -64,7 +64,7 @@
       }
     },
     "Timestamp": {
-      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.",
+      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
       "allOf": [
         {
           "$ref": "#/definitions/Uint64"

--- a/contracts/ibc-reflect-send/schema/packet_msg.json
+++ b/contracts/ibc-reflect-send/schema/packet_msg.json
@@ -520,7 +520,7 @@
       ]
     },
     "Timestamp": {
-      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.",
+      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
       "allOf": [
         {
           "$ref": "#/definitions/Uint64"

--- a/contracts/ibc-reflect/schema/packet_msg.json
+++ b/contracts/ibc-reflect/schema/packet_msg.json
@@ -519,7 +519,7 @@
       ]
     },
     "Timestamp": {
-      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.",
+      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
       "allOf": [
         {
           "$ref": "#/definitions/Uint64"

--- a/contracts/reflect/schema/execute_msg.json
+++ b/contracts/reflect/schema/execute_msg.json
@@ -602,7 +602,7 @@
       }
     },
     "Timestamp": {
-      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.",
+      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
       "allOf": [
         {
           "$ref": "#/definitions/Uint64"

--- a/contracts/reflect/schema/response_for__custom_msg.json
+++ b/contracts/reflect/schema/response_for__custom_msg.json
@@ -590,7 +590,7 @@
       }
     },
     "Timestamp": {
-      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.",
+      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
       "allOf": [
         {
           "$ref": "#/definitions/Uint64"

--- a/packages/std/schema/timestamp.json
+++ b/packages/std/schema/timestamp.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Timestamp",
-  "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.",
+  "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
   "allOf": [
     {
       "$ref": "#/definitions/Uint64"

--- a/packages/std/src/timestamp.rs
+++ b/packages/std/src/timestamp.rs
@@ -15,12 +15,12 @@ use crate::math::Uint64;
 /// let ts = Timestamp::from_nanos(1_000_000_202);
 /// assert_eq!(ts.nanos(), 1_000_000_202);
 /// assert_eq!(ts.seconds(), 1);
-/// assert_eq!(ts.subsec_nanos(), (202));
+/// assert_eq!(ts.subsec_nanos(), 202);
 ///
 /// let ts = ts.plus_seconds(2);
 /// assert_eq!(ts.nanos(), 3_000_000_202);
 /// assert_eq!(ts.seconds(), 3);
-/// assert_eq!(ts.subsec_nanos(), (202));
+/// assert_eq!(ts.subsec_nanos(), 202);
 /// ```
 #[derive(
     Serialize, Deserialize, Copy, Clone, Default, Debug, PartialEq, Eq, PartialOrd, Ord, JsonSchema,

--- a/packages/std/src/timestamp.rs
+++ b/packages/std/src/timestamp.rs
@@ -7,6 +7,21 @@ use crate::math::Uint64;
 /// A point in time in nanosecond precision.
 ///
 /// This type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.
+///
+/// ## Examples
+///
+/// ```
+/// # use cosmwasm_std::Timestamp;
+/// let ts = Timestamp::from_nanos(1_000_000_202);
+/// assert_eq!(ts.nanos(), 1_000_000_202);
+/// assert_eq!(ts.seconds(), 1);
+/// assert_eq!(ts.subsec_nanos(), (202));
+///
+/// let ts = ts.plus_seconds(2);
+/// assert_eq!(ts.nanos(), 3_000_000_202);
+/// assert_eq!(ts.seconds(), 3);
+/// assert_eq!(ts.subsec_nanos(), (202));
+/// ```
 #[derive(
     Serialize, Deserialize, Copy, Clone, Default, Debug, PartialEq, Eq, PartialOrd, Ord, JsonSchema,
 )]
@@ -53,7 +68,8 @@ impl Timestamp {
         self.0.u64() / 1_000_000_000
     }
 
-    /// Returns seconds since epoch (truncate nanoseconds)
+    /// Returns nanoseconds since the last whole second (the remainder truncated
+    /// by `seconds()`)
     #[inline]
     pub fn subsec_nanos(&self) -> u64 {
         self.0.u64() % 1_000_000_000

--- a/packages/std/src/timestamp.rs
+++ b/packages/std/src/timestamp.rs
@@ -79,7 +79,7 @@ impl Timestamp {
 impl fmt::Display for Timestamp {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let whole = self.seconds();
-        let fractional = self.nanos() % 1_000_000_000;
+        let fractional = self.subsec_nanos();
         write!(f, "{}.{:09}", whole, fractional)
     }
 }

--- a/packages/std/src/timestamp.rs
+++ b/packages/std/src/timestamp.rs
@@ -52,6 +52,12 @@ impl Timestamp {
     pub fn seconds(&self) -> u64 {
         self.0.u64() / 1_000_000_000
     }
+
+    /// Returns seconds since epoch (truncate nanoseconds)
+    #[inline]
+    pub fn subsec_nanos(&self) -> u64 {
+        self.0.u64() % 1_000_000_000
+    }
 }
 
 impl fmt::Display for Timestamp {
@@ -136,6 +142,8 @@ mod tests {
         assert_eq!(sum.nanos(), 123);
         let sum = Timestamp::from_nanos(0);
         assert_eq!(sum.nanos(), 0);
+        let sum = Timestamp::from_nanos(987654321000);
+        assert_eq!(sum.nanos(), 987654321000);
     }
 
     #[test]
@@ -144,6 +152,14 @@ mod tests {
         assert_eq!(sum.seconds(), 987);
         let sum = Timestamp::from_seconds(1234567).plus_nanos(8765436);
         assert_eq!(sum.seconds(), 1234567);
+    }
+
+    #[test]
+    fn timestamp_subsec_nanos() {
+        let sum = Timestamp::from_nanos(987654321000);
+        assert_eq!(sum.subsec_nanos(), 654321000);
+        let sum = Timestamp::from_seconds(1234567).plus_nanos(8765436);
+        assert_eq!(sum.subsec_nanos(), 8765436);
     }
 
     #[test]

--- a/packages/std/src/timestamp.rs
+++ b/packages/std/src/timestamp.rs
@@ -42,14 +42,21 @@ impl Timestamp {
     }
 
     /// Returns nanoseconds since epoch
+    #[inline]
     pub fn nanos(&self) -> u64 {
         self.0.u64()
+    }
+
+    /// Returns seconds since epoch (truncate nanoseconds)
+    #[inline]
+    pub fn seconds(&self) -> u64 {
+        self.0.u64() / 1_000_000_000
     }
 }
 
 impl fmt::Display for Timestamp {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let whole = self.nanos() / 1_000_000_000;
+        let whole = self.seconds();
         let fractional = self.nanos() % 1_000_000_000;
         write!(f, "{}.{:09}", whole, fractional)
     }
@@ -129,6 +136,14 @@ mod tests {
         assert_eq!(sum.nanos(), 123);
         let sum = Timestamp::from_nanos(0);
         assert_eq!(sum.nanos(), 0);
+    }
+
+    #[test]
+    fn timestamp_seconds() {
+        let sum = Timestamp::from_nanos(987654321000);
+        assert_eq!(sum.seconds(), 987);
+        let sum = Timestamp::from_seconds(1234567).plus_nanos(8765436);
+        assert_eq!(sum.seconds(), 1234567);
     }
 
     #[test]

--- a/packages/std/src/types.rs
+++ b/packages/std/src/types.rs
@@ -36,8 +36,8 @@ pub struct BlockInfo {
     /// # };
     /// # extern crate chrono;
     /// use chrono::NaiveDateTime;
-    /// let seconds = env.block.time.nanos() / 1_000_000_000;
-    /// let nsecs = env.block.time.nanos() % 1_000_000_000;
+    /// let seconds = env.block.time.seconds();
+    /// let nsecs = env.block.time.subsec_nanos();
     /// let dt = NaiveDateTime::from_timestamp(seconds as i64, nsecs as u32);
     /// ```
     ///


### PR DESCRIPTION
Just a little thing I found useful when working on contracts.

For user-provided times, we usually would prefer second values, this allows us to more easily compare `env.block.time` with a seconds-based timeout.

Does this need/deserve a CHANGELOG entry?