### PR TITLE
Ci formatting checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ workflows:
       - contract_reflect
       - contract_staking
       - fmt
+      - fmt_extra
       - clippy
       - benchmarking:
           requires:
@@ -674,6 +675,24 @@ jobs:
             - target/debug/build
             - target/debug/deps
           key: cargocache-v2-fmt-rust:1.51.0-{{ checksum "Cargo.lock" }}
+
+  fmt_extra:
+    docker:
+      - image: node:16.3.0-buster
+    steps:
+      - checkout
+      - run:
+          name: Install shfmt
+          command: curl -sS https://webinstall.dev/shfmt | bash
+      - run:
+          name: Validate Markdown files
+          command: devtools/format_md.sh -c
+      - run:
+          name: Validate shell scripts
+          command: PATH="/root/.local/bin:$PATH" devtools/format_sh.sh -c
+      - run:
+          name: Validate YAML files
+          command: devtools/format_yml.sh -c
 
   clippy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -426,7 +426,6 @@ jobs:
             - target/wasm32-unknown-unknown/release/deps
           key: cargocache-v2-contract_ibc_reflect-rust:1.51.0-{{ checksum "Cargo.lock" }}
 
-
   contract_ibc_reflect_send:
     docker:
       - image: rust:1.51.0

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,3 +1,10 @@
 {
-  "proseWrap": "always"
+  "overrides": [
+    {
+      "files": "*.md",
+      "options": {
+        "proseWrap": "always"
+      }
+    }
+  ]
 }

--- a/devtools/format_md.sh
+++ b/devtools/format_md.sh
@@ -2,4 +2,13 @@
 set -o errexit -o nounset -o pipefail
 command -v shellcheck >/dev/null && shellcheck "$0"
 
-npx prettier@2.2.1 --write "./**/*.md"
+# Running with -c makes the script only validate instead of editing in place.
+op="write"
+while getopts c option; do
+  case "${option}" in
+
+  c) op="check" ;;
+  esac
+done
+
+npx prettier@2.2.1 --$op "./**/*.md"

--- a/devtools/format_sh.sh
+++ b/devtools/format_sh.sh
@@ -2,4 +2,13 @@
 set -o errexit -o nounset -o pipefail
 command -v shellcheck >/dev/null && shellcheck "$0"
 
-shfmt -w devtools packages
+# Running with -c makes the script only validate instead of editing in place.
+op="w"
+while getopts c option; do
+  case "${option}" in
+
+  c) op="d" ;;
+  esac
+done
+
+shfmt -$op devtools packages

--- a/devtools/format_yml.sh
+++ b/devtools/format_yml.sh
@@ -2,4 +2,13 @@
 set -o errexit -o nounset -o pipefail
 command -v shellcheck >/dev/null && shellcheck "$0"
 
-npx prettier@2.2.1 --write "./**/*.yml"
+# Running with -c makes the script only validate instead of editing in place.
+op="write"
+while getopts c option; do
+  case "${option}" in
+
+  c) op="check" ;;
+  esac
+done
+
+npx prettier@2.2.1 --$op "./**/*.yml"


### PR DESCRIPTION
Closes #951 

Do we need to update the docs somewhere with the new flags that can be used with the `format_*.sh` scripts? I haven't found anything.