### PR TITLE
Impl Storage for {,Readonly}PrefixedStorage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- cosmwasm-storage: Implement `Storage` for `PrefixedStorage` and `ReadonlyPrefixedStorage`.
+  - NOTE: Calling `set` or `remove` on `ReadonlyPrefixedStorage` will panic!
+
 ## [0.14.1] - 2021-06-14
 
 ### Added

--- a/packages/storage/src/prefixed_storage.rs
+++ b/packages/storage/src/prefixed_storage.rs
@@ -99,7 +99,7 @@ impl<'a> Storage for ReadonlyPrefixedStorage<'a> {
         get_with_prefix(self.storage, &self.prefix, key)
     }
 
-    fn set(&mut self, _key: &[u8], value: &[u8]) {
+    fn set(&mut self, _key: &[u8], _value: &[u8]) {
         panic!("Unimplemented");
     }
 

--- a/packages/storage/src/prefixed_storage.rs
+++ b/packages/storage/src/prefixed_storage.rs
@@ -1,5 +1,3 @@
-use core::panic;
-
 use cosmwasm_std::Storage;
 #[cfg(feature = "iterator")]
 use cosmwasm_std::{Order, Pair};

--- a/packages/storage/src/prefixed_storage.rs
+++ b/packages/storage/src/prefixed_storage.rs
@@ -1,3 +1,5 @@
+use core::panic;
+
 use cosmwasm_std::Storage;
 #[cfg(feature = "iterator")]
 use cosmwasm_std::{Order, Pair};
@@ -41,23 +43,25 @@ impl<'a> PrefixedStorage<'a> {
             prefix: to_length_prefixed_nested(namespaces),
         }
     }
+}
 
-    pub fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
+impl<'a> Storage for PrefixedStorage<'a> {
+    fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
         get_with_prefix(self.storage, &self.prefix, key)
     }
 
-    pub fn set(&mut self, key: &[u8], value: &[u8]) {
+    fn set(&mut self, key: &[u8], value: &[u8]) {
         set_with_prefix(self.storage, &self.prefix, key, value);
     }
 
-    pub fn remove(&mut self, key: &[u8]) {
+    fn remove(&mut self, key: &[u8]) {
         remove_with_prefix(self.storage, &self.prefix, key);
     }
 
     #[cfg(feature = "iterator")]
     /// range allows iteration over a set of keys, either forwards or backwards
     /// uses standard rust range notation, and eg db.range(b"foo"..b"bar") also works reverse
-    pub fn range<'b>(
+    fn range<'b>(
         &'b self,
         start: Option<&[u8]>,
         end: Option<&[u8]>,
@@ -88,14 +92,24 @@ impl<'a> ReadonlyPrefixedStorage<'a> {
             prefix: to_length_prefixed_nested(namespaces),
         }
     }
+}
 
-    pub fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
+impl<'a> Storage for ReadonlyPrefixedStorage<'a> {
+    fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
         get_with_prefix(self.storage, &self.prefix, key)
+    }
+
+    fn set(&mut self, key: &[u8], value: &[u8]) {
+        panic!("Unimplemented");
+    }
+
+    fn remove(&mut self, key: &[u8]) {
+        panic!("Unimplemented");
     }
 
     #[cfg(feature = "iterator")]
     /// range allows iteration over a set of keys, either forwards or backwards
-    pub fn range<'b>(
+    fn range<'b>(
         &'b self,
         start: Option<&[u8]>,
         end: Option<&[u8]>,

--- a/packages/storage/src/prefixed_storage.rs
+++ b/packages/storage/src/prefixed_storage.rs
@@ -99,11 +99,11 @@ impl<'a> Storage for ReadonlyPrefixedStorage<'a> {
         get_with_prefix(self.storage, &self.prefix, key)
     }
 
-    fn set(&mut self, key: &[u8], value: &[u8]) {
+    fn set(&mut self, _key: &[u8], value: &[u8]) {
         panic!("Unimplemented");
     }
 
-    fn remove(&mut self, key: &[u8]) {
+    fn remove(&mut self, _key: &[u8]) {
         panic!("Unimplemented");
     }
 


### PR DESCRIPTION
Hi guys. :wave: 

While writing types generic over storage, we realized that the various CosmWasm storage types cannot be used in that way. This PR shows an example of the `Impl`s we expected to have that were available in CosmWasm v0.10.1.

Let us know what you think and how we can improve this design. Cc @reuvenpo

Thanks! 