### PR TITLE
Fix CI fail caused by floaty contract

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ workflows:
       - fmt
       - fmt_extra
       - clippy
+      - build_and_upload_devcontracts # Testing only. Remove later.
       - benchmarking:
           requires:
             - package_vm
@@ -959,15 +960,15 @@ jobs:
             docker run --volumes-from with_code rust:1.51.0 \
               /bin/bash -e -c 'export GLOBIGNORE="../../artifacts/floaty.wasm"; cd ./code/packages/vm; ./examples/check_contract.sh ../../artifacts/*.wasm'
             docker cp with_code:/code/artifacts .
-      - run:
-          name: Publish artifacts on GitHub
-          command: |
-            TAG="$CIRCLE_TAG"
-            TITLE="$TAG"
-            BODY="Attached there are some build artifacts generated at this tag. Those are for development purposes only! Please use crates.io to find the packages of this release."
-            ghr -t "$GITHUB_TOKEN" \
-              -u "$CIRCLE_PROJECT_USERNAME" -r "$CIRCLE_PROJECT_REPONAME" \
-              -c "$CIRCLE_SHA1" \
-              -n "$TITLE" -b "$BODY" \
-              -delete \
-              "$TAG" ./artifacts/
+      # - run:
+      #     name: Publish artifacts on GitHub
+      #     command: |
+      #       TAG="$CIRCLE_TAG"
+      #       TITLE="$TAG"
+      #       BODY="Attached there are some build artifacts generated at this tag. Those are for development purposes only! Please use crates.io to find the packages of this release."
+      #       ghr -t "$GITHUB_TOKEN" \
+      #         -u "$CIRCLE_PROJECT_USERNAME" -r "$CIRCLE_PROJECT_REPONAME" \
+      #         -c "$CIRCLE_SHA1" \
+      #         -n "$TITLE" -b "$BODY" \
+      #         -delete \
+      #         "$TAG" ./artifacts/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -951,7 +951,7 @@ jobs:
           name: Build development contracts
           command: |
             echo "Building all contracts under ./contracts"
-            docker run --volumes-from with_code cosmwasm/rust-optimizer:0.11.0 ./contracts/*/
+            docker run --volumes-from with_code cosmwasm/rust-optimizer:0.11.4 ./contracts/*/
       - run:
           name: Check development contracts
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -956,7 +956,8 @@ jobs:
           name: Check development contracts
           command: |
             echo "Checking all contracts under ./artifacts"
-            docker run --volumes-from with_code rust:1.51.0 /bin/bash -e -c 'cd ./code/packages/vm; ./examples/check_contract.sh ../../artifacts/*.wasm'
+            docker run --volumes-from with_code rust:1.51.0 \
+              /bin/bash -e -c 'export GLOBIGNORE="../../artifacts/floaty.wasm"; cd ./code/packages/vm; ./examples/check_contract.sh ../../artifacts/*.wasm'
             docker cp with_code:/code/artifacts .
       - run:
           name: Publish artifacts on GitHub

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,6 @@ workflows:
       - fmt
       - fmt_extra
       - clippy
-      - build_and_upload_devcontracts # Testing only. Remove later.
       - benchmarking:
           requires:
             - package_vm
@@ -960,15 +959,15 @@ jobs:
             docker run --volumes-from with_code rust:1.51.0 \
               /bin/bash -e -c 'export GLOBIGNORE="../../artifacts/floaty.wasm"; cd ./code/packages/vm; ./examples/check_contract.sh ../../artifacts/*.wasm'
             docker cp with_code:/code/artifacts .
-      # - run:
-      #     name: Publish artifacts on GitHub
-      #     command: |
-      #       TAG="$CIRCLE_TAG"
-      #       TITLE="$TAG"
-      #       BODY="Attached there are some build artifacts generated at this tag. Those are for development purposes only! Please use crates.io to find the packages of this release."
-      #       ghr -t "$GITHUB_TOKEN" \
-      #         -u "$CIRCLE_PROJECT_USERNAME" -r "$CIRCLE_PROJECT_REPONAME" \
-      #         -c "$CIRCLE_SHA1" \
-      #         -n "$TITLE" -b "$BODY" \
-      #         -delete \
-      #         "$TAG" ./artifacts/
+      - run:
+          name: Publish artifacts on GitHub
+          command: |
+            TAG="$CIRCLE_TAG"
+            TITLE="$TAG"
+            BODY="Attached there are some build artifacts generated at this tag. Those are for development purposes only! Please use crates.io to find the packages of this release."
+            ghr -t "$GITHUB_TOKEN" \
+              -u "$CIRCLE_PROJECT_USERNAME" -r "$CIRCLE_PROJECT_REPONAME" \
+              -c "$CIRCLE_SHA1" \
+              -n "$TITLE" -b "$BODY" \
+              -delete \
+              "$TAG" ./artifacts/

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ but the quickstart guide is:
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/rust-optimizer:0.11.0
+  cosmwasm/rust-optimizer:0.11.4
 ```
 
 It will output a highly size-optimized build as `contract.wasm` in `$CODE`. With

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -18,47 +18,47 @@ reason, use the following commands:
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="devcontract_cache_burner",target=/code/contracts/burner/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/rust-optimizer:0.11.0 ./contracts/burner
+  cosmwasm/rust-optimizer:0.11.4 ./contracts/burner
 
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="devcontract_cache_burner",target=/code/contracts/crypto-verify/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/rust-optimizer:0.11.0 ./contracts/crypto-verify
+  cosmwasm/rust-optimizer:0.11.4 ./contracts/crypto-verify
 
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="devcontract_cache_floaty",target=/code/contracts/floaty/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/rust-optimizer:0.11.0 ./contracts/floaty
+  cosmwasm/rust-optimizer:0.11.4 ./contracts/floaty
 
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="devcontract_cache_hackatom",target=/code/contracts/hackatom/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/rust-optimizer:0.11.0 ./contracts/hackatom
+  cosmwasm/rust-optimizer:0.11.4 ./contracts/hackatom
 
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="devcontract_cache_ibc_reflect",target=/code/contracts/ibc-reflect/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/rust-optimizer:0.11.0 ./contracts/ibc-reflect
+  cosmwasm/rust-optimizer:0.11.4 ./contracts/ibc-reflect
 
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="devcontract_cache_ibc_reflect_send",target=/code/contracts/ibc-reflect-send/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/rust-optimizer:0.11.0 ./contracts/ibc-reflect-send
+  cosmwasm/rust-optimizer:0.11.4 ./contracts/ibc-reflect-send
 
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="devcontract_cache_queue",target=/code/contracts/queue/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/rust-optimizer:0.11.0 ./contracts/queue
+  cosmwasm/rust-optimizer:0.11.4 ./contracts/queue
 
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="devcontract_cache_reflect",target=/code/contracts/reflect/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/rust-optimizer:0.11.0 ./contracts/reflect
+  cosmwasm/rust-optimizer:0.11.4 ./contracts/reflect
 
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="devcontract_cache_staking",target=/code/contracts/staking/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/rust-optimizer:0.11.0 ./contracts/staking
+  cosmwasm/rust-optimizer:0.11.4 ./contracts/staking
 ```
 
 ## Entry points

--- a/packages/vm/README.md
+++ b/packages/vm/README.md
@@ -39,13 +39,13 @@ To rebuild the test contracts, go to the repo root and do
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="devcontract_cache_hackatom",target=/code/contracts/hackatom/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/rust-optimizer:0.11.0 ./contracts/hackatom \
+  cosmwasm/rust-optimizer:0.11.4 ./contracts/hackatom \
   && cp artifacts/hackatom.wasm packages/vm/testdata/hackatom_0.15.wasm
 
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="devcontract_cache_ibc_reflect",target=/code/contracts/ibc-reflect/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/rust-optimizer:0.11.0 ./contracts/ibc-reflect \
+  cosmwasm/rust-optimizer:0.11.4 ./contracts/ibc-reflect \
   && cp artifacts/ibc_reflect.wasm packages/vm/testdata/ibc_reflect_0.15.wasm
 ```
 


### PR DESCRIPTION
Before the CI job `build_and_upload_devcontracts` (run on tags only) failed because floaty contains float instructions.