### PR TITLE
Enable `iterator` feature by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to
 
 - cosmwasm-std: The `attr` function now accepts types that implement
   `Into<String>` rather than `ToString`.
-- cosmwasm-std and cosmwasm-storage: The `iterator` feature is now enabled by
+- cosmwasm-std, cosmwasm-vm, cosmwasm-storage: The `iterator` feature is now enabled by
   default.
 
 ## [0.15.0] - 2021-06-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to
 
 - cosmwasm-std: The `attr` function now accepts types that implement
   `Into<String>` rather than `ToString`.
-- cosmwasm-std, cosmwasm-vm, cosmwasm-storage: The `iterator` feature is now enabled by
-  default.
+- cosmwasm-std, cosmwasm-vm, cosmwasm-storage: The `iterator` feature is now
+  enabled by default.
 
 ## [0.15.0] - 2021-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 - cosmwasm-std: The `attr` function now accepts types that implement
   `Into<String>` rather than `ToString`.
+- cosmwasm-std and cosmwasm-storage: The `iterator` feature is now enabled by
+  default.
 
 ## [0.15.0] - 2021-06-24
 

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -20,8 +20,9 @@ major releases of `cosmwasm`. Note that you can also view the
 
   It also means that `&&str` is no longer accepted.
 
-- The `iterator` feature in `cosmwasm-std`, `cosmwasm-vm` and `cosmwasm-storage` is now enabled by default. If you want to use it, you don't
-  have to explicitly enable it anymore.
+- The `iterator` feature in `cosmwasm-std`, `cosmwasm-vm` and `cosmwasm-storage`
+  is now enabled by default. If you want to use it, you don't have to explicitly
+  enable it anymore.
 
   If you don't want to use it, you **have to** disable default features when
   depending on `cosmwasm-std`. Example:

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -4,7 +4,7 @@ This guide explains what is needed to upgrade contracts when migrating over
 major releases of `cosmwasm`. Note that you can also view the
 [complete CHANGELOG](./CHANGELOG.md) to understand the differences.
 
-## 0.15 -> 1.0
+## 0.15 -> 1.0 (unreleased)
 
 - The `attr` function now accepts arguments that implement `Into<String>` rather
   than `ToString`. This means that "stringly" types like `&str` are still
@@ -19,6 +19,18 @@ major releases of `cosmwasm`. Note that you can also view the
   ```
 
   It also means that `&&str` is no longer accepted.
+
+- The `iterator` feature in `cosmwasm-std` and `cosmwasm-storage` (but not
+  `cosmwasm-vm`) is now enabled by default. If you want to use it, you don't
+  have to explicitly enable it anymore.
+
+  If you don't want to use it, you **have to** disable default features when
+  depending on `cosmwasm-std`. Example:
+
+  ```diff
+  - cosmwasm-std = { version = "0.15.0" }
+  + cosmwasm-std = { version = "0.15.0", default-features = false }
+  ```
 
 ## 0.14 -> 0.15
 

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -20,8 +20,7 @@ major releases of `cosmwasm`. Note that you can also view the
 
   It also means that `&&str` is no longer accepted.
 
-- The `iterator` feature in `cosmwasm-std` and `cosmwasm-storage` (but not
-  `cosmwasm-vm`) is now enabled by default. If you want to use it, you don't
+- The `iterator` feature in `cosmwasm-std`, `cosmwasm-vm` and `cosmwasm-storage` is now enabled by default. If you want to use it, you don't
   have to explicitly enable it anymore.
 
   If you don't want to use it, you **have to** disable default features when

--- a/contracts/hackatom/Cargo.toml
+++ b/contracts/hackatom/Cargo.toml
@@ -30,7 +30,7 @@ cranelift = ["cosmwasm-vm/cranelift"]
 backtraces = ["cosmwasm-std/backtraces", "cosmwasm-vm/backtraces"]
 
 [dependencies]
-cosmwasm-std = { path = "../../packages/std" }
+cosmwasm-std = { path = "../../packages/std", default-features = false }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 sha2 = "0.9.1"
@@ -38,5 +38,5 @@ thiserror = "1.0"
 
 [dev-dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }
-cosmwasm-storage = { path = "../../packages/storage" }
+cosmwasm-storage = { path = "../../packages/storage", default-features = false }
 cosmwasm-vm = { path = "../../packages/vm", default-features = false }

--- a/contracts/reflect/Cargo.toml
+++ b/contracts/reflect/Cargo.toml
@@ -33,8 +33,8 @@ cranelift = ["cosmwasm-vm/cranelift"]
 backtraces = ["cosmwasm-std/backtraces", "cosmwasm-vm/backtraces"]
 
 [dependencies]
-cosmwasm-std = { path = "../../packages/std", features = ["staking", "stargate"] }
-cosmwasm-storage = { path = "../../packages/storage" }
+cosmwasm-std = { path = "../../packages/std", default-features = false, features = ["staking", "stargate"] }
+cosmwasm-storage = { path = "../../packages/storage", default-features = false }
 schemars = "0.8.1"
 serde = { version = "=1.0.103", default-features = false, features = ["derive"] }
 thiserror = "1.0"

--- a/contracts/staking/Cargo.toml
+++ b/contracts/staking/Cargo.toml
@@ -31,8 +31,8 @@ cranelift = ["cosmwasm-vm/cranelift"]
 backtraces = ["cosmwasm-std/backtraces", "cosmwasm-vm/backtraces"]
 
 [dependencies]
-cosmwasm-std = { path = "../../packages/std", features = ["staking"] }
-cosmwasm-storage = { path = "../../packages/storage" }
+cosmwasm-std = { path = "../../packages/std", default-features = false, features = ["staking"] }
+cosmwasm-storage = { path = "../../packages/storage", default-features = false }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 snafu = "0.6"

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 readme = "README.md"
 
 [features]
-default = []
+default = ["iterator"]
 # iterator allows us to iterate over all DB items in a given range
 # optional as some merkle stores (like tries) don't support this
 # given Ethereum 1.0, 2.0, Substrate, and other major projects use Tries

--- a/packages/storage/Cargo.toml
+++ b/packages/storage/Cargo.toml
@@ -10,6 +10,7 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
+default = ["iterator"]
 # This enables iterator functionality, as exposed in cosmwasm-std/iterator
 iterator = ["cosmwasm-std/iterator"]
 

--- a/packages/storage/Cargo.toml
+++ b/packages/storage/Cargo.toml
@@ -16,5 +16,5 @@ iterator = ["cosmwasm-std/iterator"]
 
 [dependencies]
 # Uses the path when built locally; uses the given version from crates.io when published
-cosmwasm-std = { path = "../std", version = "0.15.0" }
+cosmwasm-std = { path = "../std", version = "0.15.0", default-features = false }
 serde = { version = "1.0.103", default-features = false, features = ["derive", "alloc"] }

--- a/packages/vm/Cargo.toml
+++ b/packages/vm/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/CosmWasm/cosmwasm/tree/main/packages/vm"
 license = "Apache-2.0"
 
 [features]
-default = ["staking"]
+default = ["staking", "iterator"]
 # backtraces provides much better context at runtime errors (in non-wasm code)
 # at the cost of a bit of code size and performance.
 # This feature requires Rust nightly because it depends on the unstable backtrace feature.

--- a/packages/vm/Cargo.toml
+++ b/packages/vm/Cargo.toml
@@ -36,7 +36,7 @@ required-features = ["iterator"]
 [dependencies]
 clru = "0.4.0"
 # Uses the path when built locally; uses the given version from crates.io when published
-cosmwasm-std = { path = "../std", version = "0.15.0" }
+cosmwasm-std = { path = "../std", version = "0.15.0", default-features = false }
 cosmwasm-crypto = { path = "../crypto", version = "0.15.0" }
 hex = "0.4"
 parity-wasm = "0.42"


### PR DESCRIPTION
Do we not want `cosmwasm-vm` to also have this on by default?

Closes #979 