### PR TITLE
Cleanup import implementations (the native_* stuff)

### DIFF
--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -9,9 +9,9 @@ use crate::environment::Environment;
 use crate::errors::{CommunicationError, VmError, VmResult};
 use crate::features::required_features_from_wasmer_instance;
 use crate::imports::{
-    do_addr_canonicalize, do_addr_humanize, do_addr_validate, do_db_remove, do_db_write, do_debug,
-    do_ed25519_batch_verify, do_ed25519_verify, do_query_chain, do_secp256k1_recover_pubkey,
-    do_secp256k1_verify, native_db_read,
+    do_addr_canonicalize, do_addr_humanize, do_addr_validate, do_db_read, do_db_remove,
+    do_db_write, do_debug, do_ed25519_batch_verify, do_ed25519_verify, do_query_chain,
+    do_secp256k1_recover_pubkey, do_secp256k1_verify,
 };
 #[cfg(feature = "iterator")]
 use crate::imports::{do_db_next, do_db_scan};
@@ -86,7 +86,7 @@ where
         // Ownership of the value pointer is transferred to the contract.
         env_imports.insert(
             "db_read",
-            Function::new_native_with_env(store, env.clone(), native_db_read),
+            Function::new_native_with_env(store, env.clone(), do_db_read),
         );
 
         // Writes the given value into the database entry at the given key.


### PR DESCRIPTION
This is a follow-up on #998 including cleanups which I did not notice during code review.