### PR TITLE
Try json optimization

### DIFF
--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -23,8 +23,8 @@ pub fn instantiate(
     deps.storage.set(
         CONFIG_KEY,
         &to_vec(&State {
-            verifier: deps.api.addr_validate(&msg.verifier)?,
-            beneficiary: deps.api.addr_validate(&msg.beneficiary)?,
+            verifier: deps.api.addr_validate(msg.verifier)?,
+            beneficiary: deps.api.addr_validate(msg.beneficiary)?,
             funder: info.sender,
         })?,
     );

--- a/contracts/hackatom/src/msg.rs
+++ b/contracts/hackatom/src/msg.rs
@@ -4,9 +4,9 @@ use serde::{Deserialize, Serialize};
 use cosmwasm_std::{Binary, Coin};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct InstantiateMsg {
-    pub verifier: String,
-    pub beneficiary: String,
+pub struct InstantiateMsg<'a> {
+    pub verifier: &'a str,
+    pub beneficiary: &'a str,
 }
 
 /// MigrateMsg allows a privileged contract administrator to run

--- a/packages/std/src/exports.rs
+++ b/packages/std/src/exports.rs
@@ -11,7 +11,7 @@ use std::fmt;
 use std::vec::Vec;
 
 use schemars::JsonSchema;
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::deps::OwnedDeps;
 use crate::imports::{ExternalApi, ExternalQuerier, ExternalStorage};
@@ -71,14 +71,14 @@ macro_rules! r#try_into_contract_result {
 /// - `M`: message type for request
 /// - `C`: custom response message type (see CosmosMsg)
 /// - `E`: error type for responses
-pub fn do_instantiate<M, C, E>(
+pub fn do_instantiate<'a, M, C, E>(
     instantiate_fn: &dyn Fn(DepsMut, Env, MessageInfo, M) -> Result<Response<C>, E>,
     env_ptr: u32,
     info_ptr: u32,
     msg_ptr: u32,
 ) -> u32
 where
-    M: DeserializeOwned + JsonSchema,
+    M: Deserialize<'a> + JsonSchema,
     C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
     E: ToString,
 {
@@ -194,14 +194,14 @@ where
     release_buffer(v) as u32
 }
 
-fn _do_instantiate<M, C, E>(
+fn _do_instantiate<'a, M, C, E>(
     instantiate_fn: &dyn Fn(DepsMut, Env, MessageInfo, M) -> Result<Response<C>, E>,
     env_ptr: *mut Region,
     info_ptr: *mut Region,
     msg_ptr: *mut Region,
 ) -> ContractResult<Response<C>>
 where
-    M: DeserializeOwned + JsonSchema,
+    M: Deserialize<'a> + JsonSchema,
     C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
     E: ToString,
 {

--- a/packages/std/src/serde.rs
+++ b/packages/std/src/serde.rs
@@ -2,13 +2,13 @@
 // The reason is two fold:
 // 1. To easily ensure that all calling libraries use the same version (minimize code size)
 // 2. To allow us to switch out to eg. serde-json-core more easily
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::any::type_name;
 
 use crate::binary::Binary;
 use crate::errors::{StdError, StdResult};
 
-pub fn from_slice<T: DeserializeOwned>(value: &[u8]) -> StdResult<T> {
+pub fn from_slice<'a, T: Deserialize<'a>>(value: &'a [u8]) -> StdResult<T> {
     serde_json_wasm::from_slice(value).map_err(|e| StdError::parse_err(type_name::<T>(), e))
 }
 


### PR DESCRIPTION
@hashedone asked some questions about ownership of variables and passing `String` vs `&str`. I realised much of the API was designed when my Rust knowledge was much weaker. I would like to allow novice developers to use the simple case, but we should allow contract developers to use &str in InstantiateMsg, ExecuteMsg, and QueryMsg to avoid copies, without affecting anyone else using this framework. (opt-in per contract).

I tried to make a simple demo on Hackatom to see what affect it would have on gas cost (as we currently meter this, so we have a nice comparison).

I had to make a few changes open to more lifetimes in cosmwasm-std, but eventually hit an issue in serde-json-wasm: 

```rust
pub fn from_slice<T>(v: &[u8]) -> Result<T>
where
    T: de::DeserializeOwned,
{
    let mut de = Deserializer::new(v);
    let value = de::Deserialize::deserialize(&mut de)?;
    de.end()?;

    Ok(value)
}
```

https://github.com/CosmWasm/serde-json-wasm/blob/main/src/de/mod.rs#L574-L584

Before I go deeper into this rabbit hole, I would like some feedback. Seems like a rather simple change to make it more general, but let devs still use existing code as DeserializedOwned without any changes.