### PR TITLE
Lock Rust toolchain version to 1.51.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.51.0"
+components = [ "rustc-dev", "rustfmt", "clippy" ]


### PR DESCRIPTION
With this, when you run things like `cargo clippy` locally, you'll get the same result as the CI gives. Should make development less confusing for contributors.