### PR TITLE
Added `into_string` function to `Addr`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to
   remove an unneeded level of indirection.
 - cosmwasm-std: Added `Event::add_attributes` for bulk adding attributes to an
   `Event` struct.
+- cosmwasm-std: Added `Addr::into_string` for explicit conversion
 
 ### Changed
 

--- a/packages/std/src/addresses.rs
+++ b/packages/std/src/addresses.rs
@@ -60,6 +60,12 @@ impl Addr {
     pub fn as_bytes(&self) -> &[u8] {
         self.0.as_bytes()
     }
+
+    /// Utility for explicit conversion to `String`.
+    #[inline]
+    pub fn into_string(self) -> String {
+        self.0
+    }
 }
 
 impl fmt::Display for Addr {


### PR DESCRIPTION
Just an utility, but useful - both for testing, and for sending address as `String` - it is default way in execution messages and queries (as it cannot be trusted anyway), eg. by `SubMsg`.