### PR TITLE
Module size using loupe

### DIFF
--- a/packages/vm/Cargo.toml
+++ b/packages/vm/Cargo.toml
@@ -47,7 +47,7 @@ sha2 = "0.9.1"
 thiserror = "1.0"
 wasmer = { version = "2.0.0", default-features = false, features = ["cranelift", "universal", "singlepass"] }
 wasmer-middlewares = "2.0.0"
-loupe = "0.1.2"
+loupe = "0.1.3"
 
 # Wasmer git/local (used for quick local debugging or patching)
 # wasmer = { git = "https://github.com/wasmerio/wasmer", rev = "1.0.2", default-features = false, features = ["jit", "singlepass"] }

--- a/packages/vm/examples/module_size.rs
+++ b/packages/vm/examples/module_size.rs
@@ -11,7 +11,7 @@ use wasmer::Module;
 
 pub fn main() {
     let matches = App::new("Module size estimation")
-        .version("0.0.2")
+        .version("0.0.3")
         .author("Mauro Lacy <mauro@lacy.com.es>")
         .arg(
             Arg::with_name("WASM")
@@ -41,6 +41,10 @@ pub fn main() {
     let module = module_compile(&wasm, memory_limit);
     mem::drop(wasm);
 
+    // Report loupe size
+    let loupe_size = loupe::size_of_val(&module);
+    println!("module size (loupe): {} bytes", loupe_size);
+
     let serialized = module.serialize().unwrap();
     mem::drop(module);
 
@@ -53,6 +57,10 @@ pub fn main() {
     mem::drop(module);
     let ser_size = serialized.len();
     println!("module size (serialized): {} bytes", ser_size);
+    println!(
+        "(loupe) module size ratio: {:.2}",
+        loupe_size as f32 / wasm_size as f32
+    );
     println!(
         "(serialized) module size ratio: {:.2}",
         ser_size as f32 / wasm_size as f32

--- a/packages/vm/examples/module_size.sh
+++ b/packages/vm/examples/module_size.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 # Uses valgrind's massif tool to compute heap memory consumption of compiled modules.
+# For a wasmer `Modulej , it has been determined that this method underestimates the size
+# of the module significanty.
+# Use loupe::size_of_val instead, to get a better estimation.
 set -e
 
 MAX_SNAPSHOTS=1000

--- a/packages/vm/src/modules/file_system_cache.rs
+++ b/packages/vm/src/modules/file_system_cache.rs
@@ -64,8 +64,7 @@ impl FileSystemCache {
 
     /// Loads a serialized module from the file system and returns a module (i.e. artifact + store),
     /// along with the size of the serialized module.
-    /// The serialized module size is a good approximation (~100.06 %) of the in-memory module size.
-    /// It should not be considered as the exact in-memory module size.
+    /// Uses loupe to get a value for the module size (artifact + store) in bytes.
     pub fn load(&self, checksum: &Checksum, store: &Store) -> VmResult<Option<(Module, usize)>> {
         let filename = checksum.to_hex();
         let file_path = self.latest_modules_path().join(filename);
@@ -73,13 +72,8 @@ impl FileSystemCache {
         let result = unsafe { Module::deserialize_from_file(store, &file_path) };
         match result {
             Ok(module) => {
-                let module_size = file_path
-                    .metadata()
-                    .map_err(|e| {
-                        VmError::cache_err(format!("Error getting module file size: {}", e))
-                    })?
-                    .len();
-                Ok(Some((module, module_size as usize)))
+                let module_size = loupe::size_of_val(&module);
+                Ok(Some((module, module_size)))
             }
             Err(DeserializeError::Io(err)) => match err.kind() {
                 io::ErrorKind::NotFound => Ok(None),
@@ -96,8 +90,7 @@ impl FileSystemCache {
     }
 
     /// Stores a serialized module to the file system. Returns the size of the serialized module.
-    /// The serialized module size is a good approximation (~100.06 %) of the in-memory module size.
-    /// It should not be considered as the exact in-memory module size.
+    /// Uses loupe to get a value for the module size (artifact + store) in bytes.
     pub fn store(&mut self, checksum: &Checksum, module: &Module) -> VmResult<usize> {
         let modules_dir = self.latest_modules_path();
         fs::create_dir_all(&modules_dir)
@@ -107,11 +100,8 @@ impl FileSystemCache {
         module
             .serialize_to_file(path.clone())
             .map_err(|e| VmError::cache_err(format!("Error writing module to disk: {}", e)))?;
-        let module_size = path
-            .metadata()
-            .map_err(|e| VmError::cache_err(format!("Error getting module file size: {}", e)))?
-            .len();
-        Ok(module_size as usize)
+        let module_size = loupe::size_of_val(&module);
+        Ok(module_size)
     }
 
     /// The path to the latest version of the modules.
@@ -168,7 +158,7 @@ mod tests {
         // This is not really testing the cache API but better safe than sorry.
         {
             let (cached_module, module_size) = cached.unwrap();
-            assert_eq!(module_size, module.serialize().unwrap().len());
+            assert!(module_size > module.serialize().unwrap().len());
             let import_object = imports! {};
             let instance = WasmerInstance::new(&cached_module, &import_object).unwrap();
             set_remaining_points(&instance, TESTING_GAS_LIMIT);

--- a/packages/vm/src/modules/file_system_cache.rs
+++ b/packages/vm/src/modules/file_system_cache.rs
@@ -98,7 +98,7 @@ impl FileSystemCache {
         let filename = checksum.to_hex();
         let path = modules_dir.join(filename);
         module
-            .serialize_to_file(path.clone())
+            .serialize_to_file(path)
             .map_err(|e| VmError::cache_err(format!("Error writing module to disk: {}", e)))?;
         let module_size = loupe::size_of_val(&module);
         Ok(module_size)


### PR DESCRIPTION
Closes #959.

Not sure if we want to keep `module_size.sh` for historical / reference reasons. I'm OK with deleting it, as it may be confusing in the future.