### PR TITLE
Don't pass too long input to VM in addr_validate/addr_canonicalize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to
 
 - Added `From<Addr>` and `From<&Addr>` conversions for `Cow<Addr>`.
 
+### Changed
+
+- cosmwasm-std: In `ExternalApi::addr_validate` and `::addr_canonicalize` do not
+  send too long inputs to VM to avoid terminating contract execution. Errors are
+  returned instead now.
+
 ## [0.16.0] - 2021-08-05
 
 ### Added

--- a/packages/vm/src/imports.rs
+++ b/packages/vm/src/imports.rs
@@ -36,7 +36,10 @@ const MAX_LENGTH_DB_KEY: usize = 64 * KI;
 const MAX_LENGTH_DB_VALUE: usize = 128 * KI;
 /// Typically 20 (Cosmos SDK, Ethereum), 32 (Nano, Substrate) or 54 (MockApi)
 const MAX_LENGTH_CANONICAL_ADDRESS: usize = 64;
-/// The maximum allowed size for bech32 (https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#bech32)
+/// The max length of human address inputs (in bytes).
+/// The maximum allowed size for [bech32](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#bech32)
+/// is 90 characters.
+/// This value will increase with https://github.com/CosmWasm/cosmwasm/issues/1056.
 const MAX_LENGTH_HUMAN_ADDRESS: usize = 90;
 const MAX_LENGTH_QUERY_CHAIN_REQUEST: usize = 64 * KI;
 /// Length of a serialized Ed25519  signature


### PR DESCRIPTION
A variant of #1043 that can easily be shipped with 0.16.x