### PR TITLE
Make Decimal generic over Uint type

### DIFF
--- a/packages/std/src/math/isqrt.rs
+++ b/packages/std/src/math/isqrt.rs
@@ -1,6 +1,6 @@
 use std::{cmp, ops};
 
-use crate::{Uint128, Uint256, Uint512, Uint64};
+use crate::math::Unsigned;
 
 /// A trait for calculating the
 /// [integer square root](https://en.wikipedia.org/wiki/Integer_square_root).
@@ -38,24 +38,12 @@ where
     }
 }
 
-/// Marker trait for types that represent unsigned integers.
-pub trait Unsigned {}
-impl Unsigned for u8 {}
-impl Unsigned for u16 {}
-impl Unsigned for u32 {}
-impl Unsigned for u64 {}
-impl Unsigned for u128 {}
-impl Unsigned for Uint64 {}
-impl Unsigned for Uint128 {}
-impl Unsigned for Uint256 {}
-impl Unsigned for Uint512 {}
-impl Unsigned for usize {}
-
 #[cfg(test)]
 mod tests {
     use std::convert::TryFrom;
 
     use super::*;
+    use crate::{Uint128, Uint256, Uint512, Uint64};
 
     #[test]
     fn isqrt_primitives() {

--- a/packages/std/src/math/mod.rs
+++ b/packages/std/src/math/mod.rs
@@ -5,6 +5,7 @@ mod uint128;
 mod uint256;
 mod uint512;
 mod uint64;
+mod unsigned;
 
 pub use decimal::Decimal;
 pub use fraction::Fraction;
@@ -13,3 +14,4 @@ pub use uint128::Uint128;
 pub use uint256::Uint256;
 pub use uint512::Uint512;
 pub use uint64::Uint64;
+pub use unsigned::Unsigned;

--- a/packages/std/src/math/uint128.rs
+++ b/packages/std/src/math/uint128.rs
@@ -380,14 +380,14 @@ impl<'a> ops::ShrAssign<&'a u32> for Uint128 {
 
 impl Uint128 {
     /// Returns `self * numerator / denominator`
-    pub fn multiply_ratio<A: Into<u128>, B: Into<u128>>(
+    pub fn multiply_ratio<A: Into<Self>, B: Into<Self>>(
         &self,
         numerator: A,
         denominator: B,
-    ) -> Uint128 {
-        let numerator: u128 = numerator.into();
-        let denominator: u128 = denominator.into();
-        if denominator == 0 {
+    ) -> Self {
+        let numerator: Uint128 = numerator.into();
+        let denominator: Uint128 = denominator.into();
+        if denominator.is_zero() {
             panic!("Denominator must not be zero");
         }
         (self.full_mul(numerator) / Uint256::from(denominator))

--- a/packages/std/src/math/unsigned.rs
+++ b/packages/std/src/math/unsigned.rs
@@ -1,0 +1,14 @@
+use crate::{Uint128, Uint256, Uint512, Uint64};
+
+/// Marker trait for types that represent unsigned integers.
+pub trait Unsigned {}
+impl Unsigned for u8 {}
+impl Unsigned for u16 {}
+impl Unsigned for u32 {}
+impl Unsigned for u64 {}
+impl Unsigned for u128 {}
+impl Unsigned for Uint64 {}
+impl Unsigned for Uint128 {}
+impl Unsigned for Uint256 {}
+impl Unsigned for Uint512 {}
+impl Unsigned for usize {}


### PR DESCRIPTION
Just to give you an idea of what this could look like if we wanted to be DRYer.

The idea is that eventually to implement `Decimal<Uint256>` we would only need to `impl DecimalInnerType for Uint256`.

The downside is I don't think `Decimal::one` or `Decimal::zero` can be be constant functions anymore because of this: https://github.com/rust-lang/rust/issues/54469

It doesn't look like we can avoid a bunch of breaking changes here, so if we like this I'm thinking I'll wait for `1.0` and for now just create a `Decimal256` that's pretty much a copy-paste of `Decimal`.