### PR TITLE
Uint padding fix

### DIFF
--- a/packages/std/src/math/uint128.rs
+++ b/packages/std/src/math/uint128.rs
@@ -518,6 +518,12 @@ mod tests {
     }
 
     #[test]
+    fn uint128_display_padding_works() {
+        let a = Uint128::from(123u64);
+        assert_eq!(format!("Embedded: {:05}", a), "Embedded: 00123");
+    }
+
+    #[test]
     fn uint128_is_zero_works() {
         assert!(Uint128::zero().is_zero());
         assert!(Uint128(0).is_zero());

--- a/packages/std/src/math/uint256.rs
+++ b/packages/std/src/math/uint256.rs
@@ -222,7 +222,11 @@ impl From<Uint256> for String {
 
 impl fmt::Display for Uint256 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.0.fmt(f)
+        // The inner type doesn't work as expected with padding, so we
+        // work around that.
+        let unpadded = self.0.to_string();
+
+        f.pad_integral(true, "", &unpadded)
     }
 }
 

--- a/packages/std/src/math/uint256.rs
+++ b/packages/std/src/math/uint256.rs
@@ -553,6 +553,12 @@ mod tests {
     }
 
     #[test]
+    fn uint256_display_padding_works() {
+        let a = Uint256::from(123u64);
+        assert_eq!(format!("Embedded: {:05}", a), "Embedded: 00123");
+    }
+
+    #[test]
     fn uint256_is_zero_works() {
         assert!(Uint256::zero().is_zero());
         assert!(Uint256(U256::from(0)).is_zero());

--- a/packages/std/src/math/uint512.rs
+++ b/packages/std/src/math/uint512.rs
@@ -253,7 +253,11 @@ impl From<Uint512> for String {
 
 impl fmt::Display for Uint512 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.0.fmt(f)
+        // The inner type doesn't work as expected with padding, so we
+        // work around that.
+        let unpadded = self.0.to_string();
+
+        f.pad_integral(true, "", &unpadded)
     }
 }
 

--- a/packages/std/src/math/uint512.rs
+++ b/packages/std/src/math/uint512.rs
@@ -551,6 +551,12 @@ mod tests {
     }
 
     #[test]
+    fn uint512_display_padding_works() {
+        let a = Uint512::from(123u64);
+        assert_eq!(format!("Embedded: {:05}", a), "Embedded: 00123");
+    }
+
+    #[test]
     fn uint512_is_zero_works() {
         assert!(Uint512::zero().is_zero());
         assert!(Uint512(U512::from(0)).is_zero());

--- a/packages/std/src/math/uint64.rs
+++ b/packages/std/src/math/uint64.rs
@@ -406,6 +406,12 @@ mod tests {
     }
 
     #[test]
+    fn uint64_display_padding_works() {
+        let a = Uint64::from(123u64);
+        assert_eq!(format!("Embedded: {:05}", a), "Embedded: 00123");
+    }
+
+    #[test]
     fn uint64_is_zero_works() {
         assert!(Uint64::zero().is_zero());
         assert!(Uint64(0).is_zero());


### PR DESCRIPTION
Fixes the issue with padding not being applied when formatting `Uint256` and `Uint512`. Also adds tests for all the `Uint*` types.