### PR TITLE
Improve middleware readability

### DIFF
--- a/packages/vm/src/wasm_backend/compile.rs
+++ b/packages/vm/src/wasm_backend/compile.rs
@@ -24,8 +24,6 @@ mod tests {
     #[test]
     fn contract_with_floats_fails_check() {
         let err = compile(CONTRACT, None).unwrap_err();
-        assert!(err
-            .to_string()
-            .contains("Non-deterministic operator detected"));
+        assert!(err.to_string().contains("Float operator detected:"));
     }
 }

--- a/packages/vm/src/wasm_backend/deterministic.rs
+++ b/packages/vm/src/wasm_backend/deterministic.rs
@@ -611,7 +611,10 @@ impl FunctionMiddleware for FunctionDeterministic {
                     state.push_operator(operator);
                     Ok(())
                 } else {
-                    let msg = format!("Non-deterministic operator detected: {:?}", operator);
+                    let msg = format!(
+                        "Float operator detected: {:?}. The use of floats is not supported.",
+                        operator
+                    );
                     Err(MiddlewareError::new(MIDDLEWARE_NAME, msg))
                 }
             }
@@ -699,7 +702,7 @@ mod tests {
         assert!(result
             .unwrap_err()
             .to_string()
-            .contains("Non-deterministic"));
+            .contains("Float operator detected:"));
     }
 
     #[test]

--- a/packages/vm/src/wasm_backend/deterministic.rs
+++ b/packages/vm/src/wasm_backend/deterministic.rs
@@ -69,6 +69,9 @@ impl Default for FunctionDeterministic {
     }
 }
 
+/// The name used in errors
+const MIDDLEWARE_NAME: &str = "Deterministic";
+
 impl FunctionMiddleware for FunctionDeterministic {
     fn feed<'a>(
         &mut self,
@@ -203,7 +206,7 @@ impl FunctionMiddleware for FunctionDeterministic {
                     Ok(())
                 } else {
                     let msg = format!("Reference type operation detected: {:?}. Reference types are not supported.", operator);
-                    Err(MiddlewareError::new("Deterministic", msg))
+                    Err(MiddlewareError::new(MIDDLEWARE_NAME, msg))
                 }
             }
             Operator::MemoryAtomicNotify { .. }
@@ -278,7 +281,7 @@ impl FunctionMiddleware for FunctionDeterministic {
                     Ok(())
                 } else {
                     let msg = format!("Threads operator detected: {:?}. The Wasm Threads extension is not supported.", operator);
-                    Err(MiddlewareError::new("Deterministic", msg))
+                    Err(MiddlewareError::new(MIDDLEWARE_NAME, msg))
                 }
             }
             Operator::V128Load { .. }
@@ -473,7 +476,7 @@ impl FunctionMiddleware for FunctionDeterministic {
                         "SIMD operator detected: {:?}. The Wasm SIMD extension is not supported.",
                         operator
                     );
-                    Err(MiddlewareError::new("Deterministic", msg))
+                    Err(MiddlewareError::new(MIDDLEWARE_NAME, msg))
                 }
             }
             Operator::F32Load { .. }
@@ -609,7 +612,7 @@ impl FunctionMiddleware for FunctionDeterministic {
                     Ok(())
                 } else {
                     let msg = format!("Non-deterministic operator detected: {:?}", operator);
-                    Err(MiddlewareError::new("Deterministic", msg))
+                    Err(MiddlewareError::new(MIDDLEWARE_NAME, msg))
                 }
             }
             Operator::MemoryInit { .. }
@@ -625,7 +628,7 @@ impl FunctionMiddleware for FunctionDeterministic {
                     Ok(())
                 } else {
                     let msg = format!("Bulk memory operation detected: {:?}. Bulk memory operations are not supported.", operator);
-                    Err(MiddlewareError::new("Deterministic", msg))
+                    Err(MiddlewareError::new(MIDDLEWARE_NAME, msg))
                 }
             }
             Operator::Try { .. }
@@ -640,7 +643,7 @@ impl FunctionMiddleware for FunctionDeterministic {
                     Ok(())
                 } else {
                     let msg = format!("Exception handling operation detected: {:?}. Exception handling is not supported.", operator);
-                    Err(MiddlewareError::new("Deterministic", msg))
+                    Err(MiddlewareError::new(MIDDLEWARE_NAME, msg))
                 }
             }
         }

--- a/packages/vm/src/wasm_backend/deterministic.rs
+++ b/packages/vm/src/wasm_backend/deterministic.rs
@@ -7,10 +7,11 @@ use wasmer::{
 
 /// A middleware that ensures only deterministic operations are used (i.e. no floats)
 #[derive(Debug, MemoryUsage)]
+#[non_exhaustive]
 pub struct Deterministic {}
 
-impl Deterministic {
-    pub fn new() -> Self {
+impl Default for Deterministic {
+    fn default() -> Self {
         Self {}
     }
 }
@@ -612,7 +613,7 @@ mod tests {
         )
         .unwrap();
 
-        let deterministic = Arc::new(Deterministic::new());
+        let deterministic = Arc::new(Deterministic::default());
         let mut compiler_config = Cranelift::default();
         compiler_config.push_middleware(deterministic);
         let store = Store::new(&Universal::new(compiler_config).engine());
@@ -633,7 +634,7 @@ mod tests {
         )
         .unwrap();
 
-        let deterministic = Arc::new(Deterministic::new());
+        let deterministic = Arc::new(Deterministic::default());
         let mut compiler_config = Cranelift::default();
         compiler_config.push_middleware(deterministic);
         let store = Store::new(&Universal::new(compiler_config).engine());
@@ -660,7 +661,7 @@ mod tests {
         )
         .unwrap();
 
-        let deterministic = Arc::new(Deterministic::new());
+        let deterministic = Arc::new(Deterministic::default());
         let mut compiler_config = Cranelift::default();
         compiler_config.push_middleware(deterministic);
         let store = Store::new(&Universal::new(compiler_config).engine());

--- a/packages/vm/src/wasm_backend/deterministic.rs
+++ b/packages/vm/src/wasm_backend/deterministic.rs
@@ -23,7 +23,7 @@ impl ModuleMiddleware for Deterministic {
 }
 
 #[derive(Debug)]
-pub struct FunctionDeterministic {}
+struct FunctionDeterministic {}
 
 impl FunctionMiddleware for FunctionDeterministic {
     fn feed<'a>(

--- a/packages/vm/src/wasm_backend/deterministic.rs
+++ b/packages/vm/src/wasm_backend/deterministic.rs
@@ -18,12 +18,19 @@ impl Deterministic {
 impl ModuleMiddleware for Deterministic {
     /// Generates a `FunctionMiddleware` for a given function.
     fn generate_function_middleware(&self, _: LocalFunctionIndex) -> Box<dyn FunctionMiddleware> {
-        Box::new(FunctionDeterministic {})
+        Box::new(FunctionDeterministic::default())
     }
 }
 
 #[derive(Debug)]
+#[non_exhaustive]
 struct FunctionDeterministic {}
+
+impl Default for FunctionDeterministic {
+    fn default() -> Self {
+        Self {}
+    }
+}
 
 impl FunctionMiddleware for FunctionDeterministic {
     fn feed<'a>(

--- a/packages/vm/src/wasm_backend/gatekeeper.rs
+++ b/packages/vm/src/wasm_backend/gatekeeper.rs
@@ -5,7 +5,8 @@ use wasmer::{
     ModuleMiddleware,
 };
 
-/// A middleware that ensures only deterministic operations are used (i.e. no floats)
+/// A middleware that ensures only deterministic operations are used (i.e. no floats).
+/// It also disallows the use of Wasm features that are not explicitly enabled.
 #[derive(Debug, MemoryUsage)]
 #[non_exhaustive]
 pub struct Gatekeeper {}

--- a/packages/vm/src/wasm_backend/gatekeeper.rs
+++ b/packages/vm/src/wasm_backend/gatekeeper.rs
@@ -10,8 +10,8 @@ struct GatekeeperConfig {
     /// True iff float operations are allowed.
     ///
     /// Note: there are float operations in the SIMD block as well and we do not yet handle
-    /// any combination of `allow_float` and `allow_feature_simd` properly.
-    allow_float: bool,
+    /// any combination of `allow_floats` and `allow_feature_simd` properly.
+    allow_floats: bool,
     //
     // Standardized features
     //
@@ -58,7 +58,7 @@ impl Gatekeeper {
 impl Default for Gatekeeper {
     fn default() -> Self {
         Self::new(GatekeeperConfig {
-            allow_float: false,
+            allow_floats: false,
             allow_feature_bulk_memory_operations: false,
             allow_feature_reference_types: false,
             allow_feature_simd: false,
@@ -625,7 +625,7 @@ impl FunctionMiddleware for FunctionGatekeeper {
             | Operator::I32x4TruncSatF32x4U
             | Operator::F32x4ConvertI32x4S
             | Operator::F32x4ConvertI32x4U => {
-                if self.config.allow_float {
+                if self.config.allow_floats {
                     state.push_operator(operator);
                     Ok(())
                 } else {

--- a/packages/vm/src/wasm_backend/gatekeeper.rs
+++ b/packages/vm/src/wasm_backend/gatekeeper.rs
@@ -8,24 +8,24 @@ use wasmer::{
 /// A middleware that ensures only deterministic operations are used (i.e. no floats)
 #[derive(Debug, MemoryUsage)]
 #[non_exhaustive]
-pub struct Deterministic {}
+pub struct Gatekeeper {}
 
-impl Default for Deterministic {
+impl Default for Gatekeeper {
     fn default() -> Self {
         Self {}
     }
 }
 
-impl ModuleMiddleware for Deterministic {
+impl ModuleMiddleware for Gatekeeper {
     /// Generates a `FunctionMiddleware` for a given function.
     fn generate_function_middleware(&self, _: LocalFunctionIndex) -> Box<dyn FunctionMiddleware> {
-        Box::new(FunctionDeterministic::default())
+        Box::new(FunctionGatekeeper::default())
     }
 }
 
 #[derive(Debug)]
 #[non_exhaustive]
-struct FunctionDeterministic {
+struct FunctionGatekeeper {
     /// True iff float operations are allowed.
     ///
     /// Note: there are float operations in the SIMD block as well and we do not yet handle
@@ -56,7 +56,7 @@ struct FunctionDeterministic {
     allow_feature_threads: bool,
 }
 
-impl Default for FunctionDeterministic {
+impl Default for FunctionGatekeeper {
     fn default() -> Self {
         Self {
             allow_float: false,
@@ -70,9 +70,9 @@ impl Default for FunctionDeterministic {
 }
 
 /// The name used in errors
-const MIDDLEWARE_NAME: &str = "Deterministic";
+const MIDDLEWARE_NAME: &str = "Gatekeeper";
 
-impl FunctionMiddleware for FunctionDeterministic {
+impl FunctionMiddleware for FunctionGatekeeper {
     fn feed<'a>(
         &mut self,
         operator: Operator<'a>,
@@ -673,7 +673,7 @@ mod tests {
         )
         .unwrap();
 
-        let deterministic = Arc::new(Deterministic::default());
+        let deterministic = Arc::new(Gatekeeper::default());
         let mut compiler_config = Cranelift::default();
         compiler_config.push_middleware(deterministic);
         let store = Store::new(&Universal::new(compiler_config).engine());
@@ -694,7 +694,7 @@ mod tests {
         )
         .unwrap();
 
-        let deterministic = Arc::new(Deterministic::default());
+        let deterministic = Arc::new(Gatekeeper::default());
         let mut compiler_config = Cranelift::default();
         compiler_config.push_middleware(deterministic);
         let store = Store::new(&Universal::new(compiler_config).engine());
@@ -721,7 +721,7 @@ mod tests {
         )
         .unwrap();
 
-        let deterministic = Arc::new(Deterministic::default());
+        let deterministic = Arc::new(Gatekeeper::default());
         let mut compiler_config = Cranelift::default();
         compiler_config.push_middleware(deterministic);
         let store = Store::new(&Universal::new(compiler_config).engine());

--- a/packages/vm/src/wasm_backend/mod.rs
+++ b/packages/vm/src/wasm_backend/mod.rs
@@ -1,5 +1,5 @@
 mod compile;
-mod deterministic;
+mod gatekeeper;
 mod limiting_tunables;
 mod store;
 

--- a/packages/vm/src/wasm_backend/store.rs
+++ b/packages/vm/src/wasm_backend/store.rs
@@ -12,7 +12,7 @@ use wasmer_middlewares::Metering;
 
 use crate::size::Size;
 
-use super::deterministic::Deterministic;
+use super::gatekeeper::Gatekeeper;
 use super::limiting_tunables::LimitingTunables;
 
 /// WebAssembly linear memory objects have sizes measured in pages. Each page
@@ -32,7 +32,7 @@ fn cost(_operator: &Operator) -> u64 {
 /// If memory_limit is None, no limit is applied.
 pub fn make_compile_time_store(memory_limit: Option<Size>) -> Store {
     let gas_limit = 0;
-    let deterministic = Arc::new(Deterministic::default());
+    let deterministic = Arc::new(Gatekeeper::default());
     let metering = Arc::new(Metering::new(gas_limit, cost));
 
     #[cfg(feature = "cranelift")]

--- a/packages/vm/src/wasm_backend/store.rs
+++ b/packages/vm/src/wasm_backend/store.rs
@@ -32,7 +32,7 @@ fn cost(_operator: &Operator) -> u64 {
 /// If memory_limit is None, no limit is applied.
 pub fn make_compile_time_store(memory_limit: Option<Size>) -> Store {
     let gas_limit = 0;
-    let deterministic = Arc::new(Deterministic::new());
+    let deterministic = Arc::new(Deterministic::default());
     let metering = Arc::new(Metering::new(gas_limit, cost));
 
     #[cfg(feature = "cranelift")]


### PR DESCRIPTION
The middleware does more than looking for float operations these days. This improve the code accordingly to solve some of the confision in #1072.

- Rename `Deterministic` -> `Gatekeeper`
- Make error messages more specific
- Prepare configuration
