### PR TITLE
add decimal creation

### DIFF
--- a/packages/std/src/math/decimal.rs
+++ b/packages/std/src/math/decimal.rs
@@ -24,6 +24,11 @@ impl Decimal {
 
     pub const MAX: Self = Self(Uint128::MAX);
 
+    /// Creates a Decimal(value).
+    pub const fn new(value: Uint128) -> Self {
+        Decimal(value)
+    }
+
     /// Create a 1.0 Decimal
     pub const fn one() -> Self {
         Decimal(Self::DECIMAL_FRACTIONAL)

--- a/packages/std/src/math/decimal256.rs
+++ b/packages/std/src/math/decimal256.rs
@@ -33,6 +33,11 @@ impl Decimal256 {
 
     pub const MAX: Self = Self(Uint256::MAX);
 
+    /// Creates a Decimal256(value).
+    pub const fn new(value: Uint256) -> Self {
+        Decimal256(value)
+    }
+
     /// Create a 1.0 Decimal256
     pub const fn one() -> Self {
         Self(Self::DECIMAL_FRACTIONAL)


### PR DESCRIPTION
There are use cases where we need to get u128 from decimal to do some math operations. However, when we would like to put u128 back to create decimal, there is no public method to create decimal efficiently.