### PR TITLE
Enable injecting extra fn imports and middlewares to cosmwasm_vm::Instance

### DIFF
--- a/packages/vm/examples/check_contract.rs
+++ b/packages/vm/examples/check_contract.rs
@@ -31,6 +31,6 @@ pub fn main() {
     check_wasm(&wasm, &features_from_csv("iterator,staking,stargate")).unwrap();
 
     // Compile module
-    compile(&wasm, None).unwrap();
+    compile(&wasm, None, &[]).unwrap();
     println!("contract checks passed.")
 }

--- a/packages/vm/examples/module_size.rs
+++ b/packages/vm/examples/module_size.rs
@@ -69,7 +69,7 @@ pub fn main() {
 
 #[inline(never)]
 fn module_compile(wasm: &[u8], memory_limit: Option<Size>) -> Module {
-    compile(wasm, memory_limit).unwrap()
+    compile(wasm, memory_limit, &[]).unwrap()
 }
 
 #[inline(never)]

--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -151,7 +151,7 @@ where
 
     pub fn save_wasm(&self, wasm: &[u8]) -> VmResult<Checksum> {
         check_wasm(wasm, &self.supported_features)?;
-        let module = compile(wasm, None)?;
+        let module = compile(wasm, None, &[])?;
 
         let mut cache = self.inner.lock().unwrap();
         let checksum = save_wasm_to_disk(&cache.wasm_path, wasm)?;
@@ -224,7 +224,7 @@ where
 
         // Re-compile from original Wasm bytecode
         let code = self.load_wasm_with_path(&cache.wasm_path, checksum)?;
-        let module = compile(&code, Some(cache.instance_memory_limit))?;
+        let module = compile(&code, Some(cache.instance_memory_limit), &[])?;
         // Store into the fs cache too
         cache.fs_cache.store(checksum, &module)?;
         let module_size = loupe::size_of_val(&module);
@@ -292,7 +292,7 @@ where
         // stored the old module format.
         let wasm = self.load_wasm_with_path(&cache.wasm_path, checksum)?;
         cache.stats.misses += 1;
-        let module = compile(&wasm, Some(cache.instance_memory_limit))?;
+        let module = compile(&wasm, Some(cache.instance_memory_limit), &[])?;
         let instance =
             Instance::from_module(&module, backend, options.gas_limit, options.print_debug)?;
         cache.fs_cache.store(checksum, &module)?;

--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -257,8 +257,13 @@ where
         // Try to get module from the pinned memory cache
         if let Some(module) = cache.pinned_memory_cache.load(checksum)? {
             cache.stats.hits_pinned_memory_cache += 1;
-            let instance =
-                Instance::from_module(&module, backend, options.gas_limit, options.print_debug)?;
+            let instance = Instance::from_module(
+                &module,
+                backend,
+                options.gas_limit,
+                options.print_debug,
+                None,
+            )?;
             return Ok(instance);
         }
 
@@ -270,6 +275,7 @@ where
                 backend,
                 options.gas_limit,
                 options.print_debug,
+                None,
             )?;
             return Ok(instance);
         }
@@ -278,8 +284,13 @@ where
         let store = make_runtime_store(Some(cache.instance_memory_limit));
         if let Some(module) = cache.fs_cache.load(checksum, &store)? {
             cache.stats.hits_fs_cache += 1;
-            let instance =
-                Instance::from_module(&module, backend, options.gas_limit, options.print_debug)?;
+            let instance = Instance::from_module(
+                &module,
+                backend,
+                options.gas_limit,
+                options.print_debug,
+                None,
+            )?;
             let module_size = loupe::size_of_val(&module);
             cache.memory_cache.store(checksum, module, module_size)?;
             return Ok(instance);
@@ -293,8 +304,13 @@ where
         let wasm = self.load_wasm_with_path(&cache.wasm_path, checksum)?;
         cache.stats.misses += 1;
         let module = compile(&wasm, Some(cache.instance_memory_limit), &[])?;
-        let instance =
-            Instance::from_module(&module, backend, options.gas_limit, options.print_debug)?;
+        let instance = Instance::from_module(
+            &module,
+            backend,
+            options.gas_limit,
+            options.print_debug,
+            None,
+        )?;
         cache.fs_cache.store(checksum, &module)?;
         let module_size = loupe::size_of_val(&module);
         cache.memory_cache.store(checksum, module, module_size)?;

--- a/packages/vm/src/environment.rs
+++ b/packages/vm/src/environment.rs
@@ -418,7 +418,7 @@ mod tests {
     ) {
         let env = Environment::new(MockApi::default(), gas_limit, false);
 
-        let module = compile(CONTRACT, TESTING_MEMORY_LIMIT).unwrap();
+        let module = compile(CONTRACT, TESTING_MEMORY_LIMIT, &[]).unwrap();
         let store = module.store();
         // we need stubs for all required imports
         let import_obj = imports! {

--- a/packages/vm/src/imports.rs
+++ b/packages/vm/src/imports.rs
@@ -481,7 +481,7 @@ mod tests {
         let gas_limit = TESTING_GAS_LIMIT;
         let env = Environment::new(api, gas_limit, false);
 
-        let module = compile(CONTRACT, TESTING_MEMORY_LIMIT).unwrap();
+        let module = compile(CONTRACT, TESTING_MEMORY_LIMIT, &[]).unwrap();
         let store = module.store();
         // we need stubs for all required imports
         let import_obj = imports! {

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -62,7 +62,7 @@ where
         options: InstanceOptions,
         memory_limit: Option<Size>,
     ) -> VmResult<Self> {
-        let module = compile(code, memory_limit)?;
+        let module = compile(code, memory_limit, &[])?;
         Instance::from_module(&module, backend, options.gas_limit, options.print_debug)
     }
 

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -355,6 +355,23 @@ where
     }
 }
 
+/// This exists only to be exported through `internals` for use by crates that are
+/// part of Cosmwasm.
+pub fn instance_from_module<A, S, Q>(
+    module: &Module,
+    backend: Backend<A, S, Q>,
+    gas_limit: u64,
+    print_debug: bool,
+    extra_imports: Option<HashMap<&str, HashMap<&str, Function>>>,
+) -> VmResult<Instance<A, S, Q>>
+where
+    A: BackendApi + 'static, // 'static is needed here to allow copying API instances into closures
+    S: Storage + 'static, // 'static is needed here to allow using this in an Environment that is cloned into closures
+    Q: Querier + 'static,
+{
+    Instance::from_module(module, backend, gas_limit, print_debug, extra_imports)
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::atomic::{AtomicBool, Ordering};

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::ptr::NonNull;
 
 use wasmer::{Exports, Function, ImportObject, Instance as WasmerInstance, Module, Val};
@@ -63,7 +63,13 @@ where
         memory_limit: Option<Size>,
     ) -> VmResult<Self> {
         let module = compile(code, memory_limit, &[])?;
-        Instance::from_module(&module, backend, options.gas_limit, options.print_debug)
+        Instance::from_module(
+            &module,
+            backend,
+            options.gas_limit,
+            options.print_debug,
+            None,
+        )
     }
 
     pub(crate) fn from_module(
@@ -71,6 +77,7 @@ where
         backend: Backend<A, S, Q>,
         gas_limit: u64,
         print_debug: bool,
+        extra_imports: Option<HashMap<&str, HashMap<&str, Function>>>,
     ) -> VmResult<Self> {
         let store = module.store();
 
@@ -199,6 +206,18 @@ where
         );
 
         import_obj.register("env", env_imports);
+
+        if let Some(extra_imports) = extra_imports {
+            for (namespace, imports) in extra_imports {
+                let mut exports_obj = Exports::new();
+
+                for (name, fun) in imports {
+                    exports_obj.insert(name, fun)
+                }
+
+                import_obj.register(namespace, exports_obj);
+            }
+        }
 
         let wasmer_instance = Box::from(WasmerInstance::new(module, &import_obj).map_err(
             |original| {
@@ -338,6 +357,9 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
     use super::*;
     use crate::backend::Storage;
     use crate::call_instantiate;
@@ -389,6 +411,53 @@ mod tests {
         assert!(instance.required_features().contains("nutrients"));
         assert!(instance.required_features().contains("sun"));
         assert!(instance.required_features().contains("water"));
+    }
+
+    #[test]
+    fn extra_imports_get_added() {
+        let wasm = wat::parse_str(
+            r#"(module
+            (import "foo" "bar" (func $bar))
+            (func (export "main") (call $bar))
+            )"#,
+        )
+        .unwrap();
+
+        let backend = mock_backend(&[]);
+        let (instance_options, memory_limit) = mock_instance_options();
+        let module = compile(&wasm, memory_limit, &[]).unwrap();
+
+        #[derive(wasmer::WasmerEnv, Clone)]
+        struct MyEnv {
+            // This can be mutated across threads safely. We initialize it as `false`
+            // and let our imported fn switch it to `true` to confirm it works.
+            called: Arc<AtomicBool>,
+        }
+
+        let my_env = MyEnv {
+            called: Arc::new(AtomicBool::new(false)),
+        };
+
+        let fun = Function::new_native_with_env(module.store(), my_env.clone(), |env: &MyEnv| {
+            env.called.store(true, Ordering::Relaxed);
+        });
+        let mut foo_namespace = HashMap::new();
+        foo_namespace.insert("bar", fun);
+        let mut extra_imports = HashMap::new();
+        extra_imports.insert("foo", foo_namespace);
+        let instance = Instance::from_module(
+            &module,
+            backend,
+            instance_options.gas_limit,
+            false,
+            Some(extra_imports),
+        )
+        .unwrap();
+
+        let main = instance._inner.exports.get_function("main").unwrap();
+        main.call(&[]).unwrap();
+
+        assert!(my_env.called.load(Ordering::Relaxed));
     }
 
     #[test]

--- a/packages/vm/src/lib.rs
+++ b/packages/vm/src/lib.rs
@@ -55,5 +55,6 @@ pub mod internals {
     //! they might change frequently or be removed in the future.
 
     pub use crate::compatibility::check_wasm;
+    pub use crate::instance::instance_from_module;
     pub use crate::wasm_backend::{compile, make_runtime_store};
 }

--- a/packages/vm/src/modules/file_system_cache.rs
+++ b/packages/vm/src/modules/file_system_cache.rs
@@ -140,7 +140,7 @@ mod tests {
         assert!(cached.is_none());
 
         // Store module
-        let module = compile(&wasm, None).unwrap();
+        let module = compile(&wasm, None, &[]).unwrap();
         cache.store(&checksum, &module).unwrap();
 
         // Load module

--- a/packages/vm/src/modules/in_memory_cache.rs
+++ b/packages/vm/src/modules/in_memory_cache.rs
@@ -142,7 +142,7 @@ mod tests {
         assert!(cache_entry.is_none());
 
         // Compile module
-        let original = compile(&wasm, None).unwrap();
+        let original = compile(&wasm, None, &[]).unwrap();
 
         // Ensure original module can be executed
         {
@@ -213,19 +213,19 @@ mod tests {
 
         // Add 1
         cache
-            .store(&checksum1, compile(&wasm1, None).unwrap(), 900_000)
+            .store(&checksum1, compile(&wasm1, None, &[]).unwrap(), 900_000)
             .unwrap();
         assert_eq!(cache.len(), 1);
 
         // Add 2
         cache
-            .store(&checksum2, compile(&wasm2, None).unwrap(), 900_000)
+            .store(&checksum2, compile(&wasm2, None, &[]).unwrap(), 900_000)
             .unwrap();
         assert_eq!(cache.len(), 2);
 
         // Add 3 (pushes out the previous two)
         cache
-            .store(&checksum3, compile(&wasm3, None).unwrap(), 1_500_000)
+            .store(&checksum3, compile(&wasm3, None, &[]).unwrap(), 1_500_000)
             .unwrap();
         assert_eq!(cache.len(), 1);
     }
@@ -273,19 +273,19 @@ mod tests {
 
         // Add 1
         cache
-            .store(&checksum1, compile(&wasm1, None).unwrap(), 900_000)
+            .store(&checksum1, compile(&wasm1, None, &[]).unwrap(), 900_000)
             .unwrap();
         assert_eq!(cache.size(), 900_000);
 
         // Add 2
         cache
-            .store(&checksum2, compile(&wasm2, None).unwrap(), 800_000)
+            .store(&checksum2, compile(&wasm2, None, &[]).unwrap(), 800_000)
             .unwrap();
         assert_eq!(cache.size(), 1_700_000);
 
         // Add 3 (pushes out the previous two)
         cache
-            .store(&checksum3, compile(&wasm3, None).unwrap(), 1_500_000)
+            .store(&checksum3, compile(&wasm3, None, &[]).unwrap(), 1_500_000)
             .unwrap();
         assert_eq!(cache.size(), 1_500_000);
     }

--- a/packages/vm/src/modules/pinned_memory_cache.rs
+++ b/packages/vm/src/modules/pinned_memory_cache.rs
@@ -87,7 +87,7 @@ mod tests {
         assert!(cache_entry.is_none());
 
         // Compile module
-        let original = compile(&wasm, None).unwrap();
+        let original = compile(&wasm, None, &[]).unwrap();
 
         // Ensure original module can be executed
         {
@@ -134,7 +134,7 @@ mod tests {
         assert!(!cache.has(&checksum));
 
         // Add
-        let original = compile(&wasm, None).unwrap();
+        let original = compile(&wasm, None, &[]).unwrap();
         cache.store(&checksum, original, 0).unwrap();
 
         assert!(cache.has(&checksum));
@@ -165,7 +165,7 @@ mod tests {
         assert_eq!(cache.len(), 0);
 
         // Add
-        let original = compile(&wasm, None).unwrap();
+        let original = compile(&wasm, None, &[]).unwrap();
         cache.store(&checksum, original, 0).unwrap();
 
         assert_eq!(cache.len(), 1);
@@ -207,12 +207,12 @@ mod tests {
         assert_eq!(cache.size(), 0);
 
         // Add 1
-        let original = compile(&wasm1, None).unwrap();
+        let original = compile(&wasm1, None, &[]).unwrap();
         cache.store(&checksum1, original, 500).unwrap();
         assert_eq!(cache.size(), 500);
 
         // Add 2
-        let original = compile(&wasm2, None).unwrap();
+        let original = compile(&wasm2, None, &[]).unwrap();
         cache.store(&checksum2, original, 300).unwrap();
         assert_eq!(cache.size(), 800);
 

--- a/packages/vm/src/wasm_backend/compile.rs
+++ b/packages/vm/src/wasm_backend/compile.rs
@@ -1,4 +1,6 @@
-use wasmer::Module;
+use std::sync::Arc;
+
+use wasmer::{Module, ModuleMiddleware};
 
 use crate::errors::VmResult;
 use crate::size::Size;
@@ -9,8 +11,12 @@ use super::store::make_compile_time_store;
 /// The given memory limit (in bytes) is used when memories are created.
 /// If no memory limit is passed, the resulting compiled module should
 /// not be used for execution.
-pub fn compile(code: &[u8], memory_limit: Option<Size>) -> VmResult<Module> {
-    let store = make_compile_time_store(memory_limit);
+pub fn compile(
+    code: &[u8],
+    memory_limit: Option<Size>,
+    middlewares: &[Arc<dyn ModuleMiddleware>],
+) -> VmResult<Module> {
+    let store = make_compile_time_store(memory_limit, middlewares);
     let module = Module::new(&store, code)?;
     Ok(module)
 }
@@ -23,7 +29,7 @@ mod tests {
 
     #[test]
     fn contract_with_floats_fails_check() {
-        let err = compile(CONTRACT, None).unwrap_err();
+        let err = compile(CONTRACT, None, &[]).unwrap_err();
         assert!(err.to_string().contains("Float operator detected:"));
     }
 }

--- a/packages/vm/src/wasm_backend/store.rs
+++ b/packages/vm/src/wasm_backend/store.rs
@@ -5,8 +5,8 @@ use wasmer::Cranelift;
 #[cfg(not(feature = "cranelift"))]
 use wasmer::Singlepass;
 use wasmer::{
-    wasmparser::Operator, BaseTunables, CompilerConfig, Engine, Pages, Store, Target, Universal,
-    WASM_PAGE_SIZE,
+    wasmparser::Operator, BaseTunables, CompilerConfig, Engine, ModuleMiddleware, Pages, Store,
+    Target, Universal, WASM_PAGE_SIZE,
 };
 use wasmer_middlewares::Metering;
 
@@ -30,7 +30,10 @@ fn cost(_operator: &Operator) -> u64 {
 
 /// Created a store with the default compiler and the given memory limit (in bytes).
 /// If memory_limit is None, no limit is applied.
-pub fn make_compile_time_store(memory_limit: Option<Size>) -> Store {
+pub fn make_compile_time_store(
+    memory_limit: Option<Size>,
+    middlewares: &[Arc<dyn ModuleMiddleware>],
+) -> Store {
     let gas_limit = 0;
     let deterministic = Arc::new(Gatekeeper::default());
     let metering = Arc::new(Metering::new(gas_limit, cost));
@@ -40,6 +43,9 @@ pub fn make_compile_time_store(memory_limit: Option<Size>) -> Store {
         let mut config = Cranelift::default();
         config.push_middleware(deterministic);
         config.push_middleware(metering);
+        for middleware in middlewares {
+            config.push_middleware(middleware.clone());
+        }
         let engine = Universal::new(config).engine();
         make_store_with_engine(&engine, memory_limit)
     }
@@ -49,6 +55,9 @@ pub fn make_compile_time_store(memory_limit: Option<Size>) -> Store {
         let mut config = Singlepass::default();
         config.push_middleware(deterministic);
         config.push_middleware(metering);
+        for middleware in middlewares {
+            config.push_middleware(middleware.clone());
+        }
         let engine = Universal::new(config).engine();
         make_store_with_engine(&engine, memory_limit)
     }
@@ -113,7 +122,7 @@ mod tests {
         let wasm = wat::parse_str(EXPORTED_MEMORY_WAT).unwrap();
 
         // No limit
-        let store = make_compile_time_store(None);
+        let store = make_compile_time_store(None, &[]);
         let module = Module::new(&store, &wasm).unwrap();
         let module_memory = module.info().memories.last().unwrap();
         assert_eq!(module_memory.minimum, Pages(4));
@@ -130,7 +139,7 @@ mod tests {
         assert_eq!(instance_memory.ty().maximum, None);
 
         // Set limit
-        let store = make_compile_time_store(Some(Size::kibi(23 * 64)));
+        let store = make_compile_time_store(Some(Size::kibi(23 * 64)), &[]);
         let module = Module::new(&store, &wasm).unwrap();
         let module_memory = module.info().memories.last().unwrap();
         assert_eq!(module_memory.minimum, Pages(4));
@@ -152,7 +161,7 @@ mod tests {
         // Compile
         let serialized = {
             let wasm = wat::parse_str(EXPORTED_MEMORY_WAT).unwrap();
-            let store = make_compile_time_store(None);
+            let store = make_compile_time_store(None, &[]);
             let module = Module::new(&store, &wasm).unwrap();
             module.serialize().unwrap()
         };


### PR DESCRIPTION
This enables us to inject middlewares and fn imports. This is for the contract profiler, which I'd like to remain a separate crate in this repo.

* Extra middlewares can now be added to a `cosmwasm_vm::Instance`.
* Extra fn imports can now be added to a `cosmwasm_vm::Instance`.
* `wasmer` types aren't leaked (except through `internals`).
* `MockInstance`s stay the same... for now.