### PR TITLE
Remove trait bounds on structs

### DIFF
--- a/packages/std/src/query/mod.rs
+++ b/packages/std/src/query/mod.rs
@@ -26,7 +26,7 @@ pub use wasm::{ContractInfoResponse, WasmQuery};
 #[non_exhaustive]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
-pub enum QueryRequest<C: CustomQuery> {
+pub enum QueryRequest<C> {
     Bank(BankQuery),
     Custom(C),
     #[cfg(feature = "staking")]

--- a/packages/std/src/results/cosmos_msg.rs
+++ b/packages/std/src/results/cosmos_msg.rs
@@ -15,10 +15,7 @@ use super::Empty;
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 // See https://github.com/serde-rs/serde/issues/1296 why we cannot add De-Serialize trait bounds to T
-pub enum CosmosMsg<T = Empty>
-where
-    T: Clone + fmt::Debug + PartialEq + JsonSchema,
-{
+pub enum CosmosMsg<T = Empty> {
     Bank(BankMsg),
     // by default we use RawMsg, but a contract can override that
     // to call into more app-specific code (whatever they define)

--- a/packages/std/src/results/response.rs
+++ b/packages/std/src/results/response.rs
@@ -1,6 +1,5 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::fmt;
 
 use crate::Binary;
 
@@ -62,10 +61,7 @@ use super::{Attribute, CosmosMsg, Empty, Event, SubMsg};
 /// ```
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[non_exhaustive]
-pub struct Response<T = Empty>
-where
-    T: Clone + fmt::Debug + PartialEq + JsonSchema,
-{
+pub struct Response<T = Empty> {
     /// Optional list of messages to pass. These will be executed in order.
     /// If the ReplyOn variant matches the result (Always, Success on Ok, Error on Err),
     /// the runtime will invoke this contract's `reply` entry point
@@ -89,10 +85,7 @@ where
     pub data: Option<Binary>,
 }
 
-impl<T> Default for Response<T>
-where
-    T: Clone + fmt::Debug + PartialEq + JsonSchema,
-{
+impl<T> Default for Response<T> {
     fn default() -> Self {
         Response {
             messages: vec![],
@@ -103,10 +96,7 @@ where
     }
 }
 
-impl<T> Response<T>
-where
-    T: Clone + fmt::Debug + PartialEq + JsonSchema,
-{
+impl<T> Response<T> {
     pub fn new() -> Self {
         Self::default()
     }

--- a/packages/std/src/results/submessages.rs
+++ b/packages/std/src/results/submessages.rs
@@ -1,6 +1,5 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::fmt;
 
 use crate::{Binary, ContractResult};
 
@@ -29,10 +28,7 @@ pub enum ReplyOn {
 /// but not revert any state changes in the calling contract. If this is required, it must be done
 /// manually in the `reply` entry point.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct SubMsg<T = Empty>
-where
-    T: Clone + fmt::Debug + PartialEq + JsonSchema,
-{
+pub struct SubMsg<T = Empty> {
     /// An arbitrary ID chosen by the contract.
     /// This is typically used to match `Reply`s in the `reply` entry point to the submessage.
     pub id: u64,
@@ -44,10 +40,7 @@ where
 /// This is used for cases when we use ReplyOn::Never and the id doesn't matter
 pub const UNUSED_MSG_ID: u64 = 0;
 
-impl<T> SubMsg<T>
-where
-    T: Clone + fmt::Debug + PartialEq + JsonSchema,
-{
+impl<T> SubMsg<T> {
     /// new creates a "fire and forget" message with the pre-0.14 semantics
     pub fn new(msg: impl Into<CosmosMsg<T>>) -> Self {
         SubMsg {


### PR DESCRIPTION
These are not needed in the structs, but rather in the impl blocks.
The stemmed from when I was newer to Rust and didn't realise that `#[derive(Clone)]` was valid if some generics didn't implement Clone. I discovered this is like `impl<C: Clone> Clone for Msg<C> { ... }`, so we get that check for free.

When working with multi-test and more powerful use of generics and traits, these restrictions were quite troublesome. If you have a type that doesn't implement one and it is used somewhere that needs it, that will cause a compiler error. So no need to enforce that on the type.