### PR TITLE
CustomMsg trait

### DIFF
--- a/contracts/reflect/src/msg.rs
+++ b/contracts/reflect/src/msg.rs
@@ -73,6 +73,8 @@ pub enum CustomMsg {
     Raw(Binary),
 }
 
+impl cosmwasm_std::CustomMsg for CustomMsg {}
+
 impl From<CustomMsg> for CosmosMsg<CustomMsg> {
     fn from(original: CustomMsg) -> Self {
         CosmosMsg::Custom(original)

--- a/packages/std/src/exports.rs
+++ b/packages/std/src/exports.rs
@@ -7,12 +7,10 @@
 //! and `do_sudo` should be wrapped with a extern "C" entry point including
 //! the contract-specific function pointer. This is done via the `#[entry_point]`
 //! macro attribute from cosmwasm-derive.
-use std::fmt;
 use std::marker::PhantomData;
 use std::vec::Vec;
 
-use schemars::JsonSchema;
-use serde::{de::DeserializeOwned, Serialize};
+use serde::de::DeserializeOwned;
 
 use crate::deps::OwnedDeps;
 #[cfg(feature = "stargate")]
@@ -91,7 +89,7 @@ pub fn do_instantiate<Q, M, C, E>(
 ) -> u32
 where
     Q: CustomQuery,
-    M: DeserializeOwned + JsonSchema,
+    M: DeserializeOwned,
     C: CustomMsg,
     E: ToString,
 {
@@ -119,7 +117,7 @@ pub fn do_execute<Q, M, C, E>(
 ) -> u32
 where
     Q: CustomQuery,
-    M: DeserializeOwned + JsonSchema,
+    M: DeserializeOwned,
     C: CustomMsg,
     E: ToString,
 {
@@ -146,7 +144,7 @@ pub fn do_migrate<Q, M, C, E>(
 ) -> u32
 where
     Q: CustomQuery,
-    M: DeserializeOwned + JsonSchema,
+    M: DeserializeOwned,
     C: CustomMsg,
     E: ToString,
 {
@@ -168,7 +166,7 @@ pub fn do_sudo<Q, M, C, E>(
 ) -> u32
 where
     Q: CustomQuery,
-    M: DeserializeOwned + JsonSchema,
+    M: DeserializeOwned,
     C: CustomMsg,
     E: ToString,
 {
@@ -210,7 +208,7 @@ pub fn do_query<Q, M, E>(
 ) -> u32
 where
     Q: CustomQuery,
-    M: DeserializeOwned + JsonSchema,
+    M: DeserializeOwned,
     E: ToString,
 {
     let res = _do_query(query_fn, env_ptr as *mut Region, msg_ptr as *mut Region);
@@ -366,7 +364,7 @@ fn _do_instantiate<Q, M, C, E>(
 ) -> ContractResult<Response<C>>
 where
     Q: CustomQuery,
-    M: DeserializeOwned + JsonSchema,
+    M: DeserializeOwned,
     C: CustomMsg,
     E: ToString,
 {
@@ -390,7 +388,7 @@ fn _do_execute<Q, M, C, E>(
 ) -> ContractResult<Response<C>>
 where
     Q: CustomQuery,
-    M: DeserializeOwned + JsonSchema,
+    M: DeserializeOwned,
     C: CustomMsg,
     E: ToString,
 {
@@ -413,7 +411,7 @@ fn _do_migrate<Q, M, C, E>(
 ) -> ContractResult<Response<C>>
 where
     Q: CustomQuery,
-    M: DeserializeOwned + JsonSchema,
+    M: DeserializeOwned,
     C: CustomMsg,
     E: ToString,
 {
@@ -434,7 +432,7 @@ fn _do_sudo<Q, M, C, E>(
 ) -> ContractResult<Response<C>>
 where
     Q: CustomQuery,
-    M: DeserializeOwned + JsonSchema,
+    M: DeserializeOwned,
     C: CustomMsg,
     E: ToString,
 {
@@ -475,7 +473,7 @@ fn _do_query<Q, M, E>(
 ) -> ContractResult<QueryResponse>
 where
     Q: CustomQuery,
-    M: DeserializeOwned + JsonSchema,
+    M: DeserializeOwned,
     E: ToString,
 {
     let env: Vec<u8> = unsafe { consume_region(env_ptr) };

--- a/packages/std/src/exports.rs
+++ b/packages/std/src/exports.rs
@@ -26,7 +26,7 @@ use crate::query::CustomQuery;
 use crate::results::{ContractResult, QueryResponse, Reply, Response};
 use crate::serde::{from_slice, to_vec};
 use crate::types::Env;
-use crate::{Deps, DepsMut, MessageInfo};
+use crate::{CustomMsg, Deps, DepsMut, MessageInfo};
 
 #[cfg(feature = "iterator")]
 #[no_mangle]
@@ -92,7 +92,7 @@ pub fn do_instantiate<Q, M, C, E>(
 where
     Q: CustomQuery,
     M: DeserializeOwned + JsonSchema,
-    C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
+    C: CustomMsg,
     E: ToString,
 {
     let res = _do_instantiate(
@@ -120,7 +120,7 @@ pub fn do_execute<Q, M, C, E>(
 where
     Q: CustomQuery,
     M: DeserializeOwned + JsonSchema,
-    C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
+    C: CustomMsg,
     E: ToString,
 {
     let res = _do_execute(
@@ -147,7 +147,7 @@ pub fn do_migrate<Q, M, C, E>(
 where
     Q: CustomQuery,
     M: DeserializeOwned + JsonSchema,
-    C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
+    C: CustomMsg,
     E: ToString,
 {
     let res = _do_migrate(migrate_fn, env_ptr as *mut Region, msg_ptr as *mut Region);
@@ -169,7 +169,7 @@ pub fn do_sudo<Q, M, C, E>(
 where
     Q: CustomQuery,
     M: DeserializeOwned + JsonSchema,
-    C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
+    C: CustomMsg,
     E: ToString,
 {
     let res = _do_sudo(sudo_fn, env_ptr as *mut Region, msg_ptr as *mut Region);
@@ -190,7 +190,7 @@ pub fn do_reply<Q, C, E>(
 ) -> u32
 where
     Q: CustomQuery,
-    C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
+    C: CustomMsg,
     E: ToString,
 {
     let res = _do_reply(reply_fn, env_ptr as *mut Region, msg_ptr as *mut Region);
@@ -254,7 +254,7 @@ pub fn do_ibc_channel_connect<Q, C, E>(
 ) -> u32
 where
     Q: CustomQuery,
-    C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
+    C: CustomMsg,
     E: ToString,
 {
     let res = _do_ibc_channel_connect(contract_fn, env_ptr as *mut Region, msg_ptr as *mut Region);
@@ -277,7 +277,7 @@ pub fn do_ibc_channel_close<Q, C, E>(
 ) -> u32
 where
     Q: CustomQuery,
-    C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
+    C: CustomMsg,
     E: ToString,
 {
     let res = _do_ibc_channel_close(contract_fn, env_ptr as *mut Region, msg_ptr as *mut Region);
@@ -301,7 +301,7 @@ pub fn do_ibc_packet_receive<Q, C, E>(
 ) -> u32
 where
     Q: CustomQuery,
-    C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
+    C: CustomMsg,
     E: ToString,
 {
     let res = _do_ibc_packet_receive(contract_fn, env_ptr as *mut Region, msg_ptr as *mut Region);
@@ -325,7 +325,7 @@ pub fn do_ibc_packet_ack<Q, C, E>(
 ) -> u32
 where
     Q: CustomQuery,
-    C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
+    C: CustomMsg,
     E: ToString,
 {
     let res = _do_ibc_packet_ack(contract_fn, env_ptr as *mut Region, msg_ptr as *mut Region);
@@ -350,7 +350,7 @@ pub fn do_ibc_packet_timeout<Q, C, E>(
 ) -> u32
 where
     Q: CustomQuery,
-    C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
+    C: CustomMsg,
     E: ToString,
 {
     let res = _do_ibc_packet_timeout(contract_fn, env_ptr as *mut Region, msg_ptr as *mut Region);
@@ -367,7 +367,7 @@ fn _do_instantiate<Q, M, C, E>(
 where
     Q: CustomQuery,
     M: DeserializeOwned + JsonSchema,
-    C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
+    C: CustomMsg,
     E: ToString,
 {
     let env: Vec<u8> = unsafe { consume_region(env_ptr) };
@@ -391,7 +391,7 @@ fn _do_execute<Q, M, C, E>(
 where
     Q: CustomQuery,
     M: DeserializeOwned + JsonSchema,
-    C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
+    C: CustomMsg,
     E: ToString,
 {
     let env: Vec<u8> = unsafe { consume_region(env_ptr) };
@@ -414,7 +414,7 @@ fn _do_migrate<Q, M, C, E>(
 where
     Q: CustomQuery,
     M: DeserializeOwned + JsonSchema,
-    C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
+    C: CustomMsg,
     E: ToString,
 {
     let env: Vec<u8> = unsafe { consume_region(env_ptr) };
@@ -435,7 +435,7 @@ fn _do_sudo<Q, M, C, E>(
 where
     Q: CustomQuery,
     M: DeserializeOwned + JsonSchema,
-    C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
+    C: CustomMsg,
     E: ToString,
 {
     let env: Vec<u8> = unsafe { consume_region(env_ptr) };
@@ -455,7 +455,7 @@ fn _do_reply<Q, C, E>(
 ) -> ContractResult<Response<C>>
 where
     Q: CustomQuery,
-    C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
+    C: CustomMsg,
     E: ToString,
 {
     let env: Vec<u8> = unsafe { consume_region(env_ptr) };
@@ -516,7 +516,7 @@ fn _do_ibc_channel_connect<Q, C, E>(
 ) -> ContractResult<IbcBasicResponse<C>>
 where
     Q: CustomQuery,
-    C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
+    C: CustomMsg,
     E: ToString,
 {
     let env: Vec<u8> = unsafe { consume_region(env_ptr) };
@@ -537,7 +537,7 @@ fn _do_ibc_channel_close<Q, C, E>(
 ) -> ContractResult<IbcBasicResponse<C>>
 where
     Q: CustomQuery,
-    C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
+    C: CustomMsg,
     E: ToString,
 {
     let env: Vec<u8> = unsafe { consume_region(env_ptr) };
@@ -558,7 +558,7 @@ fn _do_ibc_packet_receive<Q, C, E>(
 ) -> ContractResult<IbcReceiveResponse<C>>
 where
     Q: CustomQuery,
-    C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
+    C: CustomMsg,
     E: ToString,
 {
     let env: Vec<u8> = unsafe { consume_region(env_ptr) };
@@ -579,7 +579,7 @@ fn _do_ibc_packet_ack<Q, C, E>(
 ) -> ContractResult<IbcBasicResponse<C>>
 where
     Q: CustomQuery,
-    C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
+    C: CustomMsg,
     E: ToString,
 {
     let env: Vec<u8> = unsafe { consume_region(env_ptr) };
@@ -600,7 +600,7 @@ fn _do_ibc_packet_timeout<Q, C, E>(
 ) -> ContractResult<IbcBasicResponse<C>>
 where
     Q: CustomQuery,
-    C: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema,
+    C: CustomMsg,
     E: ToString,
 {
     let env: Vec<u8> = unsafe { consume_region(env_ptr) };

--- a/packages/std/src/ibc.rs
+++ b/packages/std/src/ibc.rs
@@ -5,12 +5,11 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::cmp::{Ord, Ordering, PartialOrd};
-use std::fmt;
 
 use crate::binary::Binary;
 use crate::coins::Coin;
 use crate::errors::StdResult;
-use crate::results::{Attribute, CosmosMsg, Empty, Event, SubMsg};
+use crate::results::{Attribute, CosmosMsg, CustomMsg, Empty, Event, SubMsg};
 use crate::serde::to_binary;
 use crate::timestamp::Timestamp;
 
@@ -441,7 +440,7 @@ impl IbcPacketTimeoutMsg {
 #[non_exhaustive]
 pub struct IbcBasicResponse<T = Empty>
 where
-    T: Clone + fmt::Debug + PartialEq + JsonSchema,
+    T: CustomMsg,
 {
     /// Optional list of messages to pass. These will be executed in order.
     /// If the ReplyOn member is set, they will invoke this contract's `reply` entry point
@@ -465,7 +464,7 @@ where
 
 impl<T> Default for IbcBasicResponse<T>
 where
-    T: Clone + fmt::Debug + PartialEq + JsonSchema,
+    T: CustomMsg,
 {
     fn default() -> Self {
         IbcBasicResponse {
@@ -478,7 +477,7 @@ where
 
 impl<T> IbcBasicResponse<T>
 where
-    T: Clone + fmt::Debug + PartialEq + JsonSchema,
+    T: CustomMsg,
 {
     pub fn new() -> Self {
         Self::default()
@@ -591,7 +590,7 @@ where
 #[non_exhaustive]
 pub struct IbcReceiveResponse<T = Empty>
 where
-    T: Clone + fmt::Debug + PartialEq + JsonSchema,
+    T: CustomMsg,
 {
     /// The bytes we return to the contract that sent the packet.
     /// This may represent a success or error of exection
@@ -618,7 +617,7 @@ where
 
 impl<T> Default for IbcReceiveResponse<T>
 where
-    T: Clone + fmt::Debug + PartialEq + JsonSchema,
+    T: CustomMsg,
 {
     fn default() -> Self {
         IbcReceiveResponse {
@@ -632,7 +631,7 @@ where
 
 impl<T> IbcReceiveResponse<T>
 where
-    T: Clone + fmt::Debug + PartialEq + JsonSchema,
+    T: CustomMsg,
 {
     pub fn new() -> Self {
         Self::default()

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -58,9 +58,9 @@ pub use crate::query::{
 #[cfg(feature = "stargate")]
 pub use crate::query::{ChannelResponse, IbcQuery, ListChannelsResponse, PortIdResponse};
 pub use crate::results::{
-    attr, wasm_execute, wasm_instantiate, Attribute, BankMsg, ContractResult, CosmosMsg, Empty,
-    Event, QueryResponse, Reply, ReplyOn, Response, SubMsg, SubMsgExecutionResponse, SystemResult,
-    WasmMsg,
+    attr, wasm_execute, wasm_instantiate, Attribute, BankMsg, ContractResult, CosmosMsg, CustomMsg,
+    Empty, Event, QueryResponse, Reply, ReplyOn, Response, SubMsg, SubMsgExecutionResponse,
+    SystemResult, WasmMsg,
 };
 #[cfg(feature = "staking")]
 pub use crate::results::{DistributionMsg, StakingMsg};

--- a/packages/std/src/results/cosmos_msg.rs
+++ b/packages/std/src/results/cosmos_msg.rs
@@ -11,6 +11,12 @@ use crate::serde::to_binary;
 
 use super::Empty;
 
+/// Like CustomQuery for better type clarity.
+/// Also makes it shorter to use as a trait bound.
+pub trait CustomMsg: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema {}
+
+impl CustomMsg for Empty {}
+
 #[non_exhaustive]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
@@ -212,7 +218,7 @@ pub fn wasm_execute(
 
 impl<T> From<BankMsg> for CosmosMsg<T>
 where
-    T: Clone + fmt::Debug + PartialEq + JsonSchema,
+    T: CustomMsg,
 {
     fn from(msg: BankMsg) -> Self {
         CosmosMsg::Bank(msg)
@@ -222,7 +228,7 @@ where
 #[cfg(feature = "staking")]
 impl<T> From<StakingMsg> for CosmosMsg<T>
 where
-    T: Clone + fmt::Debug + PartialEq + JsonSchema,
+    T: CustomMsg,
 {
     fn from(msg: StakingMsg) -> Self {
         CosmosMsg::Staking(msg)
@@ -232,7 +238,7 @@ where
 #[cfg(feature = "staking")]
 impl<T> From<DistributionMsg> for CosmosMsg<T>
 where
-    T: Clone + fmt::Debug + PartialEq + JsonSchema,
+    T: CustomMsg,
 {
     fn from(msg: DistributionMsg) -> Self {
         CosmosMsg::Distribution(msg)
@@ -241,7 +247,7 @@ where
 
 impl<T> From<WasmMsg> for CosmosMsg<T>
 where
-    T: Clone + fmt::Debug + PartialEq + JsonSchema,
+    T: CustomMsg,
 {
     fn from(msg: WasmMsg) -> Self {
         CosmosMsg::Wasm(msg)
@@ -251,7 +257,7 @@ where
 #[cfg(feature = "stargate")]
 impl<T> From<IbcMsg> for CosmosMsg<T>
 where
-    T: Clone + fmt::Debug + PartialEq + JsonSchema,
+    T: CustomMsg,
 {
     fn from(msg: IbcMsg) -> Self {
         CosmosMsg::Ibc(msg)
@@ -261,7 +267,7 @@ where
 #[cfg(feature = "stargate")]
 impl<T> From<GovMsg> for CosmosMsg<T>
 where
-    T: Clone + fmt::Debug + PartialEq + JsonSchema,
+    T: CustomMsg,
 {
     fn from(msg: GovMsg) -> Self {
         CosmosMsg::Gov(msg)

--- a/packages/std/src/results/mod.rs
+++ b/packages/std/src/results/mod.rs
@@ -10,7 +10,7 @@ mod submessages;
 mod system_result;
 
 pub use contract_result::ContractResult;
-pub use cosmos_msg::{wasm_execute, wasm_instantiate, BankMsg, CosmosMsg, WasmMsg};
+pub use cosmos_msg::{wasm_execute, wasm_instantiate, BankMsg, CosmosMsg, CustomMsg, WasmMsg};
 #[cfg(feature = "staking")]
 pub use cosmos_msg::{DistributionMsg, StakingMsg};
 #[cfg(feature = "stargate")]

--- a/packages/vm/src/calls.rs
+++ b/packages/vm/src/calls.rs
@@ -1,9 +1,7 @@
-use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
-use std::fmt;
 use wasmer::Val;
 
-use cosmwasm_std::{ContractResult, Env, MessageInfo, QueryResponse, Reply, Response};
+use cosmwasm_std::{ContractResult, CustomMsg, Env, MessageInfo, QueryResponse, Reply, Response};
 #[cfg(feature = "stargate")]
 use cosmwasm_std::{
     IbcBasicResponse, IbcChannelCloseMsg, IbcChannelConnectMsg, IbcChannelOpenMsg, IbcPacketAckMsg,
@@ -106,7 +104,7 @@ where
     A: BackendApi + 'static,
     S: Storage + 'static,
     Q: Querier + 'static,
-    U: DeserializeOwned + Clone + fmt::Debug + JsonSchema + PartialEq,
+    U: DeserializeOwned + CustomMsg,
 {
     let env = to_vec(env)?;
     let info = to_vec(info)?;
@@ -126,7 +124,7 @@ where
     A: BackendApi + 'static,
     S: Storage + 'static,
     Q: Querier + 'static,
-    U: DeserializeOwned + Clone + fmt::Debug + JsonSchema + PartialEq,
+    U: DeserializeOwned + CustomMsg,
 {
     let env = to_vec(env)?;
     let info = to_vec(info)?;
@@ -145,7 +143,7 @@ where
     A: BackendApi + 'static,
     S: Storage + 'static,
     Q: Querier + 'static,
-    U: DeserializeOwned + Clone + fmt::Debug + JsonSchema + PartialEq,
+    U: DeserializeOwned + CustomMsg,
 {
     let env = to_vec(env)?;
     let data = call_migrate_raw(instance, &env, msg)?;
@@ -163,7 +161,7 @@ where
     A: BackendApi + 'static,
     S: Storage + 'static,
     Q: Querier + 'static,
-    U: DeserializeOwned + Clone + fmt::Debug + JsonSchema + PartialEq,
+    U: DeserializeOwned + CustomMsg,
 {
     let env = to_vec(env)?;
     let data = call_sudo_raw(instance, &env, msg)?;
@@ -181,7 +179,7 @@ where
     A: BackendApi + 'static,
     S: Storage + 'static,
     Q: Querier + 'static,
-    U: DeserializeOwned + Clone + fmt::Debug + JsonSchema + PartialEq,
+    U: DeserializeOwned + CustomMsg,
 {
     let env = to_vec(env)?;
     let msg = to_vec(msg)?;
@@ -244,7 +242,7 @@ where
     A: BackendApi + 'static,
     S: Storage + 'static,
     Q: Querier + 'static,
-    U: DeserializeOwned + Clone + fmt::Debug + JsonSchema + PartialEq,
+    U: DeserializeOwned + CustomMsg,
 {
     let env = to_vec(env)?;
     let msg = to_vec(msg)?;
@@ -263,7 +261,7 @@ where
     A: BackendApi + 'static,
     S: Storage + 'static,
     Q: Querier + 'static,
-    U: DeserializeOwned + Clone + fmt::Debug + JsonSchema + PartialEq,
+    U: DeserializeOwned + CustomMsg,
 {
     let env = to_vec(env)?;
     let msg = to_vec(msg)?;
@@ -282,7 +280,7 @@ where
     A: BackendApi + 'static,
     S: Storage + 'static,
     Q: Querier + 'static,
-    U: DeserializeOwned + Clone + fmt::Debug + JsonSchema + PartialEq,
+    U: DeserializeOwned + CustomMsg,
 {
     let env = to_vec(env)?;
     let msg = to_vec(msg)?;
@@ -301,7 +299,7 @@ where
     A: BackendApi + 'static,
     S: Storage + 'static,
     Q: Querier + 'static,
-    U: DeserializeOwned + Clone + fmt::Debug + JsonSchema + PartialEq,
+    U: DeserializeOwned + CustomMsg,
 {
     let env = to_vec(env)?;
     let msg = to_vec(msg)?;
@@ -320,7 +318,7 @@ where
     A: BackendApi + 'static,
     S: Storage + 'static,
     Q: Querier + 'static,
-    U: DeserializeOwned + Clone + fmt::Debug + JsonSchema + PartialEq,
+    U: DeserializeOwned + CustomMsg,
 {
     let env = to_vec(env)?;
     let msg = to_vec(msg)?;

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -565,7 +565,7 @@ mod tests {
         // set up an instance that will experience an error in an import
         let error_message = "Api failed intentionally";
         let mut instance = mock_instance_with_failing_api(CONTRACT, &[], error_message);
-        let init_result = call_instantiate::<_, _, _, serde_json::Value>(
+        let init_result = call_instantiate::<_, _, _, Empty>(
             &mut instance,
             &mock_env(),
             &mock_info("someone", &[]),

--- a/packages/vm/src/testing/calls.rs
+++ b/packages/vm/src/testing/calls.rs
@@ -3,9 +3,8 @@
 //! use cosmwasm_vm::testing::X
 use schemars::JsonSchema;
 use serde::{de::DeserializeOwned, Serialize};
-use std::fmt;
 
-use cosmwasm_std::{ContractResult, Env, MessageInfo, QueryResponse, Reply, Response};
+use cosmwasm_std::{ContractResult, CustomMsg, Env, MessageInfo, QueryResponse, Reply, Response};
 #[cfg(feature = "stargate")]
 use cosmwasm_std::{
     IbcBasicResponse, IbcChannelCloseMsg, IbcChannelConnectMsg, IbcChannelOpenMsg, IbcPacketAckMsg,
@@ -38,7 +37,7 @@ where
     S: Storage + 'static,
     Q: Querier + 'static,
     M: Serialize + JsonSchema,
-    U: DeserializeOwned + Clone + PartialEq + JsonSchema + fmt::Debug,
+    U: DeserializeOwned + CustomMsg,
 {
     let serialized_msg = to_vec(&msg).expect("Testing error: Could not seralize request message");
     call_instantiate(instance, &env, &info, &serialized_msg).expect("VM error")
@@ -58,7 +57,7 @@ where
     S: Storage + 'static,
     Q: Querier + 'static,
     M: Serialize + JsonSchema,
-    U: DeserializeOwned + Clone + PartialEq + JsonSchema + fmt::Debug,
+    U: DeserializeOwned + CustomMsg,
 {
     let serialized_msg = to_vec(&msg).expect("Testing error: Could not seralize request message");
     call_execute(instance, &env, &info, &serialized_msg).expect("VM error")
@@ -77,7 +76,7 @@ where
     S: Storage + 'static,
     Q: Querier + 'static,
     M: Serialize + JsonSchema,
-    U: DeserializeOwned + Clone + PartialEq + JsonSchema + fmt::Debug,
+    U: DeserializeOwned + CustomMsg,
 {
     let serialized_msg = to_vec(&msg).expect("Testing error: Could not seralize request message");
     call_migrate(instance, &env, &serialized_msg).expect("VM error")
@@ -96,7 +95,7 @@ where
     S: Storage + 'static,
     Q: Querier + 'static,
     M: Serialize + JsonSchema,
-    U: DeserializeOwned + Clone + PartialEq + JsonSchema + fmt::Debug,
+    U: DeserializeOwned + CustomMsg,
 {
     let serialized_msg = to_vec(&msg).expect("Testing error: Could not seralize request message");
     call_sudo(instance, &env, &serialized_msg).expect("VM error")
@@ -114,7 +113,7 @@ where
     A: BackendApi + 'static,
     S: Storage + 'static,
     Q: Querier + 'static,
-    U: DeserializeOwned + Clone + PartialEq + JsonSchema + fmt::Debug,
+    U: DeserializeOwned + CustomMsg,
 {
     call_reply(instance, &env, &msg).expect("VM error")
 }
@@ -167,7 +166,7 @@ where
     A: BackendApi + 'static,
     S: Storage + 'static,
     Q: Querier + 'static,
-    U: DeserializeOwned + Clone + PartialEq + JsonSchema + fmt::Debug,
+    U: DeserializeOwned + CustomMsg,
 {
     call_ibc_channel_connect(instance, &env, &msg).expect("VM error")
 }
@@ -185,7 +184,7 @@ where
     A: BackendApi + 'static,
     S: Storage + 'static,
     Q: Querier + 'static,
-    U: DeserializeOwned + Clone + PartialEq + JsonSchema + fmt::Debug,
+    U: DeserializeOwned + CustomMsg,
 {
     call_ibc_channel_close(instance, &env, &msg).expect("VM error")
 }
@@ -203,7 +202,7 @@ where
     A: BackendApi + 'static,
     S: Storage + 'static,
     Q: Querier + 'static,
-    U: DeserializeOwned + Clone + PartialEq + JsonSchema + fmt::Debug,
+    U: DeserializeOwned + CustomMsg,
 {
     call_ibc_packet_receive(instance, &env, &msg).expect("VM error")
 }
@@ -221,7 +220,7 @@ where
     A: BackendApi + 'static,
     S: Storage + 'static,
     Q: Querier + 'static,
-    U: DeserializeOwned + Clone + PartialEq + JsonSchema + fmt::Debug,
+    U: DeserializeOwned + CustomMsg,
 {
     call_ibc_packet_ack(instance, &env, &msg).expect("VM error")
 }
@@ -239,7 +238,7 @@ where
     A: BackendApi + 'static,
     S: Storage + 'static,
     Q: Querier + 'static,
-    U: DeserializeOwned + Clone + PartialEq + JsonSchema + fmt::Debug,
+    U: DeserializeOwned + CustomMsg,
 {
     call_ibc_packet_timeout(instance, &env, &msg).expect("VM error")
 }


### PR DESCRIPTION
We already have a `CustomQuery` trait, this takes a similar approach for `CustomMsg`, which was `T: Clone + fmt::Debug + PartialEq + JsonSchema` all over the code.

Even if we will need it fewer places now that the struct bound is gone, I figured it is nice to have a helper trait to combine all these requirements. 

Furthermore, since almost all structs (messages, query, state) fulfil those trait bounds, it is nice to explicitly mark one as a `CustomMsg`. These occur very rarely. Outside of cosmwasm tests, there will be one such type per blockchain that makes extensions. I am sure one line to implement this trait for that type is worth the type-safety and reduced verbosity other places. 