### PR TITLE
Make pair extensible 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to
 
 ### Changed
 
-- cosmwasm-std: Make `Pair` generic over both `K` and `V` (breaking; [#1100]).
+- cosmwasm-std: Make `Pair` generic over both `K` and `V` (breaking; [#1100]: https://github.com/CosmWasm/cosmwasm/issues/1100).
 - cosmwasm-std: Make `iterator` a required feature if the `iterator` feature
   flag is set (enabled by default).
 - cosmwasm-vm: Increase `MAX_LENGTH_HUMAN_ADDRESS` from 90 to 256 in order to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to
 
 ### Changed
 
+- cosmwasm-std: Make `Pair` generic over both `K` and `V` (breaking; [#1100]).
 - cosmwasm-std: Make `iterator` a required feature if the `iterator` feature
   flag is set (enabled by default).
 - cosmwasm-vm: Increase `MAX_LENGTH_HUMAN_ADDRESS` from 90 to 256 in order to

--- a/packages/std/src/iterator.rs
+++ b/packages/std/src/iterator.rs
@@ -34,8 +34,7 @@ mod test {
     use super::Pair;
 
     #[test]
-    // Generic K works
-    fn pair_works() {
+    fn pair_works_with_generic_types() {
         let _default: Pair = (vec![1, 2, 3], vec![5]);
         let _value: Pair<u64> = (1234567890, vec![4, 3]);
         let _with_key: Pair<String, u64> = ("hello".to_owned(), 12345678);

--- a/packages/std/src/iterator.rs
+++ b/packages/std/src/iterator.rs
@@ -1,9 +1,8 @@
 use crate::errors::StdError;
 use std::convert::TryFrom;
 
-/// A Key-Value pair, returned from our iterators
-/// (since it is less common to use, and never used with default V, we place K second)
-pub type Pair<K = Vec<u8>, V = Vec<u8>> = (K, V);
+/// A pair of values, returned from our iterators
+pub type Pair<A = Vec<u8>, B = Vec<u8>> = (A, B);
 
 #[derive(Copy, Clone)]
 // We assign these to integers to provide a stable API for passing over FFI (to wasm and Go)

--- a/packages/std/src/iterator.rs
+++ b/packages/std/src/iterator.rs
@@ -3,7 +3,7 @@ use std::convert::TryFrom;
 
 /// A Key-Value pair, returned from our iterators
 /// (since it is less common to use, and never used with default V, we place K second)
-pub type Pair<V = Vec<u8>, K = Vec<u8>> = (K, V);
+pub type Pair<K = Vec<u8>, V = Vec<u8>> = (K, V);
 
 #[derive(Copy, Clone)]
 // We assign these to integers to provide a stable API for passing over FFI (to wasm and Go)
@@ -35,10 +35,10 @@ mod test {
     use super::Pair;
 
     #[test]
-    // make sure we add generic K without breaking existing code
-    fn ensure_pair_backwards_compatible() {
+    // Generic K works
+    fn pair_works() {
         let _default: Pair = (vec![1, 2, 3], vec![5]);
-        let _value: Pair<u64> = (vec![4, 3], 1234567890);
-        let _with_key: Pair<u64, String> = ("hello".to_owned(), 12345678);
+        let _value: Pair<u64> = (1234567890, vec![4, 3]);
+        let _with_key: Pair<String, u64> = ("hello".to_owned(), 12345678);
     }
 }

--- a/packages/std/src/iterator.rs
+++ b/packages/std/src/iterator.rs
@@ -2,7 +2,8 @@ use crate::errors::StdError;
 use std::convert::TryFrom;
 
 /// A Key-Value pair, returned from our iterators
-pub type Pair<V = Vec<u8>> = (Vec<u8>, V);
+/// (since it is less common to use, and never used with default V, we place K second)
+pub type Pair<V = Vec<u8>, K = Vec<u8>> = (K, V);
 
 #[derive(Copy, Clone)]
 // We assign these to integers to provide a stable API for passing over FFI (to wasm and Go)
@@ -26,5 +27,18 @@ impl TryFrom<i32> for Order {
 impl From<Order> for i32 {
     fn from(original: Order) -> i32 {
         original as _
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::Pair;
+
+    #[test]
+    // make sure we add generic K without breaking existing code
+    fn ensure_pair_backwards_compatible() {
+        let _default: Pair = (vec![1, 2, 3], vec![5]);
+        let _value: Pair<u64> = (vec![4, 3], 1234567890);
+        let _with_key: Pair<u64, String> = ("hello".to_owned(), 12345678);
     }
 }

--- a/packages/std/src/storage.rs
+++ b/packages/std/src/storage.rs
@@ -101,7 +101,7 @@ fn range_bounds(start: Option<&[u8]>, end: Option<&[u8]>) -> impl RangeBounds<Ve
 type BTreeMapPairRef<'a, T = Vec<u8>> = (&'a Vec<u8>, &'a T);
 
 #[cfg(feature = "iterator")]
-fn clone_item<T: Clone>(item_ref: BTreeMapPairRef<T>) -> Pair<T> {
+fn clone_item<T: Clone>(item_ref: BTreeMapPairRef<T>) -> Pair<Vec<u8>, T> {
     let (key, value) = item_ref;
     (key.clone(), value.clone())
 }

--- a/packages/storage/src/bucket.rs
+++ b/packages/storage/src/bucket.rs
@@ -88,7 +88,7 @@ where
         start: Option<&[u8]>,
         end: Option<&[u8]>,
         order: Order,
-    ) -> Box<dyn Iterator<Item = StdResult<Pair<T>>> + 'b> {
+    ) -> Box<dyn Iterator<Item = StdResult<Pair<Vec<u8>, T>>> + 'b> {
         let mapped = range_with_prefix(self.storage, &self.prefix, start, end, order)
             .map(deserialize_kv::<T>);
         Box::new(mapped)
@@ -159,7 +159,7 @@ where
         start: Option<&[u8]>,
         end: Option<&[u8]>,
         order: Order,
-    ) -> Box<dyn Iterator<Item = StdResult<Pair<T>>> + 'b> {
+    ) -> Box<dyn Iterator<Item = StdResult<Pair<Vec<u8>, T>>> + 'b> {
         let mapped = range_with_prefix(self.storage, &self.prefix, start, end, order)
             .map(deserialize_kv::<T>);
         Box::new(mapped)
@@ -441,7 +441,7 @@ mod tests {
         bucket.save(b"maria", &maria).unwrap();
         bucket.save(b"jose", &jose).unwrap();
 
-        let res_data: StdResult<Vec<Pair<Data>>> =
+        let res_data: StdResult<Vec<Pair<Vec<u8>, Data>>> =
             bucket.range(None, None, Order::Ascending).collect();
         let data = res_data.unwrap();
         assert_eq!(data.len(), 2);
@@ -450,7 +450,7 @@ mod tests {
 
         // also works for readonly
         let read_bucket = bucket_read::<Data>(&store, b"data");
-        let res_data: StdResult<Vec<Pair<Data>>> =
+        let res_data: StdResult<Vec<Pair<Vec<u8>, Data>>> =
             read_bucket.range(None, None, Order::Ascending).collect();
         let data = res_data.unwrap();
         assert_eq!(data.len(), 2);

--- a/packages/storage/src/type_helpers.rs
+++ b/packages/storage/src/type_helpers.rs
@@ -27,7 +27,7 @@ pub(crate) fn must_deserialize<T: DeserializeOwned>(value: &Option<Vec<u8>>) -> 
 }
 
 #[cfg(feature = "iterator")]
-pub(crate) fn deserialize_kv<T: DeserializeOwned>(kv: Pair<Vec<u8>>) -> StdResult<Pair<T>> {
+pub(crate) fn deserialize_kv<T: DeserializeOwned>(kv: Pair) -> StdResult<Pair<Vec<u8>, T>> {
     let (k, v) = kv;
     let t = from_slice::<T>(&v)?;
     Ok((k, t))

--- a/packages/vm/src/testing/storage.rs
+++ b/packages/vm/src/testing/storage.rs
@@ -153,7 +153,7 @@ fn range_bounds(start: Option<&[u8]>, end: Option<&[u8]>) -> impl RangeBounds<Ve
 type BTreeMapPairRef<'a, T = Vec<u8>> = (&'a Vec<u8>, &'a T);
 
 #[cfg(feature = "iterator")]
-fn clone_item<T: Clone>(item_ref: BTreeMapPairRef<T>) -> Pair<T> {
+fn clone_item<T: Clone>(item_ref: BTreeMapPairRef<T>) -> Pair<Vec<u8>, T> {
     let (key, value) = item_ref;
     (key.clone(), value.clone())
 }


### PR DESCRIPTION
This is a (breaking) version of `Pair`, which supports the natural order of fields. Closes #1100.