### PR TITLE
Remove balance argument from mock_dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to
 ### Changed
 
 - all: Drop support for Rust versions lower than 1.53.0.
+- cosmwasm-std: The balance argument from `mock_dependencies` was removed.
+  Remove `&[]` if you don't need a contract balance or use the new
+  `mock_dependencies_with_balance` if you need a balance.
 
 ### Removed
 

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -9,6 +9,30 @@ major releases of `cosmwasm`. Note that you can also view the
 - The minimum Rust supported version is 1.53.0. Verify your Rust version is >=
   1.53.0 with: `rustc --version`.
 
+- Simplify `mock_dependencies` calls with empty balance:
+
+  ```diff
+       #[test]
+       fn instantiate_fails() {
+  -        let mut deps = mock_dependencies(&[]);
+  +        let mut deps = mock_dependencies();
+
+           let msg = InstantiateMsg {};
+           let info = mock_info("creator", &coins(1000, "earth"));
+  ```
+
+  Or use the new `mock_dependencies_with_balance` if you need a balance:
+
+  ```diff
+       #[test]
+       fn migrate_cleans_up_data() {
+  -        let mut deps = mock_dependencies(&coins(123456, "gold"));
+  +        let mut deps = mock_dependencies_with_balance(&coins(123456, "gold"));
+
+           // store some sample data
+           deps.storage.set(b"foo", b"bar");
+  ```
+
 ## 0.16 -> 1.0.0-beta
 
 - Update CosmWasm dependencies in Cargo.toml (skip the ones you don't use):

--- a/contracts/burner/src/contract.rs
+++ b/contracts/burner/src/contract.rs
@@ -48,12 +48,14 @@ pub fn migrate(deps: DepsMut, env: Env, msg: MigrateMsg) -> StdResult<Response> 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
+    use cosmwasm_std::testing::{
+        mock_dependencies, mock_dependencies_with_balance, mock_env, mock_info,
+    };
     use cosmwasm_std::{coins, StdError, Storage, SubMsg};
 
     #[test]
     fn instantiate_fails() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
 
         let msg = InstantiateMsg {};
         let info = mock_info("creator", &coins(1000, "earth"));
@@ -69,7 +71,7 @@ mod tests {
 
     #[test]
     fn migrate_cleans_up_data() {
-        let mut deps = mock_dependencies(&coins(123456, "gold"));
+        let mut deps = mock_dependencies_with_balance(&coins(123456, "gold"));
 
         // store some sample data
         deps.storage.set(b"foo", b"bar");

--- a/contracts/crypto-verify/src/contract.rs
+++ b/contracts/crypto-verify/src/contract.rs
@@ -246,7 +246,7 @@ mod tests {
         "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c";
 
     fn setup() -> OwnedDeps<MockStorage, MockApi, MockQuerier> {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         let msg = InstantiateMsg {};
         let info = mock_info(CREATOR, &[]);
         let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();

--- a/contracts/floaty/src/contract.rs
+++ b/contracts/floaty/src/contract.rs
@@ -131,7 +131,7 @@ mod tests {
 
     #[test]
     fn proper_initialization() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
 
         let verifier = String::from("verifies");
         let beneficiary = String::from("benefits");
@@ -161,7 +161,7 @@ mod tests {
 
     #[test]
     fn instantiate_and_query() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
 
         let verifier = String::from("verifies");
         let beneficiary = String::from("benefits");
@@ -196,7 +196,7 @@ mod tests {
 
     #[test]
     fn execute_release_works() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
 
         // initialize the store
         let creator = String::from("creator");
@@ -246,7 +246,7 @@ mod tests {
 
     #[test]
     fn execute_release_fails_for_wrong_sender() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
 
         // initialize the store
         let creator = String::from("creator");
@@ -293,7 +293,7 @@ mod tests {
         // the test framework doesn't handle contracts querying contracts yet,
         // let's just make sure the last step looks right
 
-        let deps = mock_dependencies(&[]);
+        let deps = mock_dependencies();
         let contract = Addr::unchecked("my-contract");
         let bin_contract: &[u8] = b"my-contract";
 

--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -314,7 +314,7 @@ mod tests {
 
     #[test]
     fn proper_initialization() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
 
         let verifier = String::from("verifies");
         let beneficiary = String::from("benefits");
@@ -342,7 +342,7 @@ mod tests {
 
     #[test]
     fn instantiate_and_query() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
 
         let verifier = String::from("verifies");
         let beneficiary = String::from("benefits");
@@ -362,7 +362,7 @@ mod tests {
 
     #[test]
     fn migrate_verifier() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
 
         let verifier = String::from("verifies");
         let beneficiary = String::from("benefits");
@@ -394,7 +394,7 @@ mod tests {
 
     #[test]
     fn sudo_can_steal_tokens() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
 
         let verifier = String::from("verifies");
         let beneficiary = String::from("benefits");
@@ -437,7 +437,7 @@ mod tests {
 
     #[test]
     fn execute_release_works() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
 
         // initialize the store
         let creator = String::from("creator");
@@ -483,7 +483,7 @@ mod tests {
 
     #[test]
     fn execute_release_fails_for_wrong_sender() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
 
         // initialize the store
         let creator = String::from("creator");
@@ -528,7 +528,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "This page intentionally faulted")]
     fn execute_panic() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
 
         // initialize the store
         let verifier = String::from("verifies");
@@ -555,7 +555,7 @@ mod tests {
 
     #[test]
     fn execute_user_errors_in_api_calls() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
 
         let instantiate_msg = InstantiateMsg {
             verifier: String::from("verifies"),
@@ -580,7 +580,7 @@ mod tests {
         // the test framework doesn't handle contracts querying contracts yet,
         // let's just make sure the last step looks right
 
-        let deps = mock_dependencies(&[]);
+        let deps = mock_dependencies();
         let contract = Addr::unchecked("my-contract");
         let bin_contract: &[u8] = b"my-contract";
 

--- a/contracts/ibc-reflect-send/src/contract.rs
+++ b/contracts/ibc-reflect-send/src/contract.rs
@@ -209,7 +209,7 @@ mod tests {
 
     #[test]
     fn instantiate_works() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         let msg = InstantiateMsg {};
         let info = mock_info(CREATOR, &[]);
         let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();

--- a/contracts/ibc-reflect-send/src/ibc.rs
+++ b/contracts/ibc-reflect-send/src/ibc.rs
@@ -238,7 +238,7 @@ mod tests {
     const CREATOR: &str = "creator";
 
     fn setup() -> OwnedDeps<MockStorage, MockApi, MockQuerier> {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         let msg = InstantiateMsg {};
         let info = mock_info(CREATOR, &[]);
         let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();

--- a/contracts/ibc-reflect/src/contract.rs
+++ b/contracts/ibc-reflect/src/contract.rs
@@ -344,7 +344,7 @@ mod tests {
     const REFLECT_ADDR: &str = "reflect-acct-1";
 
     fn setup() -> OwnedDeps<MockStorage, MockApi, MockQuerier> {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         let msg = InstantiateMsg {
             reflect_code_id: REFLECT_ID,
         };
@@ -397,7 +397,7 @@ mod tests {
 
     #[test]
     fn instantiate_works() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
 
         let msg = InstantiateMsg {
             reflect_code_id: 17,

--- a/contracts/queue/src/contract.rs
+++ b/contracts/queue/src/contract.rs
@@ -221,12 +221,12 @@ fn query_list(deps: Deps) -> ListResponse {
 mod tests {
     use super::*;
     use cosmwasm_std::testing::{
-        mock_dependencies, mock_env, mock_info, MockApi, MockQuerier, MockStorage,
+        mock_dependencies_with_balance, mock_env, mock_info, MockApi, MockQuerier, MockStorage,
     };
     use cosmwasm_std::{coins, from_binary, OwnedDeps};
 
     fn create_contract() -> (OwnedDeps<MockStorage, MockApi, MockQuerier>, MessageInfo) {
-        let mut deps = mock_dependencies(&coins(1000, "earth"));
+        let mut deps = mock_dependencies_with_balance(&coins(1000, "earth"));
         let info = mock_info("creator", &coins(1000, "earth"));
         let res = instantiate(deps.as_mut(), mock_env(), info.clone(), InstantiateMsg {}).unwrap();
         assert_eq!(0, res.messages.len());

--- a/contracts/staking/src/contract.rs
+++ b/contracts/staking/src/contract.rs
@@ -469,7 +469,7 @@ mod tests {
 
     #[test]
     fn initialization_with_missing_validator() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         deps.querier
             .update_staking("ustake", &[sample_validator("john")], &[]);
 
@@ -496,7 +496,7 @@ mod tests {
 
     #[test]
     fn proper_initialization() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         deps.querier.update_staking(
             "ustake",
             &[
@@ -547,7 +547,7 @@ mod tests {
 
     #[test]
     fn bonding_issues_tokens() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         set_validator(&mut deps.querier);
 
         let creator = String::from("creator");
@@ -587,7 +587,7 @@ mod tests {
 
     #[test]
     fn rebonding_changes_pricing() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         set_validator(&mut deps.querier);
 
         let creator = String::from("creator");
@@ -646,7 +646,7 @@ mod tests {
 
     #[test]
     fn bonding_fails_with_wrong_denom() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         set_validator(&mut deps.querier);
 
         let creator = String::from("creator");
@@ -674,7 +674,7 @@ mod tests {
 
     #[test]
     fn unbonding_maintains_price_ratio() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         set_validator(&mut deps.querier);
 
         let creator = String::from("creator");

--- a/packages/std/src/deps.rs
+++ b/packages/std/src/deps.rs
@@ -93,7 +93,7 @@ mod tests {
 
     #[test]
     fn ensure_easy_reuse() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         execute(deps.as_mut());
         query(deps.as_ref())
     }

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -101,9 +101,10 @@ pub mod testing {
     #[cfg(feature = "staking")]
     pub use crate::mock::StakingQuerier;
     pub use crate::mock::{
-        digit_sum, mock_dependencies, mock_dependencies_with_balances, mock_env, mock_info,
-        mock_wasmd_attr, riffle_shuffle, BankQuerier, MockApi, MockQuerier,
-        MockQuerierCustomHandlerResult, MockStorage, MOCK_CONTRACT_ADDR,
+        digit_sum, mock_dependencies, mock_dependencies_with_balance,
+        mock_dependencies_with_balances, mock_env, mock_info, mock_wasmd_attr, riffle_shuffle,
+        BankQuerier, MockApi, MockQuerier, MockQuerierCustomHandlerResult, MockStorage,
+        MOCK_CONTRACT_ADDR,
     };
     #[cfg(feature = "stargate")]
     pub use crate::mock::{

--- a/packages/std/src/mock.rs
+++ b/packages/std/src/mock.rs
@@ -33,21 +33,30 @@ use crate::Attribute;
 
 pub const MOCK_CONTRACT_ADDR: &str = "cosmos2contract";
 
-/// All external requirements that can be injected for unit tests.
-/// It sets the given balance for the contract itself, nothing else
-pub fn mock_dependencies(
-    contract_balance: &[Coin],
-) -> OwnedDeps<MockStorage, MockApi, MockQuerier, Empty> {
+/// Creates all external requirements that can be injected for unit tests.
+///
+/// See also [`mock_dependencies_with_balance`] and [`mock_dependencies_with_balances`]
+/// if you want to start with some initial balances.
+pub fn mock_dependencies() -> OwnedDeps<MockStorage, MockApi, MockQuerier, Empty> {
     OwnedDeps {
         storage: MockStorage::default(),
         api: MockApi::default(),
-        querier: MockQuerier::new(&[(MOCK_CONTRACT_ADDR, contract_balance)]),
+        querier: MockQuerier::default(),
         custom_query_type: PhantomData,
     }
 }
 
+/// Creates all external requirements that can be injected for unit tests.
+///
+/// It sets the given balance for the contract itself, nothing else.
+pub fn mock_dependencies_with_balance(
+    contract_balance: &[Coin],
+) -> OwnedDeps<MockStorage, MockApi, MockQuerier, Empty> {
+    mock_dependencies_with_balances(&[(MOCK_CONTRACT_ADDR, contract_balance)])
+}
+
 /// Initializes the querier along with the mock_dependencies.
-/// Sets all balances provided (yoy must explicitly set contract balance if desired)
+/// Sets all balances provided (you must explicitly set contract balance if desired).
 pub fn mock_dependencies_with_balances(
     balances: &[(&str, &[Coin])],
 ) -> OwnedDeps<MockStorage, MockApi, MockQuerier> {
@@ -439,6 +448,12 @@ impl<C: DeserializeOwned> MockQuerier<C> {
     {
         self.custom_handler = Box::from(handler);
         self
+    }
+}
+
+impl Default for MockQuerier {
+    fn default() -> Self {
+        MockQuerier::new(&[])
     }
 }
 


### PR DESCRIPTION
This PR goes hand in hand with #1137 which both reduce the dominance of the bank querier in unit testing. Looking at the diff you see that a lot of `&[]` can be avoided this way.

`MockQuerier::default()` is vary natural now. A querier that sets all sub-queriers to their default.