### PR TITLE
Mark more Uint128, Uint64 and Decimal operations as const

### DIFF
--- a/packages/std/src/math/decimal.rs
+++ b/packages/std/src/math/decimal.rs
@@ -42,13 +42,13 @@ impl Decimal {
     }
 
     /// Convert x% into Decimal
-    pub fn percent(x: u64) -> Self {
-        Decimal(((x as u128) * 10_000_000_000_000_000).into())
+    pub const fn percent(x: u64) -> Self {
+        Decimal(Uint128::new((x as u128) * 10_000_000_000_000_000))
     }
 
     /// Convert permille (x/1000) into Decimal
-    pub fn permille(x: u64) -> Self {
-        Decimal(((x as u128) * 1_000_000_000_000_000).into())
+    pub const fn permille(x: u64) -> Self {
+        Decimal(Uint128::new((x as u128) * 1_000_000_000_000_000))
     }
 
     /// Creates a decimal from a number of atomic units and the number
@@ -117,7 +117,7 @@ impl Decimal {
         )
     }
 
-    pub fn is_zero(&self) -> bool {
+    pub const fn is_zero(&self) -> bool {
         self.0.is_zero()
     }
 
@@ -139,7 +139,7 @@ impl Decimal {
     /// assert_eq!(b.decimal_places(), 18);
     /// assert_eq!(b.atomics(), Uint128::new(1));
     /// ```
-    pub fn atomics(&self) -> Uint128 {
+    pub const fn atomics(&self) -> Uint128 {
         self.0
     }
 
@@ -147,7 +147,7 @@ impl Decimal {
     /// but this could potentially change as the type evolves.
     ///
     /// See also [`Decimal::atomics()`].
-    pub fn decimal_places(&self) -> u32 {
+    pub const fn decimal_places(&self) -> u32 {
         Self::DECIMAL_PLACES as u32
     }
 

--- a/packages/std/src/math/uint128.rs
+++ b/packages/std/src/math/uint128.rs
@@ -61,7 +61,7 @@ impl Uint128 {
         self.0.to_le_bytes()
     }
 
-    pub fn is_zero(&self) -> bool {
+    pub const fn is_zero(&self) -> bool {
         self.0 == 0
     }
 
@@ -114,35 +114,35 @@ impl Uint128 {
             .ok_or_else(|| DivideByZeroError::new(self))
     }
 
-    pub fn wrapping_add(self, other: Self) -> Self {
+    pub const fn wrapping_add(self, other: Self) -> Self {
         Self(self.0.wrapping_add(other.0))
     }
 
-    pub fn wrapping_sub(self, other: Self) -> Self {
+    pub const fn wrapping_sub(self, other: Self) -> Self {
         Self(self.0.wrapping_sub(other.0))
     }
 
-    pub fn wrapping_mul(self, other: Self) -> Self {
+    pub const fn wrapping_mul(self, other: Self) -> Self {
         Self(self.0.wrapping_mul(other.0))
     }
 
-    pub fn wrapping_pow(self, other: u32) -> Self {
+    pub const fn wrapping_pow(self, other: u32) -> Self {
         Self(self.0.wrapping_pow(other))
     }
 
-    pub fn saturating_add(self, other: Self) -> Self {
+    pub const fn saturating_add(self, other: Self) -> Self {
         Self(self.0.saturating_add(other.0))
     }
 
-    pub fn saturating_sub(self, other: Self) -> Self {
+    pub const fn saturating_sub(self, other: Self) -> Self {
         Self(self.0.saturating_sub(other.0))
     }
 
-    pub fn saturating_mul(self, other: Self) -> Self {
+    pub const fn saturating_mul(self, other: Self) -> Self {
         Self(self.0.saturating_mul(other.0))
     }
 
-    pub fn saturating_pow(self, other: u32) -> Self {
+    pub const fn saturating_pow(self, other: u32) -> Self {
         Self(self.0.saturating_pow(other))
     }
 }

--- a/packages/std/src/math/uint64.rs
+++ b/packages/std/src/math/uint64.rs
@@ -57,7 +57,7 @@ impl Uint64 {
         self.0.to_le_bytes()
     }
 
-    pub fn is_zero(&self) -> bool {
+    pub const fn is_zero(&self) -> bool {
         self.0 == 0
     }
 
@@ -103,35 +103,35 @@ impl Uint64 {
             .ok_or_else(|| DivideByZeroError::new(self))
     }
 
-    pub fn wrapping_add(self, other: Self) -> Self {
+    pub const fn wrapping_add(self, other: Self) -> Self {
         Self(self.0.wrapping_add(other.0))
     }
 
-    pub fn wrapping_sub(self, other: Self) -> Self {
+    pub const fn wrapping_sub(self, other: Self) -> Self {
         Self(self.0.wrapping_sub(other.0))
     }
 
-    pub fn wrapping_mul(self, other: Self) -> Self {
+    pub const fn wrapping_mul(self, other: Self) -> Self {
         Self(self.0.wrapping_mul(other.0))
     }
 
-    pub fn wrapping_pow(self, other: u32) -> Self {
+    pub const fn wrapping_pow(self, other: u32) -> Self {
         Self(self.0.wrapping_pow(other))
     }
 
-    pub fn saturating_add(self, other: Self) -> Self {
+    pub const fn saturating_add(self, other: Self) -> Self {
         Self(self.0.saturating_add(other.0))
     }
 
-    pub fn saturating_sub(self, other: Self) -> Self {
+    pub const fn saturating_sub(self, other: Self) -> Self {
         Self(self.0.saturating_sub(other.0))
     }
 
-    pub fn saturating_mul(self, other: Self) -> Self {
+    pub const fn saturating_mul(self, other: Self) -> Self {
         Self(self.0.saturating_mul(other.0))
     }
 
-    pub fn saturating_pow(self, other: u32) -> Self {
+    pub const fn saturating_pow(self, other: u32) -> Self {
         Self(self.0.saturating_pow(other))
     }
 }


### PR DESCRIPTION
I also tried making `checked_` operations const (so I could make `from_atomics` const), but they return `OverflowError` which takes values via the `ToString` bound.

That seems like a of waste of gas, maybe we should type them `OverflowError<T>` and take the underlying value without calling `to_string()`? Better yet would be simply returning `Option` from `checked_` operations which would line up with behavior in the standard library.