### PR TITLE
Get instance multi threaded benchmark

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,7 @@ workflows:
                 - cache-analyze
                 - fix-benches
                 - benchmark_argon2
+                - get_instance-multi-threaded-benchmark
       - coverage
   deploy:
     jobs:

--- a/packages/vm/Cargo.toml
+++ b/packages/vm/Cargo.toml
@@ -56,7 +56,7 @@ loupe = "0.1.3"
 # wasmer-middlewares = { path = "../../../wasmer/lib/middlewares" }
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = { version = "0.3", features = [ "html_reports" ] }
 hex-literal = "0.3.1"
 tempfile = "3.1.0"
 wat = "1.0"

--- a/packages/vm/benches/main.rs
+++ b/packages/vm/benches/main.rs
@@ -265,10 +265,6 @@ pub fn bench_instance_threads(c: &mut Criterion) {
                     .map(|handle| handle.join().unwrap())
                     .collect(); // join threads, collect durations
 
-                // Calculate max thread duration
-                //res += *durations.iter().max().unwrap();
-                // Calculate mean thread duration
-                //res += durations.iter().sum::<Duration>() / durations.len() as u32;
                 // Calculate median thread duration
                 durations.sort_unstable();
                 res += durations[durations.len() / 2];

--- a/packages/vm/benches/main.rs
+++ b/packages/vm/benches/main.rs
@@ -223,6 +223,7 @@ fn make_config() -> Criterion {
         .without_plots()
         .measurement_time(Duration::new(10, 0))
         .sample_size(12)
+        .configure_from_args()
 }
 
 criterion_group!(

--- a/packages/vm/benches/main.rs
+++ b/packages/vm/benches/main.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Criterion, PlottingBackend};
+use criterion::{criterion_group, criterion_main, Criterion};
 use std::time::Duration;
 use tempfile::TempDir;
 
@@ -219,7 +219,6 @@ fn bench_cache(c: &mut Criterion) {
 
 fn make_config() -> Criterion {
     Criterion::default()
-        .plotting_backend(PlottingBackend::Plotters)
         .without_plots()
         .measurement_time(Duration::new(10, 0))
         .sample_size(12)

--- a/packages/vm/benches/main.rs
+++ b/packages/vm/benches/main.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use std::time::{Duration, SystemTime};
 use tempfile::TempDir;
 
@@ -248,13 +248,15 @@ pub fn bench_instance_threads(c: &mut Criterion) {
                             let checksum = checksum;
                             // Perform measurement internally
                             let t = SystemTime::now();
-                            let _instance = cache
-                                .get_instance(
-                                    &checksum,
-                                    mock_backend(&[]),
-                                    DEFAULT_INSTANCE_OPTIONS,
-                                )
-                                .unwrap();
+                            black_box(
+                                cache
+                                    .get_instance(
+                                        &checksum,
+                                        mock_backend(&[]),
+                                        DEFAULT_INSTANCE_OPTIONS,
+                                    )
+                                    .unwrap(),
+                            );
                             t.elapsed().unwrap()
                         })
                     })

--- a/packages/vm/benches/main.rs
+++ b/packages/vm/benches/main.rs
@@ -296,7 +296,7 @@ criterion_group!(
     name = multi_threaded_instance;
     config = Criterion::default()
         .without_plots()
-        .measurement_time(Duration::new(15, 0))
+        .measurement_time(Duration::new(16, 0))
         .sample_size(10)
         .configure_from_args();
     targets = bench_instance_threads


### PR DESCRIPTION
Adds a benchmark of multi-threaded  `get_instance` calls.

After #1159, we needed a way to compare performance of both approachs to `get_instance` locking.

Surprisingly, the current approach seems significantly more performant than the new one (~60 ms vs. ~240 ms median values of lock contention, for 1024 threads calling `get_instance`).
This is in line with the findings mentioned in https://github.com/CosmWasm/cosmwasm/pull/1159#issuecomment-977559289.

Possible explanations I've come up with so far:

- We are both making a mistake when implementing this (possible but unlikely).
- Locking on the outside of `from_module` eliminates the need for locking on the inside of `from_module`. And that increases performance.
- The current approach at locking is benefitting the cache hits somehow.
