### PR TITLE
Move cache mutex up to `get_instance` context

### DIFF
--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -16,6 +16,8 @@ use crate::size::Size;
 use crate::static_analysis::{deserialize_wasm, has_ibc_entry_points};
 use crate::wasm_backend::{compile, make_runtime_store};
 
+pub(crate) type Lock = Mutex<()>;
+
 const STATE_DIR: &str = "state";
 // Things related to the state of the blockchain.
 const WASM_DIR: &str = "wasm";
@@ -72,7 +74,7 @@ pub struct Cache<A: BackendApi, S: Storage, Q: Querier> {
     type_storage: PhantomData<S>,
     type_querier: PhantomData<Q>,
     /// To prevent concurrent access to `WasmerInstance::new`
-    instantiation_lock: Mutex<()>,
+    instantiation_lock: Lock,
 }
 
 #[derive(PartialEq, Debug)]
@@ -133,7 +135,7 @@ where
             type_storage: PhantomData::<S>,
             type_api: PhantomData::<A>,
             type_querier: PhantomData::<Q>,
-            instantiation_lock: Mutex::new(()),
+            instantiation_lock: Lock::new(()),
         })
     }
 

--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -16,8 +16,6 @@ use crate::size::Size;
 use crate::static_analysis::{deserialize_wasm, has_ibc_entry_points};
 use crate::wasm_backend::{compile, make_runtime_store};
 
-pub(crate) type Lock = Mutex<()>;
-
 const STATE_DIR: &str = "state";
 // Things related to the state of the blockchain.
 const WASM_DIR: &str = "wasm";
@@ -74,7 +72,7 @@ pub struct Cache<A: BackendApi, S: Storage, Q: Querier> {
     type_storage: PhantomData<S>,
     type_querier: PhantomData<Q>,
     /// To prevent concurrent access to `WasmerInstance::new`
-    instantiation_lock: Lock,
+    instantiation_lock: Mutex<()>,
 }
 
 #[derive(PartialEq, Debug)]
@@ -135,7 +133,7 @@ where
             type_storage: PhantomData::<S>,
             type_api: PhantomData::<A>,
             type_querier: PhantomData::<Q>,
-            instantiation_lock: Lock::new(()),
+            instantiation_lock: Mutex::new(()),
         })
     }
 

--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -71,7 +71,8 @@ pub struct Cache<A: BackendApi, S: Storage, Q: Querier> {
     type_api: PhantomData<A>,
     type_storage: PhantomData<S>,
     type_querier: PhantomData<Q>,
-    m: Mutex<()>,
+    /// To prevent concurrent access to `WasmerInstance::new`
+    instantiation_lock: Mutex<()>,
 }
 
 #[derive(PartialEq, Debug)]
@@ -132,7 +133,7 @@ where
             type_storage: PhantomData::<S>,
             type_api: PhantomData::<A>,
             type_querier: PhantomData::<Q>,
-            m: Mutex::new(()),
+            instantiation_lock: Mutex::new(()),
         })
     }
 
@@ -263,7 +264,7 @@ where
             options.gas_limit,
             options.print_debug,
             None,
-            Some(&self.m),
+            Some(&self.instantiation_lock),
         )?;
         Ok(instance)
     }

--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -3,7 +3,7 @@ use std::fs::{create_dir_all, File, OpenOptions};
 use std::io::{Read, Write};
 use std::marker::PhantomData;
 use std::path::{Path, PathBuf};
-use std::sync::{Mutex, MutexGuard};
+use std::sync::Mutex;
 
 use crate::backend::{Backend, BackendApi, Querier, Storage};
 use crate::checksum::Checksum;
@@ -254,8 +254,7 @@ where
         backend: Backend<A, S, Q>,
         options: InstanceOptions,
     ) -> VmResult<Instance<A, S, Q>> {
-        let mut cache = self.inner.lock().unwrap();
-        let module = self.get_module(&mut cache, checksum)?;
+        let module = self.get_module(checksum)?;
         let instance = Instance::from_module(
             &module,
             backend,
@@ -269,11 +268,8 @@ where
     /// Returns a module tied to a previously saved Wasm.
     /// Depending on availability, this is either generated from a memory cache, file system cache or Wasm code.
     /// This is part of `get_instance` but pulled out to reduce the locking time.
-    fn get_module(
-        &self,
-        cache: &mut MutexGuard<CacheInner>,
-        checksum: &Checksum,
-    ) -> VmResult<wasmer::Module> {
+    fn get_module(&self, checksum: &Checksum) -> VmResult<wasmer::Module> {
+        let mut cache = self.inner.lock().unwrap();
         // Try to get module from the pinned memory cache
         if let Some(module) = cache.pinned_memory_cache.load(checksum)? {
             cache.stats.hits_pinned_memory_cache += 1;

--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -71,6 +71,7 @@ pub struct Cache<A: BackendApi, S: Storage, Q: Querier> {
     type_api: PhantomData<A>,
     type_storage: PhantomData<S>,
     type_querier: PhantomData<Q>,
+    m: Mutex<()>,
 }
 
 #[derive(PartialEq, Debug)]
@@ -131,6 +132,7 @@ where
             type_storage: PhantomData::<S>,
             type_api: PhantomData::<A>,
             type_querier: PhantomData::<Q>,
+            m: Mutex::new(()),
         })
     }
 
@@ -261,6 +263,7 @@ where
             options.gas_limit,
             options.print_debug,
             None,
+            Some(&self.m),
         )?;
         Ok(instance)
     }

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -1,10 +1,10 @@
 use std::collections::{HashMap, HashSet};
 use std::ptr::NonNull;
+use std::sync::Mutex;
 
 use wasmer::{Exports, Function, ImportObject, Instance as WasmerInstance, Module, Val};
 
 use crate::backend::{Backend, BackendApi, Querier, Storage};
-use crate::cache::Lock;
 use crate::conversion::{ref_to_u32, to_u32};
 use crate::environment::Environment;
 use crate::errors::{CommunicationError, VmError, VmResult};
@@ -80,7 +80,7 @@ where
         gas_limit: u64,
         print_debug: bool,
         extra_imports: Option<HashMap<&str, Exports>>,
-        instantiation_lock: Option<&Lock>,
+        instantiation_lock: Option<&Mutex<()>>,
     ) -> VmResult<Self> {
         let store = module.store();
 

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -80,7 +80,7 @@ where
         gas_limit: u64,
         print_debug: bool,
         extra_imports: Option<HashMap<&str, Exports>>,
-        m: Option<&Mutex<()>>,
+        instantiation_lock: Option<&Mutex<()>>,
     ) -> VmResult<Self> {
         let store = module.store();
 
@@ -216,7 +216,7 @@ where
             }
         }
 
-        let lock = m.map(|m| m.lock().unwrap());
+        let lock = instantiation_lock.map(|l| l.lock().unwrap());
         let wasmer_instance = Box::from(WasmerInstance::new(module, &import_obj).map_err(
             |original| {
                 VmError::instantiation_err(format!("Error instantiating module: {:?}", original))

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -1,10 +1,10 @@
 use std::collections::{HashMap, HashSet};
 use std::ptr::NonNull;
-use std::sync::Mutex;
 
 use wasmer::{Exports, Function, ImportObject, Instance as WasmerInstance, Module, Val};
 
 use crate::backend::{Backend, BackendApi, Querier, Storage};
+use crate::cache::Lock;
 use crate::conversion::{ref_to_u32, to_u32};
 use crate::environment::Environment;
 use crate::errors::{CommunicationError, VmError, VmResult};
@@ -80,7 +80,7 @@ where
         gas_limit: u64,
         print_debug: bool,
         extra_imports: Option<HashMap<&str, Exports>>,
-        instantiation_lock: Option<&Mutex<()>>,
+        instantiation_lock: Option<&Lock>,
     ) -> VmResult<Self> {
         let store = module.store();
 

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -216,15 +216,15 @@ where
             }
         }
 
-        let lock = instantiation_lock.map(|l| l.lock().unwrap());
-        let wasmer_instance = Box::from(WasmerInstance::new(module, &import_obj).map_err(
-            |original| {
+        let wasmer_instance = Box::from(
+            {
+                let _lock = instantiation_lock.map(|l| l.lock().unwrap());
+                WasmerInstance::new(module, &import_obj)
+            }
+            .map_err(|original| {
                 VmError::instantiation_err(format!("Error instantiating module: {:?}", original))
-            },
-        )?);
-        if let Some(lock) = lock {
-            drop(lock)
-        }
+            })?,
+        );
 
         let instance_ptr = NonNull::from(wasmer_instance.as_ref());
         env.set_wasmer_instance(Some(instance_ptr));


### PR DESCRIPTION
#1159 follow-up. Just locks the entire `get_instance` context. Which increases performance by having the `from_module` call in the locked context.

Did it this way just as a proof of concept. We can probably keep the cache mutex inside `get_module`, and introduce a new lock for the `from_module` call. Will do this next.

This would be a weird "more locking is less locking" case. I wonder how many of those are around. I also wonder _why_ this happens.