### PR TITLE
Add per instance locking to `get_instance`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ workflows:
                 - cache-analyze
                 - fix-benches
                 - benchmark_argon2
-                - get_instance-multi-threaded-benchmark-multi-contract
+                - 1183-per-instance-lock
       - coverage
   deploy:
     jobs:


### PR DESCRIPTION
Closes #1183.

Benchmarks didn't change much, if at all, after these changes.

Not sure we should merge this, as it adds complexity without clear advantages. Tried it with different number of threads / contracts, without seeing significant differences in performance in any scenario.