### PR TITLE
Feature tgrade

### DIFF
--- a/packages/vm/Cargo.toml
+++ b/packages/vm/Cargo.toml
@@ -24,6 +24,8 @@ staking = ["cosmwasm-std/staking"]
 stargate = ["cosmwasm-std/stargate"]
 # Use cranelift backend instead of singlepass. This is required for development on Windows.
 cranelift = ["wasmer/cranelift"]
+# this enables all tgrade-related functionality
+tgrade = []
 
 [lib]
 # See https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options

--- a/packages/vm/src/testing/instance.rs
+++ b/packages/vm/src/testing/instance.rs
@@ -98,6 +98,8 @@ impl MockInstanceOptions<'_> {
         let mut out = features_from_csv("iterator,staking");
         #[cfg(feature = "stargate")]
         out.insert("stargate".to_string());
+        #[cfg(feature = "tgrade")]
+        out.insert("tgrade".to_string());
         out
     }
 }


### PR DESCRIPTION
Adds a "tgrade" feature to `MockInstance`, so that integration tests of tgrade contracts can be written.
Related to https://github.com/confio/poe-contracts/pull/6.

Not sure this is entirely the right approach. Sending this for discussion, in any case.