### PR TITLE
Bump MSRV to 1.54

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ workflows:
           matrix:
             parameters:
               # Run with MSRV and some modern stable Rust
-              rust-version: ["1.53.0", "1.58.1"]
+              rust-version: ["1.54.0", "1.58.1"]
       - benchmarking:
           requires:
             - package_vm
@@ -62,7 +62,7 @@ workflows:
 jobs:
   package_crypto:
     docker:
-      - image: rust:1.53.0
+      - image: rust:1.54.0
     steps:
       - checkout
       - run:
@@ -70,7 +70,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-package_crypto-rust:1.53.0-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-package_crypto-rust:1.54.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Build
           working_directory: ~/project/packages/crypto
@@ -85,11 +85,11 @@ jobs:
             - target/debug/.fingerprint
             - target/debug/build
             - target/debug/deps
-          key: cargocache-v2-package_crypto-rust:1.53.0-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-package_crypto-rust:1.54.0-{{ checksum "Cargo.lock" }}
 
   package_schema:
     docker:
-      - image: rust:1.53.0
+      - image: rust:1.54.0
     steps:
       - checkout
       - run:
@@ -97,7 +97,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-package_schema-rust:1.53.0-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-package_schema-rust:1.54.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Build
           working_directory: ~/project/packages/schema
@@ -112,11 +112,11 @@ jobs:
             - target/debug/.fingerprint
             - target/debug/build
             - target/debug/deps
-          key: cargocache-v2-package_schema-rust:1.53.0-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-package_schema-rust:1.54.0-{{ checksum "Cargo.lock" }}
 
   package_std:
     docker:
-      - image: rust:1.53.0
+      - image: rust:1.54.0
     steps:
       - checkout
       - run:
@@ -124,7 +124,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-package_std-rust:1.53.0-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-package_std-rust:1.54.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Add wasm32 target
           command: rustup target add wasm32-unknown-unknown && rustup target list --installed
@@ -171,11 +171,11 @@ jobs:
             - target/debug/.fingerprint
             - target/debug/build
             - target/debug/deps
-          key: cargocache-v2-package_std-rust:1.53.0-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-package_std-rust:1.54.0-{{ checksum "Cargo.lock" }}
 
   package_storage:
     docker:
-      - image: rust:1.53.0
+      - image: rust:1.54.0
     steps:
       - checkout
       - run:
@@ -183,7 +183,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-package_storage-rust:1.53.0-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-package_storage-rust:1.54.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Build library for native target
           working_directory: ~/project/packages/storage
@@ -202,11 +202,11 @@ jobs:
             - target/debug/.fingerprint
             - target/debug/build
             - target/debug/deps
-          key: cargocache-v2-package_storage-rust:1.53.0-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-package_storage-rust:1.54.0-{{ checksum "Cargo.lock" }}
 
   package_vm:
     docker:
-      - image: rust:1.53.0
+      - image: rust:1.54.0
     steps:
       - checkout
       - run:
@@ -214,7 +214,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-package_vm-rust:1.53.0-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-package_vm-rust:1.54.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Build
           working_directory: ~/project/packages/vm
@@ -243,11 +243,11 @@ jobs:
             - target/debug/.fingerprint
             - target/debug/build
             - target/debug/deps
-          key: cargocache-v2-package_vm-rust:1.53.0-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-package_vm-rust:1.54.0-{{ checksum "Cargo.lock" }}
 
   package_profiler:
     docker:
-      - image: rust:1.53.0
+      - image: rust:1.54.0
     steps:
       - checkout
       - run:
@@ -255,7 +255,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-package_profiler-rust:1.53.0-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-package_profiler-rust:1.54.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Build
           working_directory: ~/project/packages/profiler
@@ -270,11 +270,11 @@ jobs:
             - target/debug/.fingerprint
             - target/debug/build
             - target/debug/deps
-          key: cargocache-v2-package_profiler-rust:1.53.0-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-package_profiler-rust:1.54.0-{{ checksum "Cargo.lock" }}
 
   contract_burner:
     docker:
-      - image: rust:1.53.0
+      - image: rust:1.54.0
     environment:
       RUST_BACKTRACE: 1
     working_directory: ~/cosmwasm/contracts/burner
@@ -286,7 +286,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-v2-contract_burner-rust:1.53.0-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-contract_burner-rust:1.54.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Add wasm32 target
           command: rustup target add wasm32-unknown-unknown && rustup target list --installed
@@ -320,11 +320,11 @@ jobs:
             - target/wasm32-unknown-unknown/release/.fingerprint
             - target/wasm32-unknown-unknown/release/build
             - target/wasm32-unknown-unknown/release/deps
-          key: cargocache-v2-contract_burner-rust:1.53.0-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-contract_burner-rust:1.54.0-{{ checksum "Cargo.lock" }}
 
   contract_crypto_verify:
     docker:
-      - image: rust:1.53.0
+      - image: rust:1.54.0
     environment:
       RUST_BACKTRACE: 1
     working_directory: ~/cosmwasm/contracts/crypto-verify
@@ -336,7 +336,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-v2-contract_crypto_verify-rust:1.53.0-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-contract_crypto_verify-rust:1.54.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Add wasm32 target
           command: rustup target add wasm32-unknown-unknown && rustup target list --installed
@@ -370,11 +370,11 @@ jobs:
             - target/wasm32-unknown-unknown/release/.fingerprint
             - target/wasm32-unknown-unknown/release/build
             - target/wasm32-unknown-unknown/release/deps
-          key: cargocache-v2-contract_crypto_verify-rust:1.53.0-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-contract_crypto_verify-rust:1.54.0-{{ checksum "Cargo.lock" }}
 
   contract_hackatom:
     docker:
-      - image: rust:1.53.0
+      - image: rust:1.54.0
     environment:
       RUST_BACKTRACE: 1
     working_directory: ~/cosmwasm/contracts/hackatom
@@ -386,7 +386,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-v2-contract_hackatom-rust:1.53.0-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-contract_hackatom-rust:1.54.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Add wasm32 target
           command: rustup target add wasm32-unknown-unknown && rustup target list --installed
@@ -420,11 +420,11 @@ jobs:
             - target/wasm32-unknown-unknown/release/.fingerprint
             - target/wasm32-unknown-unknown/release/build
             - target/wasm32-unknown-unknown/release/deps
-          key: cargocache-v2-contract_hackatom-rust:1.53.0-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-contract_hackatom-rust:1.54.0-{{ checksum "Cargo.lock" }}
 
   contract_ibc_reflect:
     docker:
-      - image: rust:1.53.0
+      - image: rust:1.54.0
     environment:
       RUST_BACKTRACE: 1
     working_directory: ~/cosmwasm/contracts/ibc-reflect
@@ -436,7 +436,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-v2-contract_ibc_reflect-rust:1.53.0-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-contract_ibc_reflect-rust:1.54.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Add wasm32 target
           command: rustup target add wasm32-unknown-unknown && rustup target list --installed
@@ -470,11 +470,11 @@ jobs:
             - target/wasm32-unknown-unknown/release/.fingerprint
             - target/wasm32-unknown-unknown/release/build
             - target/wasm32-unknown-unknown/release/deps
-          key: cargocache-v2-contract_ibc_reflect-rust:1.53.0-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-contract_ibc_reflect-rust:1.54.0-{{ checksum "Cargo.lock" }}
 
   contract_ibc_reflect_send:
     docker:
-      - image: rust:1.53.0
+      - image: rust:1.54.0
     environment:
       RUST_BACKTRACE: 1
     working_directory: ~/cosmwasm/contracts/ibc-reflect-send
@@ -486,7 +486,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-v2-contract_ibc_reflect_send-rust:1.53.0-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-contract_ibc_reflect_send-rust:1.54.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Add wasm32 target
           command: rustup target add wasm32-unknown-unknown && rustup target list --installed
@@ -520,11 +520,11 @@ jobs:
             - target/wasm32-unknown-unknown/release/.fingerprint
             - target/wasm32-unknown-unknown/release/build
             - target/wasm32-unknown-unknown/release/deps
-          key: cargocache-v2-contract_ibc_reflect_send-rust:1.53.0-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-contract_ibc_reflect_send-rust:1.54.0-{{ checksum "Cargo.lock" }}
 
   contract_floaty:
     docker:
-      - image: rust:1.53.0
+      - image: rust:1.54.0
     environment:
       RUST_BACKTRACE: 1
     working_directory: ~/cosmwasm/contracts/floaty
@@ -536,7 +536,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-v2-contract_floaty-rust:1.53.0-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-contract_floaty-rust:1.54.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Add wasm32 target
           command: rustup target add wasm32-unknown-unknown && rustup target list --installed
@@ -570,11 +570,11 @@ jobs:
             - target/wasm32-unknown-unknown/release/.fingerprint
             - target/wasm32-unknown-unknown/release/build
             - target/wasm32-unknown-unknown/release/deps
-          key: cargocache-v2-contract_floaty-rust:1.53.0-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-contract_floaty-rust:1.54.0-{{ checksum "Cargo.lock" }}
 
   contract_queue:
     docker:
-      - image: rust:1.53.0
+      - image: rust:1.54.0
     environment:
       RUST_BACKTRACE: 1
     working_directory: ~/cosmwasm/contracts/queue
@@ -586,7 +586,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-v2-contract_queue-rust:1.53.0-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-contract_queue-rust:1.54.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Add wasm32 target
           command: rustup target add wasm32-unknown-unknown && rustup target list --installed
@@ -620,11 +620,11 @@ jobs:
             - target/wasm32-unknown-unknown/release/.fingerprint
             - target/wasm32-unknown-unknown/release/build
             - target/wasm32-unknown-unknown/release/deps
-          key: cargocache-v2-contract_queue-rust:1.53.0-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-contract_queue-rust:1.54.0-{{ checksum "Cargo.lock" }}
 
   contract_reflect:
     docker:
-      - image: rust:1.53.0
+      - image: rust:1.54.0
     environment:
       RUST_BACKTRACE: 1
     working_directory: ~/cosmwasm/contracts/reflect
@@ -636,7 +636,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-v2-contract_reflect-rust:1.53.0-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-contract_reflect-rust:1.54.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Add wasm32 target
           command: rustup target add wasm32-unknown-unknown && rustup target list --installed
@@ -670,11 +670,11 @@ jobs:
             - target/wasm32-unknown-unknown/release/.fingerprint
             - target/wasm32-unknown-unknown/release/build
             - target/wasm32-unknown-unknown/release/deps
-          key: cargocache-v2-contract_reflect-rust:1.53.0-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-contract_reflect-rust:1.54.0-{{ checksum "Cargo.lock" }}
 
   contract_staking:
     docker:
-      - image: rust:1.53.0
+      - image: rust:1.54.0
     environment:
       RUST_BACKTRACE: 1
     working_directory: ~/cosmwasm/contracts/staking
@@ -686,7 +686,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-v2-contract_staking-rust:1.53.0-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-contract_staking-rust:1.54.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Add wasm32 target
           command: rustup target add wasm32-unknown-unknown && rustup target list --installed
@@ -720,11 +720,11 @@ jobs:
             - target/wasm32-unknown-unknown/release/.fingerprint
             - target/wasm32-unknown-unknown/release/build
             - target/wasm32-unknown-unknown/release/deps
-          key: cargocache-v2-contract_staking-rust:1.53.0-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-contract_staking-rust:1.54.0-{{ checksum "Cargo.lock" }}
 
   fmt:
     docker:
-      - image: rust:1.53.0
+      - image: rust:1.54.0
     steps:
       - checkout
       - run:
@@ -732,7 +732,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-fmt-rust:1.53.0-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-fmt-rust:1.54.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Add rustfmt component
           command: rustup component add rustfmt
@@ -773,7 +773,7 @@ jobs:
             - target/debug/.fingerprint
             - target/debug/build
             - target/debug/deps
-          key: cargocache-v2-fmt-rust:1.53.0-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-fmt-rust:1.54.0-{{ checksum "Cargo.lock" }}
 
   fmt_extra:
     docker:
@@ -795,7 +795,7 @@ jobs:
 
   deadlinks:
     docker:
-      - image: rust:1.53.0
+      - image: rust:1.54.0
     steps:
       - checkout
       - run:
@@ -803,7 +803,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-deadlinks-rust:1.53.0-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-deadlinks-rust:1.54.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Generate docs
           command: cargo doc
@@ -823,7 +823,7 @@ jobs:
             - target/debug/build
             - target/debug/deps
             - /root/.cache/pip
-          key: cargocache-v2-deadlinks-rust:1.53.0-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-deadlinks-rust:1.54.0-{{ checksum "Cargo.lock" }}
 
   clippy:
     parameters:
@@ -987,7 +987,7 @@ jobs:
 
   benchmarking:
     docker:
-      - image: rust:1.53.0
+      - image: rust:1.54.0
     environment:
       RUST_BACKTRACE: 1
     steps:
@@ -997,7 +997,7 @@ jobs:
           command: rustc --version && cargo --version
       - restore_cache:
           keys:
-            - cargocache-v2-benchmarking-rust:1.53.0-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-benchmarking-rust:1.54.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Run vm benchmarks (Singlepass)
           working_directory: ~/project/packages/vm
@@ -1015,7 +1015,7 @@ jobs:
             - target/release/.fingerprint
             - target/release/build
             - target/release/deps
-          key: cargocache-v2-benchmarking-rust:1.53.0-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-benchmarking-rust:1.54.0-{{ checksum "Cargo.lock" }}
 
   coverage:
     machine: true
@@ -1078,7 +1078,7 @@ jobs:
           name: Check development contracts
           command: |
             echo "Checking all contracts under ./artifacts"
-            docker run --volumes-from with_code rust:1.53.0 \
+            docker run --volumes-from with_code rust:1.54.0 \
               /bin/bash -e -c 'export GLOBIGNORE="../../artifacts/floaty.wasm"; cd ./code/packages/vm; ./examples/check_contract.sh ../../artifacts/*.wasm'
             docker cp with_code:/code/artifacts .
       - run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.53.0
+          toolchain: 1.54.0
           target: wasm32-unknown-unknown
           profile: minimal
           override: true

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -24,7 +24,7 @@ pull_request_rules:
       - "status-success=ci/circleci: contract_reflect"
       - "status-success=ci/circleci: contract_staking"
       - "status-success=ci/circleci: fmt"
-      - "status-success=ci/circleci: clippy-1.53.0"
+      - "status-success=ci/circleci: clippy-1.54.0"
       - "status-success=ci/circleci: clippy-1.58.1"
       - "status-success=Windows"
       - "status-success=macOS"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to
 
 ### Changed
 
+- all: Drop support for Rust versions lower than 1.54.0.
 - cosmwasm-std: The `Debug` implementation of `Binary` now produces a hex string
   instead of a list of bytes ([#1199]).
 - cosmwasm-std: Pin uint version to 0.9.1 in order to maintain a reasonably low

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -6,8 +6,8 @@ major releases of `cosmwasm`. Note that you can also view the
 
 ## 1.0.0-beta -> 1.0.0 (unreleased)
 
-- The minimum Rust supported version is 1.53.0. Verify your Rust version is >=
-  1.53.0 with: `rustc --version`.
+- The minimum Rust supported version is 1.54.0. Verify your Rust version is >=
+  1.54.0 with: `rustc --version`.
 
 - Simplify `mock_dependencies` calls with empty balance:
 

--- a/docs/MSRV.md
+++ b/docs/MSRV.md
@@ -25,13 +25,15 @@ development, you will depends on the cosmwasm-vm MSRV.
 
 ## Latest changes
 
-| Version | cosmwasm-std MSRV | cosmwasm-vm MSRV | Notes                                                                                   |
-| ------- | ----------------- | ---------------- | --------------------------------------------------------------------------------------- |
-| 1.0.0   | 1.53.0            | 1.53.0           | Not strictly needed but prepares for [Wasmer > 2] and let's us keep up with modern Rust |
-| 0.14.0  | 1.51.0            | 1.51.0           | Added support for const generics                                                        |
-| 0.13.2  | 1.47.0            | 1.48.0           | Through [Wasmer 1.0.1]                                                                  |
-| 0.13.0  | 1.47.0            | 1.47.0           |                                                                                         |
-| 0.11.0  | 1.45.2            | 1.45.2           |                                                                                         |
+| Version     | cosmwasm-std MSRV | cosmwasm-vm MSRV | Notes                                                                                   |
+| ----------- | ----------------- | ---------------- | --------------------------------------------------------------------------------------- |
+| 1.0.0-beta5 | 1.54.0            | 1.54.0           | Align with 0.16 series                                                                  |
+| 1.0.0-beta2 | 1.53.0            | 1.53.0           | Not strictly needed but prepares for [Wasmer > 2] and let's us keep up with modern Rust |
+| 0.16.4      | 1.54.0            | 1.54.0           |                                                                                         |
+| 0.14.0      | 1.51.0            | 1.51.0           | Added support for const generics                                                        |
+| 0.13.2      | 1.47.0            | 1.48.0           | Through [Wasmer 1.0.1]                                                                  |
+| 0.13.0      | 1.47.0            | 1.47.0           |                                                                                         |
+| 0.11.0      | 1.45.2            | 1.45.2           |                                                                                         |
 
 [wasmer 1.0.1]:
   https://github.com/wasmerio/wasmer/blob/master/CHANGELOG.md#101---2021-01-12

--- a/docs/MSRV.md
+++ b/docs/MSRV.md
@@ -48,10 +48,12 @@ development, you will depends on the cosmwasm-vm MSRV.
   stable Rust 1.33.3 it must not exceed 1.32.0.
 - It can be bumped without a semver major release of the crates. However, a
   minor version bump is required.
+- Before the 1.0.0 release, it can change at any time.
 
 **cosmwasm-vm MSRV**
 
 - It can be bumped without a semver major release of the crate. However, a minor
   version bump is required.
+- Before the 1.0.0 release, it can change at any time.
 - It is always higher or equal to cosmwasm-std MSRV because the VM depends on
   cosmwasm-std and related packages.


### PR DESCRIPTION
1.54.0 is used consistently now in 0.16 and 1.0. This allows up to use the 1.55 builders in wasmvm. 

Closes #1197