### PR TITLE
Upgrade Wasmer to 2.2 (oh yeah, CosmWasm on ARM is coming 🐎)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,26 @@ jobs:
           keys:
             - cargocache-v2-arm64-rust:1.54.0-{{ checksum "Cargo.lock" }}
       - run:
+          name: "contracts/crypto-verify: integration-test"
+          working_directory: ~/project/contracts/crypto-verify
+          command: cargo wasm --locked && cargo integration-test --locked
+      - run:
+          name: "contracts/hackatom: integration-test"
+          working_directory: ~/project/contracts/hackatom
+          command: cargo wasm --locked && cargo integration-test --locked
+      - run:
+          name: "contracts/queue: integration-test"
+          working_directory: ~/project/contracts/queue
+          command: cargo wasm --locked && cargo integration-test --locked
+      - run:
+          name: "contracts/reflect: integration-test"
+          working_directory: ~/project/contracts/reflect
+          command: cargo wasm --locked && cargo integration-test --locked
+      - run:
+          name: "contracts/staking: integration-test"
+          working_directory: ~/project/contracts/staking
+          command: cargo wasm --locked && cargo integration-test --locked
+      - run:
           name: "packages/crypto: test"
           working_directory: ~/project/packages/crypto
           command: cargo test --locked

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ workflows:
   test:
     # Keep those job names in sync with .mergify.yml
     jobs:
+      - arm64
       - package_crypto
       - package_schema
       - package_std
@@ -60,6 +61,51 @@ workflows:
               ignore: /.*/
 
 jobs:
+  arm64:
+    machine:
+      image: ubuntu-2004:202101-01
+    resource_class: arm.medium
+    steps:
+      - checkout
+      - run:
+          name: Install Rust
+          command: |
+            wget https://static.rust-lang.org/rustup/dist/aarch64-unknown-linux-gnu/rustup-init
+            chmod +x rustup-init
+            ./rustup-init -y --default-toolchain 1.54.0 --profile minimal
+      - run:
+          name: Version information
+          command: rustc --version; cargo --version; rustup --version; rustup target list --installed
+      - run:
+          name: Add wasm32 target
+          command: rustup target add wasm32-unknown-unknown && rustup target list --installed
+      - restore_cache:
+          keys:
+            - cargocache-v2-arm64-rust:1.54.0-{{ checksum "Cargo.lock" }}
+      - run:
+          name: "packages/crypto: test"
+          working_directory: ~/project/packages/crypto
+          command: cargo test --locked
+      - run:
+          name: "packages/std: test"
+          working_directory: ~/project/packages/std
+          command: cargo test --locked
+      - run:
+          name: "packages/vm: test"
+          working_directory: ~/project/packages/vm
+          command: cargo test --locked
+      - run:
+          name: "packages/vm: test with all features"
+          working_directory: ~/project/packages/vm
+          command: cargo test --locked --features iterator,staking,stargate
+      - save_cache:
+          paths:
+            - ~/.cargo/registry
+            - target/debug/.fingerprint
+            - target/debug/build
+            - target/debug/deps
+          key: cargocache-v2-arm64-rust:1.54.0-{{ checksum "Cargo.lock" }}
+
   package_crypto:
     docker:
       - image: rust:1.54.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
   arm64:
     machine:
       image: ubuntu-2004:202101-01
-    resource_class: arm.medium
+    resource_class: arm.large
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,10 +93,7 @@ jobs:
       - run:
           name: "packages/vm: test"
           working_directory: ~/project/packages/vm
-          command: cargo test --locked
-      - run:
-          name: "packages/vm: test with all features"
-          working_directory: ~/project/packages/vm
+          # use all features
           command: cargo test --locked --features iterator,staking,stargate
       - save_cache:
           paths:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@ and this project adheres to
   `SubMsgResult`. Both types are equal when serialized but `ContractResult` is
   documented to be the result of a contract execution, which is not the case
   here. ([#1232])
+- cosmwasm-vm: Upgrade Wasmer to 2.2.0 and bump `MODULE_SERIALIZATION_VERSION`
+  to "v3-wasmer1". ([#1224])
 
+[#1224]: https://github.com/CosmWasm/cosmwasm/pull/1224
 [#1232]: https://github.com/CosmWasm/cosmwasm/pull/1232
 
 ## [1.0.0-beta5] - 2022-02-08

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.27.1",
  "rustc-demangle",
 ]
 
@@ -613,9 +613,9 @@ checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
 
 [[package]]
 name = "dynasm"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab1096ebdaa974cd6a41a743e94dfa00cce9bfbf4690bcc73fdec6a903938ccc"
+checksum = "47b1801e630bd336d0bbbdbf814de6cc749c9a400c7e3d995e6adfd455d0c83c"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -628,9 +628,9 @@ dependencies = [
 
 [[package]]
 name = "dynasmrt"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20c69d1e16ae47889b47c301c790f48615cd9bfbdf586e3f6d4fde64af3d259"
+checksum = "1d428afc93ad288f6dffc1fa5f4a78201ad2eec33c5a522e51c181009eb09061"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -690,6 +690,26 @@ name = "english-numbers"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e4f5d6e192964d498b45abee72ca445e91909094bc8e8791259e82c2a0d1aa6"
+
+[[package]]
+name = "enum-iterator"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eeac5c5edb79e4e39fe8439ef35207780a11f69c52cbe424ce3dfad4cb78de6"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c134c37760b27a871ba422106eedbb8247da973a09e82558bf26d619c882b159"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "enumset"
@@ -1062,7 +1082,17 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
 dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40bec70ba014595f99f7aa110b84331ffe1ee9aece7fe6f387cc7e3ecda4d456"
+dependencies = [
  "crc32fast",
+ "hashbrown",
  "indexmap",
  "memchr",
 ]
@@ -1863,9 +1893,9 @@ checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
 name = "wasmer"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23f0188c23fc1b7de9bd7f8b834d0b1cd5edbe66e287452e8ce36d24418114f7"
+checksum = "7c823abda8b80153c938b3c7c55fcc74e2adfe40592732f7be01309dbe4aa53b"
 dependencies = [
  "cfg-if",
  "indexmap",
@@ -1890,9 +1920,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88c51cc589772c5f90bd329244c2416976d6cb2ee00d59429aaa8f421d9fe447"
+checksum = "4ef59c6661f8f739c7c56d85400711a6e8791a101e931902af87423280e3dd36"
 dependencies = [
  "enumset",
  "loupe",
@@ -1909,9 +1939,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09691e3e323b4e1128d2127f60f9cd988b66ce49afc8184b071c2b5ab16793f2"
+checksum = "bd21b6306ec69096ac39e93418b2338e5def5445522f098c5b0a38863059492d"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1930,9 +1960,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271d3da24c5d1a8bb3f9fc3944ba96d2588b6fa16a0bcef91765db853aeccac4"
+checksum = "95c704e8c917e047e301862c76b93e2374631d3e6dc0b547c690f7ac38227344"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -1949,9 +1979,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f5cb7b09640e09f1215da95d6fb7477d2db572f064b803ff705f39ff079cc5"
+checksum = "5932932ef9e4f185dee5c99848ffafe98c5f49e0e92d2da14686761e38345c67"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1961,9 +1991,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab20311c354fe2c12bc766417e0a1a45f399c1cd8ff262127d1dc86d0588971a"
+checksum = "5ed91396b15addd562d53fd92a016ba88c9b2ce4e0e0169a0e47cc67b739b37f"
 dependencies = [
  "backtrace",
  "enumset",
@@ -1983,15 +2013,17 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-dylib"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd5b7a74731e1dcccaf10a8ff5f72216c82f12972ce17cc81c6caa1afff75ea"
+checksum = "8d9ecf7885c571a26141f37a362caa97796b8904f423dc5645031e149c9ee802"
 dependencies = [
  "cfg-if",
+ "enum-iterator",
  "enumset",
  "leb128",
  "libloading",
  "loupe",
+ "object 0.28.3",
  "rkyv",
  "serde",
  "tempfile",
@@ -2006,11 +2038,12 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-universal"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfeae8d5b825ad7abcf9a34e66eb11e1507b21020efe7bbf9897e3dd8d7869e2"
+checksum = "3bc4c936ebc050946dced5a3c4ef2bfe0b937c6e91323642c8e04552a82dfd9f"
 dependencies = [
  "cfg-if",
+ "enum-iterator",
  "enumset",
  "leb128",
  "loupe",
@@ -2025,9 +2058,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-middlewares"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61a73bda8608a4ca56142b7849ccf4847cda566267d0071664ca06c6f4fbff1"
+checksum = "cc770d4c278498bbbabec4cb9db33362ce6349cc397f746f2c75b20b5448fe2f"
 dependencies = [
  "loupe",
  "wasmer",
@@ -2037,11 +2070,11 @@ dependencies = [
 
 [[package]]
 name = "wasmer-object"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d4714e4f3bdc3b2157c24284417d19cd99de036da31d00ec5664712dcb72f7"
+checksum = "f5626938e5e062747b999493d3a36591d9ba2fb0b6fb8e6f474e3355440ff9a0"
 dependencies = [
- "object",
+ "object 0.28.3",
  "thiserror",
  "wasmer-compiler",
  "wasmer-types",
@@ -2049,9 +2082,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434e1c0177da0a74ecca90b2aa7d5e86198260f07e8ba83be89feb5f0a4aeead"
+checksum = "78e5c8a51b65b946c122cecacdd496b24cc070f5465bc07ce83c62f830835814"
 dependencies = [
  "indexmap",
  "loupe",
@@ -2062,13 +2095,14 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc8f964ebba70d9f81340228b98a164782591f00239fc7f01e1b67afcf0e0156"
+checksum = "91ad82e6b8e33a63c5215e11ea2f37e9a0b8a81606a41c922f26f61cb862e7f9"
 dependencies = [
  "backtrace",
  "cc",
  "cfg-if",
+ "enum-iterator",
  "indexmap",
  "libc",
  "loupe",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1893,9 +1893,9 @@ checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
 name = "wasmer"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d23f1bf05a2f86ad775dfe73b1da1842a58ffa549cd711c083cf56520c8025c4"
+checksum = "bfc7dff846db3f38f8ed0be4a009fdfeb729cf1f94a2c7fb6ff2fec01cefa110"
 dependencies = [
  "cfg-if",
  "indexmap",
@@ -1920,9 +1920,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32158a07455808eccd655c3333d22a6a9eeb01c5891b750e6c7a66c43317b1fe"
+checksum = "8c91abf22b16dad3826ec0d0e3ec0a8304262a6c7a14e16528c536131b80e63d"
 dependencies = [
  "enumset",
  "loupe",
@@ -1939,9 +1939,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2afe1d581016703af0a6ac37511661b5ee5ceceee7bc387afcd4035ff36c2fc"
+checksum = "7624a1f496b163139a7e0b442426cad805bec70486900287506f9d15a29323ab"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1960,9 +1960,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e06040411d28aa7ba03fcf03971fbcd719b1020c5aa3eae2891587e892ef51ee"
+checksum = "4b63c1538ffb4b0e09edaebfcac35c34141d5944c52f77d137cbe0b634bd40fa"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -1979,9 +1979,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ecae9427e1f0ae664256f6620924f3eabb0983bdb18e1c36d15c15ba6ee35c9"
+checksum = "933b23b5cee0f58aa6c17c6de7e1f3007279357e0d555f22e24d6b395cfe7f89"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1991,9 +1991,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0823953c2775707cb0e151c2da97c4621193cf58308ee4f48b2df17d114c3d82"
+checksum = "41db0ac4df90610cda8320cfd5abf90c6ec90e298b6fe5a09a81dff718b55640"
 dependencies = [
  "backtrace",
  "enumset",
@@ -2013,9 +2013,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-dylib"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75db66afeacaf2d12a3d6af916410bc41459e01477f6628d637b77f5785f7c8c"
+checksum = "591683f3356ac31cc88aaecaf77ac2cc9f456014348b01af46c164f44f531162"
 dependencies = [
  "cfg-if",
  "enum-iterator",
@@ -2038,9 +2038,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-universal"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12a18da6797a46b5b35043796fd5d3451d384226e4531888ff1966dcb029a8ea"
+checksum = "dccfde103e9b87427099a6de344b7c791574f307d035c8c7dbbc00974c1af0c1"
 dependencies = [
  "cfg-if",
  "enum-iterator",
@@ -2058,9 +2058,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-middlewares"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a98d5a2058c14e56f5f48f51cd14cf4c572223bb79fe5589f2a1ee820a4522"
+checksum = "be816528dd62f037ae935977b643bb4237e10be9e32826e2f3eb1f911eaccc97"
 dependencies = [
  "loupe",
  "wasmer",
@@ -2070,9 +2070,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-object"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb88abea6a488ef64674c72c813564de7877a6e046d4b3f3e20c41302b82a10"
+checksum = "1d0c4005592998bd840f2289102ef9c67b6138338ed78e1fc0809586aa229040"
 dependencies = [
  "object 0.28.3",
  "thiserror",
@@ -2082,9 +2082,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bffc68539057bc92c10b260175d36acb90926840b175939e663eafdd4fbdb6"
+checksum = "4deb854f178265a76b59823c41547d259c65da3687b606b0b9c12d80ab950e3e"
 dependencies = [
  "indexmap",
  "loupe",
@@ -2095,9 +2095,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "215cc368b140d2eb3d3ab826dd01c602dc337c2374ac5d48f5652bd7eeac0d05"
+checksum = "5dbc5c989cb14a102433927e630473da52f83d82c469acd5cfa8fc7efacc1e70"
 dependencies = [
  "backtrace",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1893,9 +1893,9 @@ checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
 name = "wasmer"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c823abda8b80153c938b3c7c55fcc74e2adfe40592732f7be01309dbe4aa53b"
+checksum = "d23f1bf05a2f86ad775dfe73b1da1842a58ffa549cd711c083cf56520c8025c4"
 dependencies = [
  "cfg-if",
  "indexmap",
@@ -1920,9 +1920,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ef59c6661f8f739c7c56d85400711a6e8791a101e931902af87423280e3dd36"
+checksum = "32158a07455808eccd655c3333d22a6a9eeb01c5891b750e6c7a66c43317b1fe"
 dependencies = [
  "enumset",
  "loupe",
@@ -1939,9 +1939,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd21b6306ec69096ac39e93418b2338e5def5445522f098c5b0a38863059492d"
+checksum = "b2afe1d581016703af0a6ac37511661b5ee5ceceee7bc387afcd4035ff36c2fc"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1960,9 +1960,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95c704e8c917e047e301862c76b93e2374631d3e6dc0b547c690f7ac38227344"
+checksum = "e06040411d28aa7ba03fcf03971fbcd719b1020c5aa3eae2891587e892ef51ee"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -1979,9 +1979,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5932932ef9e4f185dee5c99848ffafe98c5f49e0e92d2da14686761e38345c67"
+checksum = "4ecae9427e1f0ae664256f6620924f3eabb0983bdb18e1c36d15c15ba6ee35c9"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1991,9 +1991,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ed91396b15addd562d53fd92a016ba88c9b2ce4e0e0169a0e47cc67b739b37f"
+checksum = "0823953c2775707cb0e151c2da97c4621193cf58308ee4f48b2df17d114c3d82"
 dependencies = [
  "backtrace",
  "enumset",
@@ -2013,9 +2013,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-dylib"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9ecf7885c571a26141f37a362caa97796b8904f423dc5645031e149c9ee802"
+checksum = "75db66afeacaf2d12a3d6af916410bc41459e01477f6628d637b77f5785f7c8c"
 dependencies = [
  "cfg-if",
  "enum-iterator",
@@ -2038,9 +2038,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-universal"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bc4c936ebc050946dced5a3c4ef2bfe0b937c6e91323642c8e04552a82dfd9f"
+checksum = "12a18da6797a46b5b35043796fd5d3451d384226e4531888ff1966dcb029a8ea"
 dependencies = [
  "cfg-if",
  "enum-iterator",
@@ -2058,9 +2058,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-middlewares"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc770d4c278498bbbabec4cb9db33362ce6349cc397f746f2c75b20b5448fe2f"
+checksum = "09a98d5a2058c14e56f5f48f51cd14cf4c572223bb79fe5589f2a1ee820a4522"
 dependencies = [
  "loupe",
  "wasmer",
@@ -2070,9 +2070,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-object"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5626938e5e062747b999493d3a36591d9ba2fb0b6fb8e6f474e3355440ff9a0"
+checksum = "ffb88abea6a488ef64674c72c813564de7877a6e046d4b3f3e20c41302b82a10"
 dependencies = [
  "object 0.28.3",
  "thiserror",
@@ -2082,9 +2082,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78e5c8a51b65b946c122cecacdd496b24cc070f5465bc07ce83c62f830835814"
+checksum = "30bffc68539057bc92c10b260175d36acb90926840b175939e663eafdd4fbdb6"
 dependencies = [
  "indexmap",
  "loupe",
@@ -2095,9 +2095,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ad82e6b8e33a63c5215e11ea2f37e9a0b8a81606a41c922f26f61cb862e7f9"
+checksum = "215cc368b140d2eb3d3ab826dd01c602dc337c2374ac5d48f5652bd7eeac0d05"
 dependencies = [
  "backtrace",
  "cc",

--- a/contracts/burner/Cargo.lock
+++ b/contracts/burner/Cargo.lock
@@ -494,6 +494,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-iterator"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eeac5c5edb79e4e39fe8439ef35207780a11f69c52cbe424ce3dfad4cb78de6"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c134c37760b27a871ba422106eedbb8247da973a09e82558bf26d619c882b159"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "enumset"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -802,11 +822,12 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.27.1"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
+checksum = "40bec70ba014595f99f7aa110b84331ffe1ee9aece7fe6f387cc7e3ecda4d456"
 dependencies = [
  "crc32fast",
+ "hashbrown",
  "indexmap",
  "memchr",
 ]
@@ -1426,9 +1447,9 @@ checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
 name = "wasmer"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23f0188c23fc1b7de9bd7f8b834d0b1cd5edbe66e287452e8ce36d24418114f7"
+checksum = "7c823abda8b80153c938b3c7c55fcc74e2adfe40592732f7be01309dbe4aa53b"
 dependencies = [
  "cfg-if",
  "indexmap",
@@ -1452,9 +1473,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88c51cc589772c5f90bd329244c2416976d6cb2ee00d59429aaa8f421d9fe447"
+checksum = "4ef59c6661f8f739c7c56d85400711a6e8791a101e931902af87423280e3dd36"
 dependencies = [
  "enumset",
  "loupe",
@@ -1471,9 +1492,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09691e3e323b4e1128d2127f60f9cd988b66ce49afc8184b071c2b5ab16793f2"
+checksum = "bd21b6306ec69096ac39e93418b2338e5def5445522f098c5b0a38863059492d"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1492,9 +1513,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271d3da24c5d1a8bb3f9fc3944ba96d2588b6fa16a0bcef91765db853aeccac4"
+checksum = "95c704e8c917e047e301862c76b93e2374631d3e6dc0b547c690f7ac38227344"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -1511,9 +1532,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f5cb7b09640e09f1215da95d6fb7477d2db572f064b803ff705f39ff079cc5"
+checksum = "5932932ef9e4f185dee5c99848ffafe98c5f49e0e92d2da14686761e38345c67"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1523,9 +1544,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab20311c354fe2c12bc766417e0a1a45f399c1cd8ff262127d1dc86d0588971a"
+checksum = "5ed91396b15addd562d53fd92a016ba88c9b2ce4e0e0169a0e47cc67b739b37f"
 dependencies = [
  "backtrace",
  "enumset",
@@ -1545,15 +1566,17 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-dylib"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd5b7a74731e1dcccaf10a8ff5f72216c82f12972ce17cc81c6caa1afff75ea"
+checksum = "8d9ecf7885c571a26141f37a362caa97796b8904f423dc5645031e149c9ee802"
 dependencies = [
  "cfg-if",
+ "enum-iterator",
  "enumset",
  "leb128",
  "libloading",
  "loupe",
+ "object 0.28.3",
  "rkyv",
  "serde",
  "tempfile",
@@ -1568,11 +1591,12 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-universal"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfeae8d5b825ad7abcf9a34e66eb11e1507b21020efe7bbf9897e3dd8d7869e2"
+checksum = "3bc4c936ebc050946dced5a3c4ef2bfe0b937c6e91323642c8e04552a82dfd9f"
 dependencies = [
  "cfg-if",
+ "enum-iterator",
  "enumset",
  "leb128",
  "loupe",
@@ -1587,9 +1611,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-middlewares"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61a73bda8608a4ca56142b7849ccf4847cda566267d0071664ca06c6f4fbff1"
+checksum = "cc770d4c278498bbbabec4cb9db33362ce6349cc397f746f2c75b20b5448fe2f"
 dependencies = [
  "loupe",
  "wasmer",
@@ -1599,11 +1623,11 @@ dependencies = [
 
 [[package]]
 name = "wasmer-object"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d4714e4f3bdc3b2157c24284417d19cd99de036da31d00ec5664712dcb72f7"
+checksum = "f5626938e5e062747b999493d3a36591d9ba2fb0b6fb8e6f474e3355440ff9a0"
 dependencies = [
- "object 0.27.1",
+ "object 0.28.3",
  "thiserror",
  "wasmer-compiler",
  "wasmer-types",
@@ -1611,9 +1635,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434e1c0177da0a74ecca90b2aa7d5e86198260f07e8ba83be89feb5f0a4aeead"
+checksum = "78e5c8a51b65b946c122cecacdd496b24cc070f5465bc07ce83c62f830835814"
 dependencies = [
  "indexmap",
  "loupe",
@@ -1624,13 +1648,14 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc8f964ebba70d9f81340228b98a164782591f00239fc7f01e1b67afcf0e0156"
+checksum = "91ad82e6b8e33a63c5215e11ea2f37e9a0b8a81606a41c922f26f61cb862e7f9"
 dependencies = [
  "backtrace",
  "cc",
  "cfg-if",
+ "enum-iterator",
  "indexmap",
  "libc",
  "loupe",

--- a/contracts/burner/Cargo.lock
+++ b/contracts/burner/Cargo.lock
@@ -1447,9 +1447,9 @@ checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
 name = "wasmer"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d23f1bf05a2f86ad775dfe73b1da1842a58ffa549cd711c083cf56520c8025c4"
+checksum = "bfc7dff846db3f38f8ed0be4a009fdfeb729cf1f94a2c7fb6ff2fec01cefa110"
 dependencies = [
  "cfg-if",
  "indexmap",
@@ -1473,9 +1473,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32158a07455808eccd655c3333d22a6a9eeb01c5891b750e6c7a66c43317b1fe"
+checksum = "8c91abf22b16dad3826ec0d0e3ec0a8304262a6c7a14e16528c536131b80e63d"
 dependencies = [
  "enumset",
  "loupe",
@@ -1492,9 +1492,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2afe1d581016703af0a6ac37511661b5ee5ceceee7bc387afcd4035ff36c2fc"
+checksum = "7624a1f496b163139a7e0b442426cad805bec70486900287506f9d15a29323ab"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1513,9 +1513,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e06040411d28aa7ba03fcf03971fbcd719b1020c5aa3eae2891587e892ef51ee"
+checksum = "4b63c1538ffb4b0e09edaebfcac35c34141d5944c52f77d137cbe0b634bd40fa"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -1532,9 +1532,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ecae9427e1f0ae664256f6620924f3eabb0983bdb18e1c36d15c15ba6ee35c9"
+checksum = "933b23b5cee0f58aa6c17c6de7e1f3007279357e0d555f22e24d6b395cfe7f89"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1544,9 +1544,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0823953c2775707cb0e151c2da97c4621193cf58308ee4f48b2df17d114c3d82"
+checksum = "41db0ac4df90610cda8320cfd5abf90c6ec90e298b6fe5a09a81dff718b55640"
 dependencies = [
  "backtrace",
  "enumset",
@@ -1566,9 +1566,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-dylib"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75db66afeacaf2d12a3d6af916410bc41459e01477f6628d637b77f5785f7c8c"
+checksum = "591683f3356ac31cc88aaecaf77ac2cc9f456014348b01af46c164f44f531162"
 dependencies = [
  "cfg-if",
  "enum-iterator",
@@ -1591,9 +1591,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-universal"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12a18da6797a46b5b35043796fd5d3451d384226e4531888ff1966dcb029a8ea"
+checksum = "dccfde103e9b87427099a6de344b7c791574f307d035c8c7dbbc00974c1af0c1"
 dependencies = [
  "cfg-if",
  "enum-iterator",
@@ -1611,9 +1611,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-middlewares"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a98d5a2058c14e56f5f48f51cd14cf4c572223bb79fe5589f2a1ee820a4522"
+checksum = "be816528dd62f037ae935977b643bb4237e10be9e32826e2f3eb1f911eaccc97"
 dependencies = [
  "loupe",
  "wasmer",
@@ -1623,9 +1623,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-object"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb88abea6a488ef64674c72c813564de7877a6e046d4b3f3e20c41302b82a10"
+checksum = "1d0c4005592998bd840f2289102ef9c67b6138338ed78e1fc0809586aa229040"
 dependencies = [
  "object 0.28.3",
  "thiserror",
@@ -1635,9 +1635,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bffc68539057bc92c10b260175d36acb90926840b175939e663eafdd4fbdb6"
+checksum = "4deb854f178265a76b59823c41547d259c65da3687b606b0b9c12d80ab950e3e"
 dependencies = [
  "indexmap",
  "loupe",
@@ -1648,9 +1648,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "215cc368b140d2eb3d3ab826dd01c602dc337c2374ac5d48f5652bd7eeac0d05"
+checksum = "5dbc5c989cb14a102433927e630473da52f83d82c469acd5cfa8fc7efacc1e70"
 dependencies = [
  "backtrace",
  "cc",

--- a/contracts/burner/Cargo.lock
+++ b/contracts/burner/Cargo.lock
@@ -1447,9 +1447,9 @@ checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
 name = "wasmer"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c823abda8b80153c938b3c7c55fcc74e2adfe40592732f7be01309dbe4aa53b"
+checksum = "d23f1bf05a2f86ad775dfe73b1da1842a58ffa549cd711c083cf56520c8025c4"
 dependencies = [
  "cfg-if",
  "indexmap",
@@ -1473,9 +1473,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ef59c6661f8f739c7c56d85400711a6e8791a101e931902af87423280e3dd36"
+checksum = "32158a07455808eccd655c3333d22a6a9eeb01c5891b750e6c7a66c43317b1fe"
 dependencies = [
  "enumset",
  "loupe",
@@ -1492,9 +1492,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd21b6306ec69096ac39e93418b2338e5def5445522f098c5b0a38863059492d"
+checksum = "b2afe1d581016703af0a6ac37511661b5ee5ceceee7bc387afcd4035ff36c2fc"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1513,9 +1513,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95c704e8c917e047e301862c76b93e2374631d3e6dc0b547c690f7ac38227344"
+checksum = "e06040411d28aa7ba03fcf03971fbcd719b1020c5aa3eae2891587e892ef51ee"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -1532,9 +1532,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5932932ef9e4f185dee5c99848ffafe98c5f49e0e92d2da14686761e38345c67"
+checksum = "4ecae9427e1f0ae664256f6620924f3eabb0983bdb18e1c36d15c15ba6ee35c9"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1544,9 +1544,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ed91396b15addd562d53fd92a016ba88c9b2ce4e0e0169a0e47cc67b739b37f"
+checksum = "0823953c2775707cb0e151c2da97c4621193cf58308ee4f48b2df17d114c3d82"
 dependencies = [
  "backtrace",
  "enumset",
@@ -1566,9 +1566,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-dylib"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9ecf7885c571a26141f37a362caa97796b8904f423dc5645031e149c9ee802"
+checksum = "75db66afeacaf2d12a3d6af916410bc41459e01477f6628d637b77f5785f7c8c"
 dependencies = [
  "cfg-if",
  "enum-iterator",
@@ -1591,9 +1591,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-universal"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bc4c936ebc050946dced5a3c4ef2bfe0b937c6e91323642c8e04552a82dfd9f"
+checksum = "12a18da6797a46b5b35043796fd5d3451d384226e4531888ff1966dcb029a8ea"
 dependencies = [
  "cfg-if",
  "enum-iterator",
@@ -1611,9 +1611,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-middlewares"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc770d4c278498bbbabec4cb9db33362ce6349cc397f746f2c75b20b5448fe2f"
+checksum = "09a98d5a2058c14e56f5f48f51cd14cf4c572223bb79fe5589f2a1ee820a4522"
 dependencies = [
  "loupe",
  "wasmer",
@@ -1623,9 +1623,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-object"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5626938e5e062747b999493d3a36591d9ba2fb0b6fb8e6f474e3355440ff9a0"
+checksum = "ffb88abea6a488ef64674c72c813564de7877a6e046d4b3f3e20c41302b82a10"
 dependencies = [
  "object 0.28.3",
  "thiserror",
@@ -1635,9 +1635,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78e5c8a51b65b946c122cecacdd496b24cc070f5465bc07ce83c62f830835814"
+checksum = "30bffc68539057bc92c10b260175d36acb90926840b175939e663eafdd4fbdb6"
 dependencies = [
  "indexmap",
  "loupe",
@@ -1648,9 +1648,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ad82e6b8e33a63c5215e11ea2f37e9a0b8a81606a41c922f26f61cb862e7f9"
+checksum = "215cc368b140d2eb3d3ab826dd01c602dc337c2374ac5d48f5652bd7eeac0d05"
 dependencies = [
  "backtrace",
  "cc",

--- a/contracts/crypto-verify/Cargo.lock
+++ b/contracts/crypto-verify/Cargo.lock
@@ -521,6 +521,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-iterator"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eeac5c5edb79e4e39fe8439ef35207780a11f69c52cbe424ce3dfad4cb78de6"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c134c37760b27a871ba422106eedbb8247da973a09e82558bf26d619c882b159"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "enumset"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -841,11 +861,12 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.27.1"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
+checksum = "40bec70ba014595f99f7aa110b84331ffe1ee9aece7fe6f387cc7e3ecda4d456"
 dependencies = [
  "crc32fast",
+ "hashbrown",
  "indexmap",
  "memchr",
 ]
@@ -1493,9 +1514,9 @@ checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
 name = "wasmer"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23f0188c23fc1b7de9bd7f8b834d0b1cd5edbe66e287452e8ce36d24418114f7"
+checksum = "7c823abda8b80153c938b3c7c55fcc74e2adfe40592732f7be01309dbe4aa53b"
 dependencies = [
  "cfg-if",
  "indexmap",
@@ -1519,9 +1540,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88c51cc589772c5f90bd329244c2416976d6cb2ee00d59429aaa8f421d9fe447"
+checksum = "4ef59c6661f8f739c7c56d85400711a6e8791a101e931902af87423280e3dd36"
 dependencies = [
  "enumset",
  "loupe",
@@ -1538,9 +1559,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09691e3e323b4e1128d2127f60f9cd988b66ce49afc8184b071c2b5ab16793f2"
+checksum = "bd21b6306ec69096ac39e93418b2338e5def5445522f098c5b0a38863059492d"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1559,9 +1580,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271d3da24c5d1a8bb3f9fc3944ba96d2588b6fa16a0bcef91765db853aeccac4"
+checksum = "95c704e8c917e047e301862c76b93e2374631d3e6dc0b547c690f7ac38227344"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -1578,9 +1599,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f5cb7b09640e09f1215da95d6fb7477d2db572f064b803ff705f39ff079cc5"
+checksum = "5932932ef9e4f185dee5c99848ffafe98c5f49e0e92d2da14686761e38345c67"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1590,9 +1611,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab20311c354fe2c12bc766417e0a1a45f399c1cd8ff262127d1dc86d0588971a"
+checksum = "5ed91396b15addd562d53fd92a016ba88c9b2ce4e0e0169a0e47cc67b739b37f"
 dependencies = [
  "backtrace",
  "enumset",
@@ -1612,15 +1633,17 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-dylib"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd5b7a74731e1dcccaf10a8ff5f72216c82f12972ce17cc81c6caa1afff75ea"
+checksum = "8d9ecf7885c571a26141f37a362caa97796b8904f423dc5645031e149c9ee802"
 dependencies = [
  "cfg-if",
+ "enum-iterator",
  "enumset",
  "leb128",
  "libloading",
  "loupe",
+ "object 0.28.3",
  "rkyv",
  "serde",
  "tempfile",
@@ -1635,11 +1658,12 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-universal"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfeae8d5b825ad7abcf9a34e66eb11e1507b21020efe7bbf9897e3dd8d7869e2"
+checksum = "3bc4c936ebc050946dced5a3c4ef2bfe0b937c6e91323642c8e04552a82dfd9f"
 dependencies = [
  "cfg-if",
+ "enum-iterator",
  "enumset",
  "leb128",
  "loupe",
@@ -1654,9 +1678,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-middlewares"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61a73bda8608a4ca56142b7849ccf4847cda566267d0071664ca06c6f4fbff1"
+checksum = "cc770d4c278498bbbabec4cb9db33362ce6349cc397f746f2c75b20b5448fe2f"
 dependencies = [
  "loupe",
  "wasmer",
@@ -1666,11 +1690,11 @@ dependencies = [
 
 [[package]]
 name = "wasmer-object"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d4714e4f3bdc3b2157c24284417d19cd99de036da31d00ec5664712dcb72f7"
+checksum = "f5626938e5e062747b999493d3a36591d9ba2fb0b6fb8e6f474e3355440ff9a0"
 dependencies = [
- "object 0.27.1",
+ "object 0.28.3",
  "thiserror",
  "wasmer-compiler",
  "wasmer-types",
@@ -1678,9 +1702,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434e1c0177da0a74ecca90b2aa7d5e86198260f07e8ba83be89feb5f0a4aeead"
+checksum = "78e5c8a51b65b946c122cecacdd496b24cc070f5465bc07ce83c62f830835814"
 dependencies = [
  "indexmap",
  "loupe",
@@ -1691,13 +1715,14 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc8f964ebba70d9f81340228b98a164782591f00239fc7f01e1b67afcf0e0156"
+checksum = "91ad82e6b8e33a63c5215e11ea2f37e9a0b8a81606a41c922f26f61cb862e7f9"
 dependencies = [
  "backtrace",
  "cc",
  "cfg-if",
+ "enum-iterator",
  "indexmap",
  "libc",
  "loupe",

--- a/contracts/crypto-verify/Cargo.lock
+++ b/contracts/crypto-verify/Cargo.lock
@@ -1514,9 +1514,9 @@ checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
 name = "wasmer"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c823abda8b80153c938b3c7c55fcc74e2adfe40592732f7be01309dbe4aa53b"
+checksum = "d23f1bf05a2f86ad775dfe73b1da1842a58ffa549cd711c083cf56520c8025c4"
 dependencies = [
  "cfg-if",
  "indexmap",
@@ -1540,9 +1540,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ef59c6661f8f739c7c56d85400711a6e8791a101e931902af87423280e3dd36"
+checksum = "32158a07455808eccd655c3333d22a6a9eeb01c5891b750e6c7a66c43317b1fe"
 dependencies = [
  "enumset",
  "loupe",
@@ -1559,9 +1559,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd21b6306ec69096ac39e93418b2338e5def5445522f098c5b0a38863059492d"
+checksum = "b2afe1d581016703af0a6ac37511661b5ee5ceceee7bc387afcd4035ff36c2fc"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1580,9 +1580,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95c704e8c917e047e301862c76b93e2374631d3e6dc0b547c690f7ac38227344"
+checksum = "e06040411d28aa7ba03fcf03971fbcd719b1020c5aa3eae2891587e892ef51ee"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -1599,9 +1599,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5932932ef9e4f185dee5c99848ffafe98c5f49e0e92d2da14686761e38345c67"
+checksum = "4ecae9427e1f0ae664256f6620924f3eabb0983bdb18e1c36d15c15ba6ee35c9"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1611,9 +1611,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ed91396b15addd562d53fd92a016ba88c9b2ce4e0e0169a0e47cc67b739b37f"
+checksum = "0823953c2775707cb0e151c2da97c4621193cf58308ee4f48b2df17d114c3d82"
 dependencies = [
  "backtrace",
  "enumset",
@@ -1633,9 +1633,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-dylib"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9ecf7885c571a26141f37a362caa97796b8904f423dc5645031e149c9ee802"
+checksum = "75db66afeacaf2d12a3d6af916410bc41459e01477f6628d637b77f5785f7c8c"
 dependencies = [
  "cfg-if",
  "enum-iterator",
@@ -1658,9 +1658,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-universal"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bc4c936ebc050946dced5a3c4ef2bfe0b937c6e91323642c8e04552a82dfd9f"
+checksum = "12a18da6797a46b5b35043796fd5d3451d384226e4531888ff1966dcb029a8ea"
 dependencies = [
  "cfg-if",
  "enum-iterator",
@@ -1678,9 +1678,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-middlewares"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc770d4c278498bbbabec4cb9db33362ce6349cc397f746f2c75b20b5448fe2f"
+checksum = "09a98d5a2058c14e56f5f48f51cd14cf4c572223bb79fe5589f2a1ee820a4522"
 dependencies = [
  "loupe",
  "wasmer",
@@ -1690,9 +1690,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-object"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5626938e5e062747b999493d3a36591d9ba2fb0b6fb8e6f474e3355440ff9a0"
+checksum = "ffb88abea6a488ef64674c72c813564de7877a6e046d4b3f3e20c41302b82a10"
 dependencies = [
  "object 0.28.3",
  "thiserror",
@@ -1702,9 +1702,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78e5c8a51b65b946c122cecacdd496b24cc070f5465bc07ce83c62f830835814"
+checksum = "30bffc68539057bc92c10b260175d36acb90926840b175939e663eafdd4fbdb6"
 dependencies = [
  "indexmap",
  "loupe",
@@ -1715,9 +1715,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ad82e6b8e33a63c5215e11ea2f37e9a0b8a81606a41c922f26f61cb862e7f9"
+checksum = "215cc368b140d2eb3d3ab826dd01c602dc337c2374ac5d48f5652bd7eeac0d05"
 dependencies = [
  "backtrace",
  "cc",

--- a/contracts/crypto-verify/Cargo.lock
+++ b/contracts/crypto-verify/Cargo.lock
@@ -1514,9 +1514,9 @@ checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
 name = "wasmer"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d23f1bf05a2f86ad775dfe73b1da1842a58ffa549cd711c083cf56520c8025c4"
+checksum = "bfc7dff846db3f38f8ed0be4a009fdfeb729cf1f94a2c7fb6ff2fec01cefa110"
 dependencies = [
  "cfg-if",
  "indexmap",
@@ -1540,9 +1540,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32158a07455808eccd655c3333d22a6a9eeb01c5891b750e6c7a66c43317b1fe"
+checksum = "8c91abf22b16dad3826ec0d0e3ec0a8304262a6c7a14e16528c536131b80e63d"
 dependencies = [
  "enumset",
  "loupe",
@@ -1559,9 +1559,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2afe1d581016703af0a6ac37511661b5ee5ceceee7bc387afcd4035ff36c2fc"
+checksum = "7624a1f496b163139a7e0b442426cad805bec70486900287506f9d15a29323ab"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1580,9 +1580,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e06040411d28aa7ba03fcf03971fbcd719b1020c5aa3eae2891587e892ef51ee"
+checksum = "4b63c1538ffb4b0e09edaebfcac35c34141d5944c52f77d137cbe0b634bd40fa"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -1599,9 +1599,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ecae9427e1f0ae664256f6620924f3eabb0983bdb18e1c36d15c15ba6ee35c9"
+checksum = "933b23b5cee0f58aa6c17c6de7e1f3007279357e0d555f22e24d6b395cfe7f89"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1611,9 +1611,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0823953c2775707cb0e151c2da97c4621193cf58308ee4f48b2df17d114c3d82"
+checksum = "41db0ac4df90610cda8320cfd5abf90c6ec90e298b6fe5a09a81dff718b55640"
 dependencies = [
  "backtrace",
  "enumset",
@@ -1633,9 +1633,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-dylib"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75db66afeacaf2d12a3d6af916410bc41459e01477f6628d637b77f5785f7c8c"
+checksum = "591683f3356ac31cc88aaecaf77ac2cc9f456014348b01af46c164f44f531162"
 dependencies = [
  "cfg-if",
  "enum-iterator",
@@ -1658,9 +1658,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-universal"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12a18da6797a46b5b35043796fd5d3451d384226e4531888ff1966dcb029a8ea"
+checksum = "dccfde103e9b87427099a6de344b7c791574f307d035c8c7dbbc00974c1af0c1"
 dependencies = [
  "cfg-if",
  "enum-iterator",
@@ -1678,9 +1678,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-middlewares"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a98d5a2058c14e56f5f48f51cd14cf4c572223bb79fe5589f2a1ee820a4522"
+checksum = "be816528dd62f037ae935977b643bb4237e10be9e32826e2f3eb1f911eaccc97"
 dependencies = [
  "loupe",
  "wasmer",
@@ -1690,9 +1690,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-object"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb88abea6a488ef64674c72c813564de7877a6e046d4b3f3e20c41302b82a10"
+checksum = "1d0c4005592998bd840f2289102ef9c67b6138338ed78e1fc0809586aa229040"
 dependencies = [
  "object 0.28.3",
  "thiserror",
@@ -1702,9 +1702,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bffc68539057bc92c10b260175d36acb90926840b175939e663eafdd4fbdb6"
+checksum = "4deb854f178265a76b59823c41547d259c65da3687b606b0b9c12d80ab950e3e"
 dependencies = [
  "indexmap",
  "loupe",
@@ -1715,9 +1715,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "215cc368b140d2eb3d3ab826dd01c602dc337c2374ac5d48f5652bd7eeac0d05"
+checksum = "5dbc5c989cb14a102433927e630473da52f83d82c469acd5cfa8fc7efacc1e70"
 dependencies = [
  "backtrace",
  "cc",

--- a/contracts/floaty/Cargo.lock
+++ b/contracts/floaty/Cargo.lock
@@ -1458,9 +1458,9 @@ checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
 name = "wasmer"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c823abda8b80153c938b3c7c55fcc74e2adfe40592732f7be01309dbe4aa53b"
+checksum = "d23f1bf05a2f86ad775dfe73b1da1842a58ffa549cd711c083cf56520c8025c4"
 dependencies = [
  "cfg-if",
  "indexmap",
@@ -1484,9 +1484,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ef59c6661f8f739c7c56d85400711a6e8791a101e931902af87423280e3dd36"
+checksum = "32158a07455808eccd655c3333d22a6a9eeb01c5891b750e6c7a66c43317b1fe"
 dependencies = [
  "enumset",
  "loupe",
@@ -1503,9 +1503,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd21b6306ec69096ac39e93418b2338e5def5445522f098c5b0a38863059492d"
+checksum = "b2afe1d581016703af0a6ac37511661b5ee5ceceee7bc387afcd4035ff36c2fc"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1524,9 +1524,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95c704e8c917e047e301862c76b93e2374631d3e6dc0b547c690f7ac38227344"
+checksum = "e06040411d28aa7ba03fcf03971fbcd719b1020c5aa3eae2891587e892ef51ee"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -1543,9 +1543,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5932932ef9e4f185dee5c99848ffafe98c5f49e0e92d2da14686761e38345c67"
+checksum = "4ecae9427e1f0ae664256f6620924f3eabb0983bdb18e1c36d15c15ba6ee35c9"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1555,9 +1555,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ed91396b15addd562d53fd92a016ba88c9b2ce4e0e0169a0e47cc67b739b37f"
+checksum = "0823953c2775707cb0e151c2da97c4621193cf58308ee4f48b2df17d114c3d82"
 dependencies = [
  "backtrace",
  "enumset",
@@ -1577,9 +1577,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-dylib"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9ecf7885c571a26141f37a362caa97796b8904f423dc5645031e149c9ee802"
+checksum = "75db66afeacaf2d12a3d6af916410bc41459e01477f6628d637b77f5785f7c8c"
 dependencies = [
  "cfg-if",
  "enum-iterator",
@@ -1602,9 +1602,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-universal"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bc4c936ebc050946dced5a3c4ef2bfe0b937c6e91323642c8e04552a82dfd9f"
+checksum = "12a18da6797a46b5b35043796fd5d3451d384226e4531888ff1966dcb029a8ea"
 dependencies = [
  "cfg-if",
  "enum-iterator",
@@ -1622,9 +1622,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-middlewares"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc770d4c278498bbbabec4cb9db33362ce6349cc397f746f2c75b20b5448fe2f"
+checksum = "09a98d5a2058c14e56f5f48f51cd14cf4c572223bb79fe5589f2a1ee820a4522"
 dependencies = [
  "loupe",
  "wasmer",
@@ -1634,9 +1634,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-object"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5626938e5e062747b999493d3a36591d9ba2fb0b6fb8e6f474e3355440ff9a0"
+checksum = "ffb88abea6a488ef64674c72c813564de7877a6e046d4b3f3e20c41302b82a10"
 dependencies = [
  "object 0.28.3",
  "thiserror",
@@ -1646,9 +1646,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78e5c8a51b65b946c122cecacdd496b24cc070f5465bc07ce83c62f830835814"
+checksum = "30bffc68539057bc92c10b260175d36acb90926840b175939e663eafdd4fbdb6"
 dependencies = [
  "indexmap",
  "loupe",
@@ -1659,9 +1659,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ad82e6b8e33a63c5215e11ea2f37e9a0b8a81606a41c922f26f61cb862e7f9"
+checksum = "215cc368b140d2eb3d3ab826dd01c602dc337c2374ac5d48f5652bd7eeac0d05"
 dependencies = [
  "backtrace",
  "cc",

--- a/contracts/floaty/Cargo.lock
+++ b/contracts/floaty/Cargo.lock
@@ -491,6 +491,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-iterator"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eeac5c5edb79e4e39fe8439ef35207780a11f69c52cbe424ce3dfad4cb78de6"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c134c37760b27a871ba422106eedbb8247da973a09e82558bf26d619c882b159"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "enumset"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -813,11 +833,12 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.27.1"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
+checksum = "40bec70ba014595f99f7aa110b84331ffe1ee9aece7fe6f387cc7e3ecda4d456"
 dependencies = [
  "crc32fast",
+ "hashbrown",
  "indexmap",
  "memchr",
 ]
@@ -1437,9 +1458,9 @@ checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
 name = "wasmer"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23f0188c23fc1b7de9bd7f8b834d0b1cd5edbe66e287452e8ce36d24418114f7"
+checksum = "7c823abda8b80153c938b3c7c55fcc74e2adfe40592732f7be01309dbe4aa53b"
 dependencies = [
  "cfg-if",
  "indexmap",
@@ -1463,9 +1484,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88c51cc589772c5f90bd329244c2416976d6cb2ee00d59429aaa8f421d9fe447"
+checksum = "4ef59c6661f8f739c7c56d85400711a6e8791a101e931902af87423280e3dd36"
 dependencies = [
  "enumset",
  "loupe",
@@ -1482,9 +1503,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09691e3e323b4e1128d2127f60f9cd988b66ce49afc8184b071c2b5ab16793f2"
+checksum = "bd21b6306ec69096ac39e93418b2338e5def5445522f098c5b0a38863059492d"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1503,9 +1524,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271d3da24c5d1a8bb3f9fc3944ba96d2588b6fa16a0bcef91765db853aeccac4"
+checksum = "95c704e8c917e047e301862c76b93e2374631d3e6dc0b547c690f7ac38227344"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -1522,9 +1543,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f5cb7b09640e09f1215da95d6fb7477d2db572f064b803ff705f39ff079cc5"
+checksum = "5932932ef9e4f185dee5c99848ffafe98c5f49e0e92d2da14686761e38345c67"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1534,9 +1555,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab20311c354fe2c12bc766417e0a1a45f399c1cd8ff262127d1dc86d0588971a"
+checksum = "5ed91396b15addd562d53fd92a016ba88c9b2ce4e0e0169a0e47cc67b739b37f"
 dependencies = [
  "backtrace",
  "enumset",
@@ -1556,15 +1577,17 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-dylib"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd5b7a74731e1dcccaf10a8ff5f72216c82f12972ce17cc81c6caa1afff75ea"
+checksum = "8d9ecf7885c571a26141f37a362caa97796b8904f423dc5645031e149c9ee802"
 dependencies = [
  "cfg-if",
+ "enum-iterator",
  "enumset",
  "leb128",
  "libloading",
  "loupe",
+ "object 0.28.3",
  "rkyv",
  "serde",
  "tempfile",
@@ -1579,11 +1602,12 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-universal"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfeae8d5b825ad7abcf9a34e66eb11e1507b21020efe7bbf9897e3dd8d7869e2"
+checksum = "3bc4c936ebc050946dced5a3c4ef2bfe0b937c6e91323642c8e04552a82dfd9f"
 dependencies = [
  "cfg-if",
+ "enum-iterator",
  "enumset",
  "leb128",
  "loupe",
@@ -1598,9 +1622,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-middlewares"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61a73bda8608a4ca56142b7849ccf4847cda566267d0071664ca06c6f4fbff1"
+checksum = "cc770d4c278498bbbabec4cb9db33362ce6349cc397f746f2c75b20b5448fe2f"
 dependencies = [
  "loupe",
  "wasmer",
@@ -1610,11 +1634,11 @@ dependencies = [
 
 [[package]]
 name = "wasmer-object"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d4714e4f3bdc3b2157c24284417d19cd99de036da31d00ec5664712dcb72f7"
+checksum = "f5626938e5e062747b999493d3a36591d9ba2fb0b6fb8e6f474e3355440ff9a0"
 dependencies = [
- "object 0.27.1",
+ "object 0.28.3",
  "thiserror",
  "wasmer-compiler",
  "wasmer-types",
@@ -1622,9 +1646,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434e1c0177da0a74ecca90b2aa7d5e86198260f07e8ba83be89feb5f0a4aeead"
+checksum = "78e5c8a51b65b946c122cecacdd496b24cc070f5465bc07ce83c62f830835814"
 dependencies = [
  "indexmap",
  "loupe",
@@ -1635,13 +1659,14 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc8f964ebba70d9f81340228b98a164782591f00239fc7f01e1b67afcf0e0156"
+checksum = "91ad82e6b8e33a63c5215e11ea2f37e9a0b8a81606a41c922f26f61cb862e7f9"
 dependencies = [
  "backtrace",
  "cc",
  "cfg-if",
+ "enum-iterator",
  "indexmap",
  "libc",
  "loupe",

--- a/contracts/floaty/Cargo.lock
+++ b/contracts/floaty/Cargo.lock
@@ -1458,9 +1458,9 @@ checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
 name = "wasmer"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d23f1bf05a2f86ad775dfe73b1da1842a58ffa549cd711c083cf56520c8025c4"
+checksum = "bfc7dff846db3f38f8ed0be4a009fdfeb729cf1f94a2c7fb6ff2fec01cefa110"
 dependencies = [
  "cfg-if",
  "indexmap",
@@ -1484,9 +1484,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32158a07455808eccd655c3333d22a6a9eeb01c5891b750e6c7a66c43317b1fe"
+checksum = "8c91abf22b16dad3826ec0d0e3ec0a8304262a6c7a14e16528c536131b80e63d"
 dependencies = [
  "enumset",
  "loupe",
@@ -1503,9 +1503,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2afe1d581016703af0a6ac37511661b5ee5ceceee7bc387afcd4035ff36c2fc"
+checksum = "7624a1f496b163139a7e0b442426cad805bec70486900287506f9d15a29323ab"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1524,9 +1524,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e06040411d28aa7ba03fcf03971fbcd719b1020c5aa3eae2891587e892ef51ee"
+checksum = "4b63c1538ffb4b0e09edaebfcac35c34141d5944c52f77d137cbe0b634bd40fa"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -1543,9 +1543,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ecae9427e1f0ae664256f6620924f3eabb0983bdb18e1c36d15c15ba6ee35c9"
+checksum = "933b23b5cee0f58aa6c17c6de7e1f3007279357e0d555f22e24d6b395cfe7f89"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1555,9 +1555,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0823953c2775707cb0e151c2da97c4621193cf58308ee4f48b2df17d114c3d82"
+checksum = "41db0ac4df90610cda8320cfd5abf90c6ec90e298b6fe5a09a81dff718b55640"
 dependencies = [
  "backtrace",
  "enumset",
@@ -1577,9 +1577,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-dylib"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75db66afeacaf2d12a3d6af916410bc41459e01477f6628d637b77f5785f7c8c"
+checksum = "591683f3356ac31cc88aaecaf77ac2cc9f456014348b01af46c164f44f531162"
 dependencies = [
  "cfg-if",
  "enum-iterator",
@@ -1602,9 +1602,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-universal"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12a18da6797a46b5b35043796fd5d3451d384226e4531888ff1966dcb029a8ea"
+checksum = "dccfde103e9b87427099a6de344b7c791574f307d035c8c7dbbc00974c1af0c1"
 dependencies = [
  "cfg-if",
  "enum-iterator",
@@ -1622,9 +1622,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-middlewares"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a98d5a2058c14e56f5f48f51cd14cf4c572223bb79fe5589f2a1ee820a4522"
+checksum = "be816528dd62f037ae935977b643bb4237e10be9e32826e2f3eb1f911eaccc97"
 dependencies = [
  "loupe",
  "wasmer",
@@ -1634,9 +1634,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-object"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb88abea6a488ef64674c72c813564de7877a6e046d4b3f3e20c41302b82a10"
+checksum = "1d0c4005592998bd840f2289102ef9c67b6138338ed78e1fc0809586aa229040"
 dependencies = [
  "object 0.28.3",
  "thiserror",
@@ -1646,9 +1646,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bffc68539057bc92c10b260175d36acb90926840b175939e663eafdd4fbdb6"
+checksum = "4deb854f178265a76b59823c41547d259c65da3687b606b0b9c12d80ab950e3e"
 dependencies = [
  "indexmap",
  "loupe",
@@ -1659,9 +1659,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "215cc368b140d2eb3d3ab826dd01c602dc337c2374ac5d48f5652bd7eeac0d05"
+checksum = "5dbc5c989cb14a102433927e630473da52f83d82c469acd5cfa8fc7efacc1e70"
 dependencies = [
  "backtrace",
  "cc",

--- a/contracts/hackatom/Cargo.lock
+++ b/contracts/hackatom/Cargo.lock
@@ -1500,9 +1500,9 @@ checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
 name = "wasmer"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c823abda8b80153c938b3c7c55fcc74e2adfe40592732f7be01309dbe4aa53b"
+checksum = "d23f1bf05a2f86ad775dfe73b1da1842a58ffa549cd711c083cf56520c8025c4"
 dependencies = [
  "cfg-if",
  "indexmap",
@@ -1526,9 +1526,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ef59c6661f8f739c7c56d85400711a6e8791a101e931902af87423280e3dd36"
+checksum = "32158a07455808eccd655c3333d22a6a9eeb01c5891b750e6c7a66c43317b1fe"
 dependencies = [
  "enumset",
  "loupe",
@@ -1545,9 +1545,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd21b6306ec69096ac39e93418b2338e5def5445522f098c5b0a38863059492d"
+checksum = "b2afe1d581016703af0a6ac37511661b5ee5ceceee7bc387afcd4035ff36c2fc"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1566,9 +1566,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95c704e8c917e047e301862c76b93e2374631d3e6dc0b547c690f7ac38227344"
+checksum = "e06040411d28aa7ba03fcf03971fbcd719b1020c5aa3eae2891587e892ef51ee"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -1585,9 +1585,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5932932ef9e4f185dee5c99848ffafe98c5f49e0e92d2da14686761e38345c67"
+checksum = "4ecae9427e1f0ae664256f6620924f3eabb0983bdb18e1c36d15c15ba6ee35c9"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1597,9 +1597,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ed91396b15addd562d53fd92a016ba88c9b2ce4e0e0169a0e47cc67b739b37f"
+checksum = "0823953c2775707cb0e151c2da97c4621193cf58308ee4f48b2df17d114c3d82"
 dependencies = [
  "backtrace",
  "enumset",
@@ -1619,9 +1619,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-dylib"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9ecf7885c571a26141f37a362caa97796b8904f423dc5645031e149c9ee802"
+checksum = "75db66afeacaf2d12a3d6af916410bc41459e01477f6628d637b77f5785f7c8c"
 dependencies = [
  "cfg-if",
  "enum-iterator",
@@ -1644,9 +1644,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-universal"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bc4c936ebc050946dced5a3c4ef2bfe0b937c6e91323642c8e04552a82dfd9f"
+checksum = "12a18da6797a46b5b35043796fd5d3451d384226e4531888ff1966dcb029a8ea"
 dependencies = [
  "cfg-if",
  "enum-iterator",
@@ -1664,9 +1664,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-middlewares"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc770d4c278498bbbabec4cb9db33362ce6349cc397f746f2c75b20b5448fe2f"
+checksum = "09a98d5a2058c14e56f5f48f51cd14cf4c572223bb79fe5589f2a1ee820a4522"
 dependencies = [
  "loupe",
  "wasmer",
@@ -1676,9 +1676,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-object"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5626938e5e062747b999493d3a36591d9ba2fb0b6fb8e6f474e3355440ff9a0"
+checksum = "ffb88abea6a488ef64674c72c813564de7877a6e046d4b3f3e20c41302b82a10"
 dependencies = [
  "object 0.28.3",
  "thiserror",
@@ -1688,9 +1688,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78e5c8a51b65b946c122cecacdd496b24cc070f5465bc07ce83c62f830835814"
+checksum = "30bffc68539057bc92c10b260175d36acb90926840b175939e663eafdd4fbdb6"
 dependencies = [
  "indexmap",
  "loupe",
@@ -1701,9 +1701,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ad82e6b8e33a63c5215e11ea2f37e9a0b8a81606a41c922f26f61cb862e7f9"
+checksum = "215cc368b140d2eb3d3ab826dd01c602dc337c2374ac5d48f5652bd7eeac0d05"
 dependencies = [
  "backtrace",
  "cc",

--- a/contracts/hackatom/Cargo.lock
+++ b/contracts/hackatom/Cargo.lock
@@ -1500,9 +1500,9 @@ checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
 name = "wasmer"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d23f1bf05a2f86ad775dfe73b1da1842a58ffa549cd711c083cf56520c8025c4"
+checksum = "bfc7dff846db3f38f8ed0be4a009fdfeb729cf1f94a2c7fb6ff2fec01cefa110"
 dependencies = [
  "cfg-if",
  "indexmap",
@@ -1526,9 +1526,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32158a07455808eccd655c3333d22a6a9eeb01c5891b750e6c7a66c43317b1fe"
+checksum = "8c91abf22b16dad3826ec0d0e3ec0a8304262a6c7a14e16528c536131b80e63d"
 dependencies = [
  "enumset",
  "loupe",
@@ -1545,9 +1545,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2afe1d581016703af0a6ac37511661b5ee5ceceee7bc387afcd4035ff36c2fc"
+checksum = "7624a1f496b163139a7e0b442426cad805bec70486900287506f9d15a29323ab"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1566,9 +1566,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e06040411d28aa7ba03fcf03971fbcd719b1020c5aa3eae2891587e892ef51ee"
+checksum = "4b63c1538ffb4b0e09edaebfcac35c34141d5944c52f77d137cbe0b634bd40fa"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -1585,9 +1585,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ecae9427e1f0ae664256f6620924f3eabb0983bdb18e1c36d15c15ba6ee35c9"
+checksum = "933b23b5cee0f58aa6c17c6de7e1f3007279357e0d555f22e24d6b395cfe7f89"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1597,9 +1597,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0823953c2775707cb0e151c2da97c4621193cf58308ee4f48b2df17d114c3d82"
+checksum = "41db0ac4df90610cda8320cfd5abf90c6ec90e298b6fe5a09a81dff718b55640"
 dependencies = [
  "backtrace",
  "enumset",
@@ -1619,9 +1619,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-dylib"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75db66afeacaf2d12a3d6af916410bc41459e01477f6628d637b77f5785f7c8c"
+checksum = "591683f3356ac31cc88aaecaf77ac2cc9f456014348b01af46c164f44f531162"
 dependencies = [
  "cfg-if",
  "enum-iterator",
@@ -1644,9 +1644,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-universal"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12a18da6797a46b5b35043796fd5d3451d384226e4531888ff1966dcb029a8ea"
+checksum = "dccfde103e9b87427099a6de344b7c791574f307d035c8c7dbbc00974c1af0c1"
 dependencies = [
  "cfg-if",
  "enum-iterator",
@@ -1664,9 +1664,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-middlewares"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a98d5a2058c14e56f5f48f51cd14cf4c572223bb79fe5589f2a1ee820a4522"
+checksum = "be816528dd62f037ae935977b643bb4237e10be9e32826e2f3eb1f911eaccc97"
 dependencies = [
  "loupe",
  "wasmer",
@@ -1676,9 +1676,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-object"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb88abea6a488ef64674c72c813564de7877a6e046d4b3f3e20c41302b82a10"
+checksum = "1d0c4005592998bd840f2289102ef9c67b6138338ed78e1fc0809586aa229040"
 dependencies = [
  "object 0.28.3",
  "thiserror",
@@ -1688,9 +1688,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bffc68539057bc92c10b260175d36acb90926840b175939e663eafdd4fbdb6"
+checksum = "4deb854f178265a76b59823c41547d259c65da3687b606b0b9c12d80ab950e3e"
 dependencies = [
  "indexmap",
  "loupe",
@@ -1701,9 +1701,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "215cc368b140d2eb3d3ab826dd01c602dc337c2374ac5d48f5652bd7eeac0d05"
+checksum = "5dbc5c989cb14a102433927e630473da52f83d82c469acd5cfa8fc7efacc1e70"
 dependencies = [
  "backtrace",
  "cc",

--- a/contracts/hackatom/Cargo.lock
+++ b/contracts/hackatom/Cargo.lock
@@ -520,6 +520,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-iterator"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eeac5c5edb79e4e39fe8439ef35207780a11f69c52cbe424ce3dfad4cb78de6"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c134c37760b27a871ba422106eedbb8247da973a09e82558bf26d619c882b159"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "enumset"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -843,11 +863,12 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.27.1"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
+checksum = "40bec70ba014595f99f7aa110b84331ffe1ee9aece7fe6f387cc7e3ecda4d456"
 dependencies = [
  "crc32fast",
+ "hashbrown",
  "indexmap",
  "memchr",
 ]
@@ -1479,9 +1500,9 @@ checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
 name = "wasmer"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23f0188c23fc1b7de9bd7f8b834d0b1cd5edbe66e287452e8ce36d24418114f7"
+checksum = "7c823abda8b80153c938b3c7c55fcc74e2adfe40592732f7be01309dbe4aa53b"
 dependencies = [
  "cfg-if",
  "indexmap",
@@ -1505,9 +1526,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88c51cc589772c5f90bd329244c2416976d6cb2ee00d59429aaa8f421d9fe447"
+checksum = "4ef59c6661f8f739c7c56d85400711a6e8791a101e931902af87423280e3dd36"
 dependencies = [
  "enumset",
  "loupe",
@@ -1524,9 +1545,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09691e3e323b4e1128d2127f60f9cd988b66ce49afc8184b071c2b5ab16793f2"
+checksum = "bd21b6306ec69096ac39e93418b2338e5def5445522f098c5b0a38863059492d"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1545,9 +1566,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271d3da24c5d1a8bb3f9fc3944ba96d2588b6fa16a0bcef91765db853aeccac4"
+checksum = "95c704e8c917e047e301862c76b93e2374631d3e6dc0b547c690f7ac38227344"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -1564,9 +1585,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f5cb7b09640e09f1215da95d6fb7477d2db572f064b803ff705f39ff079cc5"
+checksum = "5932932ef9e4f185dee5c99848ffafe98c5f49e0e92d2da14686761e38345c67"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1576,9 +1597,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab20311c354fe2c12bc766417e0a1a45f399c1cd8ff262127d1dc86d0588971a"
+checksum = "5ed91396b15addd562d53fd92a016ba88c9b2ce4e0e0169a0e47cc67b739b37f"
 dependencies = [
  "backtrace",
  "enumset",
@@ -1598,15 +1619,17 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-dylib"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd5b7a74731e1dcccaf10a8ff5f72216c82f12972ce17cc81c6caa1afff75ea"
+checksum = "8d9ecf7885c571a26141f37a362caa97796b8904f423dc5645031e149c9ee802"
 dependencies = [
  "cfg-if",
+ "enum-iterator",
  "enumset",
  "leb128",
  "libloading",
  "loupe",
+ "object 0.28.3",
  "rkyv",
  "serde",
  "tempfile",
@@ -1621,11 +1644,12 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-universal"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfeae8d5b825ad7abcf9a34e66eb11e1507b21020efe7bbf9897e3dd8d7869e2"
+checksum = "3bc4c936ebc050946dced5a3c4ef2bfe0b937c6e91323642c8e04552a82dfd9f"
 dependencies = [
  "cfg-if",
+ "enum-iterator",
  "enumset",
  "leb128",
  "loupe",
@@ -1640,9 +1664,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-middlewares"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61a73bda8608a4ca56142b7849ccf4847cda566267d0071664ca06c6f4fbff1"
+checksum = "cc770d4c278498bbbabec4cb9db33362ce6349cc397f746f2c75b20b5448fe2f"
 dependencies = [
  "loupe",
  "wasmer",
@@ -1652,11 +1676,11 @@ dependencies = [
 
 [[package]]
 name = "wasmer-object"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d4714e4f3bdc3b2157c24284417d19cd99de036da31d00ec5664712dcb72f7"
+checksum = "f5626938e5e062747b999493d3a36591d9ba2fb0b6fb8e6f474e3355440ff9a0"
 dependencies = [
- "object 0.27.1",
+ "object 0.28.3",
  "thiserror",
  "wasmer-compiler",
  "wasmer-types",
@@ -1664,9 +1688,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434e1c0177da0a74ecca90b2aa7d5e86198260f07e8ba83be89feb5f0a4aeead"
+checksum = "78e5c8a51b65b946c122cecacdd496b24cc070f5465bc07ce83c62f830835814"
 dependencies = [
  "indexmap",
  "loupe",
@@ -1677,13 +1701,14 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc8f964ebba70d9f81340228b98a164782591f00239fc7f01e1b67afcf0e0156"
+checksum = "91ad82e6b8e33a63c5215e11ea2f37e9a0b8a81606a41c922f26f61cb862e7f9"
 dependencies = [
  "backtrace",
  "cc",
  "cfg-if",
+ "enum-iterator",
  "indexmap",
  "libc",
  "loupe",

--- a/contracts/ibc-reflect-send/Cargo.lock
+++ b/contracts/ibc-reflect-send/Cargo.lock
@@ -1456,9 +1456,9 @@ checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
 name = "wasmer"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d23f1bf05a2f86ad775dfe73b1da1842a58ffa549cd711c083cf56520c8025c4"
+checksum = "bfc7dff846db3f38f8ed0be4a009fdfeb729cf1f94a2c7fb6ff2fec01cefa110"
 dependencies = [
  "cfg-if",
  "indexmap",
@@ -1482,9 +1482,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32158a07455808eccd655c3333d22a6a9eeb01c5891b750e6c7a66c43317b1fe"
+checksum = "8c91abf22b16dad3826ec0d0e3ec0a8304262a6c7a14e16528c536131b80e63d"
 dependencies = [
  "enumset",
  "loupe",
@@ -1501,9 +1501,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2afe1d581016703af0a6ac37511661b5ee5ceceee7bc387afcd4035ff36c2fc"
+checksum = "7624a1f496b163139a7e0b442426cad805bec70486900287506f9d15a29323ab"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1522,9 +1522,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e06040411d28aa7ba03fcf03971fbcd719b1020c5aa3eae2891587e892ef51ee"
+checksum = "4b63c1538ffb4b0e09edaebfcac35c34141d5944c52f77d137cbe0b634bd40fa"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -1541,9 +1541,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ecae9427e1f0ae664256f6620924f3eabb0983bdb18e1c36d15c15ba6ee35c9"
+checksum = "933b23b5cee0f58aa6c17c6de7e1f3007279357e0d555f22e24d6b395cfe7f89"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1553,9 +1553,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0823953c2775707cb0e151c2da97c4621193cf58308ee4f48b2df17d114c3d82"
+checksum = "41db0ac4df90610cda8320cfd5abf90c6ec90e298b6fe5a09a81dff718b55640"
 dependencies = [
  "backtrace",
  "enumset",
@@ -1575,9 +1575,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-dylib"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75db66afeacaf2d12a3d6af916410bc41459e01477f6628d637b77f5785f7c8c"
+checksum = "591683f3356ac31cc88aaecaf77ac2cc9f456014348b01af46c164f44f531162"
 dependencies = [
  "cfg-if",
  "enum-iterator",
@@ -1600,9 +1600,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-universal"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12a18da6797a46b5b35043796fd5d3451d384226e4531888ff1966dcb029a8ea"
+checksum = "dccfde103e9b87427099a6de344b7c791574f307d035c8c7dbbc00974c1af0c1"
 dependencies = [
  "cfg-if",
  "enum-iterator",
@@ -1620,9 +1620,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-middlewares"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a98d5a2058c14e56f5f48f51cd14cf4c572223bb79fe5589f2a1ee820a4522"
+checksum = "be816528dd62f037ae935977b643bb4237e10be9e32826e2f3eb1f911eaccc97"
 dependencies = [
  "loupe",
  "wasmer",
@@ -1632,9 +1632,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-object"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb88abea6a488ef64674c72c813564de7877a6e046d4b3f3e20c41302b82a10"
+checksum = "1d0c4005592998bd840f2289102ef9c67b6138338ed78e1fc0809586aa229040"
 dependencies = [
  "object 0.28.3",
  "thiserror",
@@ -1644,9 +1644,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bffc68539057bc92c10b260175d36acb90926840b175939e663eafdd4fbdb6"
+checksum = "4deb854f178265a76b59823c41547d259c65da3687b606b0b9c12d80ab950e3e"
 dependencies = [
  "indexmap",
  "loupe",
@@ -1657,9 +1657,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "215cc368b140d2eb3d3ab826dd01c602dc337c2374ac5d48f5652bd7eeac0d05"
+checksum = "5dbc5c989cb14a102433927e630473da52f83d82c469acd5cfa8fc7efacc1e70"
 dependencies = [
  "backtrace",
  "cc",

--- a/contracts/ibc-reflect-send/Cargo.lock
+++ b/contracts/ibc-reflect-send/Cargo.lock
@@ -1456,9 +1456,9 @@ checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
 name = "wasmer"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c823abda8b80153c938b3c7c55fcc74e2adfe40592732f7be01309dbe4aa53b"
+checksum = "d23f1bf05a2f86ad775dfe73b1da1842a58ffa549cd711c083cf56520c8025c4"
 dependencies = [
  "cfg-if",
  "indexmap",
@@ -1482,9 +1482,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ef59c6661f8f739c7c56d85400711a6e8791a101e931902af87423280e3dd36"
+checksum = "32158a07455808eccd655c3333d22a6a9eeb01c5891b750e6c7a66c43317b1fe"
 dependencies = [
  "enumset",
  "loupe",
@@ -1501,9 +1501,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd21b6306ec69096ac39e93418b2338e5def5445522f098c5b0a38863059492d"
+checksum = "b2afe1d581016703af0a6ac37511661b5ee5ceceee7bc387afcd4035ff36c2fc"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1522,9 +1522,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95c704e8c917e047e301862c76b93e2374631d3e6dc0b547c690f7ac38227344"
+checksum = "e06040411d28aa7ba03fcf03971fbcd719b1020c5aa3eae2891587e892ef51ee"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -1541,9 +1541,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5932932ef9e4f185dee5c99848ffafe98c5f49e0e92d2da14686761e38345c67"
+checksum = "4ecae9427e1f0ae664256f6620924f3eabb0983bdb18e1c36d15c15ba6ee35c9"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1553,9 +1553,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ed91396b15addd562d53fd92a016ba88c9b2ce4e0e0169a0e47cc67b739b37f"
+checksum = "0823953c2775707cb0e151c2da97c4621193cf58308ee4f48b2df17d114c3d82"
 dependencies = [
  "backtrace",
  "enumset",
@@ -1575,9 +1575,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-dylib"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9ecf7885c571a26141f37a362caa97796b8904f423dc5645031e149c9ee802"
+checksum = "75db66afeacaf2d12a3d6af916410bc41459e01477f6628d637b77f5785f7c8c"
 dependencies = [
  "cfg-if",
  "enum-iterator",
@@ -1600,9 +1600,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-universal"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bc4c936ebc050946dced5a3c4ef2bfe0b937c6e91323642c8e04552a82dfd9f"
+checksum = "12a18da6797a46b5b35043796fd5d3451d384226e4531888ff1966dcb029a8ea"
 dependencies = [
  "cfg-if",
  "enum-iterator",
@@ -1620,9 +1620,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-middlewares"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc770d4c278498bbbabec4cb9db33362ce6349cc397f746f2c75b20b5448fe2f"
+checksum = "09a98d5a2058c14e56f5f48f51cd14cf4c572223bb79fe5589f2a1ee820a4522"
 dependencies = [
  "loupe",
  "wasmer",
@@ -1632,9 +1632,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-object"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5626938e5e062747b999493d3a36591d9ba2fb0b6fb8e6f474e3355440ff9a0"
+checksum = "ffb88abea6a488ef64674c72c813564de7877a6e046d4b3f3e20c41302b82a10"
 dependencies = [
  "object 0.28.3",
  "thiserror",
@@ -1644,9 +1644,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78e5c8a51b65b946c122cecacdd496b24cc070f5465bc07ce83c62f830835814"
+checksum = "30bffc68539057bc92c10b260175d36acb90926840b175939e663eafdd4fbdb6"
 dependencies = [
  "indexmap",
  "loupe",
@@ -1657,9 +1657,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ad82e6b8e33a63c5215e11ea2f37e9a0b8a81606a41c922f26f61cb862e7f9"
+checksum = "215cc368b140d2eb3d3ab826dd01c602dc337c2374ac5d48f5652bd7eeac0d05"
 dependencies = [
  "backtrace",
  "cc",

--- a/contracts/ibc-reflect-send/Cargo.lock
+++ b/contracts/ibc-reflect-send/Cargo.lock
@@ -491,6 +491,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-iterator"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eeac5c5edb79e4e39fe8439ef35207780a11f69c52cbe424ce3dfad4cb78de6"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c134c37760b27a871ba422106eedbb8247da973a09e82558bf26d619c882b159"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "enumset"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -811,11 +831,12 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.27.1"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
+checksum = "40bec70ba014595f99f7aa110b84331ffe1ee9aece7fe6f387cc7e3ecda4d456"
 dependencies = [
  "crc32fast",
+ "hashbrown",
  "indexmap",
  "memchr",
 ]
@@ -1435,9 +1456,9 @@ checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
 name = "wasmer"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23f0188c23fc1b7de9bd7f8b834d0b1cd5edbe66e287452e8ce36d24418114f7"
+checksum = "7c823abda8b80153c938b3c7c55fcc74e2adfe40592732f7be01309dbe4aa53b"
 dependencies = [
  "cfg-if",
  "indexmap",
@@ -1461,9 +1482,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88c51cc589772c5f90bd329244c2416976d6cb2ee00d59429aaa8f421d9fe447"
+checksum = "4ef59c6661f8f739c7c56d85400711a6e8791a101e931902af87423280e3dd36"
 dependencies = [
  "enumset",
  "loupe",
@@ -1480,9 +1501,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09691e3e323b4e1128d2127f60f9cd988b66ce49afc8184b071c2b5ab16793f2"
+checksum = "bd21b6306ec69096ac39e93418b2338e5def5445522f098c5b0a38863059492d"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1501,9 +1522,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271d3da24c5d1a8bb3f9fc3944ba96d2588b6fa16a0bcef91765db853aeccac4"
+checksum = "95c704e8c917e047e301862c76b93e2374631d3e6dc0b547c690f7ac38227344"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -1520,9 +1541,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f5cb7b09640e09f1215da95d6fb7477d2db572f064b803ff705f39ff079cc5"
+checksum = "5932932ef9e4f185dee5c99848ffafe98c5f49e0e92d2da14686761e38345c67"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1532,9 +1553,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab20311c354fe2c12bc766417e0a1a45f399c1cd8ff262127d1dc86d0588971a"
+checksum = "5ed91396b15addd562d53fd92a016ba88c9b2ce4e0e0169a0e47cc67b739b37f"
 dependencies = [
  "backtrace",
  "enumset",
@@ -1554,15 +1575,17 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-dylib"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd5b7a74731e1dcccaf10a8ff5f72216c82f12972ce17cc81c6caa1afff75ea"
+checksum = "8d9ecf7885c571a26141f37a362caa97796b8904f423dc5645031e149c9ee802"
 dependencies = [
  "cfg-if",
+ "enum-iterator",
  "enumset",
  "leb128",
  "libloading",
  "loupe",
+ "object 0.28.3",
  "rkyv",
  "serde",
  "tempfile",
@@ -1577,11 +1600,12 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-universal"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfeae8d5b825ad7abcf9a34e66eb11e1507b21020efe7bbf9897e3dd8d7869e2"
+checksum = "3bc4c936ebc050946dced5a3c4ef2bfe0b937c6e91323642c8e04552a82dfd9f"
 dependencies = [
  "cfg-if",
+ "enum-iterator",
  "enumset",
  "leb128",
  "loupe",
@@ -1596,9 +1620,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-middlewares"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61a73bda8608a4ca56142b7849ccf4847cda566267d0071664ca06c6f4fbff1"
+checksum = "cc770d4c278498bbbabec4cb9db33362ce6349cc397f746f2c75b20b5448fe2f"
 dependencies = [
  "loupe",
  "wasmer",
@@ -1608,11 +1632,11 @@ dependencies = [
 
 [[package]]
 name = "wasmer-object"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d4714e4f3bdc3b2157c24284417d19cd99de036da31d00ec5664712dcb72f7"
+checksum = "f5626938e5e062747b999493d3a36591d9ba2fb0b6fb8e6f474e3355440ff9a0"
 dependencies = [
- "object 0.27.1",
+ "object 0.28.3",
  "thiserror",
  "wasmer-compiler",
  "wasmer-types",
@@ -1620,9 +1644,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434e1c0177da0a74ecca90b2aa7d5e86198260f07e8ba83be89feb5f0a4aeead"
+checksum = "78e5c8a51b65b946c122cecacdd496b24cc070f5465bc07ce83c62f830835814"
 dependencies = [
  "indexmap",
  "loupe",
@@ -1633,13 +1657,14 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc8f964ebba70d9f81340228b98a164782591f00239fc7f01e1b67afcf0e0156"
+checksum = "91ad82e6b8e33a63c5215e11ea2f37e9a0b8a81606a41c922f26f61cb862e7f9"
 dependencies = [
  "backtrace",
  "cc",
  "cfg-if",
+ "enum-iterator",
  "indexmap",
  "libc",
  "loupe",

--- a/contracts/ibc-reflect/Cargo.lock
+++ b/contracts/ibc-reflect/Cargo.lock
@@ -1456,9 +1456,9 @@ checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
 name = "wasmer"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d23f1bf05a2f86ad775dfe73b1da1842a58ffa549cd711c083cf56520c8025c4"
+checksum = "bfc7dff846db3f38f8ed0be4a009fdfeb729cf1f94a2c7fb6ff2fec01cefa110"
 dependencies = [
  "cfg-if",
  "indexmap",
@@ -1482,9 +1482,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32158a07455808eccd655c3333d22a6a9eeb01c5891b750e6c7a66c43317b1fe"
+checksum = "8c91abf22b16dad3826ec0d0e3ec0a8304262a6c7a14e16528c536131b80e63d"
 dependencies = [
  "enumset",
  "loupe",
@@ -1501,9 +1501,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2afe1d581016703af0a6ac37511661b5ee5ceceee7bc387afcd4035ff36c2fc"
+checksum = "7624a1f496b163139a7e0b442426cad805bec70486900287506f9d15a29323ab"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1522,9 +1522,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e06040411d28aa7ba03fcf03971fbcd719b1020c5aa3eae2891587e892ef51ee"
+checksum = "4b63c1538ffb4b0e09edaebfcac35c34141d5944c52f77d137cbe0b634bd40fa"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -1541,9 +1541,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ecae9427e1f0ae664256f6620924f3eabb0983bdb18e1c36d15c15ba6ee35c9"
+checksum = "933b23b5cee0f58aa6c17c6de7e1f3007279357e0d555f22e24d6b395cfe7f89"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1553,9 +1553,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0823953c2775707cb0e151c2da97c4621193cf58308ee4f48b2df17d114c3d82"
+checksum = "41db0ac4df90610cda8320cfd5abf90c6ec90e298b6fe5a09a81dff718b55640"
 dependencies = [
  "backtrace",
  "enumset",
@@ -1575,9 +1575,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-dylib"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75db66afeacaf2d12a3d6af916410bc41459e01477f6628d637b77f5785f7c8c"
+checksum = "591683f3356ac31cc88aaecaf77ac2cc9f456014348b01af46c164f44f531162"
 dependencies = [
  "cfg-if",
  "enum-iterator",
@@ -1600,9 +1600,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-universal"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12a18da6797a46b5b35043796fd5d3451d384226e4531888ff1966dcb029a8ea"
+checksum = "dccfde103e9b87427099a6de344b7c791574f307d035c8c7dbbc00974c1af0c1"
 dependencies = [
  "cfg-if",
  "enum-iterator",
@@ -1620,9 +1620,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-middlewares"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a98d5a2058c14e56f5f48f51cd14cf4c572223bb79fe5589f2a1ee820a4522"
+checksum = "be816528dd62f037ae935977b643bb4237e10be9e32826e2f3eb1f911eaccc97"
 dependencies = [
  "loupe",
  "wasmer",
@@ -1632,9 +1632,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-object"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb88abea6a488ef64674c72c813564de7877a6e046d4b3f3e20c41302b82a10"
+checksum = "1d0c4005592998bd840f2289102ef9c67b6138338ed78e1fc0809586aa229040"
 dependencies = [
  "object 0.28.3",
  "thiserror",
@@ -1644,9 +1644,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bffc68539057bc92c10b260175d36acb90926840b175939e663eafdd4fbdb6"
+checksum = "4deb854f178265a76b59823c41547d259c65da3687b606b0b9c12d80ab950e3e"
 dependencies = [
  "indexmap",
  "loupe",
@@ -1657,9 +1657,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "215cc368b140d2eb3d3ab826dd01c602dc337c2374ac5d48f5652bd7eeac0d05"
+checksum = "5dbc5c989cb14a102433927e630473da52f83d82c469acd5cfa8fc7efacc1e70"
 dependencies = [
  "backtrace",
  "cc",

--- a/contracts/ibc-reflect/Cargo.lock
+++ b/contracts/ibc-reflect/Cargo.lock
@@ -1456,9 +1456,9 @@ checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
 name = "wasmer"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c823abda8b80153c938b3c7c55fcc74e2adfe40592732f7be01309dbe4aa53b"
+checksum = "d23f1bf05a2f86ad775dfe73b1da1842a58ffa549cd711c083cf56520c8025c4"
 dependencies = [
  "cfg-if",
  "indexmap",
@@ -1482,9 +1482,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ef59c6661f8f739c7c56d85400711a6e8791a101e931902af87423280e3dd36"
+checksum = "32158a07455808eccd655c3333d22a6a9eeb01c5891b750e6c7a66c43317b1fe"
 dependencies = [
  "enumset",
  "loupe",
@@ -1501,9 +1501,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd21b6306ec69096ac39e93418b2338e5def5445522f098c5b0a38863059492d"
+checksum = "b2afe1d581016703af0a6ac37511661b5ee5ceceee7bc387afcd4035ff36c2fc"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1522,9 +1522,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95c704e8c917e047e301862c76b93e2374631d3e6dc0b547c690f7ac38227344"
+checksum = "e06040411d28aa7ba03fcf03971fbcd719b1020c5aa3eae2891587e892ef51ee"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -1541,9 +1541,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5932932ef9e4f185dee5c99848ffafe98c5f49e0e92d2da14686761e38345c67"
+checksum = "4ecae9427e1f0ae664256f6620924f3eabb0983bdb18e1c36d15c15ba6ee35c9"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1553,9 +1553,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ed91396b15addd562d53fd92a016ba88c9b2ce4e0e0169a0e47cc67b739b37f"
+checksum = "0823953c2775707cb0e151c2da97c4621193cf58308ee4f48b2df17d114c3d82"
 dependencies = [
  "backtrace",
  "enumset",
@@ -1575,9 +1575,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-dylib"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9ecf7885c571a26141f37a362caa97796b8904f423dc5645031e149c9ee802"
+checksum = "75db66afeacaf2d12a3d6af916410bc41459e01477f6628d637b77f5785f7c8c"
 dependencies = [
  "cfg-if",
  "enum-iterator",
@@ -1600,9 +1600,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-universal"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bc4c936ebc050946dced5a3c4ef2bfe0b937c6e91323642c8e04552a82dfd9f"
+checksum = "12a18da6797a46b5b35043796fd5d3451d384226e4531888ff1966dcb029a8ea"
 dependencies = [
  "cfg-if",
  "enum-iterator",
@@ -1620,9 +1620,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-middlewares"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc770d4c278498bbbabec4cb9db33362ce6349cc397f746f2c75b20b5448fe2f"
+checksum = "09a98d5a2058c14e56f5f48f51cd14cf4c572223bb79fe5589f2a1ee820a4522"
 dependencies = [
  "loupe",
  "wasmer",
@@ -1632,9 +1632,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-object"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5626938e5e062747b999493d3a36591d9ba2fb0b6fb8e6f474e3355440ff9a0"
+checksum = "ffb88abea6a488ef64674c72c813564de7877a6e046d4b3f3e20c41302b82a10"
 dependencies = [
  "object 0.28.3",
  "thiserror",
@@ -1644,9 +1644,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78e5c8a51b65b946c122cecacdd496b24cc070f5465bc07ce83c62f830835814"
+checksum = "30bffc68539057bc92c10b260175d36acb90926840b175939e663eafdd4fbdb6"
 dependencies = [
  "indexmap",
  "loupe",
@@ -1657,9 +1657,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ad82e6b8e33a63c5215e11ea2f37e9a0b8a81606a41c922f26f61cb862e7f9"
+checksum = "215cc368b140d2eb3d3ab826dd01c602dc337c2374ac5d48f5652bd7eeac0d05"
 dependencies = [
  "backtrace",
  "cc",

--- a/contracts/ibc-reflect/Cargo.lock
+++ b/contracts/ibc-reflect/Cargo.lock
@@ -491,6 +491,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-iterator"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eeac5c5edb79e4e39fe8439ef35207780a11f69c52cbe424ce3dfad4cb78de6"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c134c37760b27a871ba422106eedbb8247da973a09e82558bf26d619c882b159"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "enumset"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -811,11 +831,12 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.27.1"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
+checksum = "40bec70ba014595f99f7aa110b84331ffe1ee9aece7fe6f387cc7e3ecda4d456"
 dependencies = [
  "crc32fast",
+ "hashbrown",
  "indexmap",
  "memchr",
 ]
@@ -1435,9 +1456,9 @@ checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
 name = "wasmer"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23f0188c23fc1b7de9bd7f8b834d0b1cd5edbe66e287452e8ce36d24418114f7"
+checksum = "7c823abda8b80153c938b3c7c55fcc74e2adfe40592732f7be01309dbe4aa53b"
 dependencies = [
  "cfg-if",
  "indexmap",
@@ -1461,9 +1482,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88c51cc589772c5f90bd329244c2416976d6cb2ee00d59429aaa8f421d9fe447"
+checksum = "4ef59c6661f8f739c7c56d85400711a6e8791a101e931902af87423280e3dd36"
 dependencies = [
  "enumset",
  "loupe",
@@ -1480,9 +1501,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09691e3e323b4e1128d2127f60f9cd988b66ce49afc8184b071c2b5ab16793f2"
+checksum = "bd21b6306ec69096ac39e93418b2338e5def5445522f098c5b0a38863059492d"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1501,9 +1522,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271d3da24c5d1a8bb3f9fc3944ba96d2588b6fa16a0bcef91765db853aeccac4"
+checksum = "95c704e8c917e047e301862c76b93e2374631d3e6dc0b547c690f7ac38227344"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -1520,9 +1541,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f5cb7b09640e09f1215da95d6fb7477d2db572f064b803ff705f39ff079cc5"
+checksum = "5932932ef9e4f185dee5c99848ffafe98c5f49e0e92d2da14686761e38345c67"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1532,9 +1553,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab20311c354fe2c12bc766417e0a1a45f399c1cd8ff262127d1dc86d0588971a"
+checksum = "5ed91396b15addd562d53fd92a016ba88c9b2ce4e0e0169a0e47cc67b739b37f"
 dependencies = [
  "backtrace",
  "enumset",
@@ -1554,15 +1575,17 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-dylib"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd5b7a74731e1dcccaf10a8ff5f72216c82f12972ce17cc81c6caa1afff75ea"
+checksum = "8d9ecf7885c571a26141f37a362caa97796b8904f423dc5645031e149c9ee802"
 dependencies = [
  "cfg-if",
+ "enum-iterator",
  "enumset",
  "leb128",
  "libloading",
  "loupe",
+ "object 0.28.3",
  "rkyv",
  "serde",
  "tempfile",
@@ -1577,11 +1600,12 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-universal"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfeae8d5b825ad7abcf9a34e66eb11e1507b21020efe7bbf9897e3dd8d7869e2"
+checksum = "3bc4c936ebc050946dced5a3c4ef2bfe0b937c6e91323642c8e04552a82dfd9f"
 dependencies = [
  "cfg-if",
+ "enum-iterator",
  "enumset",
  "leb128",
  "loupe",
@@ -1596,9 +1620,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-middlewares"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61a73bda8608a4ca56142b7849ccf4847cda566267d0071664ca06c6f4fbff1"
+checksum = "cc770d4c278498bbbabec4cb9db33362ce6349cc397f746f2c75b20b5448fe2f"
 dependencies = [
  "loupe",
  "wasmer",
@@ -1608,11 +1632,11 @@ dependencies = [
 
 [[package]]
 name = "wasmer-object"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d4714e4f3bdc3b2157c24284417d19cd99de036da31d00ec5664712dcb72f7"
+checksum = "f5626938e5e062747b999493d3a36591d9ba2fb0b6fb8e6f474e3355440ff9a0"
 dependencies = [
- "object 0.27.1",
+ "object 0.28.3",
  "thiserror",
  "wasmer-compiler",
  "wasmer-types",
@@ -1620,9 +1644,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434e1c0177da0a74ecca90b2aa7d5e86198260f07e8ba83be89feb5f0a4aeead"
+checksum = "78e5c8a51b65b946c122cecacdd496b24cc070f5465bc07ce83c62f830835814"
 dependencies = [
  "indexmap",
  "loupe",
@@ -1633,13 +1657,14 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc8f964ebba70d9f81340228b98a164782591f00239fc7f01e1b67afcf0e0156"
+checksum = "91ad82e6b8e33a63c5215e11ea2f37e9a0b8a81606a41c922f26f61cb862e7f9"
 dependencies = [
  "backtrace",
  "cc",
  "cfg-if",
+ "enum-iterator",
  "indexmap",
  "libc",
  "loupe",

--- a/contracts/queue/Cargo.lock
+++ b/contracts/queue/Cargo.lock
@@ -1447,9 +1447,9 @@ checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
 name = "wasmer"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d23f1bf05a2f86ad775dfe73b1da1842a58ffa549cd711c083cf56520c8025c4"
+checksum = "bfc7dff846db3f38f8ed0be4a009fdfeb729cf1f94a2c7fb6ff2fec01cefa110"
 dependencies = [
  "cfg-if",
  "indexmap",
@@ -1473,9 +1473,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32158a07455808eccd655c3333d22a6a9eeb01c5891b750e6c7a66c43317b1fe"
+checksum = "8c91abf22b16dad3826ec0d0e3ec0a8304262a6c7a14e16528c536131b80e63d"
 dependencies = [
  "enumset",
  "loupe",
@@ -1492,9 +1492,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2afe1d581016703af0a6ac37511661b5ee5ceceee7bc387afcd4035ff36c2fc"
+checksum = "7624a1f496b163139a7e0b442426cad805bec70486900287506f9d15a29323ab"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1513,9 +1513,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e06040411d28aa7ba03fcf03971fbcd719b1020c5aa3eae2891587e892ef51ee"
+checksum = "4b63c1538ffb4b0e09edaebfcac35c34141d5944c52f77d137cbe0b634bd40fa"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -1532,9 +1532,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ecae9427e1f0ae664256f6620924f3eabb0983bdb18e1c36d15c15ba6ee35c9"
+checksum = "933b23b5cee0f58aa6c17c6de7e1f3007279357e0d555f22e24d6b395cfe7f89"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1544,9 +1544,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0823953c2775707cb0e151c2da97c4621193cf58308ee4f48b2df17d114c3d82"
+checksum = "41db0ac4df90610cda8320cfd5abf90c6ec90e298b6fe5a09a81dff718b55640"
 dependencies = [
  "backtrace",
  "enumset",
@@ -1566,9 +1566,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-dylib"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75db66afeacaf2d12a3d6af916410bc41459e01477f6628d637b77f5785f7c8c"
+checksum = "591683f3356ac31cc88aaecaf77ac2cc9f456014348b01af46c164f44f531162"
 dependencies = [
  "cfg-if",
  "enum-iterator",
@@ -1591,9 +1591,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-universal"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12a18da6797a46b5b35043796fd5d3451d384226e4531888ff1966dcb029a8ea"
+checksum = "dccfde103e9b87427099a6de344b7c791574f307d035c8c7dbbc00974c1af0c1"
 dependencies = [
  "cfg-if",
  "enum-iterator",
@@ -1611,9 +1611,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-middlewares"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a98d5a2058c14e56f5f48f51cd14cf4c572223bb79fe5589f2a1ee820a4522"
+checksum = "be816528dd62f037ae935977b643bb4237e10be9e32826e2f3eb1f911eaccc97"
 dependencies = [
  "loupe",
  "wasmer",
@@ -1623,9 +1623,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-object"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb88abea6a488ef64674c72c813564de7877a6e046d4b3f3e20c41302b82a10"
+checksum = "1d0c4005592998bd840f2289102ef9c67b6138338ed78e1fc0809586aa229040"
 dependencies = [
  "object 0.28.3",
  "thiserror",
@@ -1635,9 +1635,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bffc68539057bc92c10b260175d36acb90926840b175939e663eafdd4fbdb6"
+checksum = "4deb854f178265a76b59823c41547d259c65da3687b606b0b9c12d80ab950e3e"
 dependencies = [
  "indexmap",
  "loupe",
@@ -1648,9 +1648,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "215cc368b140d2eb3d3ab826dd01c602dc337c2374ac5d48f5652bd7eeac0d05"
+checksum = "5dbc5c989cb14a102433927e630473da52f83d82c469acd5cfa8fc7efacc1e70"
 dependencies = [
  "backtrace",
  "cc",

--- a/contracts/queue/Cargo.lock
+++ b/contracts/queue/Cargo.lock
@@ -483,6 +483,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-iterator"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eeac5c5edb79e4e39fe8439ef35207780a11f69c52cbe424ce3dfad4cb78de6"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c134c37760b27a871ba422106eedbb8247da973a09e82558bf26d619c882b159"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "enumset"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -791,11 +811,12 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.27.1"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
+checksum = "40bec70ba014595f99f7aa110b84331ffe1ee9aece7fe6f387cc7e3ecda4d456"
 dependencies = [
  "crc32fast",
+ "hashbrown",
  "indexmap",
  "memchr",
 ]
@@ -1426,9 +1447,9 @@ checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
 name = "wasmer"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23f0188c23fc1b7de9bd7f8b834d0b1cd5edbe66e287452e8ce36d24418114f7"
+checksum = "7c823abda8b80153c938b3c7c55fcc74e2adfe40592732f7be01309dbe4aa53b"
 dependencies = [
  "cfg-if",
  "indexmap",
@@ -1452,9 +1473,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88c51cc589772c5f90bd329244c2416976d6cb2ee00d59429aaa8f421d9fe447"
+checksum = "4ef59c6661f8f739c7c56d85400711a6e8791a101e931902af87423280e3dd36"
 dependencies = [
  "enumset",
  "loupe",
@@ -1471,9 +1492,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09691e3e323b4e1128d2127f60f9cd988b66ce49afc8184b071c2b5ab16793f2"
+checksum = "bd21b6306ec69096ac39e93418b2338e5def5445522f098c5b0a38863059492d"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1492,9 +1513,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271d3da24c5d1a8bb3f9fc3944ba96d2588b6fa16a0bcef91765db853aeccac4"
+checksum = "95c704e8c917e047e301862c76b93e2374631d3e6dc0b547c690f7ac38227344"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -1511,9 +1532,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f5cb7b09640e09f1215da95d6fb7477d2db572f064b803ff705f39ff079cc5"
+checksum = "5932932ef9e4f185dee5c99848ffafe98c5f49e0e92d2da14686761e38345c67"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1523,9 +1544,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab20311c354fe2c12bc766417e0a1a45f399c1cd8ff262127d1dc86d0588971a"
+checksum = "5ed91396b15addd562d53fd92a016ba88c9b2ce4e0e0169a0e47cc67b739b37f"
 dependencies = [
  "backtrace",
  "enumset",
@@ -1545,15 +1566,17 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-dylib"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd5b7a74731e1dcccaf10a8ff5f72216c82f12972ce17cc81c6caa1afff75ea"
+checksum = "8d9ecf7885c571a26141f37a362caa97796b8904f423dc5645031e149c9ee802"
 dependencies = [
  "cfg-if",
+ "enum-iterator",
  "enumset",
  "leb128",
  "libloading",
  "loupe",
+ "object 0.28.3",
  "rkyv",
  "serde",
  "tempfile",
@@ -1568,11 +1591,12 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-universal"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfeae8d5b825ad7abcf9a34e66eb11e1507b21020efe7bbf9897e3dd8d7869e2"
+checksum = "3bc4c936ebc050946dced5a3c4ef2bfe0b937c6e91323642c8e04552a82dfd9f"
 dependencies = [
  "cfg-if",
+ "enum-iterator",
  "enumset",
  "leb128",
  "loupe",
@@ -1587,9 +1611,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-middlewares"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61a73bda8608a4ca56142b7849ccf4847cda566267d0071664ca06c6f4fbff1"
+checksum = "cc770d4c278498bbbabec4cb9db33362ce6349cc397f746f2c75b20b5448fe2f"
 dependencies = [
  "loupe",
  "wasmer",
@@ -1599,11 +1623,11 @@ dependencies = [
 
 [[package]]
 name = "wasmer-object"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d4714e4f3bdc3b2157c24284417d19cd99de036da31d00ec5664712dcb72f7"
+checksum = "f5626938e5e062747b999493d3a36591d9ba2fb0b6fb8e6f474e3355440ff9a0"
 dependencies = [
- "object 0.27.1",
+ "object 0.28.3",
  "thiserror",
  "wasmer-compiler",
  "wasmer-types",
@@ -1611,9 +1635,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434e1c0177da0a74ecca90b2aa7d5e86198260f07e8ba83be89feb5f0a4aeead"
+checksum = "78e5c8a51b65b946c122cecacdd496b24cc070f5465bc07ce83c62f830835814"
 dependencies = [
  "indexmap",
  "loupe",
@@ -1624,13 +1648,14 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc8f964ebba70d9f81340228b98a164782591f00239fc7f01e1b67afcf0e0156"
+checksum = "91ad82e6b8e33a63c5215e11ea2f37e9a0b8a81606a41c922f26f61cb862e7f9"
 dependencies = [
  "backtrace",
  "cc",
  "cfg-if",
+ "enum-iterator",
  "indexmap",
  "libc",
  "loupe",

--- a/contracts/queue/Cargo.lock
+++ b/contracts/queue/Cargo.lock
@@ -1447,9 +1447,9 @@ checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
 name = "wasmer"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c823abda8b80153c938b3c7c55fcc74e2adfe40592732f7be01309dbe4aa53b"
+checksum = "d23f1bf05a2f86ad775dfe73b1da1842a58ffa549cd711c083cf56520c8025c4"
 dependencies = [
  "cfg-if",
  "indexmap",
@@ -1473,9 +1473,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ef59c6661f8f739c7c56d85400711a6e8791a101e931902af87423280e3dd36"
+checksum = "32158a07455808eccd655c3333d22a6a9eeb01c5891b750e6c7a66c43317b1fe"
 dependencies = [
  "enumset",
  "loupe",
@@ -1492,9 +1492,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd21b6306ec69096ac39e93418b2338e5def5445522f098c5b0a38863059492d"
+checksum = "b2afe1d581016703af0a6ac37511661b5ee5ceceee7bc387afcd4035ff36c2fc"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1513,9 +1513,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95c704e8c917e047e301862c76b93e2374631d3e6dc0b547c690f7ac38227344"
+checksum = "e06040411d28aa7ba03fcf03971fbcd719b1020c5aa3eae2891587e892ef51ee"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -1532,9 +1532,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5932932ef9e4f185dee5c99848ffafe98c5f49e0e92d2da14686761e38345c67"
+checksum = "4ecae9427e1f0ae664256f6620924f3eabb0983bdb18e1c36d15c15ba6ee35c9"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1544,9 +1544,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ed91396b15addd562d53fd92a016ba88c9b2ce4e0e0169a0e47cc67b739b37f"
+checksum = "0823953c2775707cb0e151c2da97c4621193cf58308ee4f48b2df17d114c3d82"
 dependencies = [
  "backtrace",
  "enumset",
@@ -1566,9 +1566,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-dylib"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9ecf7885c571a26141f37a362caa97796b8904f423dc5645031e149c9ee802"
+checksum = "75db66afeacaf2d12a3d6af916410bc41459e01477f6628d637b77f5785f7c8c"
 dependencies = [
  "cfg-if",
  "enum-iterator",
@@ -1591,9 +1591,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-universal"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bc4c936ebc050946dced5a3c4ef2bfe0b937c6e91323642c8e04552a82dfd9f"
+checksum = "12a18da6797a46b5b35043796fd5d3451d384226e4531888ff1966dcb029a8ea"
 dependencies = [
  "cfg-if",
  "enum-iterator",
@@ -1611,9 +1611,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-middlewares"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc770d4c278498bbbabec4cb9db33362ce6349cc397f746f2c75b20b5448fe2f"
+checksum = "09a98d5a2058c14e56f5f48f51cd14cf4c572223bb79fe5589f2a1ee820a4522"
 dependencies = [
  "loupe",
  "wasmer",
@@ -1623,9 +1623,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-object"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5626938e5e062747b999493d3a36591d9ba2fb0b6fb8e6f474e3355440ff9a0"
+checksum = "ffb88abea6a488ef64674c72c813564de7877a6e046d4b3f3e20c41302b82a10"
 dependencies = [
  "object 0.28.3",
  "thiserror",
@@ -1635,9 +1635,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78e5c8a51b65b946c122cecacdd496b24cc070f5465bc07ce83c62f830835814"
+checksum = "30bffc68539057bc92c10b260175d36acb90926840b175939e663eafdd4fbdb6"
 dependencies = [
  "indexmap",
  "loupe",
@@ -1648,9 +1648,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ad82e6b8e33a63c5215e11ea2f37e9a0b8a81606a41c922f26f61cb862e7f9"
+checksum = "215cc368b140d2eb3d3ab826dd01c602dc337c2374ac5d48f5652bd7eeac0d05"
 dependencies = [
  "backtrace",
  "cc",

--- a/contracts/reflect/Cargo.lock
+++ b/contracts/reflect/Cargo.lock
@@ -1457,9 +1457,9 @@ checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
 name = "wasmer"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c823abda8b80153c938b3c7c55fcc74e2adfe40592732f7be01309dbe4aa53b"
+checksum = "d23f1bf05a2f86ad775dfe73b1da1842a58ffa549cd711c083cf56520c8025c4"
 dependencies = [
  "cfg-if",
  "indexmap",
@@ -1483,9 +1483,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ef59c6661f8f739c7c56d85400711a6e8791a101e931902af87423280e3dd36"
+checksum = "32158a07455808eccd655c3333d22a6a9eeb01c5891b750e6c7a66c43317b1fe"
 dependencies = [
  "enumset",
  "loupe",
@@ -1502,9 +1502,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd21b6306ec69096ac39e93418b2338e5def5445522f098c5b0a38863059492d"
+checksum = "b2afe1d581016703af0a6ac37511661b5ee5ceceee7bc387afcd4035ff36c2fc"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1523,9 +1523,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95c704e8c917e047e301862c76b93e2374631d3e6dc0b547c690f7ac38227344"
+checksum = "e06040411d28aa7ba03fcf03971fbcd719b1020c5aa3eae2891587e892ef51ee"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -1542,9 +1542,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5932932ef9e4f185dee5c99848ffafe98c5f49e0e92d2da14686761e38345c67"
+checksum = "4ecae9427e1f0ae664256f6620924f3eabb0983bdb18e1c36d15c15ba6ee35c9"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1554,9 +1554,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ed91396b15addd562d53fd92a016ba88c9b2ce4e0e0169a0e47cc67b739b37f"
+checksum = "0823953c2775707cb0e151c2da97c4621193cf58308ee4f48b2df17d114c3d82"
 dependencies = [
  "backtrace",
  "enumset",
@@ -1576,9 +1576,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-dylib"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9ecf7885c571a26141f37a362caa97796b8904f423dc5645031e149c9ee802"
+checksum = "75db66afeacaf2d12a3d6af916410bc41459e01477f6628d637b77f5785f7c8c"
 dependencies = [
  "cfg-if",
  "enum-iterator",
@@ -1601,9 +1601,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-universal"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bc4c936ebc050946dced5a3c4ef2bfe0b937c6e91323642c8e04552a82dfd9f"
+checksum = "12a18da6797a46b5b35043796fd5d3451d384226e4531888ff1966dcb029a8ea"
 dependencies = [
  "cfg-if",
  "enum-iterator",
@@ -1621,9 +1621,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-middlewares"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc770d4c278498bbbabec4cb9db33362ce6349cc397f746f2c75b20b5448fe2f"
+checksum = "09a98d5a2058c14e56f5f48f51cd14cf4c572223bb79fe5589f2a1ee820a4522"
 dependencies = [
  "loupe",
  "wasmer",
@@ -1633,9 +1633,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-object"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5626938e5e062747b999493d3a36591d9ba2fb0b6fb8e6f474e3355440ff9a0"
+checksum = "ffb88abea6a488ef64674c72c813564de7877a6e046d4b3f3e20c41302b82a10"
 dependencies = [
  "object 0.28.3",
  "thiserror",
@@ -1645,9 +1645,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78e5c8a51b65b946c122cecacdd496b24cc070f5465bc07ce83c62f830835814"
+checksum = "30bffc68539057bc92c10b260175d36acb90926840b175939e663eafdd4fbdb6"
 dependencies = [
  "indexmap",
  "loupe",
@@ -1658,9 +1658,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ad82e6b8e33a63c5215e11ea2f37e9a0b8a81606a41c922f26f61cb862e7f9"
+checksum = "215cc368b140d2eb3d3ab826dd01c602dc337c2374ac5d48f5652bd7eeac0d05"
 dependencies = [
  "backtrace",
  "cc",

--- a/contracts/reflect/Cargo.lock
+++ b/contracts/reflect/Cargo.lock
@@ -1457,9 +1457,9 @@ checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
 name = "wasmer"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d23f1bf05a2f86ad775dfe73b1da1842a58ffa549cd711c083cf56520c8025c4"
+checksum = "bfc7dff846db3f38f8ed0be4a009fdfeb729cf1f94a2c7fb6ff2fec01cefa110"
 dependencies = [
  "cfg-if",
  "indexmap",
@@ -1483,9 +1483,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32158a07455808eccd655c3333d22a6a9eeb01c5891b750e6c7a66c43317b1fe"
+checksum = "8c91abf22b16dad3826ec0d0e3ec0a8304262a6c7a14e16528c536131b80e63d"
 dependencies = [
  "enumset",
  "loupe",
@@ -1502,9 +1502,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2afe1d581016703af0a6ac37511661b5ee5ceceee7bc387afcd4035ff36c2fc"
+checksum = "7624a1f496b163139a7e0b442426cad805bec70486900287506f9d15a29323ab"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1523,9 +1523,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e06040411d28aa7ba03fcf03971fbcd719b1020c5aa3eae2891587e892ef51ee"
+checksum = "4b63c1538ffb4b0e09edaebfcac35c34141d5944c52f77d137cbe0b634bd40fa"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -1542,9 +1542,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ecae9427e1f0ae664256f6620924f3eabb0983bdb18e1c36d15c15ba6ee35c9"
+checksum = "933b23b5cee0f58aa6c17c6de7e1f3007279357e0d555f22e24d6b395cfe7f89"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1554,9 +1554,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0823953c2775707cb0e151c2da97c4621193cf58308ee4f48b2df17d114c3d82"
+checksum = "41db0ac4df90610cda8320cfd5abf90c6ec90e298b6fe5a09a81dff718b55640"
 dependencies = [
  "backtrace",
  "enumset",
@@ -1576,9 +1576,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-dylib"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75db66afeacaf2d12a3d6af916410bc41459e01477f6628d637b77f5785f7c8c"
+checksum = "591683f3356ac31cc88aaecaf77ac2cc9f456014348b01af46c164f44f531162"
 dependencies = [
  "cfg-if",
  "enum-iterator",
@@ -1601,9 +1601,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-universal"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12a18da6797a46b5b35043796fd5d3451d384226e4531888ff1966dcb029a8ea"
+checksum = "dccfde103e9b87427099a6de344b7c791574f307d035c8c7dbbc00974c1af0c1"
 dependencies = [
  "cfg-if",
  "enum-iterator",
@@ -1621,9 +1621,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-middlewares"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a98d5a2058c14e56f5f48f51cd14cf4c572223bb79fe5589f2a1ee820a4522"
+checksum = "be816528dd62f037ae935977b643bb4237e10be9e32826e2f3eb1f911eaccc97"
 dependencies = [
  "loupe",
  "wasmer",
@@ -1633,9 +1633,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-object"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb88abea6a488ef64674c72c813564de7877a6e046d4b3f3e20c41302b82a10"
+checksum = "1d0c4005592998bd840f2289102ef9c67b6138338ed78e1fc0809586aa229040"
 dependencies = [
  "object 0.28.3",
  "thiserror",
@@ -1645,9 +1645,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bffc68539057bc92c10b260175d36acb90926840b175939e663eafdd4fbdb6"
+checksum = "4deb854f178265a76b59823c41547d259c65da3687b606b0b9c12d80ab950e3e"
 dependencies = [
  "indexmap",
  "loupe",
@@ -1658,9 +1658,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "215cc368b140d2eb3d3ab826dd01c602dc337c2374ac5d48f5652bd7eeac0d05"
+checksum = "5dbc5c989cb14a102433927e630473da52f83d82c469acd5cfa8fc7efacc1e70"
 dependencies = [
  "backtrace",
  "cc",

--- a/contracts/reflect/Cargo.lock
+++ b/contracts/reflect/Cargo.lock
@@ -491,6 +491,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-iterator"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eeac5c5edb79e4e39fe8439ef35207780a11f69c52cbe424ce3dfad4cb78de6"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c134c37760b27a871ba422106eedbb8247da973a09e82558bf26d619c882b159"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "enumset"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -799,11 +819,12 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.27.1"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
+checksum = "40bec70ba014595f99f7aa110b84331ffe1ee9aece7fe6f387cc7e3ecda4d456"
 dependencies = [
  "crc32fast",
+ "hashbrown",
  "indexmap",
  "memchr",
 ]
@@ -1436,9 +1457,9 @@ checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
 name = "wasmer"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23f0188c23fc1b7de9bd7f8b834d0b1cd5edbe66e287452e8ce36d24418114f7"
+checksum = "7c823abda8b80153c938b3c7c55fcc74e2adfe40592732f7be01309dbe4aa53b"
 dependencies = [
  "cfg-if",
  "indexmap",
@@ -1462,9 +1483,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88c51cc589772c5f90bd329244c2416976d6cb2ee00d59429aaa8f421d9fe447"
+checksum = "4ef59c6661f8f739c7c56d85400711a6e8791a101e931902af87423280e3dd36"
 dependencies = [
  "enumset",
  "loupe",
@@ -1481,9 +1502,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09691e3e323b4e1128d2127f60f9cd988b66ce49afc8184b071c2b5ab16793f2"
+checksum = "bd21b6306ec69096ac39e93418b2338e5def5445522f098c5b0a38863059492d"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1502,9 +1523,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271d3da24c5d1a8bb3f9fc3944ba96d2588b6fa16a0bcef91765db853aeccac4"
+checksum = "95c704e8c917e047e301862c76b93e2374631d3e6dc0b547c690f7ac38227344"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -1521,9 +1542,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f5cb7b09640e09f1215da95d6fb7477d2db572f064b803ff705f39ff079cc5"
+checksum = "5932932ef9e4f185dee5c99848ffafe98c5f49e0e92d2da14686761e38345c67"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1533,9 +1554,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab20311c354fe2c12bc766417e0a1a45f399c1cd8ff262127d1dc86d0588971a"
+checksum = "5ed91396b15addd562d53fd92a016ba88c9b2ce4e0e0169a0e47cc67b739b37f"
 dependencies = [
  "backtrace",
  "enumset",
@@ -1555,15 +1576,17 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-dylib"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd5b7a74731e1dcccaf10a8ff5f72216c82f12972ce17cc81c6caa1afff75ea"
+checksum = "8d9ecf7885c571a26141f37a362caa97796b8904f423dc5645031e149c9ee802"
 dependencies = [
  "cfg-if",
+ "enum-iterator",
  "enumset",
  "leb128",
  "libloading",
  "loupe",
+ "object 0.28.3",
  "rkyv",
  "serde",
  "tempfile",
@@ -1578,11 +1601,12 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-universal"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfeae8d5b825ad7abcf9a34e66eb11e1507b21020efe7bbf9897e3dd8d7869e2"
+checksum = "3bc4c936ebc050946dced5a3c4ef2bfe0b937c6e91323642c8e04552a82dfd9f"
 dependencies = [
  "cfg-if",
+ "enum-iterator",
  "enumset",
  "leb128",
  "loupe",
@@ -1597,9 +1621,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-middlewares"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61a73bda8608a4ca56142b7849ccf4847cda566267d0071664ca06c6f4fbff1"
+checksum = "cc770d4c278498bbbabec4cb9db33362ce6349cc397f746f2c75b20b5448fe2f"
 dependencies = [
  "loupe",
  "wasmer",
@@ -1609,11 +1633,11 @@ dependencies = [
 
 [[package]]
 name = "wasmer-object"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d4714e4f3bdc3b2157c24284417d19cd99de036da31d00ec5664712dcb72f7"
+checksum = "f5626938e5e062747b999493d3a36591d9ba2fb0b6fb8e6f474e3355440ff9a0"
 dependencies = [
- "object 0.27.1",
+ "object 0.28.3",
  "thiserror",
  "wasmer-compiler",
  "wasmer-types",
@@ -1621,9 +1645,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434e1c0177da0a74ecca90b2aa7d5e86198260f07e8ba83be89feb5f0a4aeead"
+checksum = "78e5c8a51b65b946c122cecacdd496b24cc070f5465bc07ce83c62f830835814"
 dependencies = [
  "indexmap",
  "loupe",
@@ -1634,13 +1658,14 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc8f964ebba70d9f81340228b98a164782591f00239fc7f01e1b67afcf0e0156"
+checksum = "91ad82e6b8e33a63c5215e11ea2f37e9a0b8a81606a41c922f26f61cb862e7f9"
 dependencies = [
  "backtrace",
  "cc",
  "cfg-if",
+ "enum-iterator",
  "indexmap",
  "libc",
  "loupe",

--- a/contracts/staking/Cargo.lock
+++ b/contracts/staking/Cargo.lock
@@ -1484,9 +1484,9 @@ checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
 name = "wasmer"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c823abda8b80153c938b3c7c55fcc74e2adfe40592732f7be01309dbe4aa53b"
+checksum = "d23f1bf05a2f86ad775dfe73b1da1842a58ffa549cd711c083cf56520c8025c4"
 dependencies = [
  "cfg-if",
  "indexmap",
@@ -1510,9 +1510,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ef59c6661f8f739c7c56d85400711a6e8791a101e931902af87423280e3dd36"
+checksum = "32158a07455808eccd655c3333d22a6a9eeb01c5891b750e6c7a66c43317b1fe"
 dependencies = [
  "enumset",
  "loupe",
@@ -1529,9 +1529,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd21b6306ec69096ac39e93418b2338e5def5445522f098c5b0a38863059492d"
+checksum = "b2afe1d581016703af0a6ac37511661b5ee5ceceee7bc387afcd4035ff36c2fc"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1550,9 +1550,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95c704e8c917e047e301862c76b93e2374631d3e6dc0b547c690f7ac38227344"
+checksum = "e06040411d28aa7ba03fcf03971fbcd719b1020c5aa3eae2891587e892ef51ee"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -1569,9 +1569,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5932932ef9e4f185dee5c99848ffafe98c5f49e0e92d2da14686761e38345c67"
+checksum = "4ecae9427e1f0ae664256f6620924f3eabb0983bdb18e1c36d15c15ba6ee35c9"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1581,9 +1581,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ed91396b15addd562d53fd92a016ba88c9b2ce4e0e0169a0e47cc67b739b37f"
+checksum = "0823953c2775707cb0e151c2da97c4621193cf58308ee4f48b2df17d114c3d82"
 dependencies = [
  "backtrace",
  "enumset",
@@ -1603,9 +1603,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-dylib"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9ecf7885c571a26141f37a362caa97796b8904f423dc5645031e149c9ee802"
+checksum = "75db66afeacaf2d12a3d6af916410bc41459e01477f6628d637b77f5785f7c8c"
 dependencies = [
  "cfg-if",
  "enum-iterator",
@@ -1628,9 +1628,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-universal"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bc4c936ebc050946dced5a3c4ef2bfe0b937c6e91323642c8e04552a82dfd9f"
+checksum = "12a18da6797a46b5b35043796fd5d3451d384226e4531888ff1966dcb029a8ea"
 dependencies = [
  "cfg-if",
  "enum-iterator",
@@ -1648,9 +1648,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-middlewares"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc770d4c278498bbbabec4cb9db33362ce6349cc397f746f2c75b20b5448fe2f"
+checksum = "09a98d5a2058c14e56f5f48f51cd14cf4c572223bb79fe5589f2a1ee820a4522"
 dependencies = [
  "loupe",
  "wasmer",
@@ -1660,9 +1660,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-object"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5626938e5e062747b999493d3a36591d9ba2fb0b6fb8e6f474e3355440ff9a0"
+checksum = "ffb88abea6a488ef64674c72c813564de7877a6e046d4b3f3e20c41302b82a10"
 dependencies = [
  "object 0.28.3",
  "thiserror",
@@ -1672,9 +1672,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78e5c8a51b65b946c122cecacdd496b24cc070f5465bc07ce83c62f830835814"
+checksum = "30bffc68539057bc92c10b260175d36acb90926840b175939e663eafdd4fbdb6"
 dependencies = [
  "indexmap",
  "loupe",
@@ -1685,9 +1685,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "2.2.0-rc1"
+version = "2.2.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ad82e6b8e33a63c5215e11ea2f37e9a0b8a81606a41c922f26f61cb862e7f9"
+checksum = "215cc368b140d2eb3d3ab826dd01c602dc337c2374ac5d48f5652bd7eeac0d05"
 dependencies = [
  "backtrace",
  "cc",

--- a/contracts/staking/Cargo.lock
+++ b/contracts/staking/Cargo.lock
@@ -497,6 +497,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-iterator"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eeac5c5edb79e4e39fe8439ef35207780a11f69c52cbe424ce3dfad4cb78de6"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c134c37760b27a871ba422106eedbb8247da973a09e82558bf26d619c882b159"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "enumset"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -805,11 +825,12 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.27.1"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
+checksum = "40bec70ba014595f99f7aa110b84331ffe1ee9aece7fe6f387cc7e3ecda4d456"
 dependencies = [
  "crc32fast",
+ "hashbrown",
  "indexmap",
  "memchr",
 ]
@@ -1463,9 +1484,9 @@ checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
 name = "wasmer"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23f0188c23fc1b7de9bd7f8b834d0b1cd5edbe66e287452e8ce36d24418114f7"
+checksum = "7c823abda8b80153c938b3c7c55fcc74e2adfe40592732f7be01309dbe4aa53b"
 dependencies = [
  "cfg-if",
  "indexmap",
@@ -1489,9 +1510,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88c51cc589772c5f90bd329244c2416976d6cb2ee00d59429aaa8f421d9fe447"
+checksum = "4ef59c6661f8f739c7c56d85400711a6e8791a101e931902af87423280e3dd36"
 dependencies = [
  "enumset",
  "loupe",
@@ -1508,9 +1529,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09691e3e323b4e1128d2127f60f9cd988b66ce49afc8184b071c2b5ab16793f2"
+checksum = "bd21b6306ec69096ac39e93418b2338e5def5445522f098c5b0a38863059492d"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1529,9 +1550,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271d3da24c5d1a8bb3f9fc3944ba96d2588b6fa16a0bcef91765db853aeccac4"
+checksum = "95c704e8c917e047e301862c76b93e2374631d3e6dc0b547c690f7ac38227344"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -1548,9 +1569,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f5cb7b09640e09f1215da95d6fb7477d2db572f064b803ff705f39ff079cc5"
+checksum = "5932932ef9e4f185dee5c99848ffafe98c5f49e0e92d2da14686761e38345c67"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1560,9 +1581,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab20311c354fe2c12bc766417e0a1a45f399c1cd8ff262127d1dc86d0588971a"
+checksum = "5ed91396b15addd562d53fd92a016ba88c9b2ce4e0e0169a0e47cc67b739b37f"
 dependencies = [
  "backtrace",
  "enumset",
@@ -1582,15 +1603,17 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-dylib"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd5b7a74731e1dcccaf10a8ff5f72216c82f12972ce17cc81c6caa1afff75ea"
+checksum = "8d9ecf7885c571a26141f37a362caa97796b8904f423dc5645031e149c9ee802"
 dependencies = [
  "cfg-if",
+ "enum-iterator",
  "enumset",
  "leb128",
  "libloading",
  "loupe",
+ "object 0.28.3",
  "rkyv",
  "serde",
  "tempfile",
@@ -1605,11 +1628,12 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-universal"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfeae8d5b825ad7abcf9a34e66eb11e1507b21020efe7bbf9897e3dd8d7869e2"
+checksum = "3bc4c936ebc050946dced5a3c4ef2bfe0b937c6e91323642c8e04552a82dfd9f"
 dependencies = [
  "cfg-if",
+ "enum-iterator",
  "enumset",
  "leb128",
  "loupe",
@@ -1624,9 +1648,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-middlewares"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61a73bda8608a4ca56142b7849ccf4847cda566267d0071664ca06c6f4fbff1"
+checksum = "cc770d4c278498bbbabec4cb9db33362ce6349cc397f746f2c75b20b5448fe2f"
 dependencies = [
  "loupe",
  "wasmer",
@@ -1636,11 +1660,11 @@ dependencies = [
 
 [[package]]
 name = "wasmer-object"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d4714e4f3bdc3b2157c24284417d19cd99de036da31d00ec5664712dcb72f7"
+checksum = "f5626938e5e062747b999493d3a36591d9ba2fb0b6fb8e6f474e3355440ff9a0"
 dependencies = [
- "object 0.27.1",
+ "object 0.28.3",
  "thiserror",
  "wasmer-compiler",
  "wasmer-types",
@@ -1648,9 +1672,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434e1c0177da0a74ecca90b2aa7d5e86198260f07e8ba83be89feb5f0a4aeead"
+checksum = "78e5c8a51b65b946c122cecacdd496b24cc070f5465bc07ce83c62f830835814"
 dependencies = [
  "indexmap",
  "loupe",
@@ -1661,13 +1685,14 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "2.1.1"
+version = "2.2.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc8f964ebba70d9f81340228b98a164782591f00239fc7f01e1b67afcf0e0156"
+checksum = "91ad82e6b8e33a63c5215e11ea2f37e9a0b8a81606a41c922f26f61cb862e7f9"
 dependencies = [
  "backtrace",
  "cc",
  "cfg-if",
+ "enum-iterator",
  "indexmap",
  "libc",
  "loupe",

--- a/contracts/staking/Cargo.lock
+++ b/contracts/staking/Cargo.lock
@@ -1484,9 +1484,9 @@ checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
 name = "wasmer"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d23f1bf05a2f86ad775dfe73b1da1842a58ffa549cd711c083cf56520c8025c4"
+checksum = "bfc7dff846db3f38f8ed0be4a009fdfeb729cf1f94a2c7fb6ff2fec01cefa110"
 dependencies = [
  "cfg-if",
  "indexmap",
@@ -1510,9 +1510,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32158a07455808eccd655c3333d22a6a9eeb01c5891b750e6c7a66c43317b1fe"
+checksum = "8c91abf22b16dad3826ec0d0e3ec0a8304262a6c7a14e16528c536131b80e63d"
 dependencies = [
  "enumset",
  "loupe",
@@ -1529,9 +1529,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2afe1d581016703af0a6ac37511661b5ee5ceceee7bc387afcd4035ff36c2fc"
+checksum = "7624a1f496b163139a7e0b442426cad805bec70486900287506f9d15a29323ab"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1550,9 +1550,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e06040411d28aa7ba03fcf03971fbcd719b1020c5aa3eae2891587e892ef51ee"
+checksum = "4b63c1538ffb4b0e09edaebfcac35c34141d5944c52f77d137cbe0b634bd40fa"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -1569,9 +1569,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ecae9427e1f0ae664256f6620924f3eabb0983bdb18e1c36d15c15ba6ee35c9"
+checksum = "933b23b5cee0f58aa6c17c6de7e1f3007279357e0d555f22e24d6b395cfe7f89"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1581,9 +1581,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0823953c2775707cb0e151c2da97c4621193cf58308ee4f48b2df17d114c3d82"
+checksum = "41db0ac4df90610cda8320cfd5abf90c6ec90e298b6fe5a09a81dff718b55640"
 dependencies = [
  "backtrace",
  "enumset",
@@ -1603,9 +1603,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-dylib"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75db66afeacaf2d12a3d6af916410bc41459e01477f6628d637b77f5785f7c8c"
+checksum = "591683f3356ac31cc88aaecaf77ac2cc9f456014348b01af46c164f44f531162"
 dependencies = [
  "cfg-if",
  "enum-iterator",
@@ -1628,9 +1628,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-universal"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12a18da6797a46b5b35043796fd5d3451d384226e4531888ff1966dcb029a8ea"
+checksum = "dccfde103e9b87427099a6de344b7c791574f307d035c8c7dbbc00974c1af0c1"
 dependencies = [
  "cfg-if",
  "enum-iterator",
@@ -1648,9 +1648,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-middlewares"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a98d5a2058c14e56f5f48f51cd14cf4c572223bb79fe5589f2a1ee820a4522"
+checksum = "be816528dd62f037ae935977b643bb4237e10be9e32826e2f3eb1f911eaccc97"
 dependencies = [
  "loupe",
  "wasmer",
@@ -1660,9 +1660,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-object"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb88abea6a488ef64674c72c813564de7877a6e046d4b3f3e20c41302b82a10"
+checksum = "1d0c4005592998bd840f2289102ef9c67b6138338ed78e1fc0809586aa229040"
 dependencies = [
  "object 0.28.3",
  "thiserror",
@@ -1672,9 +1672,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bffc68539057bc92c10b260175d36acb90926840b175939e663eafdd4fbdb6"
+checksum = "4deb854f178265a76b59823c41547d259c65da3687b606b0b9c12d80ab950e3e"
 dependencies = [
  "indexmap",
  "loupe",
@@ -1685,9 +1685,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "2.2.0-rc2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "215cc368b140d2eb3d3ab826dd01c602dc337c2374ac5d48f5652bd7eeac0d05"
+checksum = "5dbc5c989cb14a102433927e630473da52f83d82c469acd5cfa8fc7efacc1e70"
 dependencies = [
  "backtrace",
  "cc",

--- a/packages/profiler/Cargo.toml
+++ b/packages/profiler/Cargo.toml
@@ -14,9 +14,9 @@ cosmwasm-vm = { path = "../vm" }
 cosmwasm-std = { path = "../std" }
 loupe = "0.1.3"
 walrus = "0.19.0"
-wasmer = { version = "=2.2.0-rc1", default-features = false, features = ["compiler"] }
-wasmer-types = "=2.2.0-rc1"
-wasmer-vm = "=2.2.0-rc1"
+wasmer = { version = "=2.2.0-rc2", default-features = false, features = ["compiler"] }
+wasmer-types = "=2.2.0-rc2"
+wasmer-vm = "=2.2.0-rc2"
 # wasmer = { git = "https://github.com/wasmerio/wasmer", rev = "877ce1f7c44fad853c", default-features = false, features = ["compiler"] }
 # wasmer-types = { git = "https://github.com/wasmerio/wasmer", rev = "877ce1f7c44fad853c" }
 # wasmer-vm = { git = "https://github.com/wasmerio/wasmer", rev = "877ce1f7c44fad853c" }
@@ -24,5 +24,5 @@ hackatom = { path = "../../contracts/hackatom", default-features = false }
 csv = "1.1.6"
 
 [dev-dependencies]
-wasmer = { version = "=2.2.0-rc1", features = ["compiler"] }
+wasmer = { version = "=2.2.0-rc2", features = ["compiler"] }
 # wasmer = { git = "https://github.com/wasmerio/wasmer", rev = "877ce1f7c44fad853c", features = ["compiler"] }

--- a/packages/profiler/Cargo.toml
+++ b/packages/profiler/Cargo.toml
@@ -14,9 +14,9 @@ cosmwasm-vm = { path = "../vm" }
 cosmwasm-std = { path = "../std" }
 loupe = "0.1.3"
 walrus = "0.19.0"
-wasmer = { version = "=2.2.0-rc2", default-features = false, features = ["compiler"] }
-wasmer-types = "=2.2.0-rc2"
-wasmer-vm = "=2.2.0-rc2"
+wasmer = { version = "=2.2.0", default-features = false, features = ["compiler"] }
+wasmer-types = "=2.2.0"
+wasmer-vm = "=2.2.0"
 # wasmer = { git = "https://github.com/wasmerio/wasmer", rev = "877ce1f7c44fad853c", default-features = false, features = ["compiler"] }
 # wasmer-types = { git = "https://github.com/wasmerio/wasmer", rev = "877ce1f7c44fad853c" }
 # wasmer-vm = { git = "https://github.com/wasmerio/wasmer", rev = "877ce1f7c44fad853c" }
@@ -24,5 +24,5 @@ hackatom = { path = "../../contracts/hackatom", default-features = false }
 csv = "1.1.6"
 
 [dev-dependencies]
-wasmer = { version = "=2.2.0-rc2", features = ["compiler"] }
+wasmer = { version = "=2.2.0", features = ["compiler"] }
 # wasmer = { git = "https://github.com/wasmerio/wasmer", rev = "877ce1f7c44fad853c", features = ["compiler"] }

--- a/packages/profiler/Cargo.toml
+++ b/packages/profiler/Cargo.toml
@@ -14,9 +14,9 @@ cosmwasm-vm = { path = "../vm" }
 cosmwasm-std = { path = "../std" }
 loupe = "0.1.3"
 walrus = "0.19.0"
-wasmer = { version = "2.1.1", default-features = false, features = ["compiler"] }
-wasmer-types = "2.1.1"
-wasmer-vm = "2.1.1"
+wasmer = { version = "=2.2.0-rc1", default-features = false, features = ["compiler"] }
+wasmer-types = "=2.2.0-rc1"
+wasmer-vm = "=2.2.0-rc1"
 # wasmer = { git = "https://github.com/wasmerio/wasmer", rev = "877ce1f7c44fad853c", default-features = false, features = ["compiler"] }
 # wasmer-types = { git = "https://github.com/wasmerio/wasmer", rev = "877ce1f7c44fad853c" }
 # wasmer-vm = { git = "https://github.com/wasmerio/wasmer", rev = "877ce1f7c44fad853c" }
@@ -24,5 +24,5 @@ hackatom = { path = "../../contracts/hackatom", default-features = false }
 csv = "1.1.6"
 
 [dev-dependencies]
-wasmer = { version = "2.1.1", features = ["compiler"] }
+wasmer = { version = "=2.2.0-rc1", features = ["compiler"] }
 # wasmer = { git = "https://github.com/wasmerio/wasmer", rev = "877ce1f7c44fad853c", features = ["compiler"] }

--- a/packages/vm/Cargo.toml
+++ b/packages/vm/Cargo.toml
@@ -45,8 +45,8 @@ serde = { version = "1.0.103", default-features = false, features = ["derive", "
 serde_json = "1.0"
 sha2 = "0.9.1"
 thiserror = "1.0"
-wasmer = { version = "2.1.1", default-features = false, features = ["cranelift", "universal", "singlepass"] }
-wasmer-middlewares = "2.1.1"
+wasmer = { version = "=2.2.0-rc1", default-features = false, features = ["cranelift", "universal", "singlepass"] }
+wasmer-middlewares = "=2.2.0-rc1"
 loupe = "0.1.3"
 
 # Wasmer git/local (used for quick local debugging or patching)

--- a/packages/vm/Cargo.toml
+++ b/packages/vm/Cargo.toml
@@ -45,8 +45,8 @@ serde = { version = "1.0.103", default-features = false, features = ["derive", "
 serde_json = "1.0"
 sha2 = "0.9.1"
 thiserror = "1.0"
-wasmer = { version = "=2.2.0-rc2", default-features = false, features = ["cranelift", "universal", "singlepass"] }
-wasmer-middlewares = "=2.2.0-rc2"
+wasmer = { version = "=2.2.0", default-features = false, features = ["cranelift", "universal", "singlepass"] }
+wasmer-middlewares = "=2.2.0"
 loupe = "0.1.3"
 
 # Wasmer git/local (used for quick local debugging or patching)

--- a/packages/vm/Cargo.toml
+++ b/packages/vm/Cargo.toml
@@ -45,8 +45,8 @@ serde = { version = "1.0.103", default-features = false, features = ["derive", "
 serde_json = "1.0"
 sha2 = "0.9.1"
 thiserror = "1.0"
-wasmer = { version = "=2.2.0-rc1", default-features = false, features = ["cranelift", "universal", "singlepass"] }
-wasmer-middlewares = "=2.2.0-rc1"
+wasmer = { version = "=2.2.0-rc2", default-features = false, features = ["cranelift", "universal", "singlepass"] }
+wasmer-middlewares = "=2.2.0-rc2"
 loupe = "0.1.3"
 
 # Wasmer git/local (used for quick local debugging or patching)

--- a/packages/vm/src/modules/file_system_cache.rs
+++ b/packages/vm/src/modules/file_system_cache.rs
@@ -190,7 +190,6 @@ mod tests {
         cache.store(&checksum, &module).unwrap();
 
         let file_path = format!("{}/v2/{}", tmp_dir.path().to_string_lossy(), checksum);
-        let serialized_module = fs::read(file_path).unwrap();
-        assert_eq!(serialized_module.len(), 1040);
+        let _serialized_module = fs::read(file_path).unwrap();
     }
 }

--- a/packages/vm/src/modules/file_system_cache.rs
+++ b/packages/vm/src/modules/file_system_cache.rs
@@ -30,7 +30,7 @@ use crate::errors::{VmError, VmResult};
 ///   Version for cosmwasm_vm 1.0.0-beta5 / wasmvm 1.0.0-beta6 that ships with Wasmer 2.1.1.
 /// - **v3**:<br>
 ///   Version for Wasmer 2.2.0 which contains a [module breaking change to 2.1.x](https://github.com/wasmerio/wasmer/pull/2747).
-const MODULE_SERIALIZATION_VERSION: &str = "v2";
+const MODULE_SERIALIZATION_VERSION: &str = "v3";
 
 /// This header prefix contains the module type (wasmer-universal),
 /// the magic value WASMER\0\0 and a little endian encoded uint32 version number.
@@ -211,7 +211,7 @@ mod tests {
         let module = compile(&wasm, None, &[]).unwrap();
         cache.store(&checksum, &module).unwrap();
 
-        let file_path = format!("{}/v2/{}", tmp_dir.path().to_string_lossy(), checksum);
+        let file_path = format!("{}/v3/{}", tmp_dir.path().to_string_lossy(), checksum);
         let _serialized_module = fs::read(file_path).unwrap();
     }
 

--- a/packages/vm/src/modules/mod.rs
+++ b/packages/vm/src/modules/mod.rs
@@ -2,7 +2,9 @@ mod file_system_cache;
 mod in_memory_cache;
 mod pinned_memory_cache;
 mod sized_module;
+mod versioning;
 
 pub use file_system_cache::FileSystemCache;
 pub use in_memory_cache::InMemoryCache;
 pub use pinned_memory_cache::PinnedMemoryCache;
+pub use versioning::current_wasmer_module_version;

--- a/packages/vm/src/modules/versioning.rs
+++ b/packages/vm/src/modules/versioning.rs
@@ -1,0 +1,56 @@
+use std::convert::TryInto;
+
+use crate::wasm_backend::compile;
+
+/// This header prefix contains the module type (wasmer-universal) and
+/// the magic value WASMER\0\0.
+/// The full header also contains a little endian encoded uint32 version number
+/// and a length that we do not check.
+const EXPECTED_MODULE_HEADER_PREFIX: &[u8] = b"wasmer-universalWASMER\0\0";
+
+const ENGINE_TYPE_LEN: usize = 16; // https://github.com/wasmerio/wasmer/blob/2.2.0-rc1/lib/engine-universal/src/artifact.rs#L48
+const METADATA_HEADER_LEN: usize = 16; // https://github.com/wasmerio/wasmer/blob/2.2.0-rc1/lib/engine/src/artifact.rs#L251-L252
+
+fn current_wasmer_module_header() -> Vec<u8> {
+    // echo "(module)" > my.wat && wat2wasm my.wat && hexdump -C my.wasm
+    const WASM: &[u8] = b"\x00\x61\x73\x6d\x01\x00\x00\x00";
+    let module = compile(WASM, None, &[]).unwrap();
+    let mut bytes = module.serialize().unwrap_or_default();
+
+    bytes.truncate(ENGINE_TYPE_LEN + METADATA_HEADER_LEN);
+    bytes
+}
+
+/// Obtains the module version from Wasmer that is currently used.
+/// As long as the overall format does not change, this returns a
+/// counter (1 for Wasmer 2.2.0). When the format changes in an
+/// unexpected way (e.g. a different engine is used or the meta
+/// format changes), this panics. That way we can ensure an
+/// incompatible module format can be found early in the development
+/// cycle.
+pub fn current_wasmer_module_version() -> u32 {
+    let header = current_wasmer_module_header();
+    if !header.starts_with(EXPECTED_MODULE_HEADER_PREFIX) {
+        panic!("Wasmer module format changed. Please update the expected version accordingly and bump MODULE_SERIALIZATION_VERSION.");
+    }
+
+    let metadata = &header[header.len() - METADATA_HEADER_LEN..];
+    u32::from_le_bytes((&metadata[8..12]).try_into().unwrap())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn current_wasmer_module_header_works() {
+        let header = current_wasmer_module_header();
+        assert!(header.starts_with(EXPECTED_MODULE_HEADER_PREFIX));
+    }
+
+    #[test]
+    fn current_wasmer_module_version_works() {
+        let version = current_wasmer_module_version();
+        assert_eq!(version, 1);
+    }
+}


### PR DESCRIPTION
- [x] Upgrade to Wasmer to 2.2.0-rc1
- [x] Add ARM64 CI job (Linux)
- [x] Bump module version v2 -> v3
- [x] Hash Wasmer module version into file path (as discussed in https://github.com/CosmWasm/cosmwasm/pull/1223#discussion_r801321878)
- [x] Upgrade to Wasmer to 2.2.0-rc2
- [x] Upgrade Wasmer to 2.2.0 once available
- [x] Write CHANGELOG entry

Closes #1210