### PR TITLE
Set image to ubuntu-2004:202201-02 in coverage job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1018,7 +1018,9 @@ jobs:
           key: cargocache-v2-benchmarking-rust:1.54.0-{{ checksum "Cargo.lock" }}
 
   coverage:
-    machine: true
+    # https://circleci.com/developer/images?imageType=machine
+    machine:
+      image: ubuntu-2004:202201-02
     steps:
       - checkout
       - run:


### PR DESCRIPTION
When the image is not specified, we get Ubuntu 14.04

```
$ lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 14.04.5 LTS
Release:	14.04
Codename:	trusty
```