### PR TITLE
Allow interface_version_7 in modern hosts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,7 +297,7 @@ jobs:
       - run:
           name: Build with all features
           working_directory: ~/project/packages/vm
-          command: cargo build --locked --features iterator,staking,stargate
+          command: cargo build --locked --features allow_interface_version_7,iterator,staking,stargate
       - run:
           name: Test
           working_directory: ~/project/packages/vm
@@ -305,7 +305,7 @@ jobs:
       - run:
           name: Test with all features
           working_directory: ~/project/packages/vm
-          command: cargo test --locked --features iterator,staking,stargate
+          command: cargo test --locked --features allow_interface_version_7,iterator,staking,stargate
       - run:
           name: Test multi threaded cache
           working_directory: ~/project/packages/vm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to
 - cosmwasm-std: Implement `checked_multiply_ratio` for
   `Uint64`/`Uint128`/`Uint256`
 - cosmwasm-std: Implement `checked_from_ratio` for `Decimal`/`Decimal256`
+- cosmwasm-vm: Add feature `allow_interface_version_7` to run CosmWasm 0.16
+  contracts in modern hosts. Be careful if you consider using this!
 
 ### Changed
 

--- a/packages/vm/Cargo.toml
+++ b/packages/vm/Cargo.toml
@@ -24,6 +24,11 @@ staking = ["cosmwasm-std/staking"]
 stargate = ["cosmwasm-std/stargate"]
 # Use cranelift backend instead of singlepass. This is required for development on Windows.
 cranelift = ["wasmer/cranelift"]
+# It's a bit unclear if interface_version_7 (CosmWasm 0.16) contracts are fully compatible
+# with newer hosts. If old contracts are important to you and you are willing to take the risk,
+# activate this feature.
+# See also https://gist.github.com/webmaster128/3cd1988680843ecaf7548050821e1e6f.
+allow_interface_version_7 = []
 
 [lib]
 # See https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options

--- a/packages/vm/src/compatibility.rs
+++ b/packages/vm/src/compatibility.rs
@@ -41,7 +41,11 @@ const REQUIRED_EXPORTS: &[&str] = &[
 ];
 
 const INTERFACE_VERSION_PREFIX: &str = "interface_version_";
-const SUPPORTED_INTERFACE_VERSIONS: &[&str] = &["interface_version_8", "interface_version_7"];
+const SUPPORTED_INTERFACE_VERSIONS: &[&str] = &[
+    "interface_version_8",
+    #[cfg(feature = "allow_interface_version_7")]
+    "interface_version_7",
+];
 
 const MEMORY_LIMIT: u32 = 512; // in pages
 
@@ -350,21 +354,24 @@ mod tests {
         let module = deserialize_wasm(&wasm).unwrap();
         check_interface_version(&module).unwrap();
 
-        // valid legacy version
-        let wasm = wat::parse_str(
-            r#"(module
-                        (type (func))
-                        (func (type 0) nop)
-                        (export "add_one" (func 0))
-                        (export "allocate" (func 0))
-                        (export "interface_version_7" (func 0))
-                        (export "deallocate" (func 0))
-                        (export "instantiate" (func 0))
-                    )"#,
-        )
-        .unwrap();
-        let module = deserialize_wasm(&wasm).unwrap();
-        check_interface_version(&module).unwrap();
+        #[cfg(feature = "allow_interface_version_7")]
+        {
+            // valid legacy version
+            let wasm = wat::parse_str(
+                r#"(module
+                            (type (func))
+                            (func (type 0) nop)
+                            (export "add_one" (func 0))
+                            (export "allocate" (func 0))
+                            (export "interface_version_7" (func 0))
+                            (export "deallocate" (func 0))
+                            (export "instantiate" (func 0))
+                        )"#,
+            )
+            .unwrap();
+            let module = deserialize_wasm(&wasm).unwrap();
+            check_interface_version(&module).unwrap();
+        }
 
         // missing
         let wasm = wat::parse_str(

--- a/packages/vm/src/compatibility.rs
+++ b/packages/vm/src/compatibility.rs
@@ -359,14 +359,14 @@ mod tests {
             // valid legacy version
             let wasm = wat::parse_str(
                 r#"(module
-                            (type (func))
-                            (func (type 0) nop)
-                            (export "add_one" (func 0))
-                            (export "allocate" (func 0))
-                            (export "interface_version_7" (func 0))
-                            (export "deallocate" (func 0))
-                            (export "instantiate" (func 0))
-                        )"#,
+                    (type (func))
+                    (func (type 0) nop)
+                    (export "add_one" (func 0))
+                    (export "allocate" (func 0))
+                    (export "interface_version_7" (func 0))
+                    (export "deallocate" (func 0))
+                    (export "instantiate" (func 0))
+                )"#,
             )
             .unwrap();
             let module = deserialize_wasm(&wasm).unwrap();
@@ -424,14 +424,14 @@ mod tests {
         // CosmWasm 0.15
         let wasm = wat::parse_str(
             r#"(module
-                        (type (func))
-                        (func (type 0) nop)
-                        (export "add_one" (func 0))
-                        (export "allocate" (func 0))
-                        (export "interface_version_6" (func 0))
-                        (export "deallocate" (func 0))
-                        (export "instantiate" (func 0))
-                    )"#,
+                (type (func))
+                (func (type 0) nop)
+                (export "add_one" (func 0))
+                (export "allocate" (func 0))
+                (export "interface_version_6" (func 0))
+                (export "deallocate" (func 0))
+                (export "instantiate" (func 0))
+            )"#,
         )
         .unwrap();
         let module = deserialize_wasm(&wasm).unwrap();


### PR DESCRIPTION
This PR is adapted from https://github.com/terra-money/cosmwasm/commit/8bd072cf1a006481d0e64f9415f367757f4b345e. The idea is to allow users to run interface_version_7 contracts in modern hosts. 🤞 this works for them.