### PR TITLE
Small clarification in SEMANTICS.md about submessages error propagation

### DIFF
--- a/SEMANTICS.md
+++ b/SEMANTICS.md
@@ -249,7 +249,7 @@ Note, that error doesn't abort the whole transaction _if and only if_ the
 submessage is called with `ReplyOn::Success` (or `ReplyOn::Never`, which makes
 it effectively a normal message), the error in subsequent call would result in
 failing whole transaction and not commit the changes for it. The rule here is as
-follows: if for any reason you want your message Handling to succeed on
+follows: if for any reason you want your message handling to succeed on
 submessage failure, you always have to reply on failure.
 
 Obviously - on the successful processing of sub-message, if the reply is not

--- a/SEMANTICS.md
+++ b/SEMANTICS.md
@@ -244,6 +244,18 @@ intercepted by the calling contract (for `ReplyOn::Always` and
 `ReplyOn::Error`). _In this case, the messages error doesn't abort the whole
 transaction_
 
+Note, that error doesn't abort the whole transaction _if and only if_ the
+`reply` is called - so in case of `ReplyOn::Always` and `ReplyOn::Error`. If the
+submessage is called with `ReplyOn::Success` (or `ReplyOn::Never`, which makes
+it effectively a normal message), the error in subsequent call would result in
+failing whole transaction and not commit the changes for it. The rule here is as
+follows: if for any reason you want your message Handling to succeed on
+submessage failure, you always have to reply on failure.
+
+Obviously - on the successful processing of sub-message, if the reply is not
+called (in particular `ReplyOn::Error`), the whole transaction is assumed to
+succeed, and is committed.
+
 #### Handling the Reply
 
 In order to make use of `submessages`, the calling contract must have an extra


### PR DESCRIPTION
Here is some suggestion for a small improvement of SEMANTICS.md. Actually, after reading it when I know exactly how sub-messages work (because I just went through edge cases with a contract prepared exactly for this), the SEMANTICS reads pretty clearly - it was just confusing me when I didn't know the details. This causes me some difficulties on how to improve it as it is now clear. For now, this is my possible proposal to emphasise some things (sometimes rephrasing the fact in a couple of ways actually helps understanding it).