### PR TITLE
Add ibc v3 support to message types

### DIFF
--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 readme = "README.md"
 
 [package.metadata.docs.rs]
-features = ["stargate", "staking"]
+features = ["stargate", "staking", "ibcv3"]
 
 [features]
 default = ["iterator"]
@@ -29,6 +29,9 @@ backtraces = []
 # stargate enables stargate-dependent messages and queries, like raw protobuf messages
 # as well as ibc-related functionality
 stargate = []
+# ibcv3 extends ibc messages with ibcv3 only features. This should only be enabled on contracts
+# that require these types. Without this, they get the smaller ibcv1 API.
+ibcv3 = ["stargate"]
 
 [dependencies]
 base64 = "0.13.0"

--- a/packages/std/src/exports.rs
+++ b/packages/std/src/exports.rs
@@ -15,8 +15,9 @@ use serde::de::DeserializeOwned;
 use crate::deps::OwnedDeps;
 #[cfg(feature = "stargate")]
 use crate::ibc::{
-    IbcBasicResponse, IbcChannelCloseMsg, IbcChannelConnectMsg, IbcChannelOpenMsg, IbcPacketAckMsg,
-    IbcPacketReceiveMsg, IbcPacketTimeoutMsg, IbcReceiveResponse,
+    IbcBasicResponse, IbcChannelCloseMsg, IbcChannelConnectMsg, IbcChannelOpenMsg,
+    IbcChannelOpenResponse, IbcPacketAckMsg, IbcPacketReceiveMsg, IbcPacketTimeoutMsg,
+    IbcReceiveResponse,
 };
 use crate::imports::{ExternalApi, ExternalQuerier, ExternalStorage};
 use crate::memory::{alloc, consume_region, release_buffer, Region};
@@ -224,7 +225,7 @@ where
 /// - `E`: error type for responses
 #[cfg(feature = "stargate")]
 pub fn do_ibc_channel_open<Q, E>(
-    contract_fn: &dyn Fn(DepsMut<Q>, Env, IbcChannelOpenMsg) -> Result<(), E>,
+    contract_fn: &dyn Fn(DepsMut<Q>, Env, IbcChannelOpenMsg) -> Result<IbcChannelOpenResponse, E>,
     env_ptr: u32,
     msg_ptr: u32,
 ) -> u32
@@ -488,7 +489,7 @@ where
 
 #[cfg(feature = "stargate")]
 fn _do_ibc_channel_open<Q, E>(
-    contract_fn: &dyn Fn(DepsMut<Q>, Env, IbcChannelOpenMsg) -> Result<(), E>,
+    contract_fn: &dyn Fn(DepsMut<Q>, Env, IbcChannelOpenMsg) -> Result<IbcChannelOpenResponse, E>,
     env_ptr: *mut Region,
     msg_ptr: *mut Region,
 ) -> ContractResult<()>

--- a/packages/std/src/ibc.rs
+++ b/packages/std/src/ibc.rs
@@ -6,6 +6,8 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::cmp::{Ord, Ordering, PartialOrd};
 
+#[cfg(feature = "ibcv3")]
+use crate::addresses::Addr;
 use crate::binary::Binary;
 use crate::coins::Coin;
 use crate::errors::StdResult;
@@ -405,11 +407,19 @@ impl From<IbcChannelCloseMsg> for IbcChannel {
 #[non_exhaustive]
 pub struct IbcPacketReceiveMsg {
     pub packet: IbcPacket,
+    #[cfg(feature = "ibcv3")]
+    pub relayer: Addr,
 }
 
 impl IbcPacketReceiveMsg {
+    #[cfg(not(feature = "ibcv3"))]
     pub fn new(packet: IbcPacket) -> Self {
         Self { packet }
+    }
+
+    #[cfg(feature = "ibcv3")]
+    pub fn new(packet: IbcPacket, relayer: Addr) -> Self {
+        Self { packet, relayer }
     }
 }
 
@@ -419,13 +429,29 @@ impl IbcPacketReceiveMsg {
 pub struct IbcPacketAckMsg {
     pub acknowledgement: IbcAcknowledgement,
     pub original_packet: IbcPacket,
+    #[cfg(feature = "ibcv3")]
+    pub relayer: Addr,
 }
 
 impl IbcPacketAckMsg {
+    #[cfg(not(feature = "ibcv3"))]
     pub fn new(acknowledgement: IbcAcknowledgement, original_packet: IbcPacket) -> Self {
         Self {
             acknowledgement,
             original_packet,
+        }
+    }
+
+    #[cfg(feature = "ibcv3")]
+    pub fn new(
+        acknowledgement: IbcAcknowledgement,
+        original_packet: IbcPacket,
+        relayer: Addr,
+    ) -> Self {
+        Self {
+            acknowledgement,
+            original_packet,
+            relayer,
         }
     }
 }
@@ -435,11 +461,19 @@ impl IbcPacketAckMsg {
 #[non_exhaustive]
 pub struct IbcPacketTimeoutMsg {
     pub packet: IbcPacket,
+    #[cfg(feature = "ibcv3")]
+    pub relayer: Addr,
 }
 
 impl IbcPacketTimeoutMsg {
+    #[cfg(not(feature = "ibcv3"))]
     pub fn new(packet: IbcPacket) -> Self {
         Self { packet }
+    }
+
+    #[cfg(feature = "ibcv3")]
+    pub fn new(packet: IbcPacket, relayer: Addr) -> Self {
+        Self { packet, relayer }
     }
 }
 

--- a/packages/std/src/ibc.rs
+++ b/packages/std/src/ibc.rs
@@ -119,6 +119,7 @@ pub struct IbcChannel {
     pub endpoint: IbcEndpoint,
     pub counterparty_endpoint: IbcEndpoint,
     pub order: IbcOrder,
+    /// Note: in ibcv3 this may be "", in the IbcOpenChannel handshake messages
     pub version: String,
     /// The connection upon which this channel was created. If this is a multi-hop
     /// channel, we only expose the first hop.
@@ -294,6 +295,19 @@ impl From<IbcChannelOpenMsg> for IbcChannel {
             IbcChannelOpenMsg::OpenTry { channel, .. } => channel,
         }
     }
+}
+
+/// Note that this serializes as "null"
+#[cfg(not(feature = "ibcv3"))]
+pub type IbcChannelOpenResponse = ();
+
+/// This serializes as a JSON object, the parser should treat as Option to handle both v1 and v3
+#[cfg(feature = "ibcv3")]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct IbcChannelOpenResponse {
+    /// We can set the channel version to a different one than we were called with
+    /// TODO: remove option??
+    pub version: Option<String>,
 }
 
 /// The message that is passed into `ibc_channel_connect`

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -35,8 +35,9 @@ pub use crate::errors::{
 #[cfg(feature = "stargate")]
 pub use crate::ibc::{
     IbcAcknowledgement, IbcBasicResponse, IbcChannel, IbcChannelCloseMsg, IbcChannelConnectMsg,
-    IbcChannelOpenMsg, IbcEndpoint, IbcMsg, IbcOrder, IbcPacket, IbcPacketAckMsg,
-    IbcPacketReceiveMsg, IbcPacketTimeoutMsg, IbcReceiveResponse, IbcTimeout, IbcTimeoutBlock,
+    IbcChannelOpenMsg, IbcChannelOpenResponse, IbcEndpoint, IbcMsg, IbcOrder, IbcPacket,
+    IbcPacketAckMsg, IbcPacketReceiveMsg, IbcPacketTimeoutMsg, IbcReceiveResponse, IbcTimeout,
+    IbcTimeoutBlock,
 };
 #[cfg(feature = "iterator")]
 pub use crate::iterator::{Order, Record};


### PR DESCRIPTION
Added a new feature flag "ibcv3".

I made all effort to ensure the types are backwards compatible with ibcv1, meaning:

* V3 input is a superset of the previous input and extra fields can be ignored
* Output is a superset of the previous output, but all additional information is optional to the runtime