### PR TITLE
Keep new() identical for ibc1 and ibc3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ and this project adheres to
 - cosmwasm-std: Implement `Div`/`DivAssign` for `Decimal`/`Decimal256`.
 - cosmwasm-vm: Add feature `allow_interface_version_7` to run CosmWasm 0.16
   contracts in modern hosts. Be careful if you consider using this!
+- cosmwasm-std: Add new `ibc3` feature that allows to use IBC-Go V3 features,
+  like version negotiation and exposing relayer address to the contract.
+  Requires a compatible wasmd runtime (v0.27.0+) ([#1297])
+
+[#1302]: https://github.com/CosmWasm/cosmwasm/pull/1302
 
 ### Changed
 

--- a/contracts/ibc-reflect-send/tests/integration.rs
+++ b/contracts/ibc-reflect-send/tests/integration.rs
@@ -31,7 +31,7 @@ use cosmwasm_vm::testing::{
 };
 use cosmwasm_vm::{from_slice, Instance};
 
-use ibc_reflect_send::ibc::IBC_VERSION;
+use ibc_reflect_send::ibc::IBC_APP_VERSION;
 use ibc_reflect_send::ibc_msg::{AcknowledgementMsg, PacketMsg, WhoAmIResponse};
 use ibc_reflect_send::msg::{AccountResponse, AdminResponse, ExecuteMsg, InstantiateMsg, QueryMsg};
 
@@ -56,13 +56,13 @@ fn setup() -> Instance<MockApi, MockStorage, MockQuerier> {
 // save the account (tested in detail in `proper_handshake_flow`)
 fn connect(deps: &mut Instance<MockApi, MockStorage, MockQuerier>, channel_id: &str) {
     // open packet has no counterparty version, connect does
-    let handshake_open = mock_ibc_channel_open_init(channel_id, IbcOrder::Ordered, IBC_VERSION);
+    let handshake_open = mock_ibc_channel_open_init(channel_id, IbcOrder::Ordered, IBC_APP_VERSION);
     // first we try to open with a valid handshake
     ibc_channel_open(deps, mock_env(), handshake_open).unwrap();
 
     // then we connect (with counter-party version set)
     let handshake_connect =
-        mock_ibc_channel_connect_ack(channel_id, IbcOrder::Ordered, IBC_VERSION);
+        mock_ibc_channel_connect_ack(channel_id, IbcOrder::Ordered, IBC_APP_VERSION);
     let res: IbcBasicResponse = ibc_channel_connect(deps, mock_env(), handshake_connect).unwrap();
 
     // this should send a WhoAmI request, which is received some blocks later
@@ -103,13 +103,14 @@ fn instantiate_works() {
 fn enforce_version_in_handshake() {
     let mut deps = setup();
 
-    let wrong_order = mock_ibc_channel_open_try("channel-12", IbcOrder::Unordered, IBC_VERSION);
+    let wrong_order = mock_ibc_channel_open_try("channel-12", IbcOrder::Unordered, IBC_APP_VERSION);
     ibc_channel_open(&mut deps, mock_env(), wrong_order).unwrap_err();
 
     let wrong_version = mock_ibc_channel_open_try("channel-12", IbcOrder::Ordered, "reflect");
     ibc_channel_open(&mut deps, mock_env(), wrong_version).unwrap_err();
 
-    let valid_handshake = mock_ibc_channel_open_try("channel-12", IbcOrder::Ordered, IBC_VERSION);
+    let valid_handshake =
+        mock_ibc_channel_open_try("channel-12", IbcOrder::Ordered, IBC_APP_VERSION);
     ibc_channel_open(&mut deps, mock_env(), valid_handshake).unwrap();
 }
 

--- a/contracts/ibc-reflect/Cargo.toml
+++ b/contracts/ibc-reflect/Cargo.toml
@@ -32,11 +32,11 @@ cranelift = ["cosmwasm-vm/cranelift"]
 backtraces = ["cosmwasm-std/backtraces", "cosmwasm-vm/backtraces"]
 
 [dependencies]
-cosmwasm-std = { path = "../../packages/std", features = ["iterator", "ibcv3"] }
+cosmwasm-std = { path = "../../packages/std", features = ["iterator", "ibc3"] }
 cosmwasm-storage = { path = "../../packages/storage", features = ["iterator"] }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
-cosmwasm-vm = { path = "../../packages/vm", default-features = false, features = ["iterator", "ibcv3"] }
+cosmwasm-vm = { path = "../../packages/vm", default-features = false, features = ["iterator", "stargate"] }
 cosmwasm-schema = { path = "../../packages/schema" }

--- a/contracts/ibc-reflect/Cargo.toml
+++ b/contracts/ibc-reflect/Cargo.toml
@@ -32,11 +32,11 @@ cranelift = ["cosmwasm-vm/cranelift"]
 backtraces = ["cosmwasm-std/backtraces", "cosmwasm-vm/backtraces"]
 
 [dependencies]
-cosmwasm-std = { path = "../../packages/std", features = ["iterator", "staking", "stargate"] }
+cosmwasm-std = { path = "../../packages/std", features = ["iterator", "ibcv3"] }
 cosmwasm-storage = { path = "../../packages/storage", features = ["iterator"] }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
-cosmwasm-vm = { path = "../../packages/vm", default-features = false, features = ["iterator", "stargate"] }
+cosmwasm-vm = { path = "../../packages/vm", default-features = false, features = ["iterator", "ibcv3"] }
 cosmwasm-schema = { path = "../../packages/schema" }

--- a/contracts/ibc-reflect/schema/packet_msg.json
+++ b/contracts/ibc-reflect/schema/packet_msg.json
@@ -154,30 +154,6 @@
           "additionalProperties": false
         },
         {
-          "type": "object",
-          "required": [
-            "staking"
-          ],
-          "properties": {
-            "staking": {
-              "$ref": "#/definitions/StakingMsg"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "required": [
-            "distribution"
-          ],
-          "properties": {
-            "distribution": {
-              "$ref": "#/definitions/DistributionMsg"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
           "description": "A Stargate message encoded the same way as a protobuf [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto). This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)",
           "type": "object",
           "required": [
@@ -234,55 +210,6 @@
           "properties": {
             "gov": {
               "$ref": "#/definitions/GovMsg"
-            }
-          },
-          "additionalProperties": false
-        }
-      ]
-    },
-    "DistributionMsg": {
-      "description": "The message types of the distribution module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto",
-      "oneOf": [
-        {
-          "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37). `delegator_address` is automatically filled with the current contract's address.",
-          "type": "object",
-          "required": [
-            "set_withdraw_address"
-          ],
-          "properties": {
-            "set_withdraw_address": {
-              "type": "object",
-              "required": [
-                "address"
-              ],
-              "properties": {
-                "address": {
-                  "description": "The `withdraw_address`",
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "description": "This is translated to a [[MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
-          "type": "object",
-          "required": [
-            "withdraw_delegator_reward"
-          ],
-          "properties": {
-            "withdraw_delegator_reward": {
-              "type": "object",
-              "required": [
-                "validator"
-              ],
-              "properties": {
-                "validator": {
-                  "description": "The `validator_address`",
-                  "type": "string"
-                }
-              }
             }
           },
           "additionalProperties": false
@@ -476,90 +403,6 @@
           "minimum": 0.0
         }
       }
-    },
-    "StakingMsg": {
-      "description": "The message types of the staking module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto",
-      "oneOf": [
-        {
-          "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
-          "type": "object",
-          "required": [
-            "delegate"
-          ],
-          "properties": {
-            "delegate": {
-              "type": "object",
-              "required": [
-                "amount",
-                "validator"
-              ],
-              "properties": {
-                "amount": {
-                  "$ref": "#/definitions/Coin"
-                },
-                "validator": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
-          "type": "object",
-          "required": [
-            "undelegate"
-          ],
-          "properties": {
-            "undelegate": {
-              "type": "object",
-              "required": [
-                "amount",
-                "validator"
-              ],
-              "properties": {
-                "amount": {
-                  "$ref": "#/definitions/Coin"
-                },
-                "validator": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
-          "type": "object",
-          "required": [
-            "redelegate"
-          ],
-          "properties": {
-            "redelegate": {
-              "type": "object",
-              "required": [
-                "amount",
-                "dst_validator",
-                "src_validator"
-              ],
-              "properties": {
-                "amount": {
-                  "$ref": "#/definitions/Coin"
-                },
-                "dst_validator": {
-                  "type": "string"
-                },
-                "src_validator": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "additionalProperties": false
-        }
-      ]
     },
     "Timestamp": {
       "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",

--- a/contracts/ibc-reflect/src/contract.rs
+++ b/contracts/ibc-reflect/src/contract.rs
@@ -1,8 +1,8 @@
 use cosmwasm_std::{
     entry_point, from_slice, to_binary, wasm_execute, BankMsg, Binary, CosmosMsg, Deps, DepsMut,
-    Empty, Env, Event, IbcBasicResponse, IbcChannelCloseMsg, IbcChannelConnectMsg,
-    IbcChannelOpenMsg, IbcChannelOpenResponse, IbcOrder, IbcPacketAckMsg, IbcPacketReceiveMsg,
-    IbcPacketTimeoutMsg, IbcReceiveResponse, IbcV3ChannelOpenResponse, MessageInfo, Order,
+    Empty, Env, Event, Ibc3ChannelOpenResponse, IbcBasicResponse, IbcChannelCloseMsg,
+    IbcChannelConnectMsg, IbcChannelOpenMsg, IbcChannelOpenResponse, IbcOrder, IbcPacketAckMsg,
+    IbcPacketReceiveMsg, IbcPacketTimeoutMsg, IbcReceiveResponse, MessageInfo, Order,
     QueryResponse, Reply, Response, StdError, StdResult, SubMsg, SubMsgResponse, SubMsgResult,
     WasmMsg,
 };
@@ -140,7 +140,7 @@ pub fn ibc_channel_open(
     }
 
     // We return the version we need (which could be different than the counterparty version)
-    Ok(Some(IbcV3ChannelOpenResponse {
+    Ok(Some(Ibc3ChannelOpenResponse {
         version: IBC_APP_VERSION.to_string(),
     }))
 }

--- a/contracts/ibc-reflect/src/contract.rs
+++ b/contracts/ibc-reflect/src/contract.rs
@@ -2,8 +2,9 @@ use cosmwasm_std::{
     entry_point, from_slice, to_binary, wasm_execute, BankMsg, Binary, CosmosMsg, Deps, DepsMut,
     Empty, Env, Event, IbcBasicResponse, IbcChannelCloseMsg, IbcChannelConnectMsg,
     IbcChannelOpenMsg, IbcChannelOpenResponse, IbcOrder, IbcPacketAckMsg, IbcPacketReceiveMsg,
-    IbcPacketTimeoutMsg, IbcReceiveResponse, MessageInfo, Order, QueryResponse, Reply, Response,
-    StdError, StdResult, SubMsg, SubMsgResponse, SubMsgResult, WasmMsg,
+    IbcPacketTimeoutMsg, IbcReceiveResponse, IbcV3ChannelOpenResponse, MessageInfo, Order,
+    QueryResponse, Reply, Response, StdError, StdResult, SubMsg, SubMsgResponse, SubMsgResult,
+    WasmMsg,
 };
 
 use crate::msg::{
@@ -139,9 +140,9 @@ pub fn ibc_channel_open(
     }
 
     // and then return what we want
-    Ok(IbcChannelOpenResponse {
-        version: Some(IBC_VERSION.to_string()),
-    })
+    Ok(Some(IbcV3ChannelOpenResponse {
+        version: IBC_VERSION.to_string(),
+    }))
 }
 
 #[entry_point]

--- a/contracts/ibc-reflect/tests/integration.rs
+++ b/contracts/ibc-reflect/tests/integration.rs
@@ -31,7 +31,7 @@ use cosmwasm_vm::testing::{
 };
 use cosmwasm_vm::{from_slice, Instance};
 
-use ibc_reflect::contract::{IBC_VERSION, RECEIVE_DISPATCH_ID};
+use ibc_reflect::contract::{IBC_APP_VERSION, RECEIVE_DISPATCH_ID};
 use ibc_reflect::msg::{
     AccountInfo, AccountResponse, AcknowledgementMsg, DispatchResponse, InstantiateMsg,
     ListAccountsResponse, PacketMsg, QueryMsg, ReflectExecuteMsg,
@@ -77,12 +77,12 @@ fn connect(
 ) {
     let account: String = account.into();
     // first we try to open with a valid handshake
-    let handshake_open = mock_ibc_channel_open_init(channel_id, IbcOrder::Ordered, IBC_VERSION);
+    let handshake_open = mock_ibc_channel_open_init(channel_id, IbcOrder::Ordered, IBC_APP_VERSION);
     ibc_channel_open(deps, mock_env(), handshake_open).unwrap();
 
     // then we connect (with counter-party version set)
     let handshake_connect =
-        mock_ibc_channel_connect_ack(channel_id, IbcOrder::Ordered, IBC_VERSION);
+        mock_ibc_channel_connect_ack(channel_id, IbcOrder::Ordered, IBC_APP_VERSION);
     let res: IbcBasicResponse = ibc_channel_connect(deps, mock_env(), handshake_connect).unwrap();
     assert_eq!(1, res.messages.len());
     assert_eq!(1, res.events.len());
@@ -120,13 +120,15 @@ fn instantiate_works() {
 fn enforce_version_in_handshake() {
     let mut deps = setup();
 
-    let wrong_order = mock_ibc_channel_open_try("channel-1234", IbcOrder::Unordered, IBC_VERSION);
+    let wrong_order =
+        mock_ibc_channel_open_try("channel-1234", IbcOrder::Unordered, IBC_APP_VERSION);
     ibc_channel_open(&mut deps, mock_env(), wrong_order).unwrap_err();
 
     let wrong_version = mock_ibc_channel_open_try("channel-1234", IbcOrder::Ordered, "reflect");
     ibc_channel_open(&mut deps, mock_env(), wrong_version).unwrap_err();
 
-    let valid_handshake = mock_ibc_channel_open_try("channel-1234", IbcOrder::Ordered, IBC_VERSION);
+    let valid_handshake =
+        mock_ibc_channel_open_try("channel-1234", IbcOrder::Ordered, IBC_APP_VERSION);
     ibc_channel_open(&mut deps, mock_env(), valid_handshake).unwrap();
 }
 
@@ -136,12 +138,12 @@ fn proper_handshake_flow() {
     let channel_id = "channel-432";
 
     // first we try to open with a valid handshake
-    let handshake_open = mock_ibc_channel_open_init(channel_id, IbcOrder::Ordered, IBC_VERSION);
+    let handshake_open = mock_ibc_channel_open_init(channel_id, IbcOrder::Ordered, IBC_APP_VERSION);
     ibc_channel_open(&mut deps, mock_env(), handshake_open).unwrap();
 
     // then we connect (with counter-party version set)
     let handshake_connect =
-        mock_ibc_channel_connect_ack(channel_id, IbcOrder::Ordered, IBC_VERSION);
+        mock_ibc_channel_connect_ack(channel_id, IbcOrder::Ordered, IBC_APP_VERSION);
     let res: IbcBasicResponse =
         ibc_channel_connect(&mut deps, mock_env(), handshake_connect).unwrap();
     // and set up a reflect account

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 readme = "README.md"
 
 [package.metadata.docs.rs]
-features = ["stargate", "staking"]
+features = ["stargate", "staking", "ibcv3"]
 
 [features]
 default = ["iterator"]
@@ -29,6 +29,9 @@ backtraces = []
 # stargate enables stargate-dependent messages and queries, like raw protobuf messages
 # as well as ibc-related functionality
 stargate = []
+# ibcv3 extends ibc messages with ibcv3 only features. This should only be enabled on contracts
+# that require these types. Without this, they get the smaller ibcv1 API.
+ibcv3 = ["stargate"]
 
 [dependencies]
 base64 = "0.13.0"

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 readme = "README.md"
 
 [package.metadata.docs.rs]
-features = ["stargate", "staking", "ibcv3"]
+features = ["stargate", "staking", "ibc3"]
 
 [features]
 default = ["iterator"]
@@ -29,9 +29,9 @@ backtraces = []
 # stargate enables stargate-dependent messages and queries, like raw protobuf messages
 # as well as ibc-related functionality
 stargate = []
-# ibcv3 extends ibc messages with ibcv3 only features. This should only be enabled on contracts
-# that require these types. Without this, they get the smaller ibcv1 API.
-ibcv3 = ["stargate"]
+# ibc3 extends ibc messages with ibc-v3 only features. This should only be enabled on contracts
+# that require these types. Without this, they get the smaller ibc-v1 API.
+ibc3 = ["stargate"]
 
 [dependencies]
 base64 = "0.13.0"

--- a/packages/std/src/exports.rs
+++ b/packages/std/src/exports.rs
@@ -492,7 +492,7 @@ fn _do_ibc_channel_open<Q, E>(
     contract_fn: &dyn Fn(DepsMut<Q>, Env, IbcChannelOpenMsg) -> Result<IbcChannelOpenResponse, E>,
     env_ptr: *mut Region,
     msg_ptr: *mut Region,
-) -> ContractResult<()>
+) -> ContractResult<IbcChannelOpenResponse>
 where
     Q: CustomQuery,
     E: ToString,

--- a/packages/std/src/exports.rs
+++ b/packages/std/src/exports.rs
@@ -15,8 +15,9 @@ use serde::de::DeserializeOwned;
 use crate::deps::OwnedDeps;
 #[cfg(feature = "stargate")]
 use crate::ibc::{
-    IbcBasicResponse, IbcChannelCloseMsg, IbcChannelConnectMsg, IbcChannelOpenMsg, IbcPacketAckMsg,
-    IbcPacketReceiveMsg, IbcPacketTimeoutMsg, IbcReceiveResponse,
+    IbcBasicResponse, IbcChannelCloseMsg, IbcChannelConnectMsg, IbcChannelOpenMsg,
+    IbcChannelOpenResponse, IbcPacketAckMsg, IbcPacketReceiveMsg, IbcPacketTimeoutMsg,
+    IbcReceiveResponse,
 };
 use crate::imports::{ExternalApi, ExternalQuerier, ExternalStorage};
 use crate::memory::{alloc, consume_region, release_buffer, Region};
@@ -224,7 +225,7 @@ where
 /// - `E`: error type for responses
 #[cfg(feature = "stargate")]
 pub fn do_ibc_channel_open<Q, E>(
-    contract_fn: &dyn Fn(DepsMut<Q>, Env, IbcChannelOpenMsg) -> Result<(), E>,
+    contract_fn: &dyn Fn(DepsMut<Q>, Env, IbcChannelOpenMsg) -> Result<IbcChannelOpenResponse, E>,
     env_ptr: u32,
     msg_ptr: u32,
 ) -> u32
@@ -488,7 +489,7 @@ where
 
 #[cfg(feature = "stargate")]
 fn _do_ibc_channel_open<Q, E>(
-    contract_fn: &dyn Fn(DepsMut<Q>, Env, IbcChannelOpenMsg) -> Result<(), E>,
+    contract_fn: &dyn Fn(DepsMut<Q>, Env, IbcChannelOpenMsg) -> Result<IbcChannelOpenResponse, E>,
     env_ptr: *mut Region,
     msg_ptr: *mut Region,
 ) -> ContractResult<()>

--- a/packages/std/src/ibc.rs
+++ b/packages/std/src/ibc.rs
@@ -304,10 +304,10 @@ impl From<IbcChannelOpenMsg> for IbcChannel {
 pub type IbcChannelOpenResponse = ();
 /// This serializes either as "null" or a JSON object.
 #[cfg(feature = "ibc3")]
-pub type IbcChannelOpenResponse = Option<IbcV3ChannelOpenResponse>;
+pub type IbcChannelOpenResponse = Option<Ibc3ChannelOpenResponse>;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct IbcV3ChannelOpenResponse {
+pub struct Ibc3ChannelOpenResponse {
     /// We can set the channel version to a different one than we were called with
     pub version: String,
 }

--- a/packages/std/src/ibc.rs
+++ b/packages/std/src/ibc.rs
@@ -6,6 +6,8 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::cmp::{Ord, Ordering, PartialOrd};
 
+#[cfg(feature = "ibcv3")]
+use crate::addresses::Addr;
 use crate::binary::Binary;
 use crate::coins::Coin;
 use crate::errors::StdResult;
@@ -405,11 +407,19 @@ impl From<IbcChannelCloseMsg> for IbcChannel {
 #[non_exhaustive]
 pub struct IbcPacketReceiveMsg {
     pub packet: IbcPacket,
+    #[cfg(feature = "ibcv3")]
+    pub relayer: Addr,
 }
 
 impl IbcPacketReceiveMsg {
+    #[cfg(not(feature = "ibcv3"))]
     pub fn new(packet: IbcPacket) -> Self {
         Self { packet }
+    }
+
+    #[cfg(feature = "ibcv3")]
+    pub fn new(packet: IbcPacket, relayer: Addr) -> Self {
+        Self { packet, relayer }
     }
 }
 
@@ -419,13 +429,29 @@ impl IbcPacketReceiveMsg {
 pub struct IbcPacketAckMsg {
     pub acknowledgement: IbcAcknowledgement,
     pub original_packet: IbcPacket,
+    #[cfg(feature = "ibcv3")]
+    pub relayer: Addr,
 }
 
 impl IbcPacketAckMsg {
+    #[cfg(not(feature = "ibcv3"))]
     pub fn new(acknowledgement: IbcAcknowledgement, original_packet: IbcPacket) -> Self {
         Self {
             acknowledgement,
             original_packet,
+        }
+    }
+
+    #[cfg(feature = "ibcv3")]
+    pub fn new(
+        acknowledgement: IbcAcknowledgement,
+        original_packet: IbcPacket,
+        relayer: Addr,
+    ) -> Self {
+        Self {
+            acknowledgement,
+            original_packet,
+            relayer,
         }
     }
 }
@@ -435,11 +461,19 @@ impl IbcPacketAckMsg {
 #[non_exhaustive]
 pub struct IbcPacketTimeoutMsg {
     pub packet: IbcPacket,
+    #[cfg(feature = "ibcv3")]
+    pub relayer: Addr,
 }
 
 impl IbcPacketTimeoutMsg {
+    #[cfg(not(feature = "ibcv3"))]
     pub fn new(packet: IbcPacket) -> Self {
         Self { packet }
+    }
+
+    #[cfg(feature = "ibcv3")]
+    pub fn new(packet: IbcPacket, relayer: Addr) -> Self {
+        Self { packet, relayer }
     }
 }
 

--- a/packages/std/src/ibc.rs
+++ b/packages/std/src/ibc.rs
@@ -119,6 +119,7 @@ pub struct IbcChannel {
     pub endpoint: IbcEndpoint,
     pub counterparty_endpoint: IbcEndpoint,
     pub order: IbcOrder,
+    /// Note: in ibcv3 this may be "", in the IbcOpenChannel handshake messages
     pub version: String,
     /// The connection upon which this channel was created. If this is a multi-hop
     /// channel, we only expose the first hop.
@@ -294,6 +295,19 @@ impl From<IbcChannelOpenMsg> for IbcChannel {
             IbcChannelOpenMsg::OpenTry { channel, .. } => channel,
         }
     }
+}
+
+/// Note that this serializes as "null"
+#[cfg(not(feature = "ibcv3"))]
+pub type IbcChannelOpenResponse = ();
+
+/// This serializes as a JSON object, the parser should treat as Option to handle both v1 and v3
+#[cfg(feature = "ibcv3")]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct IbcChannelOpenResponse {
+    /// We can set the channel version to a different one than we were called with
+    /// TODO: remove option??
+    pub version: Option<String>,
 }
 
 /// The message that is passed into `ibc_channel_connect`

--- a/packages/std/src/ibc.rs
+++ b/packages/std/src/ibc.rs
@@ -302,14 +302,15 @@ impl From<IbcChannelOpenMsg> for IbcChannel {
 /// Note that this serializes as "null"
 #[cfg(not(feature = "ibcv3"))]
 pub type IbcChannelOpenResponse = ();
+/// This serializes either as "null"
+#[cfg(feature = "ibcv3")]
+pub type IbcChannelOpenResponse = Option<IbcV3ChannelOpenResponse>;
 
 /// This serializes as a JSON object, the parser should treat as Option to handle both v1 and v3
-#[cfg(feature = "ibcv3")]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct IbcChannelOpenResponse {
+pub struct IbcV3ChannelOpenResponse {
     /// We can set the channel version to a different one than we were called with
-    /// TODO: remove option??
-    pub version: Option<String>,
+    pub version: String,
 }
 
 /// The message that is passed into `ibc_channel_connect`

--- a/packages/std/src/ibc.rs
+++ b/packages/std/src/ibc.rs
@@ -299,14 +299,13 @@ impl From<IbcChannelOpenMsg> for IbcChannel {
     }
 }
 
-/// Note that this serializes as "null"
+/// Note that this serializes as "null".
 #[cfg(not(feature = "ibcv3"))]
 pub type IbcChannelOpenResponse = ();
-/// This serializes either as "null"
+/// This serializes either as "null" or a JSON object.
 #[cfg(feature = "ibcv3")]
 pub type IbcChannelOpenResponse = Option<IbcV3ChannelOpenResponse>;
 
-/// This serializes as a JSON object, the parser should treat as Option to handle both v1 and v3
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct IbcV3ChannelOpenResponse {
     /// We can set the channel version to a different one than we were called with

--- a/packages/std/src/ibc.rs
+++ b/packages/std/src/ibc.rs
@@ -6,7 +6,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::cmp::{Ord, Ordering, PartialOrd};
 
-#[cfg(feature = "ibcv3")]
+#[cfg(feature = "ibc3")]
 use crate::addresses::Addr;
 use crate::binary::Binary;
 use crate::coins::Coin;
@@ -300,10 +300,10 @@ impl From<IbcChannelOpenMsg> for IbcChannel {
 }
 
 /// Note that this serializes as "null".
-#[cfg(not(feature = "ibcv3"))]
+#[cfg(not(feature = "ibc3"))]
 pub type IbcChannelOpenResponse = ();
 /// This serializes either as "null" or a JSON object.
-#[cfg(feature = "ibcv3")]
+#[cfg(feature = "ibc3")]
 pub type IbcChannelOpenResponse = Option<IbcV3ChannelOpenResponse>;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -407,17 +407,17 @@ impl From<IbcChannelCloseMsg> for IbcChannel {
 #[non_exhaustive]
 pub struct IbcPacketReceiveMsg {
     pub packet: IbcPacket,
-    #[cfg(feature = "ibcv3")]
+    #[cfg(feature = "ibc3")]
     pub relayer: Addr,
 }
 
 impl IbcPacketReceiveMsg {
-    #[cfg(not(feature = "ibcv3"))]
+    #[cfg(not(feature = "ibc3"))]
     pub fn new(packet: IbcPacket) -> Self {
         Self { packet }
     }
 
-    #[cfg(feature = "ibcv3")]
+    #[cfg(feature = "ibc3")]
     pub fn new(packet: IbcPacket, relayer: Addr) -> Self {
         Self { packet, relayer }
     }
@@ -429,12 +429,12 @@ impl IbcPacketReceiveMsg {
 pub struct IbcPacketAckMsg {
     pub acknowledgement: IbcAcknowledgement,
     pub original_packet: IbcPacket,
-    #[cfg(feature = "ibcv3")]
+    #[cfg(feature = "ibc3")]
     pub relayer: Addr,
 }
 
 impl IbcPacketAckMsg {
-    #[cfg(not(feature = "ibcv3"))]
+    #[cfg(not(feature = "ibc3"))]
     pub fn new(acknowledgement: IbcAcknowledgement, original_packet: IbcPacket) -> Self {
         Self {
             acknowledgement,
@@ -442,7 +442,7 @@ impl IbcPacketAckMsg {
         }
     }
 
-    #[cfg(feature = "ibcv3")]
+    #[cfg(feature = "ibc3")]
     pub fn new(
         acknowledgement: IbcAcknowledgement,
         original_packet: IbcPacket,
@@ -461,17 +461,17 @@ impl IbcPacketAckMsg {
 #[non_exhaustive]
 pub struct IbcPacketTimeoutMsg {
     pub packet: IbcPacket,
-    #[cfg(feature = "ibcv3")]
+    #[cfg(feature = "ibc3")]
     pub relayer: Addr,
 }
 
 impl IbcPacketTimeoutMsg {
-    #[cfg(not(feature = "ibcv3"))]
+    #[cfg(not(feature = "ibc3"))]
     pub fn new(packet: IbcPacket) -> Self {
         Self { packet }
     }
 
-    #[cfg(feature = "ibcv3")]
+    #[cfg(feature = "ibc3")]
     pub fn new(packet: IbcPacket, relayer: Addr) -> Self {
         Self { packet, relayer }
     }

--- a/packages/std/src/ibc.rs
+++ b/packages/std/src/ibc.rs
@@ -412,13 +412,16 @@ pub struct IbcPacketReceiveMsg {
 }
 
 impl IbcPacketReceiveMsg {
-    #[cfg(not(feature = "ibc3"))]
     pub fn new(packet: IbcPacket) -> Self {
-        Self { packet }
+        Self {
+            packet,
+            #[cfg(feature = "ibc3")]
+            relayer: Addr::unchecked("relayer"),
+        }
     }
 
     #[cfg(feature = "ibc3")]
-    pub fn new(packet: IbcPacket, relayer: Addr) -> Self {
+    pub fn new_with_relayer(packet: IbcPacket, relayer: Addr) -> Self {
         Self { packet, relayer }
     }
 }
@@ -434,16 +437,17 @@ pub struct IbcPacketAckMsg {
 }
 
 impl IbcPacketAckMsg {
-    #[cfg(not(feature = "ibc3"))]
     pub fn new(acknowledgement: IbcAcknowledgement, original_packet: IbcPacket) -> Self {
         Self {
             acknowledgement,
             original_packet,
+            #[cfg(feature = "ibc3")]
+            relayer: Addr::unchecked("relayer"),
         }
     }
 
     #[cfg(feature = "ibc3")]
-    pub fn new(
+    pub fn new_with_relayer(
         acknowledgement: IbcAcknowledgement,
         original_packet: IbcPacket,
         relayer: Addr,
@@ -466,13 +470,16 @@ pub struct IbcPacketTimeoutMsg {
 }
 
 impl IbcPacketTimeoutMsg {
-    #[cfg(not(feature = "ibc3"))]
     pub fn new(packet: IbcPacket) -> Self {
-        Self { packet }
+        Self {
+            packet,
+            #[cfg(feature = "ibc3")]
+            relayer: Addr::unchecked("relayer"),
+        }
     }
 
     #[cfg(feature = "ibc3")]
-    pub fn new(packet: IbcPacket, relayer: Addr) -> Self {
+    pub fn new_with_relayer(packet: IbcPacket, relayer: Addr) -> Self {
         Self { packet, relayer }
     }
 }

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -35,8 +35,9 @@ pub use crate::errors::{
 #[cfg(feature = "stargate")]
 pub use crate::ibc::{
     IbcAcknowledgement, IbcBasicResponse, IbcChannel, IbcChannelCloseMsg, IbcChannelConnectMsg,
-    IbcChannelOpenMsg, IbcEndpoint, IbcMsg, IbcOrder, IbcPacket, IbcPacketAckMsg,
-    IbcPacketReceiveMsg, IbcPacketTimeoutMsg, IbcReceiveResponse, IbcTimeout, IbcTimeoutBlock,
+    IbcChannelOpenMsg, IbcChannelOpenResponse, IbcEndpoint, IbcMsg, IbcOrder, IbcPacket,
+    IbcPacketAckMsg, IbcPacketReceiveMsg, IbcPacketTimeoutMsg, IbcReceiveResponse, IbcTimeout,
+    IbcTimeoutBlock,
 };
 #[cfg(feature = "iterator")]
 pub use crate::iterator::{Order, Record};

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -37,7 +37,7 @@ pub use crate::ibc::{
     IbcAcknowledgement, IbcBasicResponse, IbcChannel, IbcChannelCloseMsg, IbcChannelConnectMsg,
     IbcChannelOpenMsg, IbcChannelOpenResponse, IbcEndpoint, IbcMsg, IbcOrder, IbcPacket,
     IbcPacketAckMsg, IbcPacketReceiveMsg, IbcPacketTimeoutMsg, IbcReceiveResponse, IbcTimeout,
-    IbcTimeoutBlock,
+    IbcTimeoutBlock, IbcV3ChannelOpenResponse,
 };
 #[cfg(feature = "iterator")]
 pub use crate::iterator::{Order, Record};

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -34,10 +34,10 @@ pub use crate::errors::{
 };
 #[cfg(feature = "stargate")]
 pub use crate::ibc::{
-    IbcAcknowledgement, IbcBasicResponse, IbcChannel, IbcChannelCloseMsg, IbcChannelConnectMsg,
-    IbcChannelOpenMsg, IbcChannelOpenResponse, IbcEndpoint, IbcMsg, IbcOrder, IbcPacket,
-    IbcPacketAckMsg, IbcPacketReceiveMsg, IbcPacketTimeoutMsg, IbcReceiveResponse, IbcTimeout,
-    IbcTimeoutBlock, IbcV3ChannelOpenResponse,
+    Ibc3ChannelOpenResponse, IbcAcknowledgement, IbcBasicResponse, IbcChannel, IbcChannelCloseMsg,
+    IbcChannelConnectMsg, IbcChannelOpenMsg, IbcChannelOpenResponse, IbcEndpoint, IbcMsg, IbcOrder,
+    IbcPacket, IbcPacketAckMsg, IbcPacketReceiveMsg, IbcPacketTimeoutMsg, IbcReceiveResponse,
+    IbcTimeout, IbcTimeoutBlock,
 };
 #[cfg(feature = "iterator")]
 pub use crate::iterator::{Order, Record};

--- a/packages/std/src/mock.rs
+++ b/packages/std/src/mock.rs
@@ -348,7 +348,7 @@ pub fn mock_ibc_packet_recv(
             }
             .into(),
         },
-        #[cfg(feature = "ibcv3")]
+        #[cfg(feature = "ibc3")]
         Addr::unchecked("relayer"),
     ))
 }
@@ -391,7 +391,7 @@ pub fn mock_ibc_packet_ack(
     Ok(IbcPacketAckMsg::new(
         ack,
         packet,
-        #[cfg(feature = "ibcv3")]
+        #[cfg(feature = "ibc3")]
         Addr::unchecked("relayer"),
     ))
 }
@@ -407,7 +407,7 @@ pub fn mock_ibc_packet_timeout(
     let packet = mock_ibc_packet(my_channel_id, data)?;
     Ok(IbcPacketTimeoutMsg::new(
         packet,
-        #[cfg(feature = "ibcv3")]
+        #[cfg(feature = "ibc3")]
         Addr::unchecked("relayer"),
     ))
 }

--- a/packages/std/src/mock.rs
+++ b/packages/std/src/mock.rs
@@ -330,27 +330,23 @@ pub fn mock_ibc_packet_recv(
     my_channel_id: &str,
     data: &impl Serialize,
 ) -> StdResult<IbcPacketReceiveMsg> {
-    Ok(IbcPacketReceiveMsg::new(
-        IbcPacket {
-            data: to_binary(data)?,
-            src: IbcEndpoint {
-                port_id: "their-port".to_string(),
-                channel_id: "channel-1234".to_string(),
-            },
-            dest: IbcEndpoint {
-                port_id: "our-port".to_string(),
-                channel_id: my_channel_id.into(),
-            },
-            sequence: 27,
-            timeout: IbcTimeoutBlock {
-                revision: 1,
-                height: 12345678,
-            }
-            .into(),
+    Ok(IbcPacketReceiveMsg::new(IbcPacket {
+        data: to_binary(data)?,
+        src: IbcEndpoint {
+            port_id: "their-port".to_string(),
+            channel_id: "channel-1234".to_string(),
         },
-        #[cfg(feature = "ibc3")]
-        Addr::unchecked("relayer"),
-    ))
+        dest: IbcEndpoint {
+            port_id: "our-port".to_string(),
+            channel_id: my_channel_id.into(),
+        },
+        sequence: 27,
+        timeout: IbcTimeoutBlock {
+            revision: 1,
+            height: 12345678,
+        }
+        .into(),
+    }))
 }
 
 /// Creates a IbcPacket for testing ibc_packet_{ack,timeout}. You set a few key parameters that are
@@ -388,12 +384,7 @@ pub fn mock_ibc_packet_ack(
 ) -> StdResult<IbcPacketAckMsg> {
     let packet = mock_ibc_packet(my_channel_id, data)?;
 
-    Ok(IbcPacketAckMsg::new(
-        ack,
-        packet,
-        #[cfg(feature = "ibc3")]
-        Addr::unchecked("relayer"),
-    ))
+    Ok(IbcPacketAckMsg::new(ack, packet))
 }
 
 /// Creates a IbcPacketTimeoutMsg for testing ibc_packet_timeout. You set a few key parameters that are
@@ -405,11 +396,7 @@ pub fn mock_ibc_packet_timeout(
     data: &impl Serialize,
 ) -> StdResult<IbcPacketTimeoutMsg> {
     let packet = mock_ibc_packet(my_channel_id, data)?;
-    Ok(IbcPacketTimeoutMsg::new(
-        packet,
-        #[cfg(feature = "ibc3")]
-        Addr::unchecked("relayer"),
-    ))
+    Ok(IbcPacketTimeoutMsg::new(packet))
 }
 
 /// The same type as cosmwasm-std's QuerierResult, but easier to reuse in

--- a/packages/vm/Cargo.toml
+++ b/packages/vm/Cargo.toml
@@ -22,6 +22,8 @@ iterator = ["cosmwasm-std/iterator"]
 staking = ["cosmwasm-std/staking"]
 # this enables all stargate-related functionality, including the ibc entry points
 stargate = ["cosmwasm-std/stargate"]
+# extend stargate with ibcv3 extra functionality
+ibcv3 = ["cosmwasm-std/ibcv3", "stargate"]
 # Use cranelift backend instead of singlepass. This is required for development on Windows.
 cranelift = ["wasmer/cranelift"]
 # It's a bit unclear if interface_version_7 (CosmWasm 0.16) contracts are fully compatible

--- a/packages/vm/Cargo.toml
+++ b/packages/vm/Cargo.toml
@@ -21,9 +21,7 @@ backtraces = []
 iterator = ["cosmwasm-std/iterator"]
 staking = ["cosmwasm-std/staking"]
 # this enables all stargate-related functionality, including the ibc entry points
-stargate = ["cosmwasm-std/stargate"]
-# extend stargate with ibcv3 extra functionality
-ibcv3 = ["cosmwasm-std/ibcv3", "stargate"]
+stargate = ["cosmwasm-std/stargate", "cosmwasm-std/ibc3"]
 # Use cranelift backend instead of singlepass. This is required for development on Windows.
 cranelift = ["wasmer/cranelift"]
 # It's a bit unclear if interface_version_7 (CosmWasm 0.16) contracts are fully compatible

--- a/packages/vm/src/calls.rs
+++ b/packages/vm/src/calls.rs
@@ -4,8 +4,9 @@ use wasmer::Val;
 use cosmwasm_std::{ContractResult, CustomMsg, Env, MessageInfo, QueryResponse, Reply, Response};
 #[cfg(feature = "stargate")]
 use cosmwasm_std::{
-    IbcBasicResponse, IbcChannelCloseMsg, IbcChannelConnectMsg, IbcChannelOpenMsg, IbcPacketAckMsg,
-    IbcPacketReceiveMsg, IbcPacketTimeoutMsg, IbcReceiveResponse, IbcV3ChannelOpenResponse,
+    Ibc3ChannelOpenResponse, IbcBasicResponse, IbcChannelCloseMsg, IbcChannelConnectMsg,
+    IbcChannelOpenMsg, IbcPacketAckMsg, IbcPacketReceiveMsg, IbcPacketTimeoutMsg,
+    IbcReceiveResponse,
 };
 
 use crate::backend::{BackendApi, Querier, Storage};
@@ -218,7 +219,7 @@ pub fn call_ibc_channel_open<A, S, Q>(
     instance: &mut Instance<A, S, Q>,
     env: &Env,
     msg: &IbcChannelOpenMsg,
-) -> VmResult<ContractResult<Option<IbcV3ChannelOpenResponse>>>
+) -> VmResult<ContractResult<Option<Ibc3ChannelOpenResponse>>>
 where
     A: BackendApi + 'static,
     S: Storage + 'static,
@@ -227,7 +228,7 @@ where
     let env = to_vec(env)?;
     let msg = to_vec(msg)?;
     let data = call_ibc_channel_open_raw(instance, &env, &msg)?;
-    let result: ContractResult<Option<IbcV3ChannelOpenResponse>> =
+    let result: ContractResult<Option<Ibc3ChannelOpenResponse>> =
         from_slice(&data, deserialization_limits::RESULT_IBC_CHANNEL_OPEN)?;
     Ok(result)
 }

--- a/packages/vm/src/calls.rs
+++ b/packages/vm/src/calls.rs
@@ -4,8 +4,9 @@ use wasmer::Val;
 use cosmwasm_std::{ContractResult, CustomMsg, Env, MessageInfo, QueryResponse, Reply, Response};
 #[cfg(feature = "stargate")]
 use cosmwasm_std::{
-    IbcBasicResponse, IbcChannelCloseMsg, IbcChannelConnectMsg, IbcChannelOpenMsg, IbcPacketAckMsg,
-    IbcPacketReceiveMsg, IbcPacketTimeoutMsg, IbcReceiveResponse,
+    IbcBasicResponse, IbcChannelCloseMsg, IbcChannelConnectMsg, IbcChannelOpenMsg,
+    IbcChannelOpenResponse, IbcPacketAckMsg, IbcPacketReceiveMsg, IbcPacketTimeoutMsg,
+    IbcReceiveResponse,
 };
 
 use crate::backend::{BackendApi, Querier, Storage};
@@ -218,7 +219,7 @@ pub fn call_ibc_channel_open<A, S, Q>(
     instance: &mut Instance<A, S, Q>,
     env: &Env,
     msg: &IbcChannelOpenMsg,
-) -> VmResult<ContractResult<()>>
+) -> VmResult<ContractResult<IbcChannelOpenResponse>>
 where
     A: BackendApi + 'static,
     S: Storage + 'static,
@@ -227,7 +228,7 @@ where
     let env = to_vec(env)?;
     let msg = to_vec(msg)?;
     let data = call_ibc_channel_open_raw(instance, &env, &msg)?;
-    let result: ContractResult<()> =
+    let result: ContractResult<IbcChannelOpenResponse> =
         from_slice(&data, deserialization_limits::RESULT_IBC_CHANNEL_OPEN)?;
     Ok(result)
 }

--- a/packages/vm/src/calls.rs
+++ b/packages/vm/src/calls.rs
@@ -4,9 +4,8 @@ use wasmer::Val;
 use cosmwasm_std::{ContractResult, CustomMsg, Env, MessageInfo, QueryResponse, Reply, Response};
 #[cfg(feature = "stargate")]
 use cosmwasm_std::{
-    IbcBasicResponse, IbcChannelCloseMsg, IbcChannelConnectMsg, IbcChannelOpenMsg,
-    IbcChannelOpenResponse, IbcPacketAckMsg, IbcPacketReceiveMsg, IbcPacketTimeoutMsg,
-    IbcReceiveResponse,
+    IbcBasicResponse, IbcChannelCloseMsg, IbcChannelConnectMsg, IbcChannelOpenMsg, IbcPacketAckMsg,
+    IbcPacketReceiveMsg, IbcPacketTimeoutMsg, IbcReceiveResponse, IbcV3ChannelOpenResponse,
 };
 
 use crate::backend::{BackendApi, Querier, Storage};
@@ -219,7 +218,7 @@ pub fn call_ibc_channel_open<A, S, Q>(
     instance: &mut Instance<A, S, Q>,
     env: &Env,
     msg: &IbcChannelOpenMsg,
-) -> VmResult<ContractResult<IbcChannelOpenResponse>>
+) -> VmResult<ContractResult<Option<IbcV3ChannelOpenResponse>>>
 where
     A: BackendApi + 'static,
     S: Storage + 'static,
@@ -228,7 +227,7 @@ where
     let env = to_vec(env)?;
     let msg = to_vec(msg)?;
     let data = call_ibc_channel_open_raw(instance, &env, &msg)?;
-    let result: ContractResult<IbcChannelOpenResponse> =
+    let result: ContractResult<Option<IbcV3ChannelOpenResponse>> =
         from_slice(&data, deserialization_limits::RESULT_IBC_CHANNEL_OPEN)?;
     Ok(result)
 }

--- a/packages/vm/src/testing/calls.rs
+++ b/packages/vm/src/testing/calls.rs
@@ -7,8 +7,9 @@ use serde::{de::DeserializeOwned, Serialize};
 use cosmwasm_std::{ContractResult, CustomMsg, Env, MessageInfo, QueryResponse, Reply, Response};
 #[cfg(feature = "stargate")]
 use cosmwasm_std::{
-    IbcBasicResponse, IbcChannelCloseMsg, IbcChannelConnectMsg, IbcChannelOpenMsg, IbcPacketAckMsg,
-    IbcPacketReceiveMsg, IbcPacketTimeoutMsg, IbcReceiveResponse, IbcV3ChannelOpenResponse,
+    Ibc3ChannelOpenResponse, IbcBasicResponse, IbcChannelCloseMsg, IbcChannelConnectMsg,
+    IbcChannelOpenMsg, IbcPacketAckMsg, IbcPacketReceiveMsg, IbcPacketTimeoutMsg,
+    IbcReceiveResponse,
 };
 
 use crate::calls::{
@@ -144,7 +145,7 @@ pub fn ibc_channel_open<A, S, Q>(
     instance: &mut Instance<A, S, Q>,
     env: Env,
     msg: IbcChannelOpenMsg,
-) -> ContractResult<Option<IbcV3ChannelOpenResponse>>
+) -> ContractResult<Option<Ibc3ChannelOpenResponse>>
 where
     A: BackendApi + 'static,
     S: Storage + 'static,

--- a/packages/vm/src/testing/calls.rs
+++ b/packages/vm/src/testing/calls.rs
@@ -7,9 +7,8 @@ use serde::{de::DeserializeOwned, Serialize};
 use cosmwasm_std::{ContractResult, CustomMsg, Env, MessageInfo, QueryResponse, Reply, Response};
 #[cfg(feature = "stargate")]
 use cosmwasm_std::{
-    IbcBasicResponse, IbcChannelCloseMsg, IbcChannelConnectMsg, IbcChannelOpenMsg,
-    IbcChannelOpenResponse, IbcPacketAckMsg, IbcPacketReceiveMsg, IbcPacketTimeoutMsg,
-    IbcReceiveResponse,
+    IbcBasicResponse, IbcChannelCloseMsg, IbcChannelConnectMsg, IbcChannelOpenMsg, IbcPacketAckMsg,
+    IbcPacketReceiveMsg, IbcPacketTimeoutMsg, IbcReceiveResponse, IbcV3ChannelOpenResponse,
 };
 
 use crate::calls::{
@@ -145,7 +144,7 @@ pub fn ibc_channel_open<A, S, Q>(
     instance: &mut Instance<A, S, Q>,
     env: Env,
     msg: IbcChannelOpenMsg,
-) -> ContractResult<IbcChannelOpenResponse>
+) -> ContractResult<Option<IbcV3ChannelOpenResponse>>
 where
     A: BackendApi + 'static,
     S: Storage + 'static,

--- a/packages/vm/src/testing/calls.rs
+++ b/packages/vm/src/testing/calls.rs
@@ -7,8 +7,9 @@ use serde::{de::DeserializeOwned, Serialize};
 use cosmwasm_std::{ContractResult, CustomMsg, Env, MessageInfo, QueryResponse, Reply, Response};
 #[cfg(feature = "stargate")]
 use cosmwasm_std::{
-    IbcBasicResponse, IbcChannelCloseMsg, IbcChannelConnectMsg, IbcChannelOpenMsg, IbcPacketAckMsg,
-    IbcPacketReceiveMsg, IbcPacketTimeoutMsg, IbcReceiveResponse,
+    IbcBasicResponse, IbcChannelCloseMsg, IbcChannelConnectMsg, IbcChannelOpenMsg,
+    IbcChannelOpenResponse, IbcPacketAckMsg, IbcPacketReceiveMsg, IbcPacketTimeoutMsg,
+    IbcReceiveResponse,
 };
 
 use crate::calls::{
@@ -144,7 +145,7 @@ pub fn ibc_channel_open<A, S, Q>(
     instance: &mut Instance<A, S, Q>,
     env: Env,
     msg: IbcChannelOpenMsg,
-) -> ContractResult<()>
+) -> ContractResult<IbcChannelOpenResponse>
 where
     A: BackendApi + 'static,
     S: Storage + 'static,


### PR DESCRIPTION
Optional addition to #1302 

This would make the ibc3 feature flag less breaking compile time. It would use a default value for relayer if not explicitly provided. These functions are only really used by the mock tooling as far as I know.

Merge if you like or reject if it is not an improvement. It is an attempt to address some PR comments.