### PR TITLE
Add `abs_diff` function for math package

### DIFF
--- a/packages/std/src/math/decimal.rs
+++ b/packages/std/src/math/decimal.rs
@@ -258,6 +258,14 @@ impl Decimal {
             Decimal(inner.isqrt().checked_mul(Uint128::from(outer_mul)).unwrap())
         })
     }
+
+    pub fn abs_diff(self, other: Self) -> Self {
+        if self < other {
+            other - self
+        } else {
+            self - other
+        }
+    }
 }
 
 impl Fraction<Uint128> for Decimal {
@@ -1663,5 +1671,14 @@ mod tests {
             from_slice::<Decimal>(br#""87.65""#).unwrap(),
             Decimal::percent(8765)
         );
+    }
+
+    #[test]
+    fn decimal_abs_diff_works() {
+        let a = Decimal::percent(285);
+        let b = Decimal::percent(200);
+        let expected = Decimal::percent(85);
+        assert_eq!(a.abs_diff(b), expected);
+        assert_eq!(b.abs_diff(a), expected);
     }
 }

--- a/packages/std/src/math/decimal256.rs
+++ b/packages/std/src/math/decimal256.rs
@@ -270,6 +270,14 @@ impl Decimal256 {
             Self(inner.isqrt().checked_mul(outer_mul).unwrap())
         })
     }
+
+    pub fn abs_diff(self, other: Self) -> Self {
+        if self < other {
+            other - self
+        } else {
+            self - other
+        }
+    }
 }
 
 impl Fraction<Uint256> for Decimal256 {
@@ -1782,5 +1790,14 @@ mod tests {
             from_slice::<Decimal256>(br#""87.65""#).unwrap(),
             Decimal256::percent(8765)
         );
+    }
+
+    #[test]
+    fn decimal256_abs_diff_works() {
+        let a = Decimal256::percent(285);
+        let b = Decimal256::percent(200);
+        let expected = Decimal256::percent(85);
+        assert_eq!(a.abs_diff(b), expected);
+        assert_eq!(b.abs_diff(a), expected);
     }
 }

--- a/packages/std/src/math/uint128.rs
+++ b/packages/std/src/math/uint128.rs
@@ -208,6 +208,10 @@ impl Uint128 {
     pub fn saturating_pow(self, other: u32) -> Self {
         Self(self.0.saturating_pow(other))
     }
+
+    pub fn abs_diff(self, other: impl Into<u128>) -> Self {
+        Self(self.0.abs_diff(other.into()))
+    }
 }
 
 // `From<u{128,64,32,16,8}>` is implemented manually instead of
@@ -964,5 +968,14 @@ mod tests {
         let b = Uint128::from(6u32);
         a %= &b;
         assert_eq!(a, Uint128::from(1u32));
+    }
+
+    #[test]
+    fn uint128_abs_diff_works() {
+        let a = Uint128::from(42u32);
+        let b = Uint128::from(5u32);
+        let expected = Uint128::from(37u32);
+        assert_eq!(a.abs_diff(b), expected);
+        assert_eq!(b.abs_diff(a), expected);
     }
 }

--- a/packages/std/src/math/uint256.rs
+++ b/packages/std/src/math/uint256.rs
@@ -283,6 +283,15 @@ impl Uint256 {
     pub fn saturating_mul(self, other: Self) -> Self {
         Self(self.0.saturating_mul(other.0))
     }
+
+    pub fn abs_diff(self, other: impl Into<Uint256>) -> Self {
+        let other = other.into();
+        if self < other {
+            other - self
+        } else {
+            self - other
+        }
+    }
 }
 
 impl From<Uint128> for Uint256 {
@@ -1515,5 +1524,14 @@ mod tests {
         let b = Uint256::from(6u32);
         a %= &b;
         assert_eq!(a, Uint256::from(1u32));
+    }
+
+    #[test]
+    fn uint256_abs_diff_works() {
+        let a = Uint256::from(42u32);
+        let b = Uint256::from(5u32);
+        let expected = Uint256::from(37u32);
+        assert_eq!(a.abs_diff(b), expected);
+        assert_eq!(b.abs_diff(a), expected);
     }
 }

--- a/packages/std/src/math/uint512.rs
+++ b/packages/std/src/math/uint512.rs
@@ -258,6 +258,15 @@ impl Uint512 {
     pub fn saturating_mul(self, other: Self) -> Self {
         Self(self.0.saturating_mul(other.0))
     }
+
+    pub fn abs_diff(self, other: impl Into<Uint512>) -> Self {
+        let other = other.into();
+        if self < other {
+            other - self
+        } else {
+            self - other
+        }
+    }
 }
 
 impl From<Uint256> for Uint512 {
@@ -1150,5 +1159,14 @@ mod tests {
         let b = Uint512::from(6u32);
         a %= &b;
         assert_eq!(a, Uint512::from(1u32));
+    }
+
+    #[test]
+    fn uint512_abs_diff_works() {
+        let a = Uint512::from(42u32);
+        let b = Uint512::from(5u32);
+        let expected = Uint512::from(37u32);
+        assert_eq!(a.abs_diff(b), expected);
+        assert_eq!(b.abs_diff(a), expected);
     }
 }

--- a/packages/std/src/math/uint64.rs
+++ b/packages/std/src/math/uint64.rs
@@ -204,6 +204,10 @@ impl Uint64 {
     pub fn saturating_pow(self, other: u32) -> Self {
         Self(self.0.saturating_pow(other))
     }
+
+    pub fn abs_diff(self, other: impl Into<u64>) -> Self {
+        Self(self.0.abs_diff(other.into()))
+    }
 }
 
 // `From<u{128,64,32,16,8}>` is implemented manually instead of
@@ -877,5 +881,14 @@ mod tests {
         let b = Uint64::from(6u32);
         a %= &b;
         assert_eq!(a, Uint64::from(1u32));
+    }
+
+    #[test]
+    fn uint64_abs_diff_works() {
+        let a = Uint64::from(42u32);
+        let b = Uint64::from(5u32);
+        let expected = Uint64::from(37u32);
+        assert_eq!(a.abs_diff(b), expected);
+        assert_eq!(b.abs_diff(a), expected);
     }
 }


### PR DESCRIPTION
Add the `abs_diff` function for calculating the absolute difference in cosmwasm-math package as suggested.