### PR TITLE
Fix cosmwasm-vm tests on windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,6 +350,7 @@ dependencies = [
 name = "cosmwasm-vm"
 version = "1.0.0"
 dependencies = [
+ "cfg-if",
  "clap",
  "clru",
  "cosmwasm-crypto",

--- a/packages/vm/Cargo.toml
+++ b/packages/vm/Cargo.toml
@@ -68,6 +68,7 @@ wat = "1.0"
 clap = "2.33.3"
 rand = "0.8"
 leb128 = "0.2"
+cfg-if = "1.0.0"
 
 [[bench]]
 name = "main"

--- a/packages/vm/benches/main.rs
+++ b/packages/vm/benches/main.rs
@@ -31,7 +31,13 @@ const MEMORY_CACHE_SIZE: Size = Size::mebi(200);
 const INSTANTIATION_THREADS: usize = 128;
 const CONTRACTS: u64 = 10;
 
-static CONTRACT: &[u8] = include_bytes!("../testdata/hackatom.wasm");
+cfg_if::cfg_if! {
+    if #[cfg(windows)] {
+        static CONTRACT: &[u8] = include_bytes!("../testdata/hackatom_windows.wasm");
+    } else {
+        static CONTRACT: &[u8] = include_bytes!("../testdata/hackatom.wasm");
+    }
+}
 
 fn bench_instance(c: &mut Criterion) {
     let mut group = c.benchmark_group("Instance");

--- a/packages/vm/examples/multi_threaded_cache.rs
+++ b/packages/vm/examples/multi_threaded_cache.rs
@@ -18,7 +18,13 @@ const DEFAULT_INSTANCE_OPTIONS: InstanceOptions = InstanceOptions {
 // Cache
 const MEMORY_CACHE_SIZE: Size = Size::mebi(200);
 
-static CONTRACT: &[u8] = include_bytes!("../testdata/hackatom.wasm");
+cfg_if::cfg_if! {
+    if #[cfg(windows)] {
+        static CONTRACT: &[u8] = include_bytes!("../testdata/hackatom_windows.wasm");
+    } else {
+        static CONTRACT: &[u8] = include_bytes!("../testdata/hackatom.wasm");
+    }
+}
 
 const SAVE_WASM_THREADS: usize = 32;
 const INSTANTIATION_THREADS: usize = 2048;

--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -385,8 +385,21 @@ mod tests {
     };
     const TESTING_MEMORY_CACHE_SIZE: Size = Size::mebi(200);
 
-    static CONTRACT: &[u8] = include_bytes!("../testdata/hackatom.wasm");
-    static IBC_CONTRACT: &[u8] = include_bytes!("../testdata/ibc_reflect.wasm");
+    cfg_if::cfg_if! {
+        if #[cfg(windows)] {
+            static CONTRACT: &[u8] = include_bytes!("../testdata/hackatom_windows.wasm");
+        } else {
+            static CONTRACT: &[u8] = include_bytes!("../testdata/hackatom.wasm");
+        }
+    }
+
+    cfg_if::cfg_if! {
+        if #[cfg(windows)] {
+            static IBC_CONTRACT: &[u8] = include_bytes!("../testdata/ibc_reflect_windows.wasm");
+        } else {
+            static IBC_CONTRACT: &[u8] = include_bytes!("../testdata/ibc_reflect.wasm");
+        }
+    }
 
     fn default_features() -> HashSet<String> {
         features_from_csv("iterator,staking")
@@ -523,8 +536,21 @@ mod tests {
 
         match cache.load_wasm(&checksum).unwrap_err() {
             VmError::CacheErr { msg, .. } => {
-                assert!(msg
-                    .starts_with("Error opening Wasm file for reading: No such file or directory"))
+                cfg_if::cfg_if! {
+                    if #[cfg(windows)] {
+                        assert!(
+                            msg.starts_with(
+                                "Error opening Wasm file for reading: The system cannot find the file specified"
+                            )
+                        )
+                    } else {
+                        assert!(
+                            msg.starts_with(
+                                "Error opening Wasm file for reading: No such file or directory"
+                            )
+                        )
+                    }
+                }
             }
             e => panic!("Unexpected error: {:?}", e),
         }

--- a/packages/vm/src/calls.rs
+++ b/packages/vm/src/calls.rs
@@ -594,7 +594,13 @@ mod tests {
     use crate::testing::{mock_env, mock_info, mock_instance};
     use cosmwasm_std::{coins, Empty};
 
-    static CONTRACT: &[u8] = include_bytes!("../testdata/hackatom.wasm");
+    cfg_if::cfg_if! {
+        if #[cfg(windows)] {
+            static CONTRACT: &[u8] = include_bytes!("../testdata/hackatom_windows.wasm");
+        } else {
+            static CONTRACT: &[u8] = include_bytes!("../testdata/hackatom.wasm");
+        }
+    }
 
     #[test]
     fn call_instantiate_works() {
@@ -685,7 +691,13 @@ mod tests {
             Empty, Event, IbcAcknowledgement, IbcOrder, Reply, ReplyOn, SubMsgResponse,
             SubMsgResult,
         };
-        static CONTRACT: &[u8] = include_bytes!("../testdata/ibc_reflect.wasm");
+        cfg_if::cfg_if! {
+            if #[cfg(windows)] {
+                static CONTRACT: &[u8] = include_bytes!("../testdata/ibc_reflect_windows.wasm");
+            } else {
+                static CONTRACT: &[u8] = include_bytes!("../testdata/ibc_reflect.wasm");
+            }
+        }
         const IBC_VERSION: &str = "ibc-reflect-v1";
         fn setup(
             instance: &mut Instance<MockApi, MockStorage, MockQuerier>,

--- a/packages/vm/src/compatibility.rs
+++ b/packages/vm/src/compatibility.rs
@@ -196,7 +196,13 @@ mod tests {
     static CONTRACT_0_12: &[u8] = include_bytes!("../testdata/hackatom_0.12.wasm");
     static CONTRACT_0_14: &[u8] = include_bytes!("../testdata/hackatom_0.14.wasm");
     static CONTRACT_0_15: &[u8] = include_bytes!("../testdata/hackatom_0.15.wasm");
-    static CONTRACT: &[u8] = include_bytes!("../testdata/hackatom.wasm");
+    cfg_if::cfg_if! {
+        if #[cfg(windows)] {
+            static CONTRACT: &[u8] = include_bytes!("../testdata/hackatom_windows.wasm");
+        } else {
+            static CONTRACT: &[u8] = include_bytes!("../testdata/hackatom.wasm");
+        }
+    }
 
     fn default_features() -> HashSet<String> {
         ["staking".to_string()].iter().cloned().collect()

--- a/packages/vm/src/environment.rs
+++ b/packages/vm/src/environment.rs
@@ -370,7 +370,13 @@ mod tests {
     };
     use wasmer::{imports, Function, Instance as WasmerInstance};
 
-    static CONTRACT: &[u8] = include_bytes!("../testdata/hackatom.wasm");
+    cfg_if::cfg_if! {
+        if #[cfg(windows)] {
+            static CONTRACT: &[u8] = include_bytes!("../testdata/hackatom_windows.wasm");
+        } else {
+            static CONTRACT: &[u8] = include_bytes!("../testdata/hackatom.wasm");
+        }
+    }
 
     // prepared data
     const INIT_KEY: &[u8] = b"foo";

--- a/packages/vm/src/imports.rs
+++ b/packages/vm/src/imports.rs
@@ -475,7 +475,13 @@ mod tests {
     use crate::testing::{MockApi, MockQuerier, MockStorage};
     use crate::wasm_backend::compile;
 
-    static CONTRACT: &[u8] = include_bytes!("../testdata/hackatom.wasm");
+    cfg_if::cfg_if! {
+        if #[cfg(windows)] {
+            static CONTRACT: &[u8] = include_bytes!("../testdata/hackatom_windows.wasm");
+        } else {
+            static CONTRACT: &[u8] = include_bytes!("../testdata/hackatom.wasm");
+        }
+    }
 
     // prepared data
     const KEY1: &[u8] = b"ant";

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -403,7 +403,13 @@ mod tests {
     const KIB: usize = 1024;
     const MIB: usize = 1024 * 1024;
     const DEFAULT_QUERY_GAS_LIMIT: u64 = 300_000;
-    static CONTRACT: &[u8] = include_bytes!("../testdata/hackatom.wasm");
+    cfg_if::cfg_if! {
+        if #[cfg(windows)] {
+            static CONTRACT: &[u8] = include_bytes!("../testdata/hackatom_windows.wasm");
+        } else {
+            static CONTRACT: &[u8] = include_bytes!("../testdata/hackatom.wasm");
+        }
+    }
 
     #[test]
     fn required_features_works() {

--- a/packages/vm/src/static_analysis.rs
+++ b/packages/vm/src/static_analysis.rs
@@ -88,7 +88,13 @@ mod tests {
     use parity_wasm::elements::Internal;
     use wasmer::{Cranelift, Store, Universal};
 
-    static CONTRACT: &[u8] = include_bytes!("../testdata/hackatom.wasm");
+    cfg_if::cfg_if! {
+        if #[cfg(windows)] {
+            static CONTRACT: &[u8] = include_bytes!("../testdata/hackatom_windows.wasm");
+        } else {
+            static CONTRACT: &[u8] = include_bytes!("../testdata/hackatom.wasm");
+        }
+    }
     static CORRUPTED: &[u8] = include_bytes!("../testdata/corrupted.wasm");
 
     #[test]

--- a/packages/vm/src/wasm_backend/compile.rs
+++ b/packages/vm/src/wasm_backend/compile.rs
@@ -25,7 +25,13 @@ pub fn compile(
 mod tests {
     use super::*;
 
-    static CONTRACT: &[u8] = include_bytes!("../../testdata/floaty.wasm");
+    cfg_if::cfg_if! {
+        if #[cfg(windows)] {
+            static CONTRACT: &[u8] = include_bytes!("../../testdata/floaty_windows.wasm");
+        } else {
+            static CONTRACT: &[u8] = include_bytes!("../../testdata/floaty.wasm");
+        }
+    }
 
     #[test]
     fn contract_with_floats_fails_check() {

--- a/packages/vm/testdata/floaty_windows.wasm
+++ b/packages/vm/testdata/floaty_windows.wasm
@@ -1,0 +1,1 @@
+./floaty_1.0.wasm

--- a/packages/vm/testdata/hackatom_windows.wasm
+++ b/packages/vm/testdata/hackatom_windows.wasm
@@ -1,0 +1,1 @@
+./hackatom_1.0.wasm

--- a/packages/vm/testdata/ibc_reflect_windows.wasm
+++ b/packages/vm/testdata/ibc_reflect_windows.wasm
@@ -1,0 +1,1 @@
+./ibc_reflect_1.0.wasm


### PR DESCRIPTION
There are 2 major changes:

- Created windows symlinks for wasm files as windows does not recognize linux symlinks.
- Windows returns different error message when file not found.