### PR TITLE
Use `grcov` instead of `tarpaulin` for coverage including branch data

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1125,35 +1125,47 @@ jobs:
           key: cargocache-v2-benchmarking-rust:1.59.0-{{ checksum "Cargo.lock" }}
 
   coverage:
-    # https://circleci.com/developer/images?imageType=machine
-    machine:
-      image: ubuntu-2004:202201-02
+    docker:
+      - image: rust:1.61
     steps:
       - checkout
       - run:
-          name: Run tests with coverage
+          name: Install dependencies
           command: |
-            mkdir -p reports/crypto
-            mkdir -p reports/derive
-            mkdir -p reports/schema
-            mkdir -p reports/std
-            mkdir -p reports/storage
-            docker run --security-opt seccomp=unconfined -v "${PWD}:/volume" xd009642/tarpaulin \
-              sh -c "cargo tarpaulin --skip-clean --out Xml --output-dir reports/crypto --packages cosmwasm-crypto && cargo tarpaulin --skip-clean --out Xml --output-dir reports/derive --packages cosmwasm-derive && cargo tarpaulin --skip-clean --out Xml --output-dir reports/schema --packages cosmwasm-schema && cargo tarpaulin --skip-clean --out Xml --output-dir reports/std --packages cosmwasm-std && cargo tarpaulin --skip-clean --out Xml --output-dir reports/storage --packages cosmwasm-storage"
+            rustup component add llvm-tools-preview
+            cargo install grcov
+      - run:
+          name: Run tests with gcov coverage
+          command: |
+            export RUSTC_BOOTSTRAP=1
+            export CARGO_INCREMENTAL=0
+            export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests"
+            export RUSTDOCFLAGS="-Cpanic=abort"
+            cargo build
+            cargo test --no-fail-fast || true
+      - run:
+          name: Aggregate coverage data
+          command: |
+            mkdir -p reports
+            grcov . -s packages/crypto/src -t lcov --llvm --branch --ignore-not-existing -o ./reports/crypto.info
+            grcov . -s packages/derive/src -t lcov --llvm --branch --ignore-not-existing -o ./reports/derive.info
+            grcov . -s packages/schema/src -t lcov --llvm --branch --ignore-not-existing -o ./reports/schema.info
+            grcov . -s packages/std/src -t lcov --llvm --branch --ignore-not-existing -o ./reports/std.info
+            grcov . -s packages/storage/src -t lcov --llvm --branch --ignore-not-existing -o ./reports/storage.info
       - codecov/upload:
-          file: reports/crypto/cobertura.xml
+          file: reports/crypto.info
           flags: cosmwasm-crypto
       - codecov/upload:
-          file: reports/derive/cobertura.xml
+          file: reports/derive.info
           flags: cosmwasm-derive
       - codecov/upload:
-          file: reports/schema/cobertura.xml
+          file: reports/schema.info
           flags: cosmwasm-schema
       - codecov/upload:
-          file: reports/std/cobertura.xml
+          file: reports/std.info
           flags: cosmwasm-std
       - codecov/upload:
-          file: reports/storage/cobertura.xml
+          file: reports/storage.info
           flags: cosmwasm-storage
 
   # This job roughly follows the instructions from https://circleci.com/blog/publishing-to-github-releases-via-circleci/


### PR DESCRIPTION
Playing around with using `grcov` instead of `tarpaulin` for coverage. The advantage is `grcov` supports branch coverage data produced by `gcov`.

I'm not yet sure if this is "better". The numbers this produces are way different.