### PR TITLE
`s/handle/execute/` in `entry_point!` docs

### DIFF
--- a/packages/derive/src/lib.rs
+++ b/packages/derive/src/lib.rs
@@ -30,7 +30,7 @@ use std::str::FromStr;
 /// }
 ///
 /// #[entry_point]
-/// pub fn handle(
+/// pub fn execute(
 ///     deps: DepsMut,
 ///     env: Env,
 ///     info: MessageInfo,


### PR DESCRIPTION
Hi all :wave:, we got some feedback about a mistake in https://docs.rs/cosmwasm-std/1.0.0/cosmwasm_std/attr.entry_point.html where it says `handle` instead of `execute`:
```diff
  #[entry_point]
- pub fn handle(
+ pub fn execute(
```
 
Original feedback by @darwinzer0: https://forum.scrt.network/t/cosmwasm-v1-is-in-public-beta/6172/2 