### PR TITLE
Implement PartialEq for references on all math types - LHS and tests

### DIFF
--- a/packages/std/src/math/decimal.rs
+++ b/packages/std/src/math/decimal.rs
@@ -624,6 +624,12 @@ impl PartialEq<&Decimal> for Decimal {
     }
 }
 
+impl PartialEq<Decimal> for &Decimal {
+    fn eq(&self, rhs: &Decimal) -> bool {
+        *self == rhs
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/packages/std/src/math/decimal.rs
+++ b/packages/std/src/math/decimal.rs
@@ -1942,4 +1942,24 @@ mod tests {
             Err(RoundUpOverflowError { .. })
         ));
     }
+
+    #[test]
+    fn decimal_partial_eq() {
+        let test_cases = [
+            ("1", "1", true),
+            ("0.5", "0.5", true),
+            ("0.5", "0.51", false),
+            ("0", "0.00000", true),
+        ]
+        .into_iter()
+        .map(|(lhs, rhs, expected)| (dec(lhs), dec(rhs), expected));
+
+        #[allow(clippy::op_ref)]
+        for (lhs, rhs, expected) in test_cases {
+            assert_eq!(lhs == rhs, expected);
+            assert_eq!(&lhs == rhs, expected);
+            assert_eq!(lhs == &rhs, expected);
+            assert_eq!(&lhs == &rhs, expected);
+        }
+    }
 }

--- a/packages/std/src/math/decimal256.rs
+++ b/packages/std/src/math/decimal256.rs
@@ -2089,4 +2089,24 @@ mod tests {
         );
         assert_eq!(Decimal256::MAX.checked_ceil(), Err(RoundUpOverflowError));
     }
+
+    #[test]
+    fn decimal256_partial_eq() {
+        let test_cases = [
+            ("1", "1", true),
+            ("0.5", "0.5", true),
+            ("0.5", "0.51", false),
+            ("0", "0.00000", true),
+        ]
+        .into_iter()
+        .map(|(lhs, rhs, expected)| (dec(lhs), dec(rhs), expected));
+
+        #[allow(clippy::op_ref)]
+        for (lhs, rhs, expected) in test_cases {
+            assert_eq!(lhs == rhs, expected);
+            assert_eq!(&lhs == rhs, expected);
+            assert_eq!(lhs == &rhs, expected);
+            assert_eq!(&lhs == &rhs, expected);
+        }
+    }
 }

--- a/packages/std/src/math/decimal256.rs
+++ b/packages/std/src/math/decimal256.rs
@@ -649,6 +649,12 @@ impl PartialEq<&Decimal256> for Decimal256 {
     }
 }
 
+impl PartialEq<Decimal256> for &Decimal256 {
+    fn eq(&self, rhs: &Decimal256) -> bool {
+        *self == rhs
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/packages/std/src/math/uint128.rs
+++ b/packages/std/src/math/uint128.rs
@@ -994,4 +994,19 @@ mod tests {
         assert_eq!(a.abs_diff(b), expected);
         assert_eq!(b.abs_diff(a), expected);
     }
+
+    #[test]
+    fn uint128_partial_eq() {
+        let test_cases = [(1, 1, true), (42, 42, true), (42, 24, false), (0, 0, true)]
+            .into_iter()
+            .map(|(lhs, rhs, expected)| (Uint128::new(lhs), Uint128::new(rhs), expected));
+
+        #[allow(clippy::op_ref)]
+        for (lhs, rhs, expected) in test_cases {
+            assert_eq!(lhs == rhs, expected);
+            assert_eq!(&lhs == rhs, expected);
+            assert_eq!(lhs == &rhs, expected);
+            assert_eq!(&lhs == &rhs, expected);
+        }
+    }
 }

--- a/packages/std/src/math/uint128.rs
+++ b/packages/std/src/math/uint128.rs
@@ -517,6 +517,12 @@ impl PartialEq<&Uint128> for Uint128 {
     }
 }
 
+impl PartialEq<Uint128> for &Uint128 {
+    fn eq(&self, rhs: &Uint128) -> bool {
+        *self == rhs
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/packages/std/src/math/uint256.rs
+++ b/packages/std/src/math/uint256.rs
@@ -1545,4 +1545,25 @@ mod tests {
         assert_eq!(a.abs_diff(b), expected);
         assert_eq!(b.abs_diff(a), expected);
     }
+
+    #[test]
+    fn uint256_partial_eq() {
+        let test_cases = [(1, 1, true), (42, 42, true), (42, 24, false), (0, 0, true)]
+            .into_iter()
+            .map(|(lhs, rhs, expected)| {
+                (
+                    Uint256::from(lhs as u64),
+                    Uint256::from(rhs as u64),
+                    expected,
+                )
+            });
+
+        #[allow(clippy::op_ref)]
+        for (lhs, rhs, expected) in test_cases {
+            assert_eq!(lhs == rhs, expected);
+            assert_eq!(&lhs == rhs, expected);
+            assert_eq!(lhs == &rhs, expected);
+            assert_eq!(&lhs == &rhs, expected);
+        }
+    }
 }

--- a/packages/std/src/math/uint256.rs
+++ b/packages/std/src/math/uint256.rs
@@ -614,6 +614,12 @@ impl PartialEq<&Uint256> for Uint256 {
     }
 }
 
+impl PartialEq<Uint256> for &Uint256 {
+    fn eq(&self, rhs: &Uint256) -> bool {
+        *self == rhs
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/packages/std/src/math/uint512.rs
+++ b/packages/std/src/math/uint512.rs
@@ -575,6 +575,12 @@ impl PartialEq<&Uint512> for Uint512 {
     }
 }
 
+impl PartialEq<Uint512> for &Uint512 {
+    fn eq(&self, rhs: &Uint512) -> bool {
+        *self == rhs
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/packages/std/src/math/uint512.rs
+++ b/packages/std/src/math/uint512.rs
@@ -1180,4 +1180,25 @@ mod tests {
         assert_eq!(a.abs_diff(b), expected);
         assert_eq!(b.abs_diff(a), expected);
     }
+
+    #[test]
+    fn uint512_partial_eq() {
+        let test_cases = [(1, 1, true), (42, 42, true), (42, 24, false), (0, 0, true)]
+            .into_iter()
+            .map(|(lhs, rhs, expected)| {
+                (
+                    Uint512::from(lhs as u64),
+                    Uint512::from(rhs as u64),
+                    expected,
+                )
+            });
+
+        #[allow(clippy::op_ref)]
+        for (lhs, rhs, expected) in test_cases {
+            assert_eq!(lhs == rhs, expected);
+            assert_eq!(&lhs == rhs, expected);
+            assert_eq!(lhs == &rhs, expected);
+            assert_eq!(&lhs == &rhs, expected);
+        }
+    }
 }

--- a/packages/std/src/math/uint64.rs
+++ b/packages/std/src/math/uint64.rs
@@ -907,4 +907,19 @@ mod tests {
         assert_eq!(a.abs_diff(b), expected);
         assert_eq!(b.abs_diff(a), expected);
     }
+
+    #[test]
+    fn uint64_partial_eq() {
+        let test_cases = [(1, 1, true), (42, 42, true), (42, 24, false), (0, 0, true)]
+            .into_iter()
+            .map(|(lhs, rhs, expected)| (Uint64::new(lhs), Uint64::new(rhs), expected));
+
+        #[allow(clippy::op_ref)]
+        for (lhs, rhs, expected) in test_cases {
+            assert_eq!(lhs == rhs, expected);
+            assert_eq!(&lhs == rhs, expected);
+            assert_eq!(lhs == &rhs, expected);
+            assert_eq!(&lhs == &rhs, expected);
+        }
+    }
 }

--- a/packages/std/src/math/uint64.rs
+++ b/packages/std/src/math/uint64.rs
@@ -471,6 +471,12 @@ impl PartialEq<&Uint64> for Uint64 {
     }
 }
 
+impl PartialEq<Uint64> for &Uint64 {
+    fn eq(&self, rhs: &Uint64) -> bool {
+        *self == rhs
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Adds things to #1350:
* tests
* `PartialEq` implementation for when LHS operand is a reference