### PR TITLE
Use clippy from Rust 1.63.0 in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ workflows:
           matrix:
             parameters:
               # Run with MSRV and some modern stable Rust
-              rust-version: ["1.59.0", "1.62.0"]
+              rust-version: ["1.59.0", "1.63.0"]
       - benchmarking:
           requires:
             - package_vm

--- a/contracts/floaty/src/state.rs
+++ b/contracts/floaty/src/state.rs
@@ -5,7 +5,7 @@ use cosmwasm_std::Addr;
 
 pub const CONFIG_KEY: &[u8] = b"config";
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct State {
     pub verifier: Addr,
     pub beneficiary: Addr,

--- a/contracts/hackatom/src/state.rs
+++ b/contracts/hackatom/src/state.rs
@@ -5,7 +5,7 @@ use cosmwasm_std::Addr;
 
 pub const CONFIG_KEY: &[u8] = b"config";
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct State {
     pub verifier: Addr,
     pub beneficiary: Addr,

--- a/contracts/ibc-reflect-send/src/ibc_msg.rs
+++ b/contracts/ibc-reflect-send/src/ibc_msg.rs
@@ -3,7 +3,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// This is the message we send over the IBC channel
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum PacketMsg {
     Dispatch { msgs: Vec<CosmosMsg> },
@@ -21,14 +21,14 @@ pub type DispatchResponse = ();
 
 /// This is the success response we send on ack for PacketMsg::WhoAmI.
 /// Return the caller's account address on the remote chain
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct WhoAmIResponse {
     pub account: String,
 }
 
 /// This is the success response we send on ack for PacketMsg::Balance.
 /// Just acknowledge success or error
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct BalancesResponse {
     pub account: String,
     pub balances: Vec<Coin>,

--- a/contracts/ibc-reflect-send/src/state.rs
+++ b/contracts/ibc-reflect-send/src/state.rs
@@ -9,12 +9,12 @@ use cosmwasm_storage::{
 pub const KEY_CONFIG: &[u8] = b"config";
 pub const PREFIX_ACCOUNTS: &[u8] = b"accounts";
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct Config {
     pub admin: Addr,
 }
 
-#[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq, Eq)]
 pub struct AccountData {
     /// last block balance was updated (0 is never)
     pub last_update_time: Timestamp,

--- a/contracts/ibc-reflect/src/state.rs
+++ b/contracts/ibc-reflect/src/state.rs
@@ -11,7 +11,7 @@ pub const KEY_CONFIG: &[u8] = b"config";
 pub const KEY_PENDING_CHANNEL: &[u8] = b"pending";
 pub const PREFIX_ACCOUNTS: &[u8] = b"accounts";
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct Config {
     pub reflect_code_id: u64,
 }

--- a/contracts/queue/src/state.rs
+++ b/contracts/queue/src/state.rs
@@ -2,7 +2,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 // we store one entry for each item in the queue
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct Item {
     pub value: i32,
 }

--- a/contracts/reflect/src/state.rs
+++ b/contracts/reflect/src/state.rs
@@ -10,7 +10,7 @@ use cosmwasm_storage::{
 const CONFIG_KEY: &[u8] = b"config";
 const RESULT_PREFIX: &[u8] = b"result";
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct State {
     pub owner: Addr,
 }

--- a/contracts/staking/src/state.rs
+++ b/contracts/staking/src/state.rs
@@ -33,7 +33,7 @@ pub fn claims_read(storage: &dyn Storage) -> ReadonlyBucket<Uint128> {
 }
 
 /// Investment info is fixed at initialization, and is used to control the function of the contract
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct InvestmentInfo {
     /// owner created the contract and takes a cut
     pub owner: Addr,
@@ -50,7 +50,7 @@ pub struct InvestmentInfo {
 }
 
 /// Info to display the derivative token in a UI
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct TokenInfo {
     /// name of the derivative token
     pub name: String,
@@ -61,7 +61,7 @@ pub struct TokenInfo {
 }
 
 /// Supply is dynamic and tracks the current supply of staked and ERC20 tokens.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 pub struct Supply {
     /// issued is how many derivative tokens this contract has issued
     pub issued: Uint128,

--- a/devtools/check_workspace.sh
+++ b/devtools/check_workspace.sh
@@ -17,4 +17,5 @@ cargo fmt
 )
 (cd packages/storage && cargo build && cargo clippy --all-targets --features iterator -- -D warnings)
 (cd packages/schema && cargo build && cargo clippy --all-targets -- -D warnings)
+(cd packages/schema-derive && cargo build && cargo clippy --all-targets -- -D warnings)
 (cd packages/vm && cargo build --features iterator,stargate && cargo clippy --all-targets --features iterator,stargate -- -D warnings)

--- a/devtools/test_workspace.sh
+++ b/devtools/test_workspace.sh
@@ -7,4 +7,5 @@ cargo fmt
 (cd packages/std && cargo test --features iterator)
 (cd packages/storage && cargo test --features iterator)
 (cd packages/schema && cargo test)
+(cd packages/schema-derive && cargo test)
 (cd packages/vm && cargo test --features iterator,stargate)

--- a/packages/profiler/src/code_blocks.rs
+++ b/packages/profiler/src/code_blocks.rs
@@ -69,7 +69,7 @@ impl BlockStore {
 }
 
 /// Represents a non-branching Wasm code block.
-#[derive(Debug, MemoryUsage, Hash, PartialEq)]
+#[derive(Debug, MemoryUsage, Hash, PartialEq, Eq)]
 pub struct CodeBlock {
     inner: Vec<OperatorSymbol>,
 }

--- a/packages/profiler/src/operators.rs
+++ b/packages/profiler/src/operators.rs
@@ -3,7 +3,7 @@ use std::hash::Hash;
 use loupe::MemoryUsage;
 use wasmer::wasmparser::Operator;
 
-#[derive(Debug, Clone, Hash, PartialEq, MemoryUsage)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, MemoryUsage)]
 pub enum OperatorSymbol {
     Unreachable,
     Nop,

--- a/packages/schema-derive/src/cw_serde.rs
+++ b/packages/schema-derive/src/cw_serde.rs
@@ -11,6 +11,7 @@ pub fn cw_serde_impl(input: DeriveInput) -> DeriveInput {
                 PartialEq,
                 schemars::JsonSchema
             )]
+            #[allow(clippy::derive_partial_eq_without_eq)] // Allow users of `#[cw_serde]` to not implement Eq without clippy complaining
             #[serde(deny_unknown_fields)]
             #input
         },
@@ -23,6 +24,7 @@ pub fn cw_serde_impl(input: DeriveInput) -> DeriveInput {
                 PartialEq,
                 schemars::JsonSchema
             )]
+            #[allow(clippy::derive_partial_eq_without_eq)] // Allow users of `#[cw_serde]` to not implement Eq without clippy complaining
             #[serde(deny_unknown_fields, rename_all = "snake_case")]
             #input
         },
@@ -52,6 +54,7 @@ mod tests {
                 PartialEq,
                 schemars::JsonSchema
             )]
+            #[allow(clippy::derive_partial_eq_without_eq)]
             #[serde(deny_unknown_fields)]
             pub struct InstantiateMsg {
                 pub verifier: String,
@@ -82,6 +85,7 @@ mod tests {
                 PartialEq,
                 schemars::JsonSchema
             )]
+            #[allow(clippy::derive_partial_eq_without_eq)]
             #[serde(deny_unknown_fields, rename_all = "snake_case")]
             pub enum SudoMsg {
                 StealFunds {

--- a/packages/schema/src/query_response.rs
+++ b/packages/schema/src/query_response.rs
@@ -77,7 +77,7 @@ fn check_api_integrity<T: QueryResponses + ?Sized>(
     Ok(())
 }
 
-#[derive(Debug, Error, PartialEq)]
+#[derive(Debug, Error, PartialEq, Eq)]
 pub enum IntegrityError {
     #[error("the structure of the QueryMsg schema was unexpected")]
     InvalidQueryMsgSchema,

--- a/packages/schema/tests/idl.rs
+++ b/packages/schema/tests/idl.rs
@@ -5,7 +5,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct InstantiateMsg {
     pub admin: String,
     pub cap: u128,
@@ -13,26 +13,26 @@ pub struct InstantiateMsg {
 
 // failure modes to help test wasmd, based on this comment
 // https://github.com/cosmwasm/wasmd/issues/8#issuecomment-576146751
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
     Mint { amount: u128 },
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema, QueryResponses)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema, QueryResponses)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
     #[returns(u128)]
     Balance { account: String },
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum SudoMsg {
     SetAdmin { new_admin: String },
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct MigrateMsg {
     pub admin: String,
     pub cap: u128,

--- a/packages/std/src/coins.rs
+++ b/packages/std/src/coins.rs
@@ -4,7 +4,7 @@ use std::fmt;
 
 use crate::math::Uint128;
 
-#[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq, Eq, JsonSchema)]
 pub struct Coin {
     pub denom: String,
     pub amount: Uint128,

--- a/packages/std/src/errors/system_error.rs
+++ b/packages/std/src/errors/system_error.rs
@@ -12,7 +12,7 @@ use crate::Binary;
 ///
 /// Such errors are only created by the VM. The error type is defined in the standard library, to ensure
 /// the contract understands the error format without creating a dependency on cosmwasm-vm.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum SystemError {

--- a/packages/std/src/ibc.rs
+++ b/packages/std/src/ibc.rs
@@ -18,7 +18,7 @@ use crate::timestamp::Timestamp;
 /// These are messages in the IBC lifecycle. Only usable by IBC-enabled contracts
 /// (contracts that directly speak the IBC protocol via 6 entry points)
 #[non_exhaustive]
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum IbcMsg {
     /// Sends bank tokens owned by the contract to the given address on another chain.
@@ -51,7 +51,7 @@ pub enum IbcMsg {
     CloseChannel { channel_id: String },
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct IbcEndpoint {
     pub port_id: String,
     pub channel_id: String,
@@ -60,7 +60,7 @@ pub struct IbcEndpoint {
 /// In IBC each package must set at least one type of timeout:
 /// the timestamp or the block height. Using this rather complex enum instead of
 /// two timeout fields we ensure that at least one timeout is set.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct IbcTimeout {
     // use private fields to enforce the use of constructors, which ensure that at least one is set
@@ -115,7 +115,7 @@ impl From<IbcTimeoutBlock> for IbcTimeout {
 
 /// IbcChannel defines all information on a channel.
 /// This is generally used in the hand-shake process, but can be queried directly.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[non_exhaustive]
 pub struct IbcChannel {
     pub endpoint: IbcEndpoint,
@@ -150,7 +150,7 @@ impl IbcChannel {
 /// IbcOrder defines if a channel is ORDERED or UNORDERED
 /// Values come from https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/ibc/core/channel/v1/channel.proto#L69-L80
 /// Naming comes from the protobuf files and go translations.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub enum IbcOrder {
     #[serde(rename = "ORDER_UNORDERED")]
     Unordered,
@@ -193,7 +193,7 @@ impl Ord for IbcTimeoutBlock {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[non_exhaustive]
 pub struct IbcPacket {
     /// The raw data sent from the other side in the packet
@@ -226,7 +226,7 @@ impl IbcPacket {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[non_exhaustive]
 pub struct IbcAcknowledgement {
     pub data: Binary,
@@ -247,7 +247,7 @@ impl IbcAcknowledgement {
 }
 
 /// The message that is passed into `ibc_channel_open`
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum IbcChannelOpenMsg {
@@ -306,14 +306,14 @@ pub type IbcChannelOpenResponse = ();
 #[cfg(feature = "ibc3")]
 pub type IbcChannelOpenResponse = Option<Ibc3ChannelOpenResponse>;
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct Ibc3ChannelOpenResponse {
     /// We can set the channel version to a different one than we were called with
     pub version: String,
 }
 
 /// The message that is passed into `ibc_channel_connect`
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum IbcChannelConnectMsg {
@@ -366,7 +366,7 @@ impl From<IbcChannelConnectMsg> for IbcChannel {
 }
 
 /// The message that is passed into `ibc_channel_close`
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum IbcChannelCloseMsg {
@@ -403,7 +403,7 @@ impl From<IbcChannelCloseMsg> for IbcChannel {
 }
 
 /// The message that is passed into `ibc_packet_receive`
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[non_exhaustive]
 pub struct IbcPacketReceiveMsg {
     pub packet: IbcPacket,
@@ -424,7 +424,7 @@ impl IbcPacketReceiveMsg {
 }
 
 /// The message that is passed into `ibc_packet_ack`
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[non_exhaustive]
 pub struct IbcPacketAckMsg {
     pub acknowledgement: IbcAcknowledgement,
@@ -457,7 +457,7 @@ impl IbcPacketAckMsg {
 }
 
 /// The message that is passed into `ibc_packet_timeout`
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[non_exhaustive]
 pub struct IbcPacketTimeoutMsg {
     pub packet: IbcPacket,
@@ -484,7 +484,7 @@ impl IbcPacketTimeoutMsg {
 /// Callbacks that have return values (like receive_packet)
 /// or that cannot redispatch messages (like the handshake callbacks)
 /// will use other Response types
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[non_exhaustive]
 pub struct IbcBasicResponse<T = Empty> {
     /// Optional list of messages to pass. These will be executed in order.
@@ -626,7 +626,7 @@ impl<T> IbcBasicResponse<T> {
 // Where the acknowledgement bytes contain an encoded error message to be returned to
 // the calling chain. (Returning ContractResult::Err will abort processing of this packet
 // and not inform the calling chain).
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[non_exhaustive]
 pub struct IbcReceiveResponse<T = Empty> {
     /// The bytes we return to the contract that sent the packet.

--- a/packages/std/src/math/decimal.rs
+++ b/packages/std/src/math/decimal.rs
@@ -22,7 +22,7 @@ use super::{Uint128, Uint256};
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, PartialOrd, Ord, JsonSchema)]
 pub struct Decimal(#[schemars(with = "String")] Uint128);
 
-#[derive(Error, Debug, PartialEq)]
+#[derive(Error, Debug, PartialEq, Eq)]
 #[error("Decimal range exceeded")]
 pub struct DecimalRangeExceeded;
 

--- a/packages/std/src/math/decimal256.rs
+++ b/packages/std/src/math/decimal256.rs
@@ -25,7 +25,7 @@ use super::Uint256;
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, PartialOrd, Ord, JsonSchema)]
 pub struct Decimal256(#[schemars(with = "String")] Uint256);
 
-#[derive(Error, Debug, PartialEq)]
+#[derive(Error, Debug, PartialEq, Eq)]
 #[error("Decimal256 range exceeded")]
 pub struct Decimal256RangeExceeded;
 

--- a/packages/std/src/query/bank.rs
+++ b/packages/std/src/query/bank.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use crate::Coin;
 
 #[non_exhaustive]
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum BankQuery {
     /// This calls into the native bank module for one denomination
@@ -16,7 +16,7 @@ pub enum BankQuery {
     AllBalances { address: String },
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct BalanceResponse {
     /// Always returns a Coin with the requested denom.
@@ -24,7 +24,7 @@ pub struct BalanceResponse {
     pub amount: Coin,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct AllBalanceResponse {
     /// Returns all non-zero coins held by this account.

--- a/packages/std/src/query/ibc.rs
+++ b/packages/std/src/query/ibc.rs
@@ -8,7 +8,7 @@ use crate::ibc::IbcChannel;
 /// These are queries to the various IBC modules to see the state of the contract's
 /// IBC connection. These will return errors if the contract is not "ibc enabled"
 #[non_exhaustive]
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum IbcQuery {
     /// Gets the Port ID the current contract is bound to.
@@ -32,17 +32,17 @@ pub enum IbcQuery {
     // TODO: Add more
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct PortIdResponse {
     pub port_id: String,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct ListChannelsResponse {
     pub channels: Vec<IbcChannel>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct ChannelResponse {
     pub channel: Option<IbcChannel>,
 }

--- a/packages/std/src/query/mod.rs
+++ b/packages/std/src/query/mod.rs
@@ -21,7 +21,7 @@ pub use staking::{
 pub use wasm::{ContractInfoResponse, WasmQuery};
 
 #[non_exhaustive]
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryRequest<C> {
     Bank(BankQuery),

--- a/packages/std/src/query/staking.rs
+++ b/packages/std/src/query/staking.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use crate::{Addr, Coin, Decimal};
 
 #[non_exhaustive]
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum StakingQuery {
     /// Returns the denomination that can be bonded (if there are multiple native tokens on the chain)
@@ -34,14 +34,14 @@ pub enum StakingQuery {
 }
 
 /// BondedDenomResponse is data format returned from StakingRequest::BondedDenom query
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct BondedDenomResponse {
     pub denom: String,
 }
 
 /// DelegationsResponse is data format returned from StakingRequest::AllDelegations query
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct AllDelegationsResponse {
     pub delegations: Vec<Delegation>,
@@ -50,7 +50,7 @@ pub struct AllDelegationsResponse {
 /// Delegation is basic (cheap to query) data about a delegation.
 ///
 /// Instances are created in the querier.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct Delegation {
     pub delegator: Addr,
     /// A validator address (e.g. cosmosvaloper1...)
@@ -70,7 +70,7 @@ impl From<FullDelegation> for Delegation {
 }
 
 /// DelegationResponse is data format returned from StakingRequest::Delegation query
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct DelegationResponse {
     pub delegation: Option<FullDelegation>,
@@ -80,7 +80,7 @@ pub struct DelegationResponse {
 /// is expensive to query.
 ///
 /// Instances are created in the querier.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct FullDelegation {
     pub delegator: Addr,
     /// A validator address (e.g. cosmosvaloper1...)
@@ -96,19 +96,19 @@ pub struct FullDelegation {
 }
 
 /// The data format returned from StakingRequest::AllValidators query
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct AllValidatorsResponse {
     pub validators: Vec<Validator>,
 }
 
 /// The data format returned from StakingRequest::Validator query
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct ValidatorResponse {
     pub validator: Option<Validator>,
 }
 
 /// Instances are created in the querier.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct Validator {
     /// A validator address (e.g. cosmosvaloper1...)
     pub address: String,

--- a/packages/std/src/query/wasm.rs
+++ b/packages/std/src/query/wasm.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use crate::Binary;
 
 #[non_exhaustive]
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum WasmQuery {
     /// this queries the public API of another contract at a known address (with known ABI)
@@ -27,7 +27,7 @@ pub enum WasmQuery {
 }
 
 #[non_exhaustive]
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct ContractInfoResponse {
     pub code_id: u64,
     /// address that instantiated this contract

--- a/packages/std/src/results/contract_result.rs
+++ b/packages/std/src/results/contract_result.rs
@@ -29,7 +29,7 @@ use std::fmt;
 /// let result: ContractResult<Response> = ContractResult::Err(error_msg);
 /// assert_eq!(to_vec(&result).unwrap(), br#"{"error":"Something went wrong"}"#);
 /// ```
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ContractResult<S> {
     Ok(S),

--- a/packages/std/src/results/cosmos_msg.rs
+++ b/packages/std/src/results/cosmos_msg.rs
@@ -19,7 +19,7 @@ pub trait CustomMsg: Serialize + Clone + fmt::Debug + PartialEq + JsonSchema {}
 impl CustomMsg for Empty {}
 
 #[non_exhaustive]
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 // See https://github.com/serde-rs/serde/issues/1296 why we cannot add De-Serialize trait bounds to T
 pub enum CosmosMsg<T = Empty> {
@@ -49,7 +49,7 @@ pub enum CosmosMsg<T = Empty> {
 ///
 /// See https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto
 #[non_exhaustive]
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum BankMsg {
     /// Sends native tokens from the contract to the given address.
@@ -71,7 +71,7 @@ pub enum BankMsg {
 /// See https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto
 #[cfg(feature = "staking")]
 #[non_exhaustive]
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum StakingMsg {
     /// This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90).
@@ -94,7 +94,7 @@ pub enum StakingMsg {
 /// See https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto
 #[cfg(feature = "staking")]
 #[non_exhaustive]
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum DistributionMsg {
     /// This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37).
@@ -122,7 +122,7 @@ fn binary_to_string(data: &Binary, fmt: &mut std::fmt::Formatter) -> Result<(), 
 ///
 /// See https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto
 #[non_exhaustive]
-#[derive(Serialize, Deserialize, Clone, Derivative, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Derivative, PartialEq, Eq, JsonSchema)]
 #[derivative(Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum WasmMsg {
@@ -178,7 +178,7 @@ pub enum WasmMsg {
 }
 
 #[cfg(feature = "stargate")]
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum GovMsg {
     /// This maps directly to [MsgVote](https://github.com/cosmos/cosmos-sdk/blob/v0.42.5/proto/cosmos/gov/v1beta1/tx.proto#L46-L56) in the Cosmos SDK with voter set to the contract address.
@@ -186,7 +186,7 @@ pub enum GovMsg {
 }
 
 #[cfg(feature = "stargate")]
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum VoteOption {
     Yes,

--- a/packages/std/src/results/empty.rs
+++ b/packages/std/src/results/empty.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 /// It is designed to be expressable in correct JSON and JSON Schema but
 /// contains no meaningful data. Previously we used enums without cases,
 /// but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema, Default)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema, Default)]
 pub struct Empty {}
 
 #[cfg(test)]

--- a/packages/std/src/results/events.rs
+++ b/packages/std/src/results/events.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// [*Cosmos SDK* event]: https://docs.cosmos.network/master/core/events.html
 /// [*Cosmos SDK* StringEvent]: https://github.com/cosmos/cosmos-sdk/blob/v0.42.5/proto/cosmos/base/abci/v1beta1/abci.proto#L56-L70
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[non_exhaustive]
 pub struct Event {
     /// The event type. This is renamed to "ty" because "type" is reserved in Rust. This sucks, we know.
@@ -55,7 +55,7 @@ impl Event {
 }
 
 /// An key value pair that is used in the context of event attributes in logs
-#[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq, Eq, JsonSchema)]
 pub struct Attribute {
     pub key: String,
     pub value: String,

--- a/packages/std/src/results/response.rs
+++ b/packages/std/src/results/response.rs
@@ -59,7 +59,7 @@ use super::{Attribute, CosmosMsg, Empty, Event, SubMsg};
 ///     Ok(response)
 /// }
 /// ```
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[non_exhaustive]
 pub struct Response<T = Empty> {
     /// Optional list of messages to pass. These will be executed in order.

--- a/packages/std/src/results/submessages.rs
+++ b/packages/std/src/results/submessages.rs
@@ -8,7 +8,7 @@ use super::{CosmosMsg, Empty, Event};
 /// Use this to define when the contract gets a response callback.
 /// If you only need it for errors or success you can select just those in order
 /// to save gas.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ReplyOn {
     /// Always perform a callback after SubMsg is processed
@@ -27,7 +27,7 @@ pub enum ReplyOn {
 /// Note: On error the submessage execution will revert any partial state changes due to this message,
 /// but not revert any state changes in the calling contract. If this is required, it must be done
 /// manually in the `reply` entry point.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct SubMsg<T = Empty> {
     /// An arbitrary ID chosen by the contract.
     /// This is typically used to match `Reply`s in the `reply` entry point to the submessage.
@@ -95,7 +95,7 @@ impl<T> SubMsg<T> {
 
 /// The result object returned to `reply`. We always get the ID from the submessage
 /// back and then must handle success and error cases ourselves.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct Reply {
     /// The ID that the contract set when emitting the `SubMsg`.
     /// Use this to identify which submessage triggered the `reply`.
@@ -135,7 +135,7 @@ pub struct Reply {
 /// let result = SubMsgResult::Err(error_msg);
 /// assert_eq!(to_vec(&result).unwrap(), br#"{"error":"Something went wrong"}"#);
 /// ```
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum SubMsgResult {
     Ok(SubMsgResponse),
@@ -191,7 +191,7 @@ impl From<SubMsgResult> for Result<SubMsgResponse, String> {
 
 /// The information we get back from a successful sub message execution,
 /// with full Cosmos SDK events.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct SubMsgResponse {
     pub events: Vec<Event>,
     pub data: Option<Binary>,

--- a/packages/std/src/results/system_result.rs
+++ b/packages/std/src/results/system_result.rs
@@ -29,7 +29,7 @@ use super::super::errors::SystemError;
 /// let result: SystemResult<Binary> = SystemResult::Err(error);
 /// assert_eq!(to_vec(&result).unwrap(), br#"{"error":{"unknown":{}}}"#);
 /// ```
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum SystemResult<S> {
     Ok(S),

--- a/packages/std/src/types.rs
+++ b/packages/std/src/types.rs
@@ -5,7 +5,7 @@ use crate::addresses::Addr;
 use crate::coins::Coin;
 use crate::timestamp::Timestamp;
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct Env {
     pub block: BlockInfo,
     /// Information on the transaction this message was executed in.
@@ -15,7 +15,7 @@ pub struct Env {
     pub contract: ContractInfo,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct TransactionInfo {
     /// The position of this transaction in the block. The first
     /// transaction has index 0.
@@ -26,7 +26,7 @@ pub struct TransactionInfo {
     pub index: u32,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct BlockInfo {
     /// The height of a block is the number of blocks preceding it in the blockchain.
     pub height: u64,
@@ -87,7 +87,7 @@ pub struct BlockInfo {
 ///
 /// [MsgInstantiateContract]: https://github.com/CosmWasm/wasmd/blob/v0.15.0/x/wasm/internal/types/tx.proto#L47-L61
 /// [MsgExecuteContract]: https://github.com/CosmWasm/wasmd/blob/v0.15.0/x/wasm/internal/types/tx.proto#L68-L78
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct MessageInfo {
     /// The `sender` field from `MsgInstantiateContract` and `MsgExecuteContract`.
     /// You can think of this as the address that initiated the action (i.e. the message). What that
@@ -105,7 +105,7 @@ pub struct MessageInfo {
     pub funds: Vec<Coin>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct ContractInfo {
     pub address: Addr,
 }

--- a/packages/vm/src/backend.rs
+++ b/packages/vm/src/backend.rs
@@ -10,7 +10,7 @@ use cosmwasm_std::{Order, Record};
 /// A structure that represents gas cost to be deducted from the remaining gas.
 /// This is always needed when computations are performed outside of
 /// Wasm execution, such as calling crypto APIs or calls into the blockchain.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct GasInfo {
     /// The gas cost of a computation that was executed already but not yet charged.
     ///
@@ -157,7 +157,7 @@ pub trait Querier {
 /// attached.
 pub type BackendResult<T> = (core::result::Result<T, BackendError>, GasInfo);
 
-#[derive(Error, Debug, PartialEq)]
+#[derive(Error, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum BackendError {
     #[error("Panic in FFI call")]

--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -75,7 +75,7 @@ pub struct Cache<A: BackendApi, S: Storage, Q: Querier> {
     instantiation_lock: Mutex<()>,
 }
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub struct AnalysisReport {
     pub has_ibc_entry_points: bool,
     pub required_features: HashSet<String>,

--- a/packages/vm/src/environment.rs
+++ b/packages/vm/src/environment.rs
@@ -16,7 +16,7 @@ pub enum Never {}
 
 /** gas config data */
 
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct GasConfig {
     /// Gas costs of VM (not Backend) provided functionality
     /// secp256k1 signature verification cost
@@ -52,7 +52,7 @@ impl Default for GasConfig {
 
 /** context data **/
 
-#[derive(Clone, PartialEq, Debug, Default)]
+#[derive(Clone, PartialEq, Eq, Debug, Default)]
 pub struct GasState {
     /// Gas limit for the computation, including internally and externally used gas.
     /// This is set when the Environment is created and never mutated.


### PR DESCRIPTION
Most changes here are due to the this new clippy rule: https://rust-lang.github.io/rust-clippy/master/index.html#derive_partial_eq_without_eq

@uint please have a look at the schema-derive change in particular