### PR TITLE
Run check_contract on every wasm file.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1216,7 +1216,8 @@ jobs:
           command: |
             echo "Checking all contracts under ./artifacts"
             docker run --volumes-from with_code rust:1.59.0 \
-              /bin/bash -e -c 'export GLOBIGNORE="../../artifacts/floaty.wasm"; cd ./code/packages/vm; find ../../artifacts/ -type f -name "*.wasm" -exec cargo run --bin cw-check-contract {} \;
+              /bin/bash -e -c 'export GLOBIGNORE="../../artifacts/floaty.wasm"; cd ./code/packages/vm; \
+              find ../../artifacts/ -type f -name "*.wasm" ! -name "floaty.wasm" -exec cargo run --bin cw-check-contract {} \;
             docker cp with_code:/code/artifacts .
       - run:
           name: Publish artifacts on GitHub

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1216,7 +1216,7 @@ jobs:
           command: |
             echo "Checking all contracts under ./artifacts"
             docker run --volumes-from with_code rust:1.59.0 \
-              /bin/bash -e -c 'export GLOBIGNORE="../../artifacts/floaty.wasm"; cd ./code/packages/vm; cargo run --bin cw-check-contract ../../artifacts/*.wasm'
+              /bin/bash -e -c 'export GLOBIGNORE="../../artifacts/floaty.wasm"; cd ./code/packages/vm; find ../../artifacts/ -type f -name "*.wasm" -exec cargo run --bin cw-check-contract {} \;
             docker cp with_code:/code/artifacts .
       - run:
           name: Publish artifacts on GitHub


### PR DESCRIPTION
Instead of passing wildcard to script CI will find
every wasm file and run check_contract on it.