### PR TITLE
`cosmwasm-check` multiple args

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1216,8 +1216,7 @@ jobs:
           command: |
             echo "Checking all contracts under ./artifacts"
             docker run --volumes-from with_code rust:1.59.0 \
-              /bin/bash -e -c 'export GLOBIGNORE="../../artifacts/floaty.wasm"; cd ./code/packages/vm; \
-              find ../../artifacts/ -type f -name "*.wasm" ! -name "floaty.wasm" -exec cargo run --bin cw-check-contract {} \;
+              /bin/bash -e -c 'export GLOBIGNORE="artifacts/floaty.wasm"; cd ./code; cargo run --bin cw-check-contract artifacts/*.wasm'
             docker cp with_code:/code/artifacts .
       - run:
           name: Publish artifacts on GitHub

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,7 +622,6 @@ dependencies = [
  "colored",
  "cosmwasm-std",
  "cosmwasm-vm",
- "termcolor",
 ]
 
 [[package]]
@@ -1809,15 +1808,6 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -606,6 +606,7 @@ dependencies = [
 name = "cw-check-contract"
 version = "1.0.0"
 dependencies = [
+ "anyhow",
  "clap",
  "cosmwasm-std",
  "cosmwasm-vm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,6 +238,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "591ff76ca0691bd91c1b0b5b987e5cf93b21ec810ad96665c5a569c60846dd93"
 
 [[package]]
+name = "colored"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+dependencies = [
+ "atty",
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -608,8 +619,10 @@ version = "1.0.0"
 dependencies = [
  "anyhow",
  "clap",
+ "colored",
  "cosmwasm-std",
  "cosmwasm-vm",
+ "termcolor",
 ]
 
 [[package]]
@@ -1796,6 +1809,15 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]

--- a/packages/cw-check-contract/Cargo.toml
+++ b/packages/cw-check-contract/Cargo.toml
@@ -9,8 +9,7 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = "1"
+clap = "2"
+colored = "2"
 cosmwasm-vm = { path = "../vm", version = "1.0.0" }
 cosmwasm-std = { path = "../std", version = "1.0.0" }
-clap = "2.33"
-termcolor = "1.1.3"
-colored = "2.0.0"

--- a/packages/cw-check-contract/Cargo.toml
+++ b/packages/cw-check-contract/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/CosmWasm/cosmwasm/tree/main/packages/cw-check-c
 license = "Apache-2.0"
 
 [dependencies]
+anyhow = "1"
 cosmwasm-vm = { path = "../vm", version = "1.0.0" }
 cosmwasm-std = { path = "../std", version = "1.0.0" }
-clap = "2.33.3"
+clap = "2.33"

--- a/packages/cw-check-contract/Cargo.toml
+++ b/packages/cw-check-contract/Cargo.toml
@@ -12,3 +12,5 @@ anyhow = "1"
 cosmwasm-vm = { path = "../vm", version = "1.0.0" }
 cosmwasm-std = { path = "../std", version = "1.0.0" }
 clap = "2.33"
+termcolor = "1.1.3"
+colored = "2.0.0"

--- a/packages/cw-check-contract/src/main.rs
+++ b/packages/cw-check-contract/src/main.rs
@@ -61,7 +61,7 @@ pub fn main() {
     println!();
 
     if failures.is_empty() {
-        println!("All {} contracts passed checks!", passes.len());
+        println!("All contracts ({}) passed checks!", passes.len());
     } else {
         println!("Passes: {}, failures: {}", passes.len(), failures.len());
         exit(1);

--- a/packages/cw-check-contract/src/main.rs
+++ b/packages/cw-check-contract/src/main.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use std::process::exit;
 
 use clap::{App, Arg};
+use colored::Colorize;
 
 use cosmwasm_vm::capabilities_from_csv;
 use cosmwasm_vm::internals::{check_wasm, compile};
@@ -49,9 +50,9 @@ pub fn main() {
         .map(|p| {
             let result = check_contract(p, &available_capabilities);
             match &result {
-                Ok(_) => println!("{}: pass", p),
+                Ok(_) => println!("{}: {}", p, "pass".green()),
                 Err(e) => {
-                    println!("{}: failure", p);
+                    println!("{}: {}", p, "failure".red());
                     println!("{}", e);
                 }
             };
@@ -61,9 +62,19 @@ pub fn main() {
     println!();
 
     if failures.is_empty() {
-        println!("All contracts ({}) passed checks!", passes.len());
+        println!(
+            "All contracts ({}) {} checks!",
+            passes.len(),
+            "passed".green()
+        );
     } else {
-        println!("Passes: {}, failures: {}", passes.len(), failures.len());
+        println!(
+            "{}: {}, {}: {}",
+            "Passes".green(),
+            passes.len(),
+            "failures".red(),
+            failures.len()
+        );
         exit(1);
     }
 }


### PR DESCRIPTION
Closes #1392

Test cases:

```
[tom@trilby cosmwasm]$ export GLOBIGNORE=artifacts/floaty.wasm
[tom@trilby cosmwasm]$ cargo run --bin cw-check-contract artifacts/*.wasm
    Finished dev [unoptimized + debuginfo] target(s) in 0.05s
     Running `target/debug/cw-check-contract artifacts/burner.wasm artifacts/hackatom.wasm`
Available capabilities: {"staking", "stargate", "iterator"}

artifacts/burner.wasm: pass
artifacts/hackatom.wasm: pass

All 2 contracts passed checks!
[tom@trilby cosmwasm]$ echo $?
0
```

```
[tom@trilby cosmwasm]$ unset GLOBIGNORE
[tom@trilby cosmwasm]$ cargo run --bin cw-check-contract artifacts/*.wasm
    Finished dev [unoptimized + debuginfo] target(s) in 0.05s
     Running `target/debug/cw-check-contract artifacts/burner.wasm artifacts/floaty.wasm artifacts/hackatom.wasm`
Available capabilities: {"staking", "stargate", "iterator"}

artifacts/burner.wasm: pass
artifacts/floaty.wasm: failure
Error compiling Wasm: Could not compile: WebAssembly translation error: Error in middleware Gatekeeper: Float operator detected: F64Const { value: Ieee64(0) }. The use of floats is not supported.
artifacts/hackatom.wasm: pass

Passes: 2, failures: 1
[tom@trilby cosmwasm]$ echo $?
1
```