### PR TITLE
Change filesystem errors to be consistent across operating systems

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   codecov: codecov/codecov@3.2.0
+  win: circleci/windows@5.0
 
 workflows:
   test:
@@ -15,6 +16,7 @@ workflows:
       - package_std
       - package_storage
       - package_vm
+      - package_vm_windows
       - contract_burner
       - contract_crypto_verify
       - contract_cyberpunk
@@ -375,6 +377,49 @@ jobs:
             - target/debug/build
             - target/debug/deps
           key: cargocache-v2-package_vm-rust:1.59.0-{{ checksum "Cargo.lock" }}
+
+  package_vm_windows:
+    executor:
+      name: win/default
+      shell: bash.exe
+    steps:
+      - run:
+          name: Enable symlinks for the checkout
+          command: git config --global core.symlinks true
+      - checkout
+      - run:
+          name: Reset git config set by CircleCI to make Cargo work
+          command: git config --global --unset url.ssh://git@github.com.insteadof
+      - run:
+          name: Install Rust
+          command: |
+            set -o errexit
+            curl -sS --output rustup-init.exe https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe
+            ./rustup-init.exe --default-toolchain 1.65.0 -y
+            echo 'export PATH="$PATH;$USERPROFILE/.cargo/bin"' >> "$BASH_ENV"
+      - run:
+          name: Version information
+          command: |
+            set -o errexit
+            rustc --version; cargo --version; rustup --version; rustup target list --installed
+      - restore_cache:
+          keys:
+            - cargocache-v2-package_vm_windows-rust:1.65.0-{{ checksum "Cargo.lock" }}
+      - run:
+          name: Test
+          working_directory: ~/project/packages/vm
+          command: cargo test --locked
+      - run:
+          name: Test with all features
+          working_directory: ~/project/packages/vm
+          command: cargo test --locked --features allow_interface_version_7,iterator,staking,stargate
+      - save_cache:
+          paths:
+            - /usr/local/cargo/registry
+            - target/debug/.fingerprint
+            - target/debug/build
+            - target/debug/deps
+          key: cargocache-v2-package_vm_windows-rust:1.65.0-{{ checksum "Cargo.lock" }}
 
   contract_burner:
     docker:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- cosmwasm-vm: Avoid exposing OS specific file system errors in order to test
+  cosmwasm-vm on Windows. This gives us confidence for integrating cosmwasm-vm
+  in a libwasmvm build on Windows. This change is likely to be consensus
+  breaking as error messages change. ([#1406])
+
+[#1406]: https://github.com/CosmWasm/cosmwasm/pull/1406
+
 ## [1.1.6] - 2022-11-16
 
 ### Added

--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -351,12 +351,12 @@ fn save_wasm_to_disk(dir: impl Into<PathBuf>, wasm: &[u8]) -> VmResult<Checksum>
 fn load_wasm_from_disk(dir: impl Into<PathBuf>, checksum: &Checksum) -> VmResult<Vec<u8>> {
     // this requires the directory and file to exist
     let path = dir.into().join(checksum.to_hex());
-    let mut file = File::open(path)
-        .map_err(|e| VmError::cache_err(format!("Error opening Wasm file for reading: {}", e)))?;
+    let mut file =
+        File::open(path).map_err(|_e| VmError::cache_err("Error opening Wasm file for reading"))?;
 
     let mut wasm = Vec::<u8>::new();
     file.read_to_end(&mut wasm)
-        .map_err(|e| VmError::cache_err(format!("Error reading Wasm file: {}", e)))?;
+        .map_err(|_e| VmError::cache_err("Error reading Wasm file"))?;
     Ok(wasm)
 }
 
@@ -518,8 +518,7 @@ mod tests {
 
         match cache.load_wasm(&checksum).unwrap_err() {
             VmError::CacheErr { msg, .. } => {
-                assert!(msg
-                    .starts_with("Error opening Wasm file for reading: No such file or directory"))
+                assert_eq!(msg, "Error opening Wasm file for reading")
             }
             e => panic!("Unexpected error: {:?}", e),
         }

--- a/packages/vm/src/filesystem.rs
+++ b/packages/vm/src/filesystem.rs
@@ -1,0 +1,43 @@
+use std::{fs::create_dir_all, path::Path};
+
+#[derive(Debug)]
+pub struct MkdirPFailure;
+
+/// An implementation for `mkdir -p`.
+///
+/// This is a thin wrapper around fs::create_dir_all that
+/// hides all OS specific error messages to ensure they don't end up
+/// breaking consensus.
+pub fn mkdir_p(path: &Path) -> Result<(), MkdirPFailure> {
+    create_dir_all(path).map_err(|_e| MkdirPFailure)
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[test]
+    fn mkdir_p_works() {
+        let tmp_root = TempDir::new().unwrap();
+
+        // Can create
+        let path = tmp_root.path().join("something");
+        assert!(!path.is_dir());
+        mkdir_p(&path).unwrap();
+        assert!(path.is_dir());
+
+        // Can be called on existing dir
+        let path = tmp_root.path().join("something else");
+        assert!(!path.is_dir());
+        mkdir_p(&path).unwrap();
+        assert!(path.is_dir());
+        mkdir_p(&path).unwrap(); // no-op
+        assert!(path.is_dir());
+
+        // Fails for dir with null
+        let path = tmp_root.path().join("something\0with NULL");
+        mkdir_p(&path).unwrap_err();
+    }
+}

--- a/packages/vm/src/lib.rs
+++ b/packages/vm/src/lib.rs
@@ -9,6 +9,7 @@ mod compatibility;
 mod conversion;
 mod environment;
 mod errors;
+mod filesystem;
 mod imports;
 mod instance;
 mod limited;

--- a/packages/vm/src/modules/mod.rs
+++ b/packages/vm/src/modules/mod.rs
@@ -4,7 +4,7 @@ mod pinned_memory_cache;
 mod sized_module;
 mod versioning;
 
-pub use file_system_cache::FileSystemCache;
+pub use file_system_cache::{FileSystemCache, NewFileSystemCacheError};
 pub use in_memory_cache::InMemoryCache;
 pub use pinned_memory_cache::PinnedMemoryCache;
 pub use versioning::current_wasmer_module_version;


### PR DESCRIPTION
This addresses Windows compatibility to make everyone's life easier and reduce the risk of having system-dependent error messages breaking consensus.

This is an alternative to the OS specific checks in https://github.com/CosmWasm/cosmwasm/pull/1369

Closes #1369