### PR TITLE
schema-derive: Support unit-like variants in `QueryMsg`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- cosmwasm-schema: Using `QueryResponses` with a `QueryMsg` containing a
+  unit-like variant will no longer crash. The different variant types in Rust
+  are:
+  ```rust
+  enum QueryMsg {
+      UnitLike,
+      Tuple(),
+      Struct {},
+  }
+  ```
+  It's still recommended to only use struct variants, even if there are no
+  fields.
+
 ## [1.1.0] - 2022-09-05
 
 ### Added

--- a/packages/schema/src/query_response.rs
+++ b/packages/schema/src/query_response.rs
@@ -129,7 +129,7 @@ mod tests {
     #[allow(dead_code)]
     pub enum GoodMsg {
         BalanceFor { account: String },
-        AccountIdFor { account: String },
+        AccountIdFor(String),
         Supply {},
         Liquidity,
         AccountCount(),

--- a/packages/vm/src/compatibility.rs
+++ b/packages/vm/src/compatibility.rs
@@ -89,7 +89,7 @@ fn check_wasm_memories(module: &Module) -> VmResult<()> {
         )));
     }
 
-    if limits.maximum() != None {
+    if limits.maximum().is_some() {
         return Err(VmError::static_validation_err(
             "Wasm contract memory's maximum must be unset. The host will set it for you.",
         ));


### PR DESCRIPTION
Closes #1416

* Add support for unit-like enum variants in `QueryMsg`
* Add tests for both unit-like and tuple-like enum variants in `QueryMsg`