### PR TITLE
Schema macros: disambiguate expanded paths and hide deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to
   ```
   It's still recommended to only use struct variants, even if there are no
   fields.
+
+### Changed
+
 - cosmwasm-schema: It is no longer necessary to specify `serde` or `schemars` as
   a dependency in order to make `cosmwasm-schema` macros work.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to
   ```
   It's still recommended to only use struct variants, even if there are no
   fields.
+- cosmwasm-schema: It is no longer necessary to specify `serde` or `schemars` as
+  a dependency in order to make `cosmwasm-schema` macros work.
 
 ## [1.1.0] - 2022-09-05
 

--- a/contracts/cyberpunk/Cargo.lock
+++ b/contracts/cyberpunk/Cargo.lock
@@ -451,8 +451,6 @@ dependencies = [
  "cosmwasm-storage",
  "cosmwasm-vm",
  "rust-argon2",
- "schemars",
- "serde",
  "thiserror",
 ]
 

--- a/contracts/cyberpunk/Cargo.toml
+++ b/contracts/cyberpunk/Cargo.toml
@@ -32,8 +32,6 @@ backtraces = ["cosmwasm-std/backtraces", "cosmwasm-vm/backtraces"]
 cosmwasm-schema = { path = "../../packages/schema" }
 cosmwasm-std = { path = "../../packages/std", default-features = false, features = ["abort"] }
 rust-argon2 = "0.8"
-schemars = "0.8.1"
-serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/packages/schema-derive/src/cw_serde.rs
+++ b/packages/schema-derive/src/cw_serde.rs
@@ -4,12 +4,12 @@ pub fn cw_serde_impl(input: DeriveInput) -> DeriveInput {
     match input.data {
         syn::Data::Struct(_) => parse_quote! {
             #[derive(
-                serde::Serialize,
-                serde::Deserialize,
-                Clone,
-                Debug,
-                PartialEq,
-                schemars::JsonSchema
+                ::cosmwasm_schema::serde::Serialize,
+                ::cosmwasm_schema::serde::Deserialize,
+                ::std::clone::Clone,
+                ::std::fmt::Debug,
+                ::std::cmp::PartialEq,
+                ::cosmwasm_schema::schemars::JsonSchema
             )]
             #[allow(clippy::derive_partial_eq_without_eq)] // Allow users of `#[cw_serde]` to not implement Eq without clippy complaining
             #[serde(deny_unknown_fields)]
@@ -17,12 +17,12 @@ pub fn cw_serde_impl(input: DeriveInput) -> DeriveInput {
         },
         syn::Data::Enum(_) => parse_quote! {
             #[derive(
-                serde::Serialize,
-                serde::Deserialize,
-                Clone,
-                Debug,
-                PartialEq,
-                schemars::JsonSchema
+                ::cosmwasm_schema::serde::Serialize,
+                ::cosmwasm_schema::serde::Deserialize,
+                ::std::clone::Clone,
+                ::std::fmt::Debug,
+                ::std::cmp::PartialEq,
+                ::cosmwasm_schema::schemars::JsonSchema
             )]
             #[allow(clippy::derive_partial_eq_without_eq)] // Allow users of `#[cw_serde]` to not implement Eq without clippy complaining
             #[serde(deny_unknown_fields, rename_all = "snake_case")]
@@ -47,12 +47,12 @@ mod tests {
 
         let expected = parse_quote! {
             #[derive(
-                serde::Serialize,
-                serde::Deserialize,
-                Clone,
-                Debug,
-                PartialEq,
-                schemars::JsonSchema
+                ::cosmwasm_schema::serde::Serialize,
+                ::cosmwasm_schema::serde::Deserialize,
+                ::std::clone::Clone,
+                ::std::fmt::Debug,
+                ::std::cmp::PartialEq,
+                ::cosmwasm_schema::schemars::JsonSchema
             )]
             #[allow(clippy::derive_partial_eq_without_eq)]
             #[serde(deny_unknown_fields)]
@@ -73,12 +73,12 @@ mod tests {
 
         let expected = parse_quote! {
             #[derive(
-                serde::Serialize,
-                serde::Deserialize,
-                Clone,
-                Debug,
-                PartialEq,
-                schemars::JsonSchema
+                ::cosmwasm_schema::serde::Serialize,
+                ::cosmwasm_schema::serde::Deserialize,
+                ::std::clone::Clone,
+                ::std::fmt::Debug,
+                ::std::cmp::PartialEq,
+                ::cosmwasm_schema::schemars::JsonSchema
             )]
             #[allow(clippy::derive_partial_eq_without_eq)]
             #[serde(deny_unknown_fields)]
@@ -101,12 +101,12 @@ mod tests {
 
         let expected = parse_quote! {
             #[derive(
-                serde::Serialize,
-                serde::Deserialize,
-                Clone,
-                Debug,
-                PartialEq,
-                schemars::JsonSchema
+                ::cosmwasm_schema::serde::Serialize,
+                ::cosmwasm_schema::serde::Deserialize,
+                ::std::clone::Clone,
+                ::std::fmt::Debug,
+                ::std::cmp::PartialEq,
+                ::cosmwasm_schema::schemars::JsonSchema
             )]
             #[allow(clippy::derive_partial_eq_without_eq)]
             #[serde(deny_unknown_fields, rename_all = "snake_case")]

--- a/packages/schema-derive/src/cw_serde.rs
+++ b/packages/schema-derive/src/cw_serde.rs
@@ -12,7 +12,8 @@ pub fn cw_serde_impl(input: DeriveInput) -> DeriveInput {
                 ::cosmwasm_schema::schemars::JsonSchema
             )]
             #[allow(clippy::derive_partial_eq_without_eq)] // Allow users of `#[cw_serde]` to not implement Eq without clippy complaining
-            #[serde(deny_unknown_fields)]
+            #[serde(deny_unknown_fields, crate = "::cosmwasm_schema::serde")]
+            #[schemars(crate = "::cosmwasm_schema::schemars")]
             #input
         },
         syn::Data::Enum(_) => parse_quote! {
@@ -25,7 +26,8 @@ pub fn cw_serde_impl(input: DeriveInput) -> DeriveInput {
                 ::cosmwasm_schema::schemars::JsonSchema
             )]
             #[allow(clippy::derive_partial_eq_without_eq)] // Allow users of `#[cw_serde]` to not implement Eq without clippy complaining
-            #[serde(deny_unknown_fields, rename_all = "snake_case")]
+            #[serde(deny_unknown_fields, rename_all = "snake_case", crate = "::cosmwasm_schema::serde")]
+            #[schemars(crate = "::cosmwasm_schema::schemars")]
             #input
         },
         syn::Data::Union(_) => panic!("unions are not supported"),
@@ -55,7 +57,8 @@ mod tests {
                 ::cosmwasm_schema::schemars::JsonSchema
             )]
             #[allow(clippy::derive_partial_eq_without_eq)]
-            #[serde(deny_unknown_fields)]
+            #[serde(deny_unknown_fields, crate = "::cosmwasm_schema::serde")]
+            #[schemars(crate = "::cosmwasm_schema::schemars")]
             pub struct InstantiateMsg {
                 pub verifier: String,
                 pub beneficiary: String,
@@ -81,7 +84,8 @@ mod tests {
                 ::cosmwasm_schema::schemars::JsonSchema
             )]
             #[allow(clippy::derive_partial_eq_without_eq)]
-            #[serde(deny_unknown_fields)]
+            #[serde(deny_unknown_fields, crate = "::cosmwasm_schema::serde")]
+            #[schemars(crate = "::cosmwasm_schema::schemars")]
             pub struct InstantiateMsg {}
         };
 
@@ -109,7 +113,8 @@ mod tests {
                 ::cosmwasm_schema::schemars::JsonSchema
             )]
             #[allow(clippy::derive_partial_eq_without_eq)]
-            #[serde(deny_unknown_fields, rename_all = "snake_case")]
+            #[serde(deny_unknown_fields, rename_all = "snake_case", crate = "::cosmwasm_schema::serde")]
+            #[schemars(crate = "::cosmwasm_schema::schemars")]
             pub enum SudoMsg {
                 StealFunds {
                     recipient: String,

--- a/packages/schema-derive/src/generate_api.rs
+++ b/packages/schema-derive/src/generate_api.rs
@@ -13,10 +13,10 @@ pub fn write_api_impl(input: Options) -> Block {
 
     parse_quote! {
         {
-            use std::env::current_dir;
-            use std::fs::{create_dir_all, write};
+            use ::std::env::current_dir;
+            use ::std::fs::{create_dir_all, write};
 
-            use cosmwasm_schema::{remove_schemas, Api, QueryResponses};
+            use ::cosmwasm_schema::{remove_schemas, Api, QueryResponses};
 
             let mut out_dir = current_dir().unwrap();
             out_dir.push("schema");
@@ -47,10 +47,10 @@ pub fn generate_api_impl(input: &Options) -> ExprStruct {
     } = input;
 
     parse_quote! {
-        cosmwasm_schema::Api {
+        ::cosmwasm_schema::Api {
             contract_name: #name.to_string(),
             contract_version: #version.to_string(),
-            instantiate: cosmwasm_schema::schema_for!(#instantiate),
+            instantiate: ::cosmwasm_schema::schema_for!(#instantiate),
             execute: #execute,
             query: #query,
             migrate: #migrate,
@@ -131,7 +131,7 @@ impl Parse for Options {
             }
         } else {
             quote! {
-                env!("CARGO_PKG_NAME")
+                ::std::env!("CARGO_PKG_NAME")
             }
         };
 
@@ -142,7 +142,7 @@ impl Parse for Options {
             }
         } else {
             quote! {
-                env!("CARGO_PKG_VERSION")
+                ::std::env!("CARGO_PKG_VERSION")
             }
         };
 
@@ -154,7 +154,7 @@ impl Parse for Options {
         let execute = match map.remove(&parse_quote!(execute)) {
             Some(ty) => {
                 let ty = ty.unwrap_type();
-                quote! {Some(cosmwasm_schema::schema_for!(#ty))}
+                quote! {Some(::cosmwasm_schema::schema_for!(#ty))}
             }
             None => quote! { None },
         };
@@ -163,8 +163,8 @@ impl Parse for Options {
             Some(ty) => {
                 let ty = ty.unwrap_type();
                 (
-                    quote! {Some(cosmwasm_schema::schema_for!(#ty))},
-                    quote! { Some(#ty::response_schemas().unwrap()) },
+                    quote! {Some(::cosmwasm_schema::schema_for!(#ty))},
+                    quote! { Some(<#ty as QueryResponses>::response_schemas().unwrap()) },
                 )
             }
             None => (quote! { None }, quote! { None }),
@@ -173,7 +173,7 @@ impl Parse for Options {
         let migrate = match map.remove(&parse_quote!(migrate)) {
             Some(ty) => {
                 let ty = ty.unwrap_type();
-                quote! {Some(cosmwasm_schema::schema_for!(#ty))}
+                quote! {Some(::cosmwasm_schema::schema_for!(#ty))}
             }
             None => quote! { None },
         };
@@ -181,7 +181,7 @@ impl Parse for Options {
         let sudo = match map.remove(&parse_quote!(sudo)) {
             Some(ty) => {
                 let ty = ty.unwrap_type();
-                quote! {Some(cosmwasm_schema::schema_for!(#ty))}
+                quote! {Some(::cosmwasm_schema::schema_for!(#ty))}
             }
             None => quote! { None },
         };
@@ -214,10 +214,10 @@ mod tests {
                 instantiate: InstantiateMsg,
             }),
             parse_quote! {
-                cosmwasm_schema::Api {
-                    contract_name: env!("CARGO_PKG_NAME").to_string(),
-                    contract_version: env!("CARGO_PKG_VERSION").to_string(),
-                    instantiate: cosmwasm_schema::schema_for!(InstantiateMsg),
+                ::cosmwasm_schema::Api {
+                    contract_name: ::std::env!("CARGO_PKG_NAME").to_string(),
+                    contract_version: ::std::env!("CARGO_PKG_VERSION").to_string(),
+                    instantiate: ::cosmwasm_schema::schema_for!(InstantiateMsg),
                     execute: None,
                     query: None,
                     migrate: None,
@@ -237,10 +237,10 @@ mod tests {
                 instantiate: InstantiateMsg,
             }),
             parse_quote! {
-                cosmwasm_schema::Api {
+                ::cosmwasm_schema::Api {
                     contract_name: "foo".to_string(),
                     contract_version: "bar".to_string(),
-                    instantiate: cosmwasm_schema::schema_for!(InstantiateMsg),
+                    instantiate: ::cosmwasm_schema::schema_for!(InstantiateMsg),
                     execute: None,
                     query: None,
                     migrate: None,
@@ -262,15 +262,15 @@ mod tests {
                 sudo: SudoMsg,
             }),
             parse_quote! {
-                cosmwasm_schema::Api {
-                    contract_name: env!("CARGO_PKG_NAME").to_string(),
-                    contract_version: env!("CARGO_PKG_VERSION").to_string(),
-                    instantiate: cosmwasm_schema::schema_for!(InstantiateMsg),
-                    execute: Some(cosmwasm_schema::schema_for!(ExecuteMsg)),
-                    query: Some(cosmwasm_schema::schema_for!(QueryMsg)),
-                    migrate: Some(cosmwasm_schema::schema_for!(MigrateMsg)),
-                    sudo: Some(cosmwasm_schema::schema_for!(SudoMsg)),
-                    responses: Some(QueryMsg::response_schemas().unwrap()),
+                ::cosmwasm_schema::Api {
+                    contract_name: ::std::env!("CARGO_PKG_NAME").to_string(),
+                    contract_version: ::std::env!("CARGO_PKG_VERSION").to_string(),
+                    instantiate: ::cosmwasm_schema::schema_for!(InstantiateMsg),
+                    execute: Some(::cosmwasm_schema::schema_for!(ExecuteMsg)),
+                    query: Some(::cosmwasm_schema::schema_for!(QueryMsg)),
+                    migrate: Some(::cosmwasm_schema::schema_for!(MigrateMsg)),
+                    sudo: Some(::cosmwasm_schema::schema_for!(SudoMsg)),
+                    responses: Some(<QueryMsg as QueryResponses>::response_schemas().unwrap()),
                 }
             }
         );

--- a/packages/schema-derive/src/query_responses.rs
+++ b/packages/schema-derive/src/query_responses.rs
@@ -10,9 +10,9 @@ pub fn query_responses_derive_impl(input: ItemEnum) -> ItemImpl {
     parse_quote! {
         #[automatically_derived]
         #[cfg(not(target_arch = "wasm32"))]
-        impl cosmwasm_schema::QueryResponses for #ident {
-            fn response_schemas_impl() -> std::collections::BTreeMap<String, schemars::schema::RootSchema> {
-                std::collections::BTreeMap::from([
+        impl ::cosmwasm_schema::QueryResponses for #ident {
+            fn response_schemas_impl() -> ::std::collections::BTreeMap<String, ::cosmwasm_schema::schemars::schema::RootSchema> {
+                ::std::collections::BTreeMap::from([
                     #( #mappings, )*
                 ])
             }
@@ -33,7 +33,7 @@ fn parse_query(v: Variant) -> (String, Expr) {
 
     (
         query,
-        parse_quote!(cosmwasm_schema::schema_for!(#response_ty)),
+        parse_quote!(::cosmwasm_schema::schema_for!(#response_ty)),
     )
 }
 
@@ -79,11 +79,11 @@ mod tests {
             parse_quote! {
                 #[automatically_derived]
                 #[cfg(not(target_arch = "wasm32"))]
-                impl cosmwasm_schema::QueryResponses for QueryMsg {
-                    fn response_schemas_impl() -> std::collections::BTreeMap<String, schemars::schema::RootSchema> {
-                        std::collections::BTreeMap::from([
-                            ("supply".to_string(), cosmwasm_schema::schema_for!(some_crate::AnotherType)),
-                            ("balance".to_string(), cosmwasm_schema::schema_for!(SomeType)),
+                impl ::cosmwasm_schema::QueryResponses for QueryMsg {
+                    fn response_schemas_impl() -> ::std::collections::BTreeMap<String, ::cosmwasm_schema::schemars::schema::RootSchema> {
+                        ::std::collections::BTreeMap::from([
+                            ("supply".to_string(), ::cosmwasm_schema::schema_for!(some_crate::AnotherType)),
+                            ("balance".to_string(), ::cosmwasm_schema::schema_for!(SomeType)),
                         ])
                     }
                 }
@@ -104,9 +104,9 @@ mod tests {
             parse_quote! {
                 #[automatically_derived]
                 #[cfg(not(target_arch = "wasm32"))]
-                impl cosmwasm_schema::QueryResponses for QueryMsg {
-                    fn response_schemas_impl() -> std::collections::BTreeMap<String, schemars::schema::RootSchema> {
-                        std::collections::BTreeMap::from([])
+                impl ::cosmwasm_schema::QueryResponses for QueryMsg {
+                    fn response_schemas_impl() -> ::std::collections::BTreeMap<String, ::cosmwasm_schema::schemars::schema::RootSchema> {
+                        ::std::collections::BTreeMap::from([])
                     }
                 }
             }
@@ -156,7 +156,7 @@ mod tests {
         assert_eq!(
             parse_tuple(parse_query(variant)),
             parse_quote! {
-                ("get_foo".to_string(), cosmwasm_schema::schema_for!(Foo))
+                ("get_foo".to_string(), ::cosmwasm_schema::schema_for!(Foo))
             }
         );
 
@@ -167,7 +167,7 @@ mod tests {
 
         assert_eq!(
             parse_tuple(parse_query(variant)),
-            parse_quote! { ("get_foo".to_string(), cosmwasm_schema::schema_for!(some_crate::Foo)) }
+            parse_quote! { ("get_foo".to_string(), ::cosmwasm_schema::schema_for!(some_crate::Foo)) }
         );
     }
 

--- a/packages/schema/src/lib.rs
+++ b/packages/schema/src/lib.rs
@@ -92,3 +92,7 @@ pub use cosmwasm_schema_derive::generate_api;
 /// ```
 pub use cosmwasm_schema_derive::write_api;
 pub use schemars::schema_for;
+
+// For use in macro expansions
+pub use schemars;
+pub use serde;


### PR DESCRIPTION
Improvements for the macros in `cosmwasm-schema`.

* The expanded paths are now less likely to cause name conflicts.
* `serde` and `schemars` are reexported in `cosmwasm-schema`. Macro expansions use those reexports. What this means is that if someone uses `cosmwasm-schema` macros, they don't necessarily have to specify `serde` or `schemars` as deps in their project.

We still don't support renaming the `cosmwasm-schema` crate, but that's a bigger fish.