### PR TITLE
Properly analyzing schemas generated for untagged enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+- cosmwasm-schema: Properly analyzing schemas generated for `untagged` enums
+
 ## [1.1.3] - 2022-09-29
 
 ### Fixed

--- a/packages/schema/src/query_response.rs
+++ b/packages/schema/src/query_response.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use schemars::{
-    schema::{InstanceType, RootSchema, SingleOrVec},
+    schema::{InstanceType, RootSchema, SingleOrVec, SubschemaValidation},
     JsonSchema,
 };
 use thiserror::Error;
@@ -45,70 +45,127 @@ pub trait QueryResponses: JsonSchema {
     fn response_schemas_impl() -> BTreeMap<String, RootSchema>;
 }
 
-/// `generated_queries` is expected to be a sorted slice here!
-fn check_api_integrity<T: QueryResponses + ?Sized>(
-    generated_queries: BTreeSet<String>,
-) -> Result<(), IntegrityError> {
-    let schema = crate::schema_for!(T);
+/// Returns possible enum variants from `one_of` analysis
+fn enum_variants(
+    subschemas: SubschemaValidation,
+) -> Result<impl Iterator<Item = Result<String, IntegrityError>>, IntegrityError> {
+    let iter = subschemas
+        .one_of
+        .ok_or(IntegrityError::InvalidQueryMsgSchema)?
+        .into_iter()
+        .map(|s| {
+            let s = s.into_object();
 
-    // something more readable below?
+            if let Some(SingleOrVec::Single(ty)) = s.instance_type {
+                match *ty {
+                    // We'll have an object if the Rust enum variant was C-like or tuple-like
+                    InstanceType::Object => s
+                        .object
+                        .ok_or(IntegrityError::InvalidQueryMsgSchema)?
+                        .required
+                        .into_iter()
+                        .next()
+                        .ok_or(IntegrityError::InvalidQueryMsgSchema),
+                    // We might have a string here if the Rust enum variant was unit-like
+                    InstanceType::String => {
+                        let values = s.enum_values.ok_or(IntegrityError::InvalidQueryMsgSchema)?;
 
-    let schema_queries: BTreeSet<_> = match schema.schema.subschemas {
-        Some(subschemas) => subschemas
-            .one_of
-            .ok_or(IntegrityError::InvalidQueryMsgSchema)?
-            .into_iter()
-            .map(|s| {
-                let s = s.into_object();
-
-                if let Some(SingleOrVec::Single(ty)) = s.instance_type {
-                    match *ty {
-                        // We'll have an object if the Rust enum variant was C-like or tuple-like
-                        InstanceType::Object => s
-                            .object
-                            .ok_or(IntegrityError::InvalidQueryMsgSchema)?
-                            .required
-                            .into_iter()
-                            .next()
-                            .ok_or(IntegrityError::InvalidQueryMsgSchema),
-                        // We might have a string here if the Rust enum variant was unit-like
-                        InstanceType::String => {
-                            let values =
-                                s.enum_values.ok_or(IntegrityError::InvalidQueryMsgSchema)?;
-
-                            if values.len() != 1 {
-                                return Err(IntegrityError::InvalidQueryMsgSchema);
-                            }
-
-                            values[0]
-                                .as_str()
-                                .map(String::from)
-                                .ok_or(IntegrityError::InvalidQueryMsgSchema)
+                        if values.len() != 1 {
+                            return Err(IntegrityError::InvalidQueryMsgSchema);
                         }
-                        _ => Err(IntegrityError::InvalidQueryMsgSchema),
-                    }
-                } else {
-                    Err(IntegrityError::InvalidQueryMsgSchema)
-                }
-            })
-            .collect::<Result<_, _>>()?,
-        None => BTreeSet::new(),
-    };
 
-    if schema_queries != generated_queries {
+                        values[0]
+                            .as_str()
+                            .map(String::from)
+                            .ok_or(IntegrityError::InvalidQueryMsgSchema)
+                    }
+                    _ => Err(IntegrityError::InvalidQueryMsgSchema),
+                }
+            } else {
+                Err(IntegrityError::InvalidQueryMsgSchema)
+            }
+        });
+
+    Ok(iter)
+}
+
+fn verify_queries(
+    query_msg: BTreeSet<String>,
+    responses: BTreeSet<String>,
+) -> Result<(), IntegrityError> {
+    if query_msg != responses {
         return Err(IntegrityError::InconsistentQueries {
-            query_msg: schema_queries,
-            responses: generated_queries,
+            query_msg,
+            responses,
         });
     }
 
     Ok(())
 }
 
+/// `generated_queries` is expected to be a sorted slice here!
+fn check_api_integrity<T: QueryResponses + ?Sized>(
+    generated_queries: BTreeSet<String>,
+) -> Result<(), IntegrityError> {
+    let schema = crate::schema_for!(T);
+
+    let subschemas = if let Some(subschemas) = schema.schema.subschemas {
+        subschemas
+    } else {
+        // No subschemas - no resposnes are expected
+        return verify_queries(BTreeSet::new(), generated_queries);
+    };
+
+    let schema_queries = if let Some(any_of) = subschemas.any_of {
+        // If `any_of` exists, we assume schema is generated from untagged enum
+        any_of
+            .into_iter()
+            .map(|schema| dbg!(schema.into_object()))
+            .filter_map(|obj| {
+                if let Some(reference) = obj.reference {
+                    // Subschemas can be hidden behind references - we want to map them to proper
+                    // subschemas in such case
+
+                    // Only references to definitions are supported
+                    let reference = match reference.strip_prefix("#/definitions/") {
+                        Some(reference) => reference,
+                        None => {
+                            return Some(Err(IntegrityError::ExternalReference {
+                                reference: reference.to_owned(),
+                            }))
+                        }
+                    };
+
+                    let schema = match schema.definitions.get(reference) {
+                        Some(schema) => schema.clone(),
+                        None => return Some(Err(IntegrityError::InvalidQueryMsgSchema)),
+                    };
+
+                    Ok(schema.into_object().subschemas).transpose()
+                } else {
+                    Ok(obj.subschemas).transpose()
+                }
+            })
+            .map(|subschema| enum_variants(*subschema?))
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter()
+            .flatten()
+            .collect::<Result<_, _>>()?
+    } else {
+        // If `any_of` is not present, there was no untagged enum on top, we expect normal enum at
+        // this point
+        enum_variants(*subschemas)?.collect::<Result<_, _>>()?
+    };
+
+    verify_queries(schema_queries, generated_queries)
+}
+
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum IntegrityError {
     #[error("the structure of the QueryMsg schema was unexpected")]
     InvalidQueryMsgSchema,
+    #[error("external reference in schema found, but they are not supported")]
+    ExternalReference { reference: String },
     #[error(
         "inconsistent queries - QueryMsg schema has {query_msg:?}, but query responses have {responses:?}"
     )]
@@ -201,6 +258,51 @@ mod tests {
                 query_msg: BTreeSet::from(["balance-for".to_string()]),
                 responses: BTreeSet::from(["balance_for".to_string()])
             }
+        );
+    }
+
+    #[derive(Debug, JsonSchema)]
+    #[serde(rename_all = "snake_case")]
+    #[allow(dead_code)]
+    pub enum ExtMsg {
+        Extension {},
+    }
+
+    #[derive(Debug, JsonSchema)]
+    #[serde(untagged, rename_all = "snake_case")]
+    #[allow(dead_code)]
+    pub enum UntaggedMsg {
+        Good(GoodMsg),
+        Ext(ExtMsg),
+        Empty(EmptyMsg),
+    }
+
+    impl QueryResponses for UntaggedMsg {
+        fn response_schemas_impl() -> BTreeMap<String, RootSchema> {
+            BTreeMap::from([
+                ("balance_for".to_string(), schema_for!(u128)),
+                ("account_id_for".to_string(), schema_for!(u128)),
+                ("supply".to_string(), schema_for!(u128)),
+                ("liquidity".to_string(), schema_for!(u128)),
+                ("account_count".to_string(), schema_for!(u128)),
+                ("extension".to_string(), schema_for!(())),
+            ])
+        }
+    }
+
+    #[test]
+    fn untagged_msg_works() {
+        let response_schemas = UntaggedMsg::response_schemas().unwrap();
+        assert_eq!(
+            response_schemas,
+            BTreeMap::from([
+                ("balance_for".to_string(), schema_for!(u128)),
+                ("account_id_for".to_string(), schema_for!(u128)),
+                ("supply".to_string(), schema_for!(u128)),
+                ("liquidity".to_string(), schema_for!(u128)),
+                ("account_count".to_string(), schema_for!(u128)),
+                ("extension".to_string(), schema_for!(())),
+            ])
         );
     }
 }


### PR DESCRIPTION
The untagged enums are generating schemas using `any_of` subschema, as they cannot assume that all underlying types are enums. This is what we expect in cosmwasm, but in general, untagged enum can have arbitrary types on branches - both structures, and other types with custom serialization (and schema generation).

The solution is, that if there is `any_of` on the subschema, we treat schema as generated from untagged enum, and just merge are subschemas as they are generated from normal enums.