### PR TITLE
`QueryResponses` - add a `nested` option

### DIFF
--- a/packages/schema-derive/src/lib.rs
+++ b/packages/schema-derive/src/lib.rs
@@ -5,7 +5,7 @@ mod query_responses;
 use quote::ToTokens;
 use syn::{parse_macro_input, DeriveInput, ItemEnum};
 
-#[proc_macro_derive(QueryResponses, attributes(returns))]
+#[proc_macro_derive(QueryResponses, attributes(returns, query_responses))]
 pub fn query_responses_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse_macro_input!(input as ItemEnum);
 

--- a/packages/schema-derive/src/query_responses.rs
+++ b/packages/schema-derive/src/query_responses.rs
@@ -1,23 +1,50 @@
-use syn::{parse_quote, Expr, ExprTuple, ItemEnum, ItemImpl, Type, Variant};
+use syn::{parse_quote, Expr, ExprTuple, Ident, ItemEnum, ItemImpl, Type, Variant};
 
 pub fn query_responses_derive_impl(input: ItemEnum) -> ItemImpl {
-    let ident = input.ident;
-    let mappings = input.variants.into_iter().map(parse_query);
-    let mut queries: Vec<_> = mappings.clone().map(|(q, _)| q).collect();
-    queries.sort();
-    let mappings = mappings.map(parse_tuple);
+    let is_nested = has_attr(&input, "query_responses", "nested");
 
-    // Handle generics if the type has any
-    let (impl_generics, type_generics, where_clause) = input.generics.split_for_impl();
+    if is_nested {
+        if !has_attr(&input, "serde", "untagged") {
+            panic!("#[query_responses(nested)] only makes sense in conjunction with #[serde(untagged)]");
+        }
+        let ident = input.ident;
+        let subquery_calls = input.variants.into_iter().map(parse_subquery);
 
-    parse_quote! {
-        #[automatically_derived]
-        #[cfg(not(target_arch = "wasm32"))]
-        impl #impl_generics ::cosmwasm_schema::QueryResponses for #ident #type_generics #where_clause {
-            fn response_schemas_impl() -> ::std::collections::BTreeMap<String, ::cosmwasm_schema::schemars::schema::RootSchema> {
-                ::std::collections::BTreeMap::from([
-                    #( #mappings, )*
-                ])
+        // Handle generics if the type has any
+        let (impl_generics, type_generics, where_clause) = input.generics.split_for_impl();
+
+        let subquery_len = subquery_calls.len();
+        parse_quote! {
+            #[automatically_derived]
+            #[cfg(not(target_arch = "wasm32"))]
+            impl #impl_generics ::cosmwasm_schema::QueryResponses for #ident #type_generics #where_clause {
+                fn response_schemas_impl() -> ::std::collections::BTreeMap<String, ::cosmwasm_schema::schemars::schema::RootSchema> {
+                    let subqueries = [
+                        #( #subquery_calls, )*
+                    ];
+                    ::cosmwasm_schema::combine_subqueries::<#subquery_len, #ident>(subqueries)
+                }
+            }
+        }
+    } else {
+        let ident = input.ident;
+        let mappings = input.variants.into_iter().map(parse_query);
+        let mut queries: Vec<_> = mappings.clone().map(|(q, _)| q).collect();
+        queries.sort();
+        let mappings = mappings.map(parse_tuple);
+
+        // Handle generics if the type has any
+        let (impl_generics, type_generics, where_clause) = input.generics.split_for_impl();
+
+        parse_quote! {
+            #[automatically_derived]
+            #[cfg(not(target_arch = "wasm32"))]
+            impl #impl_generics ::cosmwasm_schema::QueryResponses for #ident #type_generics #where_clause {
+                fn response_schemas_impl() -> ::std::collections::BTreeMap<String, ::cosmwasm_schema::schemars::schema::RootSchema> {
+                    ::std::collections::BTreeMap::from([
+                        #( #mappings, )*
+                    ])
+                }
             }
         }
     }
@@ -38,6 +65,34 @@ fn parse_query(v: Variant) -> (String, Expr) {
         query,
         parse_quote!(::cosmwasm_schema::schema_for!(#response_ty)),
     )
+}
+
+/// Extract the nested query  -> response mapping out of an enum variant.
+fn parse_subquery(v: Variant) -> Expr {
+    let submsg = match v.fields {
+        syn::Fields::Named(_) => panic!("nested query response can only contain tuple structs"),
+        syn::Fields::Unnamed(fields) => {
+            if fields.unnamed.len() != 1 {
+                panic!("invalid number of subquery parameters");
+            }
+
+            fields.unnamed[0].ty.clone()
+        }
+        syn::Fields::Unit => panic!("a unit variant is not a valid subquery"),
+    };
+    parse_quote!(<#submsg as ::cosmwasm_schema::QueryResponses>::response_schemas_impl())
+}
+
+/// Checks whether the input has the given #[query_responses($attr))] attribute
+fn has_attr(input: &ItemEnum, path: &str, attr: &str) -> bool {
+    input
+        .attrs
+        .iter()
+        .find(|a| {
+            a.path.get_ident().unwrap() == path
+                && a.parse_args::<Ident>().ok().map_or(false, |i| i == attr)
+        })
+        .is_some()
 }
 
 fn parse_tuple((q, r): (String, Expr)) -> ExprTuple {
@@ -267,5 +322,123 @@ mod tests {
     fn to_snake_case_works() {
         assert_eq!(to_snake_case("SnakeCase"), "snake_case");
         assert_eq!(to_snake_case("Wasm123AndCo"), "wasm123_and_co");
+    }
+
+    #[test]
+    fn nested_works() {
+        let input: ItemEnum = parse_quote! {
+            #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema, QueryResponses)]
+            #[serde(untagged)]
+            #[query_responses(nested)]
+            pub enum ContractQueryMsg {
+                Cw1(QueryMsg1),
+                Whitelist(whitelist::QueryMsg),
+                Cw1WhitelistContract(QueryMsg),
+            }
+        };
+        let result = query_responses_derive_impl(input);
+        assert_eq!(
+            result,
+            parse_quote! {
+                #[automatically_derived]
+                #[cfg(not(target_arch = "wasm32"))]
+                impl ::cosmwasm_schema::QueryResponses for ContractQueryMsg {
+                    fn response_schemas_impl() -> ::std::collections::BTreeMap<String, ::cosmwasm_schema::schemars::schema::RootSchema> {
+                        let subqueries = [
+                            <QueryMsg1 as ::cosmwasm_schema::QueryResponses>::response_schemas_impl(),
+                            <whitelist::QueryMsg as ::cosmwasm_schema::QueryResponses>::response_schemas_impl(),
+                            <QueryMsg as ::cosmwasm_schema::QueryResponses>::response_schemas_impl(),
+                        ];
+                        ::cosmwasm_schema::combine_subqueries::<3usize, ContractQueryMsg>(subqueries)
+                    }
+                }
+            }
+        );
+    }
+
+    #[test]
+    fn nested_empty() {
+        let input: ItemEnum = parse_quote! {
+            #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema, QueryResponses)]
+            #[serde(untagged)]
+            #[query_responses(nested)]
+            pub enum EmptyMsg {}
+        };
+        let result = query_responses_derive_impl(input);
+        assert_eq!(
+            result,
+            parse_quote! {
+                #[automatically_derived]
+                #[cfg(not(target_arch = "wasm32"))]
+                impl ::cosmwasm_schema::QueryResponses for EmptyMsg {
+                    fn response_schemas_impl() -> ::std::collections::BTreeMap<String, ::cosmwasm_schema::schemars::schema::RootSchema> {
+                        let subqueries = [];
+                        ::cosmwasm_schema::combine_subqueries::<0usize, EmptyMsg>(subqueries)
+                    }
+                }
+            }
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid number of subquery parameters")]
+    fn nested_too_many_params() {
+        let input: ItemEnum = parse_quote! {
+            #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema, QueryResponses)]
+            #[serde(untagged)]
+            #[query_responses(nested)]
+            pub enum ContractQueryMsg {
+                Msg1(QueryMsg1, QueryMsg2),
+                Whitelist(whitelist::QueryMsg),
+            }
+        };
+        query_responses_derive_impl(input);
+    }
+
+    #[test]
+    #[should_panic(expected = "nested query response can only contain tuple structs")]
+    fn nested_mixed() {
+        let input: ItemEnum = parse_quote! {
+            #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema, QueryResponses)]
+            #[serde(untagged)]
+            #[query_responses(nested)]
+            pub enum ContractQueryMsg {
+                Cw1(cw1::QueryMsg),
+                Test {
+                    mixed: bool,
+                }
+            }
+        };
+        query_responses_derive_impl(input);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "#[query_responses(nested)] only makes sense in conjunction with #[serde(untagged)]"
+    )]
+    fn nested_without_untagged() {
+        let input: ItemEnum = parse_quote! {
+            #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema, QueryResponses)]
+            #[query_responses(nested)]
+            pub enum ContractQueryMsg {
+                Cw1(cw1::QueryMsg),
+            }
+        };
+        query_responses_derive_impl(input);
+    }
+
+    #[test]
+    #[should_panic(expected = "a unit variant is not a valid subquery")]
+    fn nested_unit_variant() {
+        let input: ItemEnum = parse_quote! {
+            #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema, QueryResponses)]
+            #[serde(untagged)]
+            #[query_responses(nested)]
+            pub enum ContractQueryMsg {
+                Cw1(cw1::QueryMsg),
+                Whitelist,
+            }
+        };
+        query_responses_derive_impl(input);
     }
 }

--- a/packages/schema-derive/src/query_responses.rs
+++ b/packages/schema-derive/src/query_responses.rs
@@ -4,9 +4,6 @@ pub fn query_responses_derive_impl(input: ItemEnum) -> ItemImpl {
     let is_nested = has_attr(&input, "query_responses", "nested");
 
     if is_nested {
-        if !has_attr(&input, "serde", "untagged") {
-            panic!("#[query_responses(nested)] only makes sense in conjunction with #[serde(untagged)]");
-        }
         let ident = input.ident;
         let subquery_calls = input.variants.into_iter().map(parse_subquery);
 
@@ -403,21 +400,6 @@ mod tests {
                 Test {
                     mixed: bool,
                 }
-            }
-        };
-        query_responses_derive_impl(input);
-    }
-
-    #[test]
-    #[should_panic(
-        expected = "#[query_responses(nested)] only makes sense in conjunction with #[serde(untagged)]"
-    )]
-    fn nested_without_untagged() {
-        let input: ItemEnum = parse_quote! {
-            #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema, QueryResponses)]
-            #[query_responses(nested)]
-            pub enum ContractQueryMsg {
-                Cw1(cw1::QueryMsg),
             }
         };
         query_responses_derive_impl(input);

--- a/packages/schema-derive/src/query_responses.rs
+++ b/packages/schema-derive/src/query_responses.rs
@@ -85,14 +85,10 @@ fn parse_subquery(v: Variant) -> Expr {
 
 /// Checks whether the input has the given #[query_responses($attr))] attribute
 fn has_attr(input: &ItemEnum, path: &str, attr: &str) -> bool {
-    input
-        .attrs
-        .iter()
-        .find(|a| {
-            a.path.get_ident().unwrap() == path
-                && a.parse_args::<Ident>().ok().map_or(false, |i| i == attr)
-        })
-        .is_some()
+    input.attrs.iter().any(|a| {
+        a.path.get_ident().unwrap() == path
+            && a.parse_args::<Ident>().ok().map_or(false, |i| i == attr)
+    })
 }
 
 fn parse_tuple((q, r): (String, Expr)) -> ExprTuple {

--- a/packages/schema-derive/src/query_responses.rs
+++ b/packages/schema-derive/src/query_responses.rs
@@ -83,7 +83,7 @@ fn parse_subquery(v: Variant) -> Expr {
     parse_quote!(<#submsg as ::cosmwasm_schema::QueryResponses>::response_schemas_impl())
 }
 
-/// Checks whether the input has the given #[query_responses($attr))] attribute
+/// Checks whether the input has the given `#[$path($attr))]` attribute
 fn has_attr(input: &ItemEnum, path: &str, attr: &str) -> bool {
     input.attrs.iter().any(|a| {
         a.path.get_ident().unwrap() == path

--- a/packages/schema-derive/src/query_responses.rs
+++ b/packages/schema-derive/src/query_responses.rs
@@ -70,7 +70,7 @@ fn parse_query(v: Variant) -> (String, Expr) {
 /// Extract the nested query  -> response mapping out of an enum variant.
 fn parse_subquery(v: Variant) -> Expr {
     let submsg = match v.fields {
-        syn::Fields::Named(_) => panic!("nested query response can only contain tuple structs"),
+        syn::Fields::Named(_) => panic!("a struct variant is not a valid subquery"),
         syn::Fields::Unnamed(fields) => {
             if fields.unnamed.len() != 1 {
                 panic!("invalid number of subquery parameters");
@@ -392,7 +392,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "nested query response can only contain tuple structs")]
+    #[should_panic(expected = "a struct variant is not a valid subquery")]
     fn nested_mixed() {
         let input: ItemEnum = parse_quote! {
             #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema, QueryResponses)]

--- a/packages/schema/src/lib.rs
+++ b/packages/schema/src/lib.rs
@@ -6,7 +6,7 @@ mod remove;
 
 pub use export::{export_schema, export_schema_with_title};
 pub use idl::{Api, IDL_VERSION};
-pub use query_response::{IntegrityError, QueryResponses};
+pub use query_response::{combine_subqueries, IntegrityError, QueryResponses};
 pub use remove::remove_schemas;
 
 // Re-exports

--- a/packages/schema/tests/idl.rs
+++ b/packages/schema/tests/idl.rs
@@ -136,13 +136,96 @@ fn test_query_responses_generics() {
         .as_array()
         .unwrap();
 
-    // Find the "balance" query in the queries schema
+    // Find the "query_data" query in the queries schema
     assert_eq!(queries.len(), 1);
     assert_eq!(
         queries[0].get("required").unwrap().get(0).unwrap(),
         "query_data"
     );
 
-    // Find the "balance" query in responses
+    // Find the "query_data" query in responses
     api.get("responses").unwrap().get("query_data").unwrap();
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema, QueryResponses)]
+#[serde(untagged)]
+#[query_responses(nested)]
+pub enum NestedQueryMsg {
+    Query(QueryMsg),
+    Sub(SubQueryMsg1),
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema, QueryResponses)]
+#[serde(rename_all = "snake_case")]
+pub enum SubQueryMsg1 {
+    #[returns(u128)]
+    Variant1 { test: String },
+}
+
+#[test]
+fn test_nested_query_responses() {
+    let api_str = generate_api! {
+        instantiate: InstantiateMsg,
+        query: NestedQueryMsg,
+    }
+    .render()
+    .to_string()
+    .unwrap();
+
+    let api: Value = serde_json::from_str(&api_str).unwrap();
+    let queries = api
+        .get("query")
+        .unwrap()
+        .get("anyOf")
+        .unwrap()
+        .as_array()
+        .unwrap();
+    let definitions = api.get("query").unwrap().get("definitions").unwrap();
+
+    // Find the subqueries
+    assert_eq!(queries.len(), 2);
+    assert_eq!(
+        queries[0].get("$ref").unwrap().as_str().unwrap(),
+        "#/definitions/QueryMsg"
+    );
+    assert_eq!(
+        queries[1].get("$ref").unwrap().as_str().unwrap(),
+        "#/definitions/SubQueryMsg1"
+    );
+    let query_msg_queries = definitions
+        .get("QueryMsg")
+        .unwrap()
+        .get("oneOf")
+        .unwrap()
+        .as_array()
+        .unwrap();
+    let sub_query_msg_queries = definitions
+        .get("SubQueryMsg1")
+        .unwrap()
+        .get("oneOf")
+        .unwrap()
+        .as_array()
+        .unwrap();
+
+    // Find "balance" and "variant1" queries in the query schema
+    assert_eq!(
+        query_msg_queries[0]
+            .get("required")
+            .unwrap()
+            .get(0)
+            .unwrap(),
+        "balance"
+    );
+    assert_eq!(
+        sub_query_msg_queries[0]
+            .get("required")
+            .unwrap()
+            .get(0)
+            .unwrap(),
+        "variant1"
+    );
+
+    // Find "balance" and "variant1" queries in responses
+    api.get("responses").unwrap().get("balance").unwrap();
+    api.get("responses").unwrap().get("variant1").unwrap();
 }

--- a/packages/schema/tests/idl.rs
+++ b/packages/schema/tests/idl.rs
@@ -229,3 +229,26 @@ fn test_nested_query_responses() {
     api.get("responses").unwrap().get("balance").unwrap();
     api.get("responses").unwrap().get("variant1").unwrap();
 }
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema, QueryResponses)]
+#[serde(rename_all = "snake_case")]
+enum QueryMsg2 {
+    #[returns(u128)]
+    Balance {},
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema, QueryResponses)]
+#[query_responses(nested)]
+enum NestedNameCollision {
+    Q1(QueryMsg),
+    Q2(QueryMsg2),
+}
+
+#[test]
+#[should_panic = "name collision in subqueries for idl::NestedNameCollision"]
+fn nested_name_collision_caught() {
+    generate_api! {
+        instantiate: InstantiateMsg,
+        query: NestedNameCollision,
+    };
+}

--- a/packages/schema/tests/idl.rs
+++ b/packages/schema/tests/idl.rs
@@ -147,7 +147,7 @@ fn test_query_responses_generics() {
     api.get("responses").unwrap().get("query_data").unwrap();
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema, QueryResponses)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema, QueryResponses)]
 #[serde(untagged)]
 #[query_responses(nested)]
 pub enum NestedQueryMsg {
@@ -155,7 +155,7 @@ pub enum NestedQueryMsg {
     Sub(SubQueryMsg1),
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema, QueryResponses)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema, QueryResponses)]
 #[serde(rename_all = "snake_case")]
 pub enum SubQueryMsg1 {
     #[returns(u128)]


### PR DESCRIPTION
closes #1441 

just saw, that Bart also adapted the `check_api_integration` function to support untagged enums in a separate branch, so if you want, I can rebase on that and just use his version.