### PR TITLE
Remove non_exhaustive from IBC message types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,12 @@ and this project adheres to
 
 ### Changed
 
-- cosmwasm-std: Remove non_exhaustive from IBC message types
+- cosmwasm-std: Remove `non_exhaustive` from IBC types `IbcChannelOpenMsg`,
+  `IbcChannelConnectMsg` and `IbcChannelCloseMsg` in order to allow exhaustive
+  matching over the possible scenarios without an unused fallback case
+  ([#1449]).
+
+[#1449]: https://github.com/CosmWasm/cosmwasm/pull/1449
 
 ## [1.1.4] - 2022-10-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to
   `ed25519_verify` and `ed25519_batch_verify` import implementations we now exit
   early if the gas left is not sufficient to perform the operation.
 
+### Changed
+
+- cosmwasm-std: Remove non_exhaustive from IBC message types
+
 ## [1.1.4] - 2022-10-03
 
 ### Fixed

--- a/packages/std/src/ibc.rs
+++ b/packages/std/src/ibc.rs
@@ -249,7 +249,6 @@ impl IbcAcknowledgement {
 /// The message that is passed into `ibc_channel_open`
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
-#[non_exhaustive]
 pub enum IbcChannelOpenMsg {
     /// The ChanOpenInit step from https://github.com/cosmos/ibc/tree/master/spec/core/ics-004-channel-and-packet-semantics#channel-lifecycle-management
     OpenInit { channel: IbcChannel },
@@ -315,7 +314,6 @@ pub struct Ibc3ChannelOpenResponse {
 /// The message that is passed into `ibc_channel_connect`
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
-#[non_exhaustive]
 pub enum IbcChannelConnectMsg {
     /// The ChanOpenAck step from https://github.com/cosmos/ibc/tree/master/spec/core/ics-004-channel-and-packet-semantics#channel-lifecycle-management
     OpenAck {
@@ -368,7 +366,6 @@ impl From<IbcChannelConnectMsg> for IbcChannel {
 /// The message that is passed into `ibc_channel_close`
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
-#[non_exhaustive]
 pub enum IbcChannelCloseMsg {
     /// The ChanCloseInit step from https://github.com/cosmos/ibc/tree/master/spec/core/ics-004-channel-and-packet-semantics#channel-lifecycle-management
     CloseInit { channel: IbcChannel },


### PR DESCRIPTION
IBC message types being non exhaustive means that contract authors have to include a wildcard arm in any match expression deailing with them. IMO, this is actually quite undesirable. I my contract to fail to compile if a message is added!