### PR TITLE
Improve error when compiling schema gen for wasm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- cosmwasm-schema: Better error messaging when attempting to compile schema
+  generator for `wasm32`
+
 ## [1.1.4] - 2022-10-03
 
 ### Fixed

--- a/packages/schema-derive/src/generate_api.rs
+++ b/packages/schema-derive/src/generate_api.rs
@@ -13,6 +13,8 @@ pub fn write_api_impl(input: Options) -> Block {
 
     parse_quote! {
         {
+            #[cfg(target_arch = "wasm32")]
+            compile_error!("can't compile schema generator for the `wasm32` arch\nhint: are you trying to compile a smart contract without specifying `--lib`?");
             use ::std::env::current_dir;
             use ::std::fs::{create_dir_all, write};
 


### PR DESCRIPTION
Should've done this earlier.

In contracts, we've been moving `examples/schema.rs` to `src/bin/schema.rs`. This causes `cargo build` to build the `schema.rs` binary by default, rather than the smart contract itself. The solution is to start adding `--lib` to `cargo builld`, especially in the `cargo wasm*` aliases and CI.

People (me too) have been getting bitten by this. Let's make the compilation error more helpful.

![Screenshot from 2022-10-10 11-48-18](https://user-images.githubusercontent.com/360248/194840021-5b5eee52-22a8-40f9-a2d8-d7941c692750.png)
