### PR TITLE
Upgrade rust-optimizer to 0.12.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1270,7 +1270,7 @@ jobs:
           name: Build development contracts
           command: |
             echo "Building all contracts under ./contracts"
-            docker run --volumes-from with_code cosmwasm/rust-optimizer:0.12.5 ./contracts/*/
+            docker run --volumes-from with_code cosmwasm/rust-optimizer:0.12.9 ./contracts/*/
       - run:
           name: Check development contracts
           command: |

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ but the quickstart guide is:
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/rust-optimizer:0.12.5
+  cosmwasm/rust-optimizer:0.12.9
 ```
 
 It will output a highly size-optimized build as `contract.wasm` in `$CODE`. With

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -18,47 +18,47 @@ reason, use the following commands:
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="devcontract_cache_burner",target=/code/contracts/burner/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/rust-optimizer:0.12.5 ./contracts/burner
+  cosmwasm/rust-optimizer:0.12.9 ./contracts/burner
 
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="devcontract_cache_crypto_verify",target=/code/contracts/crypto-verify/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/rust-optimizer:0.12.5 ./contracts/crypto-verify
+  cosmwasm/rust-optimizer:0.12.9 ./contracts/crypto-verify
 
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="devcontract_cache_floaty",target=/code/contracts/floaty/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/rust-optimizer:0.12.5 ./contracts/floaty
+  cosmwasm/rust-optimizer:0.12.9 ./contracts/floaty
 
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="devcontract_cache_hackatom",target=/code/contracts/hackatom/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/rust-optimizer:0.12.5 ./contracts/hackatom
+  cosmwasm/rust-optimizer:0.12.9 ./contracts/hackatom
 
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="devcontract_cache_ibc_reflect",target=/code/contracts/ibc-reflect/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/rust-optimizer:0.12.5 ./contracts/ibc-reflect
+  cosmwasm/rust-optimizer:0.12.9 ./contracts/ibc-reflect
 
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="devcontract_cache_ibc_reflect_send",target=/code/contracts/ibc-reflect-send/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/rust-optimizer:0.12.5 ./contracts/ibc-reflect-send
+  cosmwasm/rust-optimizer:0.12.9 ./contracts/ibc-reflect-send
 
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="devcontract_cache_queue",target=/code/contracts/queue/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/rust-optimizer:0.12.5 ./contracts/queue
+  cosmwasm/rust-optimizer:0.12.9 ./contracts/queue
 
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="devcontract_cache_reflect",target=/code/contracts/reflect/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/rust-optimizer:0.12.5 ./contracts/reflect
+  cosmwasm/rust-optimizer:0.12.9 ./contracts/reflect
 
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="devcontract_cache_staking",target=/code/contracts/staking/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/rust-optimizer:0.12.5 ./contracts/staking
+  cosmwasm/rust-optimizer:0.12.9 ./contracts/staking
 ```
 
 ## Entry points

--- a/packages/vm/README.md
+++ b/packages/vm/README.md
@@ -53,19 +53,19 @@ To rebuild the test contracts, go to the repo root and do
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="devcontract_cache_hackatom",target=/code/contracts/hackatom/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/rust-optimizer:0.12.5 ./contracts/hackatom \
+  cosmwasm/rust-optimizer:0.12.9 ./contracts/hackatom \
   && cp artifacts/hackatom.wasm packages/vm/testdata/hackatom_1.0.wasm
 
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="devcontract_cache_ibc_reflect",target=/code/contracts/ibc-reflect/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/rust-optimizer:0.12.5 ./contracts/ibc-reflect \
+  cosmwasm/rust-optimizer:0.12.9 ./contracts/ibc-reflect \
   && cp artifacts/ibc_reflect.wasm packages/vm/testdata/ibc_reflect_1.0.wasm
 
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="devcontract_cache_floaty",target=/code/contracts/floaty/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/rust-optimizer:0.12.5 ./contracts/floaty \
+  cosmwasm/rust-optimizer:0.12.9 ./contracts/floaty \
   && cp artifacts/floaty.wasm packages/vm/testdata/floaty_1.0.wasm
 ```
 


### PR DESCRIPTION
The CI run of the v1.1.5 tag build failed because rust-optimizer was too old (rust-optimizer:0.12.5 comes with Rust v1.58.1).

https://app.circleci.com/pipelines/github/CosmWasm/cosmwasm/4439/workflows/15a877cb-e90e-47ec-8cc1-d30540e46bdf/jobs/58375