### PR TITLE
Increase dependency requirements to make -Zminimal-versions pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to
 
 [#1463]: https://github.com/CosmWasm/cosmwasm/pull/1463
 
+### Changed
+
+- all: Bump a few dependency versions to make the codebase compile with
+  `-Zminimal-versions` ([#1465]).
+
+[#1465]: https://github.com/CosmWasm/cosmwasm/pull/1465
+
 ## [1.1.5] - 2022-10-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,14 +325,11 @@ name = "cosmwasm-std"
 version = "1.1.5"
 dependencies = [
  "base64",
- "bitflags",
- "bytecheck",
  "chrono",
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "cosmwasm-schema",
  "derivative",
- "enumset",
  "forward_ref",
  "hex",
  "hex-literal",
@@ -355,11 +352,14 @@ dependencies = [
 name = "cosmwasm-vm"
 version = "1.1.5"
 dependencies = [
+ "bitflags",
+ "bytecheck",
  "clap",
  "clru",
  "cosmwasm-crypto",
  "cosmwasm-std",
  "criterion",
+ "enumset",
  "hex",
  "hex-literal",
  "leb128",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,11 +325,14 @@ name = "cosmwasm-std"
 version = "1.1.5"
 dependencies = [
  "base64",
+ "bitflags",
+ "bytecheck",
  "chrono",
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "cosmwasm-schema",
  "derivative",
+ "enumset",
  "forward_ref",
  "hex",
  "hex-literal",

--- a/contracts/burner/Cargo.lock
+++ b/contracts/burner/Cargo.lock
@@ -215,9 +215,12 @@ name = "cosmwasm-std"
 version = "1.1.5"
 dependencies = [
  "base64",
+ "bitflags",
+ "bytecheck",
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derivative",
+ "enumset",
  "forward_ref",
  "hex",
  "schemars",

--- a/contracts/burner/Cargo.lock
+++ b/contracts/burner/Cargo.lock
@@ -215,12 +215,9 @@ name = "cosmwasm-std"
 version = "1.1.5"
 dependencies = [
  "base64",
- "bitflags",
- "bytecheck",
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derivative",
- "enumset",
  "forward_ref",
  "hex",
  "schemars",
@@ -234,9 +231,12 @@ dependencies = [
 name = "cosmwasm-vm"
 version = "1.1.5"
 dependencies = [
+ "bitflags",
+ "bytecheck",
  "clru",
  "cosmwasm-crypto",
  "cosmwasm-std",
+ "enumset",
  "hex",
  "loupe",
  "parity-wasm",

--- a/contracts/burner/Cargo.toml
+++ b/contracts/burner/Cargo.toml
@@ -34,7 +34,7 @@ backtraces = ["cosmwasm-std/backtraces", "cosmwasm-vm/backtraces"]
 [dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }
 cosmwasm-std = { path = "../../packages/std", features = ["iterator"] }
-schemars = "0.8.1"
+schemars = "0.8.3"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 
 [dev-dependencies]

--- a/contracts/crypto-verify/Cargo.lock
+++ b/contracts/crypto-verify/Cargo.lock
@@ -210,12 +210,9 @@ name = "cosmwasm-std"
 version = "1.1.5"
 dependencies = [
  "base64",
- "bitflags",
- "bytecheck",
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derivative",
- "enumset",
  "forward_ref",
  "hex",
  "schemars",
@@ -237,9 +234,12 @@ dependencies = [
 name = "cosmwasm-vm"
 version = "1.1.5"
 dependencies = [
+ "bitflags",
+ "bytecheck",
  "clru",
  "cosmwasm-crypto",
  "cosmwasm-std",
+ "enumset",
  "hex",
  "loupe",
  "parity-wasm",

--- a/contracts/crypto-verify/Cargo.lock
+++ b/contracts/crypto-verify/Cargo.lock
@@ -210,9 +210,12 @@ name = "cosmwasm-std"
 version = "1.1.5"
 dependencies = [
  "base64",
+ "bitflags",
+ "bytecheck",
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derivative",
+ "enumset",
  "forward_ref",
  "hex",
  "schemars",

--- a/contracts/crypto-verify/Cargo.toml
+++ b/contracts/crypto-verify/Cargo.toml
@@ -38,7 +38,7 @@ cosmwasm-std = { path = "../../packages/std", features = ["iterator"] }
 cosmwasm-storage = { path = "../../packages/storage", features = ["iterator"] }
 hex = "0.4"
 rlp = "0.5"
-schemars = "0.8.1"
+schemars = "0.8.3"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 sha2 = "0.10"
 sha3 = "0.10"

--- a/contracts/cyberpunk/Cargo.lock
+++ b/contracts/cyberpunk/Cargo.lock
@@ -233,9 +233,12 @@ name = "cosmwasm-std"
 version = "1.1.5"
 dependencies = [
  "base64",
+ "bitflags",
+ "bytecheck",
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derivative",
+ "enumset",
  "forward_ref",
  "hex",
  "schemars",

--- a/contracts/cyberpunk/Cargo.lock
+++ b/contracts/cyberpunk/Cargo.lock
@@ -233,12 +233,9 @@ name = "cosmwasm-std"
 version = "1.1.5"
 dependencies = [
  "base64",
- "bitflags",
- "bytecheck",
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derivative",
- "enumset",
  "forward_ref",
  "hex",
  "schemars",
@@ -260,9 +257,12 @@ dependencies = [
 name = "cosmwasm-vm"
 version = "1.1.5"
 dependencies = [
+ "bitflags",
+ "bytecheck",
  "clru",
  "cosmwasm-crypto",
  "cosmwasm-std",
+ "enumset",
  "hex",
  "loupe",
  "parity-wasm",

--- a/contracts/floaty/Cargo.lock
+++ b/contracts/floaty/Cargo.lock
@@ -204,12 +204,9 @@ name = "cosmwasm-std"
 version = "1.1.5"
 dependencies = [
  "base64",
- "bitflags",
- "bytecheck",
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derivative",
- "enumset",
  "forward_ref",
  "hex",
  "schemars",
@@ -231,9 +228,12 @@ dependencies = [
 name = "cosmwasm-vm"
 version = "1.1.5"
 dependencies = [
+ "bitflags",
+ "bytecheck",
  "clru",
  "cosmwasm-crypto",
  "cosmwasm-std",
+ "enumset",
  "hex",
  "loupe",
  "parity-wasm",

--- a/contracts/floaty/Cargo.lock
+++ b/contracts/floaty/Cargo.lock
@@ -204,9 +204,12 @@ name = "cosmwasm-std"
 version = "1.1.5"
 dependencies = [
  "base64",
+ "bitflags",
+ "bytecheck",
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derivative",
+ "enumset",
  "forward_ref",
  "hex",
  "schemars",

--- a/contracts/floaty/Cargo.toml
+++ b/contracts/floaty/Cargo.toml
@@ -33,7 +33,7 @@ backtraces = ["cosmwasm-std/backtraces", "cosmwasm-vm/backtraces"]
 [dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }
 cosmwasm-std = { path = "../../packages/std" }
-schemars = "0.8.1"
+schemars = "0.8.3"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = "1.0"
 

--- a/contracts/hackatom/Cargo.lock
+++ b/contracts/hackatom/Cargo.lock
@@ -204,12 +204,9 @@ name = "cosmwasm-std"
 version = "1.1.5"
 dependencies = [
  "base64",
- "bitflags",
- "bytecheck",
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derivative",
- "enumset",
  "forward_ref",
  "hex",
  "schemars",
@@ -231,9 +228,12 @@ dependencies = [
 name = "cosmwasm-vm"
 version = "1.1.5"
 dependencies = [
+ "bitflags",
+ "bytecheck",
  "clru",
  "cosmwasm-crypto",
  "cosmwasm-std",
+ "enumset",
  "hex",
  "loupe",
  "parity-wasm",

--- a/contracts/hackatom/Cargo.lock
+++ b/contracts/hackatom/Cargo.lock
@@ -204,9 +204,12 @@ name = "cosmwasm-std"
 version = "1.1.5"
 dependencies = [
  "base64",
+ "bitflags",
+ "bytecheck",
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derivative",
+ "enumset",
  "forward_ref",
  "hex",
  "schemars",

--- a/contracts/hackatom/Cargo.toml
+++ b/contracts/hackatom/Cargo.toml
@@ -33,7 +33,7 @@ backtraces = ["cosmwasm-std/backtraces", "cosmwasm-vm/backtraces"]
 [dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }
 cosmwasm-std = { path = "../../packages/std", default-features = false, features = ["abort"] }
-schemars = "0.8.1"
+schemars = "0.8.3"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 sha2 = "0.10"
 thiserror = "1.0"

--- a/contracts/ibc-reflect-send/Cargo.lock
+++ b/contracts/ibc-reflect-send/Cargo.lock
@@ -204,12 +204,9 @@ name = "cosmwasm-std"
 version = "1.1.5"
 dependencies = [
  "base64",
- "bitflags",
- "bytecheck",
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derivative",
- "enumset",
  "forward_ref",
  "hex",
  "schemars",
@@ -231,9 +228,12 @@ dependencies = [
 name = "cosmwasm-vm"
 version = "1.1.5"
 dependencies = [
+ "bitflags",
+ "bytecheck",
  "clru",
  "cosmwasm-crypto",
  "cosmwasm-std",
+ "enumset",
  "hex",
  "loupe",
  "parity-wasm",

--- a/contracts/ibc-reflect-send/Cargo.lock
+++ b/contracts/ibc-reflect-send/Cargo.lock
@@ -204,9 +204,12 @@ name = "cosmwasm-std"
 version = "1.1.5"
 dependencies = [
  "base64",
+ "bitflags",
+ "bytecheck",
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derivative",
+ "enumset",
  "forward_ref",
  "hex",
  "schemars",

--- a/contracts/ibc-reflect-send/Cargo.toml
+++ b/contracts/ibc-reflect-send/Cargo.toml
@@ -35,7 +35,7 @@ backtraces = ["cosmwasm-std/backtraces", "cosmwasm-vm/backtraces"]
 cosmwasm-schema = { path = "../../packages/schema" }
 cosmwasm-std = { path = "../../packages/std", features = ["iterator", "staking", "stargate"] }
 cosmwasm-storage = { path = "../../packages/storage", features = ["iterator"] }
-schemars = "0.8.1"
+schemars = "0.8.3"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 
 [dev-dependencies]

--- a/contracts/ibc-reflect/Cargo.lock
+++ b/contracts/ibc-reflect/Cargo.lock
@@ -204,12 +204,9 @@ name = "cosmwasm-std"
 version = "1.1.5"
 dependencies = [
  "base64",
- "bitflags",
- "bytecheck",
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derivative",
- "enumset",
  "forward_ref",
  "hex",
  "schemars",
@@ -231,9 +228,12 @@ dependencies = [
 name = "cosmwasm-vm"
 version = "1.1.5"
 dependencies = [
+ "bitflags",
+ "bytecheck",
  "clru",
  "cosmwasm-crypto",
  "cosmwasm-std",
+ "enumset",
  "hex",
  "loupe",
  "parity-wasm",

--- a/contracts/ibc-reflect/Cargo.lock
+++ b/contracts/ibc-reflect/Cargo.lock
@@ -204,9 +204,12 @@ name = "cosmwasm-std"
 version = "1.1.5"
 dependencies = [
  "base64",
+ "bitflags",
+ "bytecheck",
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derivative",
+ "enumset",
  "forward_ref",
  "hex",
  "schemars",

--- a/contracts/ibc-reflect/Cargo.toml
+++ b/contracts/ibc-reflect/Cargo.toml
@@ -35,7 +35,7 @@ backtraces = ["cosmwasm-std/backtraces", "cosmwasm-vm/backtraces"]
 cosmwasm-schema = { path = "../../packages/schema" }
 cosmwasm-std = { path = "../../packages/std", features = ["iterator", "ibc3"] }
 cosmwasm-storage = { path = "../../packages/storage", features = ["iterator"] }
-schemars = "0.8.1"
+schemars = "0.8.3"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 
 [dev-dependencies]

--- a/contracts/queue/Cargo.lock
+++ b/contracts/queue/Cargo.lock
@@ -204,9 +204,12 @@ name = "cosmwasm-std"
 version = "1.1.5"
 dependencies = [
  "base64",
+ "bitflags",
+ "bytecheck",
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derivative",
+ "enumset",
  "forward_ref",
  "hex",
  "schemars",

--- a/contracts/queue/Cargo.lock
+++ b/contracts/queue/Cargo.lock
@@ -204,12 +204,9 @@ name = "cosmwasm-std"
 version = "1.1.5"
 dependencies = [
  "base64",
- "bitflags",
- "bytecheck",
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derivative",
- "enumset",
  "forward_ref",
  "hex",
  "schemars",
@@ -223,9 +220,12 @@ dependencies = [
 name = "cosmwasm-vm"
 version = "1.1.5"
 dependencies = [
+ "bitflags",
+ "bytecheck",
  "clru",
  "cosmwasm-crypto",
  "cosmwasm-std",
+ "enumset",
  "hex",
  "loupe",
  "parity-wasm",

--- a/contracts/queue/Cargo.toml
+++ b/contracts/queue/Cargo.toml
@@ -36,7 +36,7 @@ library = []
 [dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }
 cosmwasm-std = { path = "../../packages/std", features = ["iterator"] }
-schemars = "0.8.1"
+schemars = "0.8.3"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 
 [dev-dependencies]

--- a/contracts/reflect/Cargo.lock
+++ b/contracts/reflect/Cargo.lock
@@ -204,12 +204,9 @@ name = "cosmwasm-std"
 version = "1.1.5"
 dependencies = [
  "base64",
- "bitflags",
- "bytecheck",
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derivative",
- "enumset",
  "forward_ref",
  "hex",
  "schemars",
@@ -231,9 +228,12 @@ dependencies = [
 name = "cosmwasm-vm"
 version = "1.1.5"
 dependencies = [
+ "bitflags",
+ "bytecheck",
  "clru",
  "cosmwasm-crypto",
  "cosmwasm-std",
+ "enumset",
  "hex",
  "loupe",
  "parity-wasm",

--- a/contracts/reflect/Cargo.lock
+++ b/contracts/reflect/Cargo.lock
@@ -204,9 +204,12 @@ name = "cosmwasm-std"
 version = "1.1.5"
 dependencies = [
  "base64",
+ "bitflags",
+ "bytecheck",
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derivative",
+ "enumset",
  "forward_ref",
  "hex",
  "schemars",

--- a/contracts/reflect/Cargo.toml
+++ b/contracts/reflect/Cargo.toml
@@ -36,7 +36,7 @@ backtraces = ["cosmwasm-std/backtraces", "cosmwasm-vm/backtraces"]
 cosmwasm-schema = { path = "../../packages/schema" }
 cosmwasm-std = { path = "../../packages/std", default-features = false, features = ["staking", "stargate", "cosmwasm_1_1"] }
 cosmwasm-storage = { path = "../../packages/storage", default-features = false }
-schemars = "0.8.1"
+schemars = "0.8.3"
 serde = { version = "=1.0.103", default-features = false, features = ["derive"] }
 thiserror = "1.0"
 

--- a/contracts/staking/Cargo.lock
+++ b/contracts/staking/Cargo.lock
@@ -204,12 +204,9 @@ name = "cosmwasm-std"
 version = "1.1.5"
 dependencies = [
  "base64",
- "bitflags",
- "bytecheck",
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derivative",
- "enumset",
  "forward_ref",
  "hex",
  "schemars",
@@ -231,9 +228,12 @@ dependencies = [
 name = "cosmwasm-vm"
 version = "1.1.5"
 dependencies = [
+ "bitflags",
+ "bytecheck",
  "clru",
  "cosmwasm-crypto",
  "cosmwasm-std",
+ "enumset",
  "hex",
  "loupe",
  "parity-wasm",

--- a/contracts/staking/Cargo.lock
+++ b/contracts/staking/Cargo.lock
@@ -204,9 +204,12 @@ name = "cosmwasm-std"
 version = "1.1.5"
 dependencies = [
  "base64",
+ "bitflags",
+ "bytecheck",
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derivative",
+ "enumset",
  "forward_ref",
  "hex",
  "schemars",

--- a/contracts/staking/Cargo.toml
+++ b/contracts/staking/Cargo.toml
@@ -35,9 +35,9 @@ backtraces = ["cosmwasm-std/backtraces", "cosmwasm-vm/backtraces"]
 cosmwasm-schema = { path = "../../packages/schema" }
 cosmwasm-std = { path = "../../packages/std", default-features = false, features = ["staking"] }
 cosmwasm-storage = { path = "../../packages/storage", default-features = false }
-schemars = "0.8.1"
+schemars = "0.8.3"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-snafu = "0.6"
+snafu = "0.6.6"
 
 [dev-dependencies]
 cosmwasm-vm = { path = "../../packages/vm", default-features = false, features = ["staking"] }

--- a/devtools/build_min.sh
+++ b/devtools/build_min.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -o errexit -o nounset -o pipefail
+command -v shellcheck >/dev/null && shellcheck "$0"
+
+rm Cargo.lock
+cargo +nightly build -Zminimal-versions
+
+for contract_dir in contracts/*/; do
+  (
+    cd "$contract_dir"
+    rm Cargo.lock
+    cargo +nightly build -Zminimal-versions
+  )
+done

--- a/packages/check/Cargo.toml
+++ b/packages/check/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/CosmWasm/cosmwasm/tree/main/packages/check"
 license = "Apache-2.0"
 
 [dependencies]
-anyhow = "1"
+anyhow = "1.0.57"
 clap = "2"
 colored = "2"
 cosmwasm-vm = { path = "../vm", version = "1.1.5" }

--- a/packages/crypto/Cargo.toml
+++ b/packages/crypto/Cargo.toml
@@ -19,16 +19,16 @@ backtraces = []
 bench = false
 
 [dependencies]
-k256 = { version = "0.11", features = ["ecdsa"] }
+k256 = { version = "0.11.1", features = ["ecdsa"] }
 ed25519-zebra = "3"
 digest = "0.10"
 rand_core = { version = "0.6", features = ["getrandom"] }
-thiserror = "1.0"
+thiserror = "1.0.13"
 
 [dev-dependencies]
 criterion = "0.3"
 serde = { version = "1.0.103", default-features = false, features = ["derive", "alloc"] }
-serde_json = "1.0"
+serde_json = "1.0.40"
 sha2 = "0.10"
 base64 = "0.13.0"
 hex = "0.4"

--- a/packages/schema/Cargo.toml
+++ b/packages/schema/Cargo.toml
@@ -9,12 +9,12 @@ license = "Apache-2.0"
 
 [dependencies]
 cosmwasm-schema-derive = { version = "=1.1.5", path = "../schema-derive" }
-schemars = "0.8.1"
+schemars = "0.8.3"
 serde = "1.0"
-serde_json = "1.0"
-thiserror = "1"
+serde_json = "1.0.40"
+thiserror = "1.0.13"
 
 [dev-dependencies]
-anyhow = "1"
+anyhow = "1.0.57"
 semver = "1"
 tempfile = "3"

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -43,11 +43,17 @@ cosmwasm-derive = { path = "../derive", version = "1.1.5" }
 derivative = "2"
 forward_ref = "1"
 hex = "0.4"
-schemars = "0.8.1"
+schemars = "0.8.3"
 serde = { version = "1.0.103", default-features = false, features = ["derive", "alloc"] }
 serde-json-wasm = { version = "0.4.1" }
-thiserror = "1.0"
+thiserror = "1.0.13"
 uint = "0.9.3"
+
+# Dependencies that we do not use ourself. We add those entries
+# to bump the min version of them.
+bytecheck = "0.6.3" # With this version the simdutf8 dependency became optional
+enumset = "1.0.2" # Fixes https://github.com/Lymia/enumset/issues/17 (https://github.com/Lymia/enumset/commit/a430550cd6a3c9b1ef636d37f75dede7616f5b62)
+bitflags = "1.1.0" # https://github.com/CensoredUsername/dynasm-rs/pull/74
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 cosmwasm-crypto = { path = "../crypto", version = "1.1.5" }

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -49,12 +49,6 @@ serde-json-wasm = { version = "0.4.1" }
 thiserror = "1.0.13"
 uint = "0.9.3"
 
-# Dependencies that we do not use ourself. We add those entries
-# to bump the min version of them.
-bytecheck = "0.6.3" # With this version the simdutf8 dependency became optional
-enumset = "1.0.2" # Fixes https://github.com/Lymia/enumset/issues/17 (https://github.com/Lymia/enumset/commit/a430550cd6a3c9b1ef636d37f75dede7616f5b62)
-bitflags = "1.1.0" # https://github.com/CensoredUsername/dynasm-rs/pull/74
-
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 cosmwasm-crypto = { path = "../crypto", version = "1.1.5" }
 

--- a/packages/vm/Cargo.toml
+++ b/packages/vm/Cargo.toml
@@ -45,11 +45,11 @@ cosmwasm-std = { path = "../std", version = "1.1.5", default-features = false }
 cosmwasm-crypto = { path = "../crypto", version = "1.1.5" }
 hex = "0.4"
 parity-wasm = "0.42"
-schemars = "0.8.1"
+schemars = "0.8.3"
 serde = { version = "1.0.103", default-features = false, features = ["derive", "alloc"] }
-serde_json = "1.0"
+serde_json = "1.0.40"
 sha2 = "0.10.3"
-thiserror = "1.0"
+thiserror = "1.0.13"
 wasmer = { version = "=2.3.0", default-features = false, features = ["cranelift", "universal", "singlepass"] }
 wasmer-middlewares = "=2.3.0"
 loupe = "0.1.3"

--- a/packages/vm/Cargo.toml
+++ b/packages/vm/Cargo.toml
@@ -54,6 +54,12 @@ wasmer = { version = "=2.3.0", default-features = false, features = ["cranelift"
 wasmer-middlewares = "=2.3.0"
 loupe = "0.1.3"
 
+# Dependencies that we do not use ourself. We add those entries
+# to bump the min version of them.
+bytecheck = "0.6.3" # With this version the simdutf8 dependency became optional
+enumset = "1.0.2" # Fixes https://github.com/Lymia/enumset/issues/17 (https://github.com/Lymia/enumset/commit/a430550cd6a3c9b1ef636d37f75dede7616f5b62)
+bitflags = "1.1.0" # https://github.com/CensoredUsername/dynasm-rs/pull/74
+
 # Wasmer git/local (used for quick local debugging or patching)
 # wasmer = { git = "https://github.com/wasmerio/wasmer", rev = "877ce1f7c44fad853c", default-features = false, features = ["cranelift", "universal", "singlepass"] }
 # wasmer-middlewares = { git = "https://github.com/wasmerio/wasmer", rev = "877ce1f7c44fad853c" }


### PR DESCRIPTION
With this change I the new `devtools/build_min.sh` passes