### PR TITLE
QueryResponses: infer the JsonSchema trait bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to
   `CanonicalAddr` ([#1463]).
 - cosmwasm-std: Implement `PartialEq` between `CanonicalAddr` and
   `HexBinary`/`Binary` ([#1463]).
+- cosmwasm-schema: `QueryResponses`
 
 [#1463]: https://github.com/CosmWasm/cosmwasm/pull/1463
 
@@ -25,6 +26,9 @@ and this project adheres to
   cannot properly measure different runtimes for differet Wasm opcodes.
 - cosmwasm-schema: schema generation is now locked to produce strictly
   `draft-07` schemas
+- cosmwasm-schema: `QueryResponses` derive now sets the `JsonSchema` trait bound
+  on the generated `impl` block. This allows the contract dev to not add a
+  `JsonSchema` trait bound on the type itself.
 
 [#1465]: https://github.com/CosmWasm/cosmwasm/pull/1465
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ and this project adheres to
   `CanonicalAddr` ([#1463]).
 - cosmwasm-std: Implement `PartialEq` between `CanonicalAddr` and
   `HexBinary`/`Binary` ([#1463]).
-- cosmwasm-schema: `QueryResponses`
 
 [#1463]: https://github.com/CosmWasm/cosmwasm/pull/1463
 

--- a/packages/schema-derive/src/query_responses.rs
+++ b/packages/schema-derive/src/query_responses.rs
@@ -65,15 +65,14 @@ fn get_context(input: &ItemEnum) -> Context {
     let params = input
         .attrs
         .iter()
-        .filter(|attr| matches!(attr.path.get_ident(), Some(id) if id.to_string() == ATTR_PATH))
-        .map(|attr| {
+        .filter(|attr| matches!(attr.path.get_ident(), Some(id) if *id == ATTR_PATH))
+        .flat_map(|attr| {
             if let Meta::List(l) = attr.parse_meta().unwrap() {
                 l.nested
             } else {
                 panic!("{} attribute must contain a meta list", ATTR_PATH);
             }
         })
-        .flatten()
         .map(|nested_meta| {
             if let NestedMeta::Meta(m) = nested_meta {
                 m

--- a/packages/schema-derive/src/query_responses/context.rs
+++ b/packages/schema-derive/src/query_responses/context.rs
@@ -1,0 +1,63 @@
+use std::collections::HashSet;
+
+use syn::{Ident, ItemEnum, Meta, NestedMeta};
+
+const ATTR_PATH: &str = "query_responses";
+
+pub struct Context {
+    /// If the enum we're trying to derive QueryResponses for collects other QueryMsgs,
+    /// setting this flag will derive the implementation appropriately, collecting all
+    /// KV pairs from the nested enums rather than expecting `#[return]` annotations.
+    pub is_nested: bool,
+    /// Disable infering the `JsonSchema` trait bound for chosen type parameters.
+    pub no_bounds_for: HashSet<Ident>,
+}
+
+pub fn get_context(input: &ItemEnum) -> Context {
+    let params = input
+        .attrs
+        .iter()
+        .filter(|attr| matches!(attr.path.get_ident(), Some(id) if *id == ATTR_PATH))
+        .flat_map(|attr| {
+            if let Meta::List(l) = attr.parse_meta().unwrap() {
+                l.nested
+            } else {
+                panic!("{} attribute must contain a meta list", ATTR_PATH);
+            }
+        })
+        .map(|nested_meta| {
+            if let NestedMeta::Meta(m) = nested_meta {
+                m
+            } else {
+                panic!("no literals allowed in QueryResponses params")
+            }
+        });
+
+    let mut ctx = Context {
+        is_nested: false,
+        no_bounds_for: HashSet::new(),
+    };
+
+    for param in params {
+        match param.path().get_ident().unwrap().to_string().as_str() {
+            "no_bounds_for" => {
+                if let Meta::List(l) = param {
+                    for item in l.nested {
+                        match item {
+                            NestedMeta::Meta(Meta::Path(p)) => {
+                                ctx.no_bounds_for.insert(p.get_ident().unwrap().clone());
+                            }
+                            _ => panic!("`no_bounds_for` only accepts a list of type params"),
+                        }
+                    }
+                } else {
+                    panic!("expected a list for `no_bounds_for`")
+                }
+            }
+            "nested" => ctx.is_nested = true,
+            path => panic!("unrecognized QueryResponses param: {}", path),
+        }
+    }
+
+    ctx
+}

--- a/packages/schema/src/query_response.rs
+++ b/packages/schema/src/query_response.rs
@@ -13,7 +13,7 @@ pub use cosmwasm_schema_derive::QueryResponses;
 ///
 /// Using the derive macro is the preferred way of implementing this trait.
 ///
-/// # Example
+/// # Examples
 /// ```
 /// use cosmwasm_schema::QueryResponses;
 /// use schemars::JsonSchema;
@@ -30,20 +30,40 @@ pub use cosmwasm_schema_derive::QueryResponses;
 ///     #[returns(AccountInfo)]
 ///     AccountInfo { account: String },
 /// }
+/// ```
 ///
-/// // You can also compose multiple queries using #[query_responses(nested)]:
+/// You can compose multiple queries using `#[query_responses(nested)]`. This might be useful
+/// together with `#[serde(untagged)]`. If the `nested` flag is set, no `returns` attributes
+/// are necessary on the enum variants. Instead, the response types are collected from the
+/// nested enums.
+///
+/// ```
+/// # use cosmwasm_schema::QueryResponses;
+/// # use schemars::JsonSchema;
 /// #[derive(JsonSchema, QueryResponses)]
 /// #[query_responses(nested)]
 /// #[serde(untagged)]
-/// enum QueryMsg2 {
-///     MsgA(QueryMsg),
+/// enum QueryMsg {
+///     MsgA(QueryA),
 ///     MsgB(QueryB),
 /// }
+///
+/// #[derive(JsonSchema, QueryResponses)]
+/// enum QueryA {
+///     #[returns(Vec<String>)]
+///     Denoms {},
+/// }
+///
 /// #[derive(JsonSchema, QueryResponses)]
 /// enum QueryB {
 ///     #[returns(AccountInfo)]
 ///     AccountInfo { account: String },
 /// }
+///
+/// # #[derive(JsonSchema)]
+/// # struct AccountInfo {
+/// #     IcqHandle: String,
+/// # }
 /// ```
 pub trait QueryResponses: JsonSchema {
     fn response_schemas() -> Result<BTreeMap<String, RootSchema>, IntegrityError> {

--- a/packages/schema/tests/idl.rs
+++ b/packages/schema/tests/idl.rs
@@ -109,10 +109,7 @@ fn test_query_responses() {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema, QueryResponses)]
 #[serde(rename_all = "snake_case")]
-pub enum QueryMsgWithGenerics<T: std::fmt::Debug>
-where
-    T: JsonSchema,
-{
+pub enum QueryMsgWithGenerics<T: std::fmt::Debug> {
     #[returns(u128)]
     QueryData { data: T },
 }

--- a/packages/schema/tests/idl.rs
+++ b/packages/schema/tests/idl.rs
@@ -109,7 +109,17 @@ fn test_query_responses() {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema, QueryResponses)]
 #[serde(rename_all = "snake_case")]
-pub enum QueryMsgWithGenerics<T: std::fmt::Debug> {
+pub enum QueryMsgWithGenerics<T> {
+    #[returns(u128)]
+    QueryData { data: T },
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema, QueryResponses)]
+#[serde(rename_all = "snake_case")]
+pub enum QueryMsgWithGenericsAndTraitBounds<T: std::fmt::Debug>
+where
+    T: PartialEq,
+{
     #[returns(u128)]
     QueryData { data: T },
 }
@@ -119,6 +129,36 @@ fn test_query_responses_generics() {
     let api_str = generate_api! {
         instantiate: InstantiateMsg,
         query: QueryMsgWithGenerics<u32>,
+    }
+    .render()
+    .to_string()
+    .unwrap();
+
+    let api: Value = serde_json::from_str(&api_str).unwrap();
+    let queries = api
+        .get("query")
+        .unwrap()
+        .get("oneOf")
+        .unwrap()
+        .as_array()
+        .unwrap();
+
+    // Find the "query_data" query in the queries schema
+    assert_eq!(queries.len(), 1);
+    assert_eq!(
+        queries[0].get("required").unwrap().get(0).unwrap(),
+        "query_data"
+    );
+
+    // Find the "query_data" query in responses
+    api.get("responses").unwrap().get("query_data").unwrap();
+}
+
+#[test]
+fn test_query_responses_generics_and_trait_bounds() {
+    let api_str = generate_api! {
+        instantiate: InstantiateMsg,
+        query: QueryMsgWithGenericsAndTraitBounds<u32>,
     }
     .render()
     .to_string()


### PR DESCRIPTION
Closes #1471

TODO:
- [x] ~~Probably follow the `serde` pattern of accepting `bounds = "T: ..."` rather than removing all bounds with `no_bounds_for`~~ not sure there's really a use case
- [x] Refactor
- [x] ~~See if it's possible to come up with a sensible test for disabling trait bound inference~~couldn't manage to get one, `JsonSchema` tends to get in the way