### PR TITLE
Lock JSON schema version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to
   `-Zminimal-versions` ([#1465]).
 - cosmwasm-profiler: Package was removed 🪦. It served its job showing us that we
   cannot properly measure different runtimes for differet Wasm opcodes.
+- cosmwasm-schema: schema generation is now locked to produce strictly
+  `draft-07` schemas
 
 [#1465]: https://github.com/CosmWasm/cosmwasm/pull/1465
 

--- a/packages/schema/src/lib.rs
+++ b/packages/schema/src/lib.rs
@@ -3,6 +3,7 @@ mod export;
 mod idl;
 mod query_response;
 mod remove;
+mod schema_for;
 
 pub use export::{export_schema, export_schema_with_title};
 pub use idl::{Api, IDL_VERSION};
@@ -91,7 +92,6 @@ pub use cosmwasm_schema_derive::generate_api;
 /// };
 /// ```
 pub use cosmwasm_schema_derive::write_api;
-pub use schemars::schema_for;
 
 // For use in macro expansions
 pub use schemars;

--- a/packages/schema/src/schema_for.rs
+++ b/packages/schema/src/schema_for.rs
@@ -6,7 +6,8 @@
 ///
 /// # Example
 /// ```
-/// use schemars::{schema_for, JsonSchema};
+/// use cosmwasm_schema::schema_for;
+/// use schemars::JsonSchema;
 ///
 /// #[derive(JsonSchema)]
 /// struct MyStruct {

--- a/packages/schema/src/schema_for.rs
+++ b/packages/schema/src/schema_for.rs
@@ -1,9 +1,26 @@
+/// Generates a [`RootSchema`](crate::schemars::schema::RootSchema) for the given type using default settings.
+///
+/// The type must implement [`JsonSchema`](crate::schemars::JsonSchema).
+///
+/// The schema version is strictly `draft-07`.
+///
+/// # Example
+/// ```
+/// use schemars::{schema_for, JsonSchema};
+///
+/// #[derive(JsonSchema)]
+/// struct MyStruct {
+///     foo: i32,
+/// }
+///
+/// let my_schema = schema_for!(MyStruct);
+/// ```
 #[macro_export]
 macro_rules! schema_for {
     ($type:ty) => {
         $crate::schemars::gen::SchemaGenerator::new($crate::schemars::gen::SchemaSettings::draft07()).into_root_schema_for::<$type>()
     };
     ($_:expr) => {
-        compile_error!("This argument to `schema_for!` is not a type - did you mean to use `schema_for_value!` instead?")
+        compile_error!("The argument to `schema_for!` is not a type.")
     };
 }

--- a/packages/schema/src/schema_for.rs
+++ b/packages/schema/src/schema_for.rs
@@ -1,0 +1,9 @@
+#[macro_export]
+macro_rules! schema_for {
+    ($type:ty) => {
+        $crate::schemars::gen::SchemaGenerator::new($crate::schemars::gen::SchemaSettings::draft07()).into_root_schema_for::<$type>()
+    };
+    ($_:expr) => {
+        compile_error!("This argument to `schema_for!` is not a type - did you mean to use `schema_for_value!` instead?")
+    };
+}


### PR DESCRIPTION
So the schemas we generate are [`draft07`](https://github.com/CosmWasm/cosmwasm/blob/main/contracts/hackatom/schema/hackatom.json#L6) schemas. That's what `schemars` does right now, but it's bound to change in the future. This PR "locks" the version.