### PR TITLE
Document type of gas that is used for gas limits

### DIFF
--- a/contracts/reflect/schema/reflect.json
+++ b/contracts/reflect/schema/reflect.json
@@ -638,6 +638,7 @@
         ],
         "properties": {
           "gas_limit": {
+            "description": "Gas limit measured in [Cosmos SDK gas](https://github.com/CosmWasm/cosmwasm/blob/main/docs/GAS.md).",
             "type": [
               "integer",
               "null"

--- a/packages/std/src/results/submessages.rs
+++ b/packages/std/src/results/submessages.rs
@@ -33,6 +33,7 @@ pub struct SubMsg<T = Empty> {
     /// This is typically used to match `Reply`s in the `reply` entry point to the submessage.
     pub id: u64,
     pub msg: CosmosMsg<T>,
+    /// Gas limit measured in [Cosmos SDK gas](https://github.com/CosmWasm/cosmwasm/blob/main/docs/GAS.md).
     pub gas_limit: Option<u64>,
     pub reply_on: ReplyOn,
 }
@@ -67,6 +68,7 @@ impl<T> SubMsg<T> {
     }
 
     /// Add a gas limit to the message.
+    /// This gas limit measured in [Cosmos SDK gas](https://github.com/CosmWasm/cosmwasm/blob/main/docs/GAS.md).
     ///
     /// ## Examples
     ///

--- a/packages/vm/src/environment.rs
+++ b/packages/vm/src/environment.rs
@@ -56,6 +56,8 @@ impl Default for GasConfig {
 pub struct GasState {
     /// Gas limit for the computation, including internally and externally used gas.
     /// This is set when the Environment is created and never mutated.
+    ///
+    /// Measured in [CosmWasm gas](https://github.com/CosmWasm/cosmwasm/blob/main/docs/GAS.md).
     pub gas_limit: u64,
     /// Tracking the gas used in the Cosmos SDK, in CosmWasm gas units.
     pub externally_used_gas: u64,

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -35,6 +35,7 @@ pub struct GasReport {
 
 #[derive(Copy, Clone, Debug)]
 pub struct InstanceOptions {
+    /// Gas limit measured in [CosmWasm gas](https://github.com/CosmWasm/cosmwasm/blob/main/docs/GAS.md).
     pub gas_limit: u64,
     pub print_debug: bool,
 }

--- a/packages/vm/src/testing/instance.rs
+++ b/packages/vm/src/testing/instance.rs
@@ -62,6 +62,8 @@ pub fn mock_instance_with_balances(
     )
 }
 
+/// Creates an instance from the given Wasm bytecode.
+/// The gas limit is measured in [CosmWasm gas](https://github.com/CosmWasm/cosmwasm/blob/main/docs/GAS.md).
 pub fn mock_instance_with_gas_limit(
     wasm: &[u8],
     gas_limit: u64,
@@ -86,6 +88,7 @@ pub struct MockInstanceOptions<'a> {
 
     // instance
     pub available_capabilities: HashSet<String>,
+    /// Gas limit measured in [CosmWasm gas](https://github.com/CosmWasm/cosmwasm/blob/main/docs/GAS.md).
     pub gas_limit: u64,
     pub print_debug: bool,
     /// Memory limit in bytes. Use a value that is divisible by the Wasm page size 65536, e.g. full MiBs.


### PR DESCRIPTION
SubMsg uses Cosmos SDK gas and instances use CosmWasm gas