### PR TITLE
Use resolver version 2 in workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,7 @@
 [workspace]
 members = ["packages/*"]
 exclude = ["contracts"]
+
+# Resolver has to be set explicitely in workspaces
+# due to https://github.com/rust-lang/cargo/issues/9956
+resolver = "2"


### PR DESCRIPTION
In most other packages this is used automatically by setting edition to 2021.

Needed for https://github.com/CosmWasm/cosmwasm/pull/1483 but useful often when compiling various dependencies to the Wasm target.