### PR TITLE
QueryResponses: no default type in gen'd impl block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,8 @@ and this project adheres to
 
 - all: Bump a few dependency versions to make the codebase compile with
   `-Zminimal-versions` ([#1465]).
-- cosmwasm-profiler: Package was removed 🪦. It served its job showing us that
-  we cannot properly measure different runtimes for differet Wasm opcodes.
+- cosmwasm-profiler: Package was removed 🪦. It served its job showing us that we
+  cannot properly measure different runtimes for differet Wasm opcodes.
 - cosmwasm-schema: schema generation is now locked to produce strictly
   `draft-07` schemas
 - cosmwasm-schema: `QueryResponses` derive now sets the `JsonSchema` trait bound

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- cosmwasm-schema: Fix type params on `QueryMsg` causing a compiler error when
+  used with the `QueryResponses` derive macro.
+
 ## [1.1.6] - 2022-11-16
 
 ### Added
@@ -23,8 +28,8 @@ and this project adheres to
 
 - all: Bump a few dependency versions to make the codebase compile with
   `-Zminimal-versions` ([#1465]).
-- cosmwasm-profiler: Package was removed 🪦. It served its job showing us that we
-  cannot properly measure different runtimes for differet Wasm opcodes.
+- cosmwasm-profiler: Package was removed 🪦. It served its job showing us that
+  we cannot properly measure different runtimes for differet Wasm opcodes.
 - cosmwasm-schema: schema generation is now locked to produce strictly
   `draft-07` schemas
 - cosmwasm-schema: `QueryResponses` derive now sets the `JsonSchema` trait bound

--- a/packages/schema-derive/src/query_responses.rs
+++ b/packages/schema-derive/src/query_responses.rs
@@ -58,6 +58,10 @@ pub fn query_responses_derive_impl(input: ItemEnum) -> ItemImpl {
 fn impl_generics(ctx: &Context, generics: &Generics) -> Generics {
     let mut impl_generics = generics.to_owned();
     for param in impl_generics.type_params_mut() {
+        // remove the default type if present, as those are invalid in
+        // a trait implementation
+        param.default = None;
+
         if !ctx.no_bounds_for.contains(&param.ident) {
             param
                 .bounds

--- a/packages/schema/tests/idl.rs
+++ b/packages/schema/tests/idl.rs
@@ -124,6 +124,13 @@ where
     QueryData { data: T },
 }
 
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema, QueryResponses)]
+#[serde(rename_all = "snake_case")]
+pub enum QueryMsgWithGenericsAndDefaultType<T = u128> {
+    #[returns(u128)]
+    QueryData { data: T },
+}
+
 #[test]
 fn test_query_responses_generics() {
     let api_str = generate_api! {


### PR DESCRIPTION
Closes #1504

Once this is merged, I'll release 1.1.7 off of the `1.1` branch as discussed before, and then yank `1.1.6`