### PR TITLE
Port #1505 to `main`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@ and this project adheres to
 
 [#1406]: https://github.com/CosmWasm/cosmwasm/pull/1406
 
+## [1.1.8] - 2022-11-22
+
+### Fixed
+
+- cosmwasm-schema: Fix type params on `QueryMsg` causing a compiler error when
+  used with the `QueryResponses` derive macro.
+
 ## [1.1.6] - 2022-11-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,8 +53,8 @@ and this project adheres to
 
 - all: Bump a few dependency versions to make the codebase compile with
   `-Zminimal-versions` ([#1465]).
-- cosmwasm-profiler: Package was removed 🪦. It served its job showing us that we
-  cannot properly measure different runtimes for differet Wasm opcodes.
+- cosmwasm-profiler: Package was removed 🪦. It served its job showing us that
+  we cannot properly measure different runtimes for differet Wasm opcodes.
 - cosmwasm-schema: schema generation is now locked to produce strictly
   `draft-07` schemas
 - cosmwasm-schema: `QueryResponses` derive now sets the `JsonSchema` trait bound

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,8 +53,8 @@ and this project adheres to
 
 - all: Bump a few dependency versions to make the codebase compile with
   `-Zminimal-versions` ([#1465]).
-- cosmwasm-profiler: Package was removed 🪦. It served its job showing us that
-  we cannot properly measure different runtimes for differet Wasm opcodes.
+- cosmwasm-profiler: Package was removed 🪦. It served its job showing us that we
+  cannot properly measure different runtimes for differet Wasm opcodes.
 - cosmwasm-schema: schema generation is now locked to produce strictly
   `draft-07` schemas
 - cosmwasm-schema: `QueryResponses` derive now sets the `JsonSchema` trait bound

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-check"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "anyhow",
  "clap",
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "base64",
  "criterion",
@@ -276,7 +276,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "cosmwasm-std",
  "syn",
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "anyhow",
  "cosmwasm-schema-derive",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -307,7 +307,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "base64",
  "chrono",
@@ -329,7 +329,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "bitflags",
  "bytecheck",

--- a/contracts/burner/Cargo.lock
+++ b/contracts/burner/Cargo.lock
@@ -174,7 +174,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "digest 0.10.3",
  "ed25519-zebra",
@@ -185,14 +185,14 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "syn",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "cosmwasm-schema-derive",
  "schemars",
@@ -203,7 +203,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "bitflags",
  "bytecheck",

--- a/contracts/crypto-verify/Cargo.lock
+++ b/contracts/crypto-verify/Cargo.lock
@@ -169,7 +169,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "digest 0.10.3",
  "ed25519-zebra",
@@ -180,14 +180,14 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "syn",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "cosmwasm-schema-derive",
  "schemars",
@@ -198,7 +198,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -233,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "bitflags",
  "bytecheck",

--- a/contracts/cyberpunk/Cargo.lock
+++ b/contracts/cyberpunk/Cargo.lock
@@ -192,7 +192,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "digest 0.10.3",
  "ed25519-zebra",
@@ -203,14 +203,14 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "syn",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "cosmwasm-schema-derive",
  "schemars",
@@ -221,7 +221,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
@@ -248,7 +248,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -256,7 +256,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "bitflags",
  "bytecheck",

--- a/contracts/floaty/Cargo.lock
+++ b/contracts/floaty/Cargo.lock
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "digest 0.10.3",
  "ed25519-zebra",
@@ -174,14 +174,14 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "syn",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "cosmwasm-schema-derive",
  "schemars",
@@ -192,7 +192,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "bitflags",
  "bytecheck",

--- a/contracts/hackatom/Cargo.lock
+++ b/contracts/hackatom/Cargo.lock
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "digest 0.10.3",
  "ed25519-zebra",
@@ -174,14 +174,14 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "syn",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "cosmwasm-schema-derive",
  "schemars",
@@ -192,7 +192,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "bitflags",
  "bytecheck",

--- a/contracts/ibc-reflect-send/Cargo.lock
+++ b/contracts/ibc-reflect-send/Cargo.lock
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "digest 0.10.3",
  "ed25519-zebra",
@@ -174,14 +174,14 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "syn",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "cosmwasm-schema-derive",
  "schemars",
@@ -192,7 +192,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "bitflags",
  "bytecheck",

--- a/contracts/ibc-reflect/Cargo.lock
+++ b/contracts/ibc-reflect/Cargo.lock
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "digest 0.10.3",
  "ed25519-zebra",
@@ -174,14 +174,14 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "syn",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "cosmwasm-schema-derive",
  "schemars",
@@ -192,7 +192,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "bitflags",
  "bytecheck",

--- a/contracts/queue/Cargo.lock
+++ b/contracts/queue/Cargo.lock
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "digest 0.10.3",
  "ed25519-zebra",
@@ -174,14 +174,14 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "syn",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "cosmwasm-schema-derive",
  "schemars",
@@ -192,7 +192,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "bitflags",
  "bytecheck",

--- a/contracts/reflect/Cargo.lock
+++ b/contracts/reflect/Cargo.lock
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "digest 0.10.3",
  "ed25519-zebra",
@@ -174,14 +174,14 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "syn",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "cosmwasm-schema-derive",
  "schemars",
@@ -192,7 +192,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "bitflags",
  "bytecheck",

--- a/contracts/staking/Cargo.lock
+++ b/contracts/staking/Cargo.lock
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "digest 0.10.3",
  "ed25519-zebra",
@@ -174,14 +174,14 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "syn",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "cosmwasm-schema-derive",
  "schemars",
@@ -192,7 +192,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "bitflags",
  "bytecheck",

--- a/packages/check/Cargo.toml
+++ b/packages/check/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmwasm-check"
-version = "1.1.6"
+version = "1.1.8"
 authors = ["Mauro Lacy <mauro@lacy.com.es>"]
 edition = "2021"
 description = "A CLI tool for verifying CosmWasm smart contracts"
@@ -11,5 +11,5 @@ license = "Apache-2.0"
 anyhow = "1.0.57"
 clap = "2"
 colored = "2"
-cosmwasm-vm = { path = "../vm", version = "1.1.6" }
-cosmwasm-std = { path = "../std", version = "1.1.6" }
+cosmwasm-vm = { path = "../vm", version = "1.1.8" }
+cosmwasm-std = { path = "../std", version = "1.1.8" }

--- a/packages/crypto/Cargo.toml
+++ b/packages/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmwasm-crypto"
-version = "1.1.6"
+version = "1.1.8"
 authors = ["Mauro Lacy <maurolacy@users.noreply.github.com>"]
 edition = "2021"
 description = "Crypto bindings for cosmwasm contracts"

--- a/packages/derive/Cargo.toml
+++ b/packages/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmwasm-derive"
-version = "1.1.6"
+version = "1.1.8"
 authors = ["Simon Warta <webmaster128@users.noreply.github.com>"]
 edition = "2021"
 description = "A package for auto-generated code used for CosmWasm contract development. This is shipped as part of cosmwasm-std. Do not use directly."

--- a/packages/schema-derive/Cargo.toml
+++ b/packages/schema-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmwasm-schema-derive"
-version = "1.1.6"
+version = "1.1.8"
 authors = ["Tomasz Kurcz <tom@confio.gmbh>"]
 edition = "2021"
 description = "Derive macros for cosmwasm-schema"

--- a/packages/schema-derive/src/query_responses.rs
+++ b/packages/schema-derive/src/query_responses.rs
@@ -58,6 +58,10 @@ pub fn query_responses_derive_impl(input: ItemEnum) -> ItemImpl {
 fn impl_generics(ctx: &Context, generics: &Generics) -> Generics {
     let mut impl_generics = generics.to_owned();
     for param in impl_generics.type_params_mut() {
+        // remove the default type if present, as those are invalid in
+        // a trait implementation
+        param.default = None;
+
         if !ctx.no_bounds_for.contains(&param.ident) {
             param
                 .bounds

--- a/packages/schema/Cargo.toml
+++ b/packages/schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmwasm-schema"
-version = "1.1.6"
+version = "1.1.8"
 authors = ["Simon Warta <webmaster128@users.noreply.github.com>", "Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2021"
 description = "A dev-dependency for CosmWasm contracts to generate JSON Schema files."
@@ -8,7 +8,7 @@ repository = "https://github.com/CosmWasm/cosmwasm/tree/main/packages/schema"
 license = "Apache-2.0"
 
 [dependencies]
-cosmwasm-schema-derive = { version = "=1.1.6", path = "../schema-derive" }
+cosmwasm-schema-derive = { version = "=1.1.8", path = "../schema-derive" }
 schemars = "0.8.3"
 serde = "1.0"
 serde_json = "1.0.40"

--- a/packages/schema/tests/idl.rs
+++ b/packages/schema/tests/idl.rs
@@ -124,6 +124,13 @@ where
     QueryData { data: T },
 }
 
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema, QueryResponses)]
+#[serde(rename_all = "snake_case")]
+pub enum QueryMsgWithGenericsAndDefaultType<T = u128> {
+    #[returns(u128)]
+    QueryData { data: T },
+}
+
 #[test]
 fn test_query_responses_generics() {
     let api_str = generate_api! {

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmwasm-std"
-version = "1.1.6"
+version = "1.1.8"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2021"
 description = "Standard library for Wasm based smart contracts on Cosmos blockchains"
@@ -42,7 +42,7 @@ cosmwasm_1_2 = []
 
 [dependencies]
 base64 = "0.13.0"
-cosmwasm-derive = { path = "../derive", version = "1.1.6" }
+cosmwasm-derive = { path = "../derive", version = "1.1.8" }
 derivative = "2"
 forward_ref = "1"
 hex = "0.4"
@@ -54,7 +54,7 @@ thiserror = "1.0.13"
 uint = "0.9.3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-cosmwasm-crypto = { path = "../crypto", version = "1.1.6" }
+cosmwasm-crypto = { path = "../crypto", version = "1.1.8" }
 
 [dev-dependencies]
 cosmwasm-schema = { path = "../schema" }

--- a/packages/storage/Cargo.toml
+++ b/packages/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmwasm-storage"
-version = "1.1.6"
+version = "1.1.8"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2021"
 description = "CosmWasm library with useful helpers for Storage patterns"
@@ -16,5 +16,5 @@ iterator = ["cosmwasm-std/iterator"]
 
 [dependencies]
 # Uses the path when built locally; uses the given version from crates.io when published
-cosmwasm-std = { path = "../std", version = "1.1.6", default-features = false }
+cosmwasm-std = { path = "../std", version = "1.1.8", default-features = false }
 serde = { version = "1.0.103", default-features = false, features = ["derive", "alloc"] }

--- a/packages/vm/Cargo.toml
+++ b/packages/vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmwasm-vm"
-version = "1.1.6"
+version = "1.1.8"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2021"
 description = "VM bindings to run cosmwams contracts"
@@ -41,8 +41,8 @@ required-features = ["iterator"]
 [dependencies]
 clru = "0.4.0"
 # Uses the path when built locally; uses the given version from crates.io when published
-cosmwasm-std = { path = "../std", version = "1.1.6", default-features = false }
-cosmwasm-crypto = { path = "../crypto", version = "1.1.6" }
+cosmwasm-std = { path = "../std", version = "1.1.8", default-features = false }
+cosmwasm-crypto = { path = "../crypto", version = "1.1.8" }
 hex = "0.4"
 parity-wasm = "0.42"
 schemars = "0.8.3"


### PR DESCRIPTION
Closes #1504

#1505 was for the `1.1` release. This reapplies the patch to `main`.

I accidentally released 1.1.7 without the patch, so I bumped it again, hence the 1.1.8 version number.