### PR TITLE
Add Never type to avoid ibc_packet_receive errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to
 - cosmwasm-std: Implement `AsRef<[u8]>` for `Binary` and `HexBinary` ([#1550]).
 - cosmwasm-std: Allow constructing `SupplyResponse` via a `Default`
   implementation ([#1552], [#1560]).
+- cosmwasm-std: Add `Never` type which cannot be instantiated. This can be used
+  as the error type for the `ibc_packet_receive` to gain confidence that the
+  implementations never errors and the transaction does not get reverted.
 
 [#1436]: https://github.com/CosmWasm/cosmwasm/issues/1436
 [#1437]: https://github.com/CosmWasm/cosmwasm/issues/1437

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,13 +26,15 @@ and this project adheres to
 - cosmwasm-std: Allow constructing `SupplyResponse` via a `Default`
   implementation ([#1552], [#1560]).
 - cosmwasm-std: Add `Never` type which cannot be instantiated. This can be used
-  as the error type for the `ibc_packet_receive` to gain confidence that the
-  implementations never errors and the transaction does not get reverted.
+  as the error type for `ibc_packet_receive` or `ibc_packet_ack` to gain
+  confidence that the implementations never errors and the transaction does not
+  get reverted. ([#1513])
 
 [#1436]: https://github.com/CosmWasm/cosmwasm/issues/1436
 [#1437]: https://github.com/CosmWasm/cosmwasm/issues/1437
 [#1481]: https://github.com/CosmWasm/cosmwasm/pull/1481
 [#1478]: https://github.com/CosmWasm/cosmwasm/pull/1478
+[#1513]: https://github.com/CosmWasm/cosmwasm/pull/1513
 [#1533]: https://github.com/CosmWasm/cosmwasm/pull/1533
 [#1550]: https://github.com/CosmWasm/cosmwasm/issues/1550
 [#1552]: https://github.com/CosmWasm/cosmwasm/pull/1552

--- a/contracts/ibc-reflect-send/src/ibc.rs
+++ b/contracts/ibc-reflect-send/src/ibc.rs
@@ -1,7 +1,7 @@
 use cosmwasm_std::{
     entry_point, from_slice, to_binary, DepsMut, Env, IbcBasicResponse, IbcChannelCloseMsg,
     IbcChannelConnectMsg, IbcChannelOpenMsg, IbcMsg, IbcOrder, IbcPacketAckMsg,
-    IbcPacketReceiveMsg, IbcPacketTimeoutMsg, IbcReceiveResponse, StdError, StdResult,
+    IbcPacketReceiveMsg, IbcPacketTimeoutMsg, IbcReceiveResponse, Never, StdError, StdResult,
 };
 
 use crate::ibc_msg::{
@@ -95,7 +95,7 @@ pub fn ibc_packet_receive(
     _deps: DepsMut,
     _env: Env,
     _packet: IbcPacketReceiveMsg,
-) -> StdResult<IbcReceiveResponse> {
+) -> Result<IbcReceiveResponse, Never> {
     Ok(IbcReceiveResponse::new()
         .set_ack(b"{}")
         .add_attribute("action", "ibc_packet_ack"))

--- a/contracts/ibc-reflect/src/contract.rs
+++ b/contracts/ibc-reflect/src/contract.rs
@@ -2,7 +2,7 @@ use cosmwasm_std::{
     entry_point, from_slice, to_binary, wasm_execute, BankMsg, Binary, CosmosMsg, Deps, DepsMut,
     Empty, Env, Event, Ibc3ChannelOpenResponse, IbcBasicResponse, IbcChannelCloseMsg,
     IbcChannelConnectMsg, IbcChannelOpenMsg, IbcChannelOpenResponse, IbcOrder, IbcPacketAckMsg,
-    IbcPacketReceiveMsg, IbcPacketTimeoutMsg, IbcReceiveResponse, MessageInfo, Order,
+    IbcPacketReceiveMsg, IbcPacketTimeoutMsg, IbcReceiveResponse, MessageInfo, Never, Order,
     QueryResponse, Reply, Response, StdError, StdResult, SubMsg, SubMsgResponse, SubMsgResult,
     WasmMsg,
 };
@@ -233,7 +233,7 @@ pub fn ibc_packet_receive(
     deps: DepsMut,
     _env: Env,
     msg: IbcPacketReceiveMsg,
-) -> StdResult<IbcReceiveResponse> {
+) -> Result<IbcReceiveResponse, Never> {
     // put this in a closure so we can convert all error responses into acknowledgements
     (|| {
         let packet = msg.packet;

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -15,6 +15,7 @@ mod import_helpers;
 #[cfg(feature = "iterator")]
 mod iterator;
 mod math;
+mod never;
 mod panic;
 mod query;
 mod results;
@@ -48,6 +49,7 @@ pub use crate::math::{
     Decimal, Decimal256, Decimal256RangeExceeded, DecimalRangeExceeded, Fraction, Isqrt, Uint128,
     Uint256, Uint512, Uint64,
 };
+pub use crate::never::Never;
 #[cfg(feature = "cosmwasm_1_1")]
 pub use crate::query::SupplyResponse;
 pub use crate::query::{

--- a/packages/std/src/never.rs
+++ b/packages/std/src/never.rs
@@ -2,10 +2,14 @@
 /// where we want to ensure that no error is returned, such as
 /// the `ibc_packet_receive` entry point.
 ///
+/// In contrast to `Empty`, this does not have a JSON schema
+/// and cannot be used for message and query types.
+///
 /// Once the ! type is stable, this is not needed anymore.
 /// See <https://github.com/rust-lang/rust/issues/35121>.
 pub enum Never {}
 
+// The Debug implementation is needed to allow the use of `Result::unwrap`.
 impl core::fmt::Debug for Never {
     fn fmt(&self, _f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         // This is unreachable because no instance of Never can exist
@@ -13,6 +17,8 @@ impl core::fmt::Debug for Never {
     }
 }
 
+// The Display implementation is needed to fulfill the ToString requirement of
+// entry point errors: `Result<IbcReceiveResponse<C>, E>` with `E: ToString`.
 impl core::fmt::Display for Never {
     fn fmt(&self, _f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         // This is unreachable because no instance of Never can exist

--- a/packages/std/src/never.rs
+++ b/packages/std/src/never.rs
@@ -12,8 +12,8 @@ pub enum Never {}
 // The Debug implementation is needed to allow the use of `Result::unwrap`.
 impl core::fmt::Debug for Never {
     fn fmt(&self, _f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        // This is unreachable because no instance of Never can exist
-        unreachable!()
+        // Unreachable because no instance of Never can exist
+        match *self {}
     }
 }
 
@@ -21,7 +21,7 @@ impl core::fmt::Debug for Never {
 // entry point errors: `Result<IbcReceiveResponse<C>, E>` with `E: ToString`.
 impl core::fmt::Display for Never {
     fn fmt(&self, _f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        // This is unreachable because no instance of Never can exist
-        unreachable!()
+        // Unreachable because no instance of Never can exist
+        match *self {}
     }
 }

--- a/packages/std/src/never.rs
+++ b/packages/std/src/never.rs
@@ -1,0 +1,21 @@
+/// Never can never be instantiated. This can be used in places
+/// where we want to ensure that no error is returned, such as
+/// the `ibc_packet_receive` entry point.
+///
+/// Once the ! type is stable, this is not needed anymore.
+/// See <https://github.com/rust-lang/rust/issues/35121>.
+pub enum Never {}
+
+impl core::fmt::Debug for Never {
+    fn fmt(&self, _f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        // This is unreachable because no instance of Never can exist
+        unreachable!()
+    }
+}
+
+impl core::fmt::Display for Never {
+    fn fmt(&self, _f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        // This is unreachable because no instance of Never can exist
+        unreachable!()
+    }
+}


### PR DESCRIPTION
When refactoring some `ibc_packet_receive` code in Nois I realized I really want type safety to ensure I don't shoot myself in the foot. A `Never` type makes explicit what is documented as best practive already: let `ibc_packet_receive` never return an error.

This way we keep compatibility with the current API (ibc_packet_receive returns `Result<IbcReceiveResponse<C>, E>` with `E: ToString`) but make it impossible to refactor code in a way that it returns an error (which is easy to get wrong with the ? operator).