### PR TITLE
Add SupplyResponse::new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to
 - cosmwasm-std: Upgrade `serde-json-wasm` dependency to 0.5.0 which adds map
   support to `to_vec`/`to_binary` and friends.
 - cosmwasm-std: Implement `AsRef<[u8]>` for `Binary` and `HexBinary` ([#1550]).
+- cosmwasm-std: Add constructor `SupplyResponse::new` ([#1552]).
 
 [#1436]: https://github.com/CosmWasm/cosmwasm/issues/1436
 [#1437]: https://github.com/CosmWasm/cosmwasm/issues/1437
@@ -30,6 +31,7 @@ and this project adheres to
 [#1478]: https://github.com/CosmWasm/cosmwasm/pull/1478
 [#1533]: https://github.com/CosmWasm/cosmwasm/pull/1533
 [#1550]: https://github.com/CosmWasm/cosmwasm/issues/1550
+[#1552]: https://github.com/CosmWasm/cosmwasm/pull/1552
 [#1554]: https://github.com/CosmWasm/cosmwasm/pull/1554
 
 ### Changed

--- a/packages/std/src/query/bank.rs
+++ b/packages/std/src/query/bank.rs
@@ -34,12 +34,9 @@ pub struct SupplyResponse {
 #[cfg(feature = "cosmwasm_1_1")]
 impl SupplyResponse {
     pub fn new(amount: Coin) -> Self {
-        Self {
-            amount,
-        }
+        Self { amount }
     }
 }
-
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]

--- a/packages/std/src/query/bank.rs
+++ b/packages/std/src/query/bank.rs
@@ -33,6 +33,11 @@ pub struct SupplyResponse {
 
 #[cfg(feature = "cosmwasm_1_1")]
 impl SupplyResponse {
+    /// Constructor for testing frameworks such as cw-multi-test.
+    /// This is required because query response types should be #[non_exhaustive].
+    /// As a contract developer you should not need this constructor since
+    /// query responses are constructed for you via deserialization.
+    #[doc(hidden)]
     pub fn new(amount: Coin) -> Self {
         Self { amount }
     }

--- a/packages/std/src/query/bank.rs
+++ b/packages/std/src/query/bank.rs
@@ -31,6 +31,16 @@ pub struct SupplyResponse {
     pub amount: Coin,
 }
 
+#[cfg(feature = "cosmwasm_1_1")]
+impl SupplyResponse {
+    pub fn new(amount: Coin) -> Self {
+        Self {
+            amount,
+        }
+    }
+}
+
+
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct BalanceResponse {

--- a/packages/std/src/query/wasm.rs
+++ b/packages/std/src/query/wasm.rs
@@ -41,7 +41,10 @@ pub struct ContractInfoResponse {
 }
 
 impl ContractInfoResponse {
-    /// Convenience constructor for tests / mocks
+    /// Constructor for testing frameworks such as cw-multi-test.
+    /// This is required because query response types should be #[non_exhaustive].
+    /// As a contract developer you should not need this constructor since
+    /// query responses are constructed for you via deserialization.
     #[doc(hidden)]
     pub fn new(code_id: u64, creator: impl Into<String>) -> Self {
         Self {


### PR DESCRIPTION
Pretty much self explanatory, without this, consumers of cosmwasm-std can't construct new SupplyResponse structs