### PR TITLE
Remove msg argument from instantiate2_address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,10 @@ and this project adheres to
   dependency. This makes the contract incompatible with chains running versions
   of CosmWasm earlier than 1.2.0 ([#1481]).
 - cosmwasm-std: Add `instantiate2_address` which allows calculating the
-  predictable addresses for `MsgInstantiateContract2` ([#1437]).
+  predictable addresses for `MsgInstantiateContract2` ([#1437], [#1554]).
 - cosmwasm-std: Add `WasmMsg::Instantiate2` (requires `cosmwasm_1_2`, see
   `GovMsg::VoteWeighted` above) to instantiate contracts at a predictable
-  address ([#1436]).
+  address ([#1436], [#1554])).
 - cosmwasm-schema: In contracts, `cosmwasm schema` will now output a separate
   JSON Schema file for each entrypoint in the `raw` subdirectory ([#1478],
   [#1533]).
@@ -30,6 +30,7 @@ and this project adheres to
 [#1478]: https://github.com/CosmWasm/cosmwasm/pull/1478
 [#1533]: https://github.com/CosmWasm/cosmwasm/pull/1533
 [#1550]: https://github.com/CosmWasm/cosmwasm/issues/1550
+[#1554]: https://github.com/CosmWasm/cosmwasm/pull/1554
 
 ### Changed
 

--- a/packages/std/src/results/cosmos_msg.rs
+++ b/packages/std/src/results/cosmos_msg.rs
@@ -164,6 +164,7 @@ pub enum WasmMsg {
     ///
     /// This is translated to a [MsgInstantiateContract2](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L73-L96).
     /// `sender` is automatically filled with the current contract's address.
+    /// `fix_msg` is automatically set to false.
     #[cfg(feature = "cosmwasm_1_2")]
     Instantiate2 {
         admin: Option<String>,
@@ -175,7 +176,6 @@ pub enum WasmMsg {
         msg: Binary,
         funds: Vec<Coin>,
         salt: Binary,
-        fix_msg: bool,
     },
     /// Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to
     /// customize behavior.


### PR DESCRIPTION
As discussed elsewhere, fixing the msg makes no sense if the contract creator can put the contract behind and address to any code and any state they want using the admin functionality. With this change, the usage of non-fixed predictable addresses gets easier.