### PR TITLE
Add constructor functions for use by cw-sdk

### DIFF
--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -42,7 +42,7 @@ cosmwasm_1_2 = []
 # This feature adds constructor functions for several query response types. The constructor
 # functions are needed because these types are marked as `#[non_exhaustive]`.
 # Only available for cw-sdk chains. For wasmd chains, these responses are created by
-#  deserialization, so constructor functions are not necessary.
+# deserialization, so constructor functions are not necessary.
 cw_sdk = []
 
 [dependencies]

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -39,6 +39,11 @@ cosmwasm_1_1 = []
 # This feature makes `GovMsg::VoteWeighted` available for the contract to call, but requires
 # the host blockchain to run CosmWasm `1.2.0` or higher.
 cosmwasm_1_2 = []
+# This feature adds constructor functions for several query response types. The constructor
+# functions are needed because these types are marked as `#[non_exhaustive]`.
+# Only available for cw-sdk chains. For wasmd chains, these responses are created by
+#  deserialization, so constructor functions are not necessary.
+cw_sdk = []
 
 [dependencies]
 base64 = "0.13.0"

--- a/packages/std/src/query/bank.rs
+++ b/packages/std/src/query/bank.rs
@@ -37,7 +37,15 @@ impl SupplyResponse {
     /// This is required because query response types should be #[non_exhaustive].
     /// As a contract developer you should not need this constructor since
     /// query responses are constructed for you via deserialization.
+    #[cfg(not(feature = "cw_sdk"))]
     #[doc(hidden)]
+    pub fn new(amount: Coin) -> Self {
+        Self { amount }
+    }
+
+    /// Constructor for use in cw-sdk.
+    /// This is required because query response types should be #[non_exhaustive].
+    #[cfg(feature = "cw_sdk")]
     pub fn new(amount: Coin) -> Self {
         Self { amount }
     }

--- a/packages/std/src/query/wasm.rs
+++ b/packages/std/src/query/wasm.rs
@@ -45,6 +45,7 @@ impl ContractInfoResponse {
     /// This is required because query response types should be #[non_exhaustive].
     /// As a contract developer you should not need this constructor since
     /// query responses are constructed for you via deserialization.
+    #[cfg(not(feature = "cw_sdk"))]
     #[doc(hidden)]
     pub fn new(code_id: u64, creator: impl Into<String>) -> Self {
         Self {
@@ -53,6 +54,25 @@ impl ContractInfoResponse {
             admin: None,
             pinned: false,
             ibc_port: None,
+        }
+    }
+
+    /// Constructor for use in cw-sdk.
+    /// This is required because query response types should be #[non_exhaustive].
+    #[cfg(feature = "cw_sdk")]
+    pub fn new(
+        code_id: u64,
+        creator: impl Into<String>,
+        admin: Option<impl Into<String>>,
+        pinned: bool,
+        ibc_port: Option<String>,
+    ) -> Self {
+        Self {
+            code_id,
+            creator: creator.into(),
+            admin: admin.map(|addr| addr.into()),
+            pinned,
+            ibc_port,
         }
     }
 }


### PR DESCRIPTION
As pointed out by #1552, two query response types (`bank::SupplyResponse` and `wasm::ContractInfoResponse`) are marked as `#[non_exhaustive]` and thus cannot be constructed directly.

This is not a problem for wasmd, as they are created by deserialization. However for cw-sdk I do need to construct these responses in Rust code.

Simply adding a `new` function is not a satisfactory solution, as @webmaster128 [pointed out](https://github.com/CosmWasm/cosmwasm/pull/1552#issuecomment-1359024045), we would not be able to add new fields to the response type without changing the function signature.

The solution I'm going with here is to add an option `cw_sdk` feature, and the constructor functions only exist if `cw_sdk` feature is enabled.