### PR TITLE
Add distribution module query type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,15 @@ and this project adheres to
   enabled for the `cosmwasm_std` dependency. This makes the contract
   incompatible with chains running anything lower than CosmWasm `1.3.0`.
   ([#1647])
+- cosmwasm-std: Add `DistributionQuery::DelegatorWithdrawAddress`. Also needs
+  the `cosmwasm_1_3` feature (see above). ([#1593])
 - cosmwasm-std: Add `FromStr` impl for `Coin`. ([#1684])
 - cosmwasm-std: Add `Coins` helper to handle multiple coins. ([#1687])
 - cosmwasm-vm: Add `Cache::save_wasm_unchecked` to save Wasm blobs that have
   been checked before. This is useful for state-sync where we know the Wasm code
   was checked when it was first uploaded. ([#1635])
 
+[#1593]: https://github.com/CosmWasm/cosmwasm/pull/1593
 [#1635]: https://github.com/CosmWasm/cosmwasm/pull/1635
 [#1647]: https://github.com/CosmWasm/cosmwasm/pull/1647
 [#1684]: https://github.com/CosmWasm/cosmwasm/pull/1684

--- a/docs/CAPABILITIES-BUILT-IN.md
+++ b/docs/CAPABILITIES-BUILT-IN.md
@@ -16,5 +16,6 @@ might define others.
 - `cosmwasm_1_2` enables the `GovMsg::VoteWeighted` and `WasmMsg::Instantiate2`
   messages. Only chains running CosmWasm `1.2.0` or higher support this.
 - `cosmwasm_1_3` enables the `BankQuery::AllDenomMetadata` and
-  `BankQuery::DenomMetadata` queries. Only chains running CosmWasm `1.3.0` or
-  higher support this.
+  `BankQuery::DenomMetadata` queries, as well as
+  `DistributionQuery::DelegatorWithdrawAddress`. Only chains running CosmWasm
+  `1.3.0` or higher support this.

--- a/packages/std/src/query/distribution.rs
+++ b/packages/std/src/query/distribution.rs
@@ -1,0 +1,17 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[non_exhaustive]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum DistributionQuery {
+    // https://github.com/cosmos/cosmos-sdk/blob/4f6f6c00021f4b5ee486bbb71ae2071a8ceb47c9/x/distribution/types/query.pb.go#L792-L795
+    DelegatorWithdrawAddress { delegator_address: String },
+}
+
+// https://github.com/cosmos/cosmos-sdk/blob/4f6f6c00021f4b5ee486bbb71ae2071a8ceb47c9/x/distribution/types/query.pb.go#L832-L835
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct DelegatorWithdrawAddressResponse {
+    withdraw_address: String,
+}

--- a/packages/std/src/query/distribution.rs
+++ b/packages/std/src/query/distribution.rs
@@ -13,5 +13,5 @@ pub enum DistributionQuery {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct DelegatorWithdrawAddressResponse {
-    withdraw_address: String,
+    pub withdraw_address: String,
 }

--- a/packages/std/src/query/distribution.rs
+++ b/packages/std/src/query/distribution.rs
@@ -1,6 +1,8 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use super::query_response::QueryResponseType;
+
 #[non_exhaustive]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
@@ -10,8 +12,11 @@ pub enum DistributionQuery {
 }
 
 // https://github.com/cosmos/cosmos-sdk/blob/4f6f6c00021f4b5ee486bbb71ae2071a8ceb47c9/x/distribution/types/query.pb.go#L832-L835
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub struct DelegatorWithdrawAddressResponse {
     pub withdraw_address: String,
 }
+
+impl QueryResponseType for DelegatorWithdrawAddressResponse {}

--- a/packages/std/src/query/mod.rs
+++ b/packages/std/src/query/mod.rs
@@ -6,6 +6,7 @@ use crate::Binary;
 use crate::Empty;
 
 mod bank;
+mod distribution;
 mod ibc;
 mod query_response;
 mod staking;
@@ -16,6 +17,8 @@ pub use bank::SupplyResponse;
 pub use bank::{AllBalanceResponse, BalanceResponse, BankQuery};
 #[cfg(feature = "cosmwasm_1_3")]
 pub use bank::{AllDenomMetadataResponse, DenomMetadataResponse};
+#[cfg(feature = "staking")]
+pub use distribution::DistributionQuery;
 #[cfg(feature = "stargate")]
 pub use ibc::{ChannelResponse, IbcQuery, ListChannelsResponse, PortIdResponse};
 #[cfg(feature = "staking")]

--- a/packages/std/src/query/mod.rs
+++ b/packages/std/src/query/mod.rs
@@ -17,7 +17,7 @@ pub use bank::SupplyResponse;
 pub use bank::{AllBalanceResponse, BalanceResponse, BankQuery};
 #[cfg(feature = "cosmwasm_1_3")]
 pub use bank::{AllDenomMetadataResponse, DenomMetadataResponse};
-#[cfg(all(feature = "staking", feature = "cosmwasm_1_3"))]
+#[cfg(feature = "cosmwasm_1_3")]
 pub use distribution::{DelegatorWithdrawAddressResponse, DistributionQuery};
 #[cfg(feature = "stargate")]
 pub use ibc::{ChannelResponse, IbcQuery, ListChannelsResponse, PortIdResponse};
@@ -38,7 +38,7 @@ pub enum QueryRequest<C> {
     Custom(C),
     #[cfg(feature = "staking")]
     Staking(StakingQuery),
-    #[cfg(all(feature = "staking", feature = "cosmwasm_1_3"))]
+    #[cfg(feature = "cosmwasm_1_3")]
     Distribution(DistributionQuery),
     /// A Stargate query is encoded the same way as abci_query, with path and protobuf encoded request data.
     /// The format is defined in [ADR-21](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-021-protobuf-query-encoding.md).
@@ -114,7 +114,7 @@ impl<C: CustomQuery> From<IbcQuery> for QueryRequest<C> {
     }
 }
 
-#[cfg(all(feature = "staking", feature = "cosmwasm_1_3"))]
+#[cfg(feature = "cosmwasm_1_3")]
 impl<C: CustomQuery> From<DistributionQuery> for QueryRequest<C> {
     fn from(msg: DistributionQuery) -> Self {
         QueryRequest::Distribution(msg)

--- a/packages/std/src/query/mod.rs
+++ b/packages/std/src/query/mod.rs
@@ -17,8 +17,8 @@ pub use bank::SupplyResponse;
 pub use bank::{AllBalanceResponse, BalanceResponse, BankQuery};
 #[cfg(feature = "cosmwasm_1_3")]
 pub use bank::{AllDenomMetadataResponse, DenomMetadataResponse};
-#[cfg(feature = "staking")]
-pub use distribution::DistributionQuery;
+#[cfg(all(feature = "staking", feature = "cosmwasm_1_3"))]
+pub use distribution::{DelegatorWithdrawAddressResponse, DistributionQuery};
 #[cfg(feature = "stargate")]
 pub use ibc::{ChannelResponse, IbcQuery, ListChannelsResponse, PortIdResponse};
 #[cfg(feature = "staking")]
@@ -38,6 +38,8 @@ pub enum QueryRequest<C> {
     Custom(C),
     #[cfg(feature = "staking")]
     Staking(StakingQuery),
+    #[cfg(all(feature = "staking", feature = "cosmwasm_1_3"))]
+    Distribution(DistributionQuery),
     /// A Stargate query is encoded the same way as abci_query, with path and protobuf encoded request data.
     /// The format is defined in [ADR-21](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-021-protobuf-query-encoding.md).
     /// The response is protobuf encoded data directly without a JSON response wrapper.
@@ -109,5 +111,12 @@ impl<C: CustomQuery> From<WasmQuery> for QueryRequest<C> {
 impl<C: CustomQuery> From<IbcQuery> for QueryRequest<C> {
     fn from(msg: IbcQuery) -> Self {
         QueryRequest::Ibc(msg)
+    }
+}
+
+#[cfg(all(feature = "staking", feature = "cosmwasm_1_3"))]
+impl<C: CustomQuery> From<DistributionQuery> for QueryRequest<C> {
+    fn from(msg: DistributionQuery) -> Self {
+        QueryRequest::Distribution(msg)
     }
 }

--- a/packages/std/src/testing/mock.rs
+++ b/packages/std/src/testing/mock.rs
@@ -28,7 +28,7 @@ use crate::query::{
     AllDelegationsResponse, AllValidatorsResponse, BondedDenomResponse, DelegationResponse,
     FullDelegation, StakingQuery, Validator, ValidatorResponse,
 };
-#[cfg(all(feature = "staking", feature = "cosmwasm_1_3"))]
+#[cfg(feature = "cosmwasm_1_3")]
 use crate::query::{DelegatorWithdrawAddressResponse, DistributionQuery};
 use crate::results::{ContractResult, Empty, SystemResult};
 use crate::serde::{from_slice, to_binary};
@@ -445,7 +445,7 @@ pub struct MockQuerier<C: DeserializeOwned = Empty> {
     bank: BankQuerier,
     #[cfg(feature = "staking")]
     staking: StakingQuerier,
-    #[cfg(all(feature = "staking", feature = "cosmwasm_1_3"))]
+    #[cfg(feature = "cosmwasm_1_3")]
     distribution: DistributionQuerier,
     wasm: WasmQuerier,
     #[cfg(feature = "stargate")]
@@ -461,7 +461,7 @@ impl<C: DeserializeOwned> MockQuerier<C> {
     pub fn new(balances: &[(&str, &[Coin])]) -> Self {
         MockQuerier {
             bank: BankQuerier::new(balances),
-            #[cfg(all(feature = "staking", feature = "cosmwasm_1_3"))]
+            #[cfg(feature = "cosmwasm_1_3")]
             distribution: DistributionQuerier::default(),
             #[cfg(feature = "staking")]
             staking: StakingQuerier::default(),
@@ -490,7 +490,7 @@ impl<C: DeserializeOwned> MockQuerier<C> {
         self.bank.set_denom_metadata(denom_metadata);
     }
 
-    #[cfg(all(feature = "staking", feature = "cosmwasm_1_3"))]
+    #[cfg(feature = "cosmwasm_1_3")]
     pub fn set_withdraw_addresses(&mut self, withdraw_addresses: HashMap<String, String>) {
         self.distribution.set_withdraw_addresses(withdraw_addresses);
     }
@@ -554,7 +554,7 @@ impl<C: CustomQuery + DeserializeOwned> MockQuerier<C> {
             QueryRequest::Custom(custom_query) => (*self.custom_handler)(custom_query),
             #[cfg(feature = "staking")]
             QueryRequest::Staking(staking_query) => self.staking.query(staking_query),
-            #[cfg(all(feature = "staking", feature = "cosmwasm_1_3"))]
+            #[cfg(feature = "cosmwasm_1_3")]
             QueryRequest::Distribution(distribution_query) => {
                 self.distribution.query(distribution_query)
             }
@@ -908,13 +908,13 @@ impl StakingQuerier {
     }
 }
 
-#[cfg(all(feature = "staking", feature = "cosmwasm_1_3"))]
+#[cfg(feature = "cosmwasm_1_3")]
 #[derive(Clone, Default)]
 pub struct DistributionQuerier {
     withdraw_addresses: HashMap<String, String>,
 }
 
-#[cfg(all(feature = "staking", feature = "cosmwasm_1_3"))]
+#[cfg(feature = "cosmwasm_1_3")]
 impl DistributionQuerier {
     pub fn new(withdraw_addresses: HashMap<String, String>) -> Self {
         DistributionQuerier { withdraw_addresses }
@@ -1477,7 +1477,7 @@ mod tests {
         );
     }
 
-    #[cfg(all(feature = "staking", feature = "cosmwasm_1_3"))]
+    #[cfg(feature = "cosmwasm_1_3")]
     #[test]
     fn distribution_querier_delegator_withdraw_address() {
         let mut distribution = DistributionQuerier::new(HashMap::new());

--- a/packages/std/src/testing/mock.rs
+++ b/packages/std/src/testing/mock.rs
@@ -490,6 +490,11 @@ impl<C: DeserializeOwned> MockQuerier<C> {
         self.bank.set_denom_metadata(denom_metadata);
     }
 
+    #[cfg(all(feature = "staking", feature = "cosmwasm_1_3"))]
+    pub fn set_withdraw_addresses(&mut self, withdraw_addresses: HashMap<String, String>) {
+        self.distribution.set_withdraw_addresses(withdraw_addresses);
+    }
+
     #[cfg(feature = "staking")]
     pub fn update_staking(
         &mut self,

--- a/packages/std/src/testing/mod.rs
+++ b/packages/std/src/testing/mod.rs
@@ -9,7 +9,7 @@ mod shuffle;
 
 pub use assertions::assert_approx_eq_impl;
 
-#[cfg(all(feature = "staking", feature = "cosmwasm_1_3"))]
+#[cfg(feature = "cosmwasm_1_3")]
 pub use mock::DistributionQuerier;
 #[cfg(feature = "staking")]
 pub use mock::StakingQuerier;

--- a/packages/std/src/testing/mod.rs
+++ b/packages/std/src/testing/mod.rs
@@ -9,6 +9,8 @@ mod shuffle;
 
 pub use assertions::assert_approx_eq_impl;
 
+#[cfg(all(feature = "staking", feature = "cosmwasm_1_3"))]
+pub use mock::DistributionQuerier;
 #[cfg(feature = "staking")]
 pub use mock::StakingQuerier;
 pub use mock::{

--- a/packages/std/src/traits.rs
+++ b/packages/std/src/traits.rs
@@ -22,7 +22,7 @@ use crate::query::{
 };
 #[cfg(feature = "cosmwasm_1_3")]
 use crate::query::{AllDenomMetadataResponse, DenomMetadataResponse};
-#[cfg(all(feature = "staking", feature = "cosmwasm_1_3"))]
+#[cfg(feature = "cosmwasm_1_3")]
 use crate::query::{DelegatorWithdrawAddressResponse, DistributionQuery};
 use crate::results::{ContractResult, Empty, SystemResult};
 use crate::serde::{from_binary, to_binary, to_vec};
@@ -245,7 +245,7 @@ impl<'a, C: CustomQuery> QuerierWrapper<'a, C> {
         Ok(res.amount)
     }
 
-    #[cfg(all(feature = "staking", feature = "cosmwasm_1_3"))]
+    #[cfg(feature = "cosmwasm_1_3")]
     pub fn query_delegator_withdraw_address(
         &self,
         delegator: impl Into<String>,

--- a/packages/std/src/traits.rs
+++ b/packages/std/src/traits.rs
@@ -22,6 +22,8 @@ use crate::query::{
 };
 #[cfg(feature = "cosmwasm_1_3")]
 use crate::query::{AllDenomMetadataResponse, DenomMetadataResponse};
+#[cfg(all(feature = "staking", feature = "cosmwasm_1_3"))]
+use crate::query::{DelegatorWithdrawAddressResponse, DistributionQuery};
 use crate::results::{ContractResult, Empty, SystemResult};
 use crate::serde::{from_binary, to_binary, to_vec};
 use crate::ContractInfoResponse;
@@ -241,6 +243,19 @@ impl<'a, C: CustomQuery> QuerierWrapper<'a, C> {
         .into();
         let res: AllBalanceResponse = self.query(&request)?;
         Ok(res.amount)
+    }
+
+    #[cfg(all(feature = "staking", feature = "cosmwasm_1_3"))]
+    pub fn query_delegator_withdraw_address(
+        &self,
+        delegator: impl Into<String>,
+    ) -> StdResult<String> {
+        let request = DistributionQuery::DelegatorWithdrawAddress {
+            delegator_address: delegator.into(),
+        }
+        .into();
+        let res: DelegatorWithdrawAddressResponse = self.query(&request)?;
+        Ok(res.withdraw_address)
     }
 
     #[cfg(feature = "cosmwasm_1_3")]


### PR DESCRIPTION
This adds a query type for the distribution module. I've linked to the cosmos-sdk protobufs where relevant, though I'd appreciate advice on how best to test this.

Related PR to add `SetWithdrawAddress` to multi-test: https://github.com/CosmWasm/cw-multi-test/pull/23