### PR TITLE
Expose CheckedMultiplyFractionError publicly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- cosmwasm-std: Add missing export `CheckedMultiplyFractionError` ([#1608]).
+
+[#1608]: https://github.com/CosmWasm/cosmwasm/pull/1608
+
 ## [1.2.1] - 2023-01-30
 
 ### Added

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -31,9 +31,9 @@ pub use crate::binary::Binary;
 pub use crate::coin::{coin, coins, has_coins, Coin};
 pub use crate::deps::{Deps, DepsMut, OwnedDeps};
 pub use crate::errors::{
-    CheckedFromRatioError, CheckedMultiplyRatioError, ConversionOverflowError, DivideByZeroError,
-    OverflowError, OverflowOperation, RecoverPubkeyError, StdError, StdResult, SystemError,
-    VerificationError,
+    CheckedFromRatioError, CheckedMultiplyFractionError, CheckedMultiplyRatioError,
+    ConversionOverflowError, DivideByZeroError, OverflowError, OverflowOperation,
+    RecoverPubkeyError, StdError, StdResult, SystemError, VerificationError,
 };
 pub use crate::hex_binary::HexBinary;
 #[cfg(feature = "stargate")]


### PR DESCRIPTION
Follow up from: https://github.com/CosmWasm/cosmwasm/pull/1566

Sadly, `CheckedMultiplyFractionError` is not re-exported in `packages/std/src/lib.rs`. This is important as it prevents consumers from doing

```rust
    #[error("{0}")]
    CheckedMultiplyFraction(#[from] CheckedMultiplyFractionError),
```

At the moment, to use Fraction math, users have to map the errors manually on every use 😢 