### PR TITLE
Extend ibc receive with advanced variant

### DIFF
--- a/contracts/ibc-reflect-send/src/ibc.rs
+++ b/contracts/ibc-reflect-send/src/ibc.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{
-    entry_point, from_slice, to_binary, DepsMut, Env, IbcBasicResponse, IbcChannelCloseMsg,
-    IbcChannelConnectMsg, IbcChannelOpenMsg, IbcMsg, IbcOrder, IbcPacketAckMsg,
+    entry_point, entry_point_adv, from_slice, to_binary, AdvResult, DepsMut, Env, IbcBasicResponse,
+    IbcChannelCloseMsg, IbcChannelConnectMsg, IbcChannelOpenMsg, IbcMsg, IbcOrder, IbcPacketAckMsg,
     IbcPacketReceiveMsg, IbcPacketTimeoutMsg, IbcReceiveResponse, Never, StdError, StdResult,
 };
 
@@ -89,16 +89,14 @@ pub fn ibc_channel_close(
         .add_attribute("channel_id", channel_id))
 }
 
-#[entry_point]
+#[entry_point_adv]
 /// never should be called as the other side never sends packets
 pub fn ibc_packet_receive(
     _deps: DepsMut,
     _env: Env,
     _packet: IbcPacketReceiveMsg,
-) -> Result<IbcReceiveResponse, Never> {
-    Ok(IbcReceiveResponse::new()
-        .set_ack(b"{}")
-        .add_attribute("action", "ibc_packet_ack"))
+) -> AdvResult<IbcReceiveResponse, Never> {
+    AdvResult::Abort
 }
 
 #[entry_point]

--- a/packages/derive/Cargo.toml
+++ b/packages/derive/Cargo.toml
@@ -13,6 +13,7 @@ proc-macro = true
 
 [features]
 default = []
+stargate = [ "cosmwasm-std/stargate"]
 
 [dependencies]
 syn = { version = "1.0", features = ["full"] }

--- a/packages/derive/src/lib.rs
+++ b/packages/derive/src/lib.rs
@@ -82,3 +82,62 @@ pub fn entry_point(_attr: TokenStream, mut item: TokenStream) -> TokenStream {
     item.extend(entry);
     item
 }
+
+/// This attribute macro generates the boilerplate required to call into the
+/// contract-specific logic from the entry-points to the Wasm module.
+///
+/// It should be added to the contract's init, handle, migrate and query implementations
+/// like this:
+/// ```
+/// # use cosmwasm_std::{
+/// #     Storage, Api, Querier, DepsMut, Deps, entry_point_adv, Env, IbcPacketReceiveMsg,
+/// #     IbcReceiveResponse, StdError, MessageInfo, Response, QueryResponse,
+/// # };
+/// #
+/// # type InstantiateMsg = ();
+/// # type ExecuteMsg = ();
+/// # type QueryMsg = ();
+///
+/// #[entry_point_adv]
+/// pub fn ibc_packet_receive(
+///     deps: DepsMut,
+///     env: Env,
+///     msg: IbcPacketReceiveMsg,
+/// ) -> Result<IbcReceiveResponse, StdError> {
+/// #   Ok(Default::default())
+/// }
+/// ```
+///
+/// This only works for ibc_packet_receive if you want to use new advanced interface
+#[cfg(feature = "stargate")]
+#[proc_macro_attribute]
+pub fn entry_point_adv(_attr: TokenStream, mut item: TokenStream) -> TokenStream {
+    let cloned = item.clone();
+    let function = parse_macro_input!(cloned as syn::ItemFn);
+    let name = function.sig.ident.to_string();
+    // The first argument is `deps`, the rest is region pointers
+    let args = function.sig.inputs.len() - 1;
+
+    // E.g. "ptr0: u32, ptr1: u32, ptr2: u32, "
+    let typed_ptrs = (0..args).fold(String::new(), |acc, i| format!("{}ptr{}: u32, ", acc, i));
+    // E.g. "ptr0, ptr1, ptr2, "
+    let ptrs = (0..args).fold(String::new(), |acc, i| format!("{}ptr{}, ", acc, i));
+
+    let new_code = format!(
+        r##"
+        #[cfg(target_arch = "wasm32")]
+        mod __wasm_export_{name} {{ // new module to avoid conflict of function name
+            #[no_mangle]
+            extern "C" fn {name}({typed_ptrs}) -> u32 {{
+                cosmwasm_std::do_{name}_adv(&super::{name}, {ptrs})
+            }}
+        }}
+    "##,
+        name = name,
+        typed_ptrs = typed_ptrs,
+        ptrs = ptrs
+    );
+    let entry = TokenStream::from_str(&new_code).unwrap();
+    item.extend(entry);
+    item
+}

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -29,7 +29,7 @@ staking = []
 backtraces = []
 # stargate enables stargate-dependent messages and queries, like raw protobuf messages
 # as well as ibc-related functionality
-stargate = []
+stargate = ["cosmwasm-derive/stargate"]
 # ibc3 extends ibc messages with ibc-v3 only features. This should only be enabled on contracts
 # that require these types. Without this, they get the smaller ibc-v1 API.
 ibc3 = ["stargate"]

--- a/packages/std/src/exports.rs
+++ b/packages/std/src/exports.rs
@@ -24,9 +24,9 @@ use crate::memory::{alloc, consume_region, release_buffer, Region};
 #[cfg(feature = "abort")]
 use crate::panic::install_panic_handler;
 use crate::query::CustomQuery;
-use crate::results::{
-    AdvContractResult, AdvResult, ContractResult, QueryResponse, Reply, Response,
-};
+#[cfg(feature = "stargate")]
+use crate::results::{AdvContractResult, AdvResult};
+use crate::results::{ContractResult, QueryResponse, Reply, Response};
 use crate::serde::{from_slice, to_vec};
 use crate::types::Env;
 use crate::{CustomMsg, Deps, DepsMut, MessageInfo};
@@ -89,6 +89,7 @@ macro_rules! r#try_into_contract_result {
 }
 
 // TODO: replace with https://doc.rust-lang.org/std/ops/trait.Try.html once stabilized
+#[cfg(feature = "stargate")]
 macro_rules! r#try_into_adv_contract_result {
     ($expr:expr) => {
         match $expr {

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -112,3 +112,5 @@ pub mod testing;
 // Re-exports
 
 pub use cosmwasm_derive::entry_point;
+#[cfg(feature = "stargate")]
+pub use cosmwasm_derive::entry_point_adv;

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -71,9 +71,9 @@ pub use crate::results::SubMsgExecutionResponse;
 #[cfg(all(feature = "stargate", feature = "cosmwasm_1_2"))]
 pub use crate::results::WeightedVoteOption;
 pub use crate::results::{
-    attr, wasm_execute, wasm_instantiate, Attribute, BankMsg, ContractResult, CosmosMsg, CustomMsg,
-    Empty, Event, QueryResponse, Reply, ReplyOn, Response, SubMsg, SubMsgResponse, SubMsgResult,
-    SystemResult, WasmMsg,
+    attr, wasm_execute, wasm_instantiate, AdvContractResult, AdvResult, Attribute, BankMsg,
+    ContractResult, CosmosMsg, CustomMsg, Empty, Event, QueryResponse, Reply, ReplyOn, Response,
+    SubMsg, SubMsgResponse, SubMsgResult, SystemResult, WasmMsg,
 };
 #[cfg(feature = "staking")]
 pub use crate::results::{DistributionMsg, StakingMsg};

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -99,7 +99,7 @@ pub use crate::exports::{do_execute, do_instantiate, do_migrate, do_query, do_re
 #[cfg(all(feature = "stargate", target_arch = "wasm32"))]
 pub use crate::exports::{
     do_ibc_channel_close, do_ibc_channel_connect, do_ibc_channel_open, do_ibc_packet_ack,
-    do_ibc_packet_receive, do_ibc_packet_timeout,
+    do_ibc_packet_receive, do_ibc_packet_receive_adv, do_ibc_packet_timeout,
 };
 #[cfg(target_arch = "wasm32")]
 pub use crate::imports::{ExternalApi, ExternalQuerier, ExternalStorage};

--- a/packages/std/src/results/adv_result.rs
+++ b/packages/std/src/results/adv_result.rs
@@ -1,6 +1,22 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+/// This is like Result but we add an Abort case
+pub enum AdvResult<S, E> {
+    Ok(S),
+    Err(E),
+    Abort,
+}
+
+impl<S, E> From<Result<S, E>> for AdvResult<S, E> {
+    fn from(original: Result<S, E>) -> AdvResult<S, E> {
+        match original {
+            Ok(value) => AdvResult::Ok(value),
+            Err(err) => AdvResult::Err(err),
+        }
+    }
+}
+
 /// This is like ContractResult, but we add one more case.
 /// This is only used for ibc-receive-packet-adv
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
@@ -15,17 +31,12 @@ pub enum AdvContractResult<S> {
     Abort {},
 }
 
-pub enum AdvResult<S, E> {
-    Ok(S),
-    Err(E),
-    Abort,
-}
-
-impl<S, E> From<Result<S, E>> for AdvResult<S, E> {
-    fn from(original: Result<S, E>) -> AdvResult<S, E> {
-        match original {
-            Ok(value) => AdvResult::Ok(value),
-            Err(err) => AdvResult::Err(err),
+impl<S> AdvContractResult<S> {
+    pub fn unwrap(self) -> S {
+        match self {
+            AdvContractResult::Ok(s) => s,
+            AdvContractResult::Err(s) => panic!("{}", s),
+            AdvContractResult::Abort {} => panic!("{}", "abort"),
         }
     }
 }

--- a/packages/std/src/results/adv_result.rs
+++ b/packages/std/src/results/adv_result.rs
@@ -1,0 +1,152 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// This is like ContractResult, but we add one more case.
+/// This is only used for ibc-receive-packet-adv
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AdvContractResult<S> {
+    Ok(S),
+    /// An error type that every custom error created by contract developers can be converted to.
+    /// This could potientially have more structure, but String is the easiest.
+    #[serde(rename = "error")]
+    Err(String),
+    /// This will abort the transaction rather than be managed somewhere
+    Abort {},
+}
+
+pub enum AdvResult<S, E> {
+    Ok(S),
+    Err(E),
+    Abort,
+}
+
+impl<S, E> From<Result<S, E>> for AdvResult<S, E> {
+    fn from(original: Result<S, E>) -> AdvResult<S, E> {
+        match original {
+            Ok(value) => AdvResult::Ok(value),
+            Err(err) => AdvResult::Err(err),
+        }
+    }
+}
+
+impl<S, E: ToString> From<AdvResult<S, E>> for AdvContractResult<S> {
+    fn from(original: AdvResult<S, E>) -> AdvContractResult<S> {
+        match original {
+            AdvResult::Ok(value) => AdvContractResult::Ok(value),
+            AdvResult::Err(err) => AdvContractResult::Err(err.to_string()),
+            AdvResult::Abort => AdvContractResult::Abort {},
+        }
+    }
+}
+
+impl<S, E: ToString> From<Result<S, E>> for AdvContractResult<S> {
+    fn from(original: Result<S, E>) -> AdvContractResult<S> {
+        let adv: AdvResult<S, E> = original.into();
+        adv.into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{from_slice, to_vec, Response, StdError, StdResult};
+
+    #[test]
+    fn adv_result_serialization_works() {
+        let result = AdvContractResult::Ok(12);
+        assert_eq!(&to_vec(&result).unwrap(), b"{\"ok\":12}");
+
+        let result = AdvContractResult::Ok("foo");
+        assert_eq!(&to_vec(&result).unwrap(), b"{\"ok\":\"foo\"}");
+
+        let result: AdvContractResult<()> = AdvContractResult::Abort {};
+        assert_eq!(&to_vec(&result).unwrap(), b"{\"abort\":{}}");
+
+        let result: AdvContractResult<Response> = AdvContractResult::Ok(Response::default());
+        assert_eq!(
+            to_vec(&result).unwrap(),
+            br#"{"ok":{"messages":[],"attributes":[],"events":[],"data":null}}"#
+        );
+
+        let result: AdvContractResult<Response> = AdvContractResult::Err("broken".to_string());
+        assert_eq!(&to_vec(&result).unwrap(), b"{\"error\":\"broken\"}");
+    }
+
+    #[test]
+    fn adv_result_deserialization_works() {
+        let result: AdvContractResult<u64> = from_slice(br#"{"ok":12}"#).unwrap();
+        assert_eq!(result, AdvContractResult::Ok(12));
+
+        let result: AdvContractResult<String> = from_slice(br#"{"ok":"foo"}"#).unwrap();
+        assert_eq!(result, AdvContractResult::Ok("foo".to_string()));
+
+        let result: AdvContractResult<String> = from_slice(br#"{"abort":{}}"#).unwrap();
+        assert_eq!(result, AdvContractResult::Abort {});
+
+        let result: AdvContractResult<Response> =
+            from_slice(br#"{"ok":{"messages":[],"attributes":[],"events":[],"data":null}}"#)
+                .unwrap();
+        assert_eq!(result, AdvContractResult::Ok(Response::default()));
+
+        let result: AdvContractResult<Response> = from_slice(br#"{"error":"broken"}"#).unwrap();
+        assert_eq!(result, AdvContractResult::Err("broken".to_string()));
+
+        // ignores whitespace
+        let result: AdvContractResult<u64> = from_slice(b" {\n\t  \"ok\": 5898\n}  ").unwrap();
+        assert_eq!(result, AdvContractResult::Ok(5898));
+
+        // fails for additional attributes
+        let parse: StdResult<AdvContractResult<u64>> =
+            from_slice(br#"{"unrelated":321,"ok":4554}"#);
+        match parse.unwrap_err() {
+            StdError::ParseErr { .. } => {}
+            err => panic!("Unexpected error: {:?}", err),
+        }
+        let parse: StdResult<AdvContractResult<u64>> =
+            from_slice(br#"{"ok":4554,"unrelated":321}"#);
+        match parse.unwrap_err() {
+            StdError::ParseErr { .. } => {}
+            err => panic!("Unexpected error: {:?}", err),
+        }
+        let parse: StdResult<AdvContractResult<u64>> =
+            from_slice(br#"{"ok":4554,"error":"What's up now?"}"#);
+        match parse.unwrap_err() {
+            StdError::ParseErr { .. } => {}
+            err => panic!("Unexpected error: {:?}", err),
+        }
+    }
+
+    #[test]
+    fn can_convert_from_core_result() {
+        let original: Result<Response, StdError> = Ok(Response::default());
+        let converted: AdvContractResult<Response> = original.into();
+        assert_eq!(converted, AdvContractResult::Ok(Response::default()));
+
+        let original: Result<Response, StdError> = Err(StdError::generic_err("broken"));
+        let converted: AdvContractResult<Response> = original.into();
+        assert_eq!(
+            converted,
+            AdvContractResult::Err("Generic error: broken".to_string())
+        );
+    }
+
+    #[test]
+    fn can_convert_from_adv_result() {
+        let original: AdvResult<Response, StdError> = AdvResult::Ok(Response::default());
+        let converted: AdvContractResult<Response> = original.into();
+        assert_eq!(converted, AdvContractResult::Ok(Response::default()));
+
+        let original: AdvResult<Response, StdError> =
+            AdvResult::Err(StdError::generic_err("broken"));
+        let converted: AdvContractResult<Response> = original.into();
+        assert_eq!(
+            converted,
+            AdvContractResult::Err("Generic error: broken".to_string())
+        );
+
+        let original: AdvResult<Response, StdError> = AdvResult::Abort;
+        let converted: AdvContractResult<Response> = original.into();
+        assert_eq!(converted, AdvContractResult::Abort {});
+    }
+}

--- a/packages/std/src/results/mod.rs
+++ b/packages/std/src/results/mod.rs
@@ -1,5 +1,6 @@
 //! This module contains the messages that are sent from the contract to the VM as an execution result
 
+mod adv_result;
 mod contract_result;
 mod cosmos_msg;
 mod empty;
@@ -9,6 +10,7 @@ mod response;
 mod submessages;
 mod system_result;
 
+pub use adv_result::{AdvContractResult, AdvResult};
 pub use contract_result::ContractResult;
 #[cfg(all(feature = "stargate", feature = "cosmwasm_1_2"))]
 pub use cosmos_msg::WeightedVoteOption;

--- a/packages/vm/src/calls.rs
+++ b/packages/vm/src/calls.rs
@@ -1,13 +1,13 @@
 use serde::de::DeserializeOwned;
 use wasmer::Val;
 
-use cosmwasm_std::{ContractResult, CustomMsg, Env, MessageInfo, QueryResponse, Reply, Response};
 #[cfg(feature = "stargate")]
 use cosmwasm_std::{
-    Ibc3ChannelOpenResponse, IbcBasicResponse, IbcChannelCloseMsg, IbcChannelConnectMsg,
-    IbcChannelOpenMsg, IbcPacketAckMsg, IbcPacketReceiveMsg, IbcPacketTimeoutMsg,
-    IbcReceiveResponse,
+    AdvContractResult, Ibc3ChannelOpenResponse, IbcBasicResponse, IbcChannelCloseMsg,
+    IbcChannelConnectMsg, IbcChannelOpenMsg, IbcPacketAckMsg, IbcPacketReceiveMsg,
+    IbcPacketTimeoutMsg, IbcReceiveResponse,
 };
+use cosmwasm_std::{ContractResult, CustomMsg, Env, MessageInfo, QueryResponse, Reply, Response};
 
 use crate::backend::{BackendApi, Querier, Storage};
 use crate::conversion::ref_to_u32;
@@ -276,7 +276,7 @@ pub fn call_ibc_packet_receive<A, S, Q, U>(
     instance: &mut Instance<A, S, Q>,
     env: &Env,
     msg: &IbcPacketReceiveMsg,
-) -> VmResult<ContractResult<IbcReceiveResponse<U>>>
+) -> VmResult<AdvContractResult<IbcReceiveResponse<U>>>
 where
     A: BackendApi + 'static,
     S: Storage + 'static,

--- a/packages/vm/src/testing/calls.rs
+++ b/packages/vm/src/testing/calls.rs
@@ -4,13 +4,13 @@
 use schemars::JsonSchema;
 use serde::{de::DeserializeOwned, Serialize};
 
-use cosmwasm_std::{ContractResult, CustomMsg, Env, MessageInfo, QueryResponse, Reply, Response};
 #[cfg(feature = "stargate")]
 use cosmwasm_std::{
-    Ibc3ChannelOpenResponse, IbcBasicResponse, IbcChannelCloseMsg, IbcChannelConnectMsg,
-    IbcChannelOpenMsg, IbcPacketAckMsg, IbcPacketReceiveMsg, IbcPacketTimeoutMsg,
-    IbcReceiveResponse,
+    AdvContractResult, Ibc3ChannelOpenResponse, IbcBasicResponse, IbcChannelCloseMsg,
+    IbcChannelConnectMsg, IbcChannelOpenMsg, IbcPacketAckMsg, IbcPacketReceiveMsg,
+    IbcPacketTimeoutMsg, IbcReceiveResponse,
 };
+use cosmwasm_std::{ContractResult, CustomMsg, Env, MessageInfo, QueryResponse, Reply, Response};
 
 use crate::calls::{
     call_execute, call_instantiate, call_migrate, call_query, call_reply, call_sudo,
@@ -198,7 +198,7 @@ pub fn ibc_packet_receive<A, S, Q, U>(
     instance: &mut Instance<A, S, Q>,
     env: Env,
     msg: IbcPacketReceiveMsg,
-) -> ContractResult<IbcReceiveResponse<U>>
+) -> AdvContractResult<IbcReceiveResponse<U>>
 where
     A: BackendApi + 'static,
     S: Storage + 'static,


### PR DESCRIPTION
This is an experiment towards solving https://github.com/CosmWasm/wasmd/issues/1220
To show it is possible and suggest a way forward. I do not expect this to be merged as is, and will likely need a lot of cleanup

Basically, I want to allow ibc_packet_receive to be able to return 3 types:

* Ok - Success and return ack
* Err - Rollback state changes and write an error string as ack
* Abort - Completely rollback the transaction.

The last case is used in places where you have some external constaints. Eg. you only want whitelisted relayers to be able to relay on a channel. If another relayer submits the package, the whole Tx should fail, not just some error message. This is a very advanced use-case and not that common. Trying to "Rollback state changes and write an error string as ack" in an Ok response is very very difficult and we made the change to behavior of Err to empower 98% of the ibc contract devs. This is just for a very few special protocols that need a full abort.

My approach is to use another type for ibc_packet_receive. It returns `AdvResult`, which is like Result, but with a new `::Abort` variant. There is a corresponding `AdvContractError`, which serializes like `ContractError`, but has one more variant.

The issue is that changing this is breaking to the API. My workaround is to add a new `#[entry_point_adv]` case, which generates the same `ibc_packet_receive` export, but has another handler that expects a function that returns `AdvResult<>` not `Result<>`. I demo how this can be used in `ibc-reflect-send`.

The other option I see if making this a CosmWasm 2.0 feature when we break APIs in a larger way. However, I would like to use this in some protocols in the next 3-6 months, and CosmWasm 2.0 seems much further off.