### PR TITLE
Add `trace` functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to
 
 ### Added
 
+- Add `Api::trace` for emitting trace messages during development.
 - cosmwasm-vm: Add `Cache::save_wasm_unchecked` to save Wasm blobs that have
   been checked before. This is useful for state-sync where we know the Wasm code
   was checked when it was first uploaded. ([#1635])

--- a/README.md
+++ b/README.md
@@ -245,6 +245,11 @@ extern "C" {
     /// In production environments it is expected that those messages are discarded.
     fn debug(source_ptr: u32);
 
+    /// Writes a trace message (UFT-8 encoded) to the host for tracing purposes.
+    /// The host is free to log or process this in any way it considers appropriate.
+    /// In production environments it is expected that those messages are discarded.
+    fn trace(source_ptr: u32);
+
     /// Executes a query on the chain (import). Not to be confused with the
     /// query export, which queries the state of the contract.
     fn query_chain(request: u32) -> u32;

--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -21,6 +21,7 @@ pub fn instantiate(
     msg: InstantiateMsg,
 ) -> Result<Response, HackError> {
     deps.api.debug("here we go 🚀");
+    deps.api.trace("here we go again 🚀");
 
     deps.storage.set(
         CONFIG_KEY,

--- a/packages/std/src/imports.rs
+++ b/packages/std/src/imports.rs
@@ -71,6 +71,11 @@ extern "C" {
     /// In production environments it is expected that those messages are discarded.
     fn debug(source_ptr: u32);
 
+    /// Writes a trace message (UFT-8 encoded) to the host for tracing purposes.
+    /// The host is free to log or process this in any way it considers appropriate.
+    /// In production environments it is expected that those messages are discarded.
+    fn trace(source_ptr: u32);
+
     /// Executes a query on the chain (import). Not to be confused with the
     /// query export, which queries the state of the contract.
     fn query_chain(request: u32) -> u32;
@@ -361,6 +366,13 @@ impl Api for ExternalApi {
         let region = build_region(message.as_bytes());
         let region_ptr = region.as_ref() as *const Region as u32;
         unsafe { debug(region_ptr) };
+    }
+
+    fn trace(&self, message: &str) {
+        // keep the boxes in scope, so we free it at the end (don't cast to pointers same line as build_region)
+        let region = build_region(message.as_bytes());
+        let region_ptr = region.as_ref() as *const Region as u32;
+        unsafe { trace(region_ptr) };
     }
 }
 

--- a/packages/std/src/testing/mock.rs
+++ b/packages/std/src/testing/mock.rs
@@ -228,6 +228,10 @@ impl Api for MockApi {
     fn debug(&self, message: &str) {
         println!("{}", message);
     }
+
+    fn trace(&self, message: &str) {
+        println!("{}, ts: NAµs", message);
+    }
 }
 
 /// Returns a default enviroment with height, time, chain_id, and contract address

--- a/packages/std/src/traits.rs
+++ b/packages/std/src/traits.rs
@@ -141,6 +141,11 @@ pub trait Api {
     /// Emits a debugging message that is handled depending on the environment (typically printed to console or ignored).
     /// Those messages are not persisted to chain.
     fn debug(&self, message: &str);
+
+    /// Emits a tracing / time-stamping message that is handled depending on the environment (typically printed to
+    /// console or ignored).
+    /// Those messages are not persisted to chain.
+    fn trace(&self, message: &str);
 }
 
 /// A short-hand alias for the two-level query result (1. accessing the contract, 2. executing query in the contract)

--- a/packages/vm/src/compatibility.rs
+++ b/packages/vm/src/compatibility.rs
@@ -22,6 +22,7 @@ const SUPPORTED_IMPORTS: &[&str] = &[
     "env.ed25519_verify",
     "env.ed25519_batch_verify",
     "env.debug",
+    "env.trace",
     "env.query_chain",
     #[cfg(feature = "iterator")]
     "env.db_scan",
@@ -798,6 +799,7 @@ mod tests {
             "env.addr_canonicalize",
             "env.addr_humanize",
             "env.debug",
+            "env.trace",
             "env.query_chain",
         ];
         let result = check_wasm_imports(&deserialize_wasm(&wasm).unwrap(), supported_imports);
@@ -806,7 +808,7 @@ mod tests {
                 println!("{}", msg);
                 assert_eq!(
                     msg,
-                    r#"Wasm contract requires unsupported import: "env.foo". Required imports: {"env.bar", "env.foo", "env.spammyspam01", "env.spammyspam02", "env.spammyspam03", "env.spammyspam04", "env.spammyspam05", "env.spammyspam06", "env.spammyspam07", "env.spammyspam08", ... 2 more}. Available imports: ["env.db_read", "env.db_write", "env.db_remove", "env.addr_canonicalize", "env.addr_humanize", "env.debug", "env.query_chain"]."#
+                    r#"Wasm contract requires unsupported import: "env.foo". Required imports: {"env.bar", "env.foo", "env.spammyspam01", "env.spammyspam02", "env.spammyspam03", "env.spammyspam04", "env.spammyspam05", "env.spammyspam06", "env.spammyspam07", "env.spammyspam08", ... 2 more}. Available imports: ["env.db_read", "env.db_write", "env.db_remove", "env.addr_canonicalize", "env.addr_humanize", "env.debug", "env.trace", "env.query_chain"]."#
                 );
             }
             err => panic!("Unexpected error: {:?}", err),

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -12,7 +12,7 @@ use crate::errors::{CommunicationError, VmError, VmResult};
 use crate::imports::{
     do_abort, do_addr_canonicalize, do_addr_humanize, do_addr_validate, do_db_read, do_db_remove,
     do_db_write, do_debug, do_ed25519_batch_verify, do_ed25519_verify, do_query_chain,
-    do_secp256k1_recover_pubkey, do_secp256k1_verify,
+    do_secp256k1_recover_pubkey, do_secp256k1_verify, do_trace,
 };
 #[cfg(feature = "iterator")]
 use crate::imports::{do_db_next, do_db_scan};
@@ -179,6 +179,15 @@ where
         env_imports.insert(
             "debug",
             Function::new_native_with_env(store, env.clone(), do_debug),
+        );
+
+        // Allows the contract to emit trace logs that the host can either process or ignore.
+        // This is never written to chain.
+        // Takes a pointer argument of a memory region that must contain an UTF-8 encoded string.
+        // Ownership of both input and output pointer is not transferred to the host.
+        env_imports.insert(
+            "trace",
+            Function::new_native_with_env(store, env.clone(), do_trace),
         );
 
         // Aborts the contract execution with an error message provided by the contract.


### PR DESCRIPTION
Related to #746.

Useful for comparing wall time between contract code and blockchain code. This way the latency of the Go -> Rust and Rust ->   Go bridges can be easily measured (and eventually improved).

Useful as well for general benchmarks of code and procedures. Elapsed time can be computed post-facto by subtracting calls to `trace()`.

The performance of code between the native and wasm runtimes cannot be compared fairly, as the WebAssembly code is running inside the VM. But time measurements are useful as a relative reference for comparing different routines and implementations in contract code.

It could also be interesting to know how much faster native code is for particular tasks, compared to wasm code.