### PR TITLE
Explore JsonAck

### DIFF
--- a/packages/std/src/json_ack.rs
+++ b/packages/std/src/json_ack.rs
@@ -1,0 +1,159 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::{to_binary, to_vec, Binary, StdResult};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum JsonAck<T> {
+    Result(T),
+    Error(String),
+}
+
+impl<T: Serialize> JsonAck<T> {
+    /// Creates a success ack by serializing the data with JSON.
+    pub fn success(data: T) -> Self {
+        JsonAck::Result(data)
+    }
+
+    /// Creates an error ack
+    pub fn error(err: impl Into<String>) -> Self {
+        JsonAck::Error(err.into())
+    }
+
+    #[must_use = "if you intended to assert that this is a success, consider `.unwrap()` instead"]
+    #[inline]
+    pub const fn is_success(&self) -> bool {
+        matches!(*self, JsonAck::Result(_))
+    }
+
+    #[must_use = "if you intended to assert that this is an error, consider `.unwrap_err()` instead"]
+    #[inline]
+    pub const fn is_error(&self) -> bool {
+        !self.is_success()
+    }
+
+    /// Serialized the ack to binary using JSON. This used for setting the acknowledgement
+    /// field in IbcReceiveResponse.
+    ///
+    /// ## Examples
+    ///
+    /// Show how the acknowledgement looks on the write:
+    ///
+    /// ```
+    /// # use cosmwasm_std::{Binary, JsonAck};
+    /// // 0x01 is a FungibleTokenPacketSuccess from ICS-20.
+    /// let ack1: JsonAck<Binary> = JsonAck::success(Binary::from([0x01]));
+    /// assert_eq!(ack1.to_binary().unwrap(), br#"{"result":"AQ=="}"#);
+    ///
+    /// let ack2: JsonAck<Binary> = JsonAck::error("kaputt"); // Some free text error message
+    /// assert_eq!(ack2.to_binary().unwrap(), br#"{"error":"kaputt"}"#);
+    /// ```
+    ///
+    /// Set acknowledgement field in `IbcReceiveResponse`:
+    ///
+    /// ```ignore
+    /// use cosmwasm_std::{Binary, JsonAck, IbcReceiveResponse};
+    ///
+    /// // 0x01 is a FungibleTokenPacketSuccess from ICS-20.
+    /// let ack: JsonAck<Binary> = JsonAck::success(Binary::from([0x01]));
+    ///
+    /// let res = IbcReceiveResponse::new().set_ack(ack.to_binary());
+    /// let res = IbcReceiveResponse::new().set_ack(ack); // Does the same but consumes the instance
+    /// ```
+    pub fn to_binary(&self) -> StdResult<Binary> {
+        to_binary(&self)
+    }
+
+    pub fn to_string(&self) -> StdResult<String> {
+        let json_bin = to_vec(&self)?;
+        let json_string = unsafe { String::from_utf8_unchecked(json_bin) };
+        Ok(json_string)
+    }
+
+    pub fn unwrap(self) -> T {
+        match self {
+            JsonAck::Result(data) => data,
+            JsonAck::Error(err) => panic!("{}", err),
+        }
+    }
+
+    pub fn unwrap_err(self) -> String {
+        match self {
+            JsonAck::Result(_) => panic!("not an error"),
+            JsonAck::Error(err) => err,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Empty, Uint128, Uint64};
+
+    use super::*;
+
+    #[test]
+    fn jsonack_success_works() {
+        let success = JsonAck::success(b"foo");
+        match success {
+            JsonAck::Result(data) => assert_eq!(data, b"foo"),
+            JsonAck::Error(_err) => panic!("must not be an error"),
+        }
+    }
+
+    #[test]
+    fn jsonack_error_works() {
+        let err = JsonAck::<Empty>::error("bar");
+        match err {
+            JsonAck::Result(_data) => panic!("must not be a success"),
+            JsonAck::Error(err) => assert_eq!(err, "bar"),
+        }
+    }
+
+    #[test]
+    fn jsonack_is_success_is_error_work() {
+        let success = JsonAck::<&str>::success("foo");
+        let err = JsonAck::<&str>::error("bar");
+        // is_success
+        assert!(success.is_success());
+        assert!(!err.is_success());
+        // is_eror
+        assert!(!success.is_error());
+        assert!(err.is_error());
+    }
+
+    #[test]
+    fn jsonack_to_string_works() {
+        // Binary data in array and vector becomes an array in JSON. Not great but consistent.
+        let ack = JsonAck::success(b"\x01");
+        assert_eq!(ack.to_string().unwrap(), r#"{"result":[1]}"#);
+        let ack = JsonAck::success(vec![0x01]);
+        assert_eq!(ack.to_string().unwrap(), r#"{"result":[1]}"#);
+        // But when we use Binary instead, we get a base64 string
+        let ack = JsonAck::success(Binary::from([0x01]));
+        assert_eq!(ack.to_string().unwrap(), r#"{"result":"AQ=="}"#);
+
+        // Numeric acks
+        let ack = JsonAck::<u32>::success(75);
+        assert_eq!(ack.to_string().unwrap(), r#"{"result":75}"#);
+        let ack = JsonAck::<i64>::success(-46518);
+        assert_eq!(ack.to_string().unwrap(), r#"{"result":-46518}"#);
+        let ack = JsonAck::<Uint64>::success(Uint64::new(32));
+        assert_eq!(ack.to_string().unwrap(), r#"{"result":"32"}"#);
+        let ack = JsonAck::<Uint128>::success(Uint128::new(684684787));
+        assert_eq!(ack.to_string().unwrap(), r#"{"result":"684684787"}"#);
+
+        // Strucures serialize as nested JSON
+        #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+        #[serde(rename_all = "snake_case")]
+        struct Foo {
+            count: u32,
+        }
+        let ack = JsonAck::success(Foo { count: 78 });
+        assert_eq!(ack.to_string().unwrap(), r#"{"result":{"count":78}}"#);
+
+        // Error
+        let ack = JsonAck::<Empty>::error("kaputt");
+        assert_eq!(ack.to_string().unwrap(), r#"{"error":"kaputt"}"#);
+    }
+}

--- a/packages/std/src/json_ack.rs
+++ b/packages/std/src/json_ack.rs
@@ -23,13 +23,13 @@ impl<T: Serialize> JsonAck<T> {
 
     #[must_use = "if you intended to assert that this is a success, consider `.unwrap()` instead"]
     #[inline]
-    pub const fn is_success(&self) -> bool {
+    pub fn is_success(&self) -> bool {
         matches!(*self, JsonAck::Result(_))
     }
 
     #[must_use = "if you intended to assert that this is an error, consider `.unwrap_err()` instead"]
     #[inline]
-    pub const fn is_error(&self) -> bool {
+    pub fn is_error(&self) -> bool {
         !self.is_success()
     }
 

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -15,6 +15,7 @@ mod ibc;
 mod import_helpers;
 #[cfg(feature = "iterator")]
 mod iterator;
+mod json_ack;
 mod math;
 mod never;
 mod panic;
@@ -46,6 +47,7 @@ pub use crate::ibc::{
 };
 #[cfg(feature = "iterator")]
 pub use crate::iterator::{Order, Record};
+pub use crate::json_ack::JsonAck;
 pub use crate::math::{
     Decimal, Decimal256, Decimal256RangeExceeded, DecimalRangeExceeded, Fraction, Isqrt, Uint128,
     Uint256, Uint512, Uint64,


### PR DESCRIPTION
This is an alternative approach to #1637, addressing the issue of nested base64 serialization brought up by @0xekez.

The JsonAck is an success/error acknowledgement type that is serialized to JSON. The content is any JSON type in `result` (success) and a string in `error`.

Success examples

* Struct (`JsonAck<Foo>`)
  ```json
  {"result":{"count":78}}
  ```
* String (`JsonAck<String>`)
  ```json
  {"result":"okay, all good"}
  ```
* Number (`JsonAck<i32>`)
  ```json
  {"result":-46518}
  ```
* ICS-20 compatible base64  (`JsonAck<Binary>`)
  ```json
  {"result":"AQ=="}
  ```

Error examples:

* Errors are aways strings (`JsonAck<_>`)
  ```json
  {"error":"kaputt"}
  ```

## Compatibility

JsonAck and the ICS-20 Acknowledgement types are compatible in the sense that the outermost structure is a JSON object with either a `result` or `error` keys. Errors are always strings. In ICS-20 success `result`s are always base64 and in JsonAck any JSON value is allowed.

Generic decoders that want to support both JsonAck and ICS-20 acks have to parse the `result` value into an arbitrary JSON value, detect error or success and in case of success further inkect the `result` value. Detecting success or error is as simple as `ack.error != ""`. [See this Go example](https://go.dev/play/p/_9s3ENyoF75).

For Rust we don't have a great deserialization solution yet (_I agree something like Go's json.RawMessage would be great, but we don't really have a good alternative in our Rust libraries. (There is one in serde-json under a feature flag but it brings in floats)._ from https://github.com/CosmWasm/cosmwasm/pull/1637#issuecomment-1479177290). But I'm not sure if ack deserialization is needed in a contract.

For debugging you can just dump the whole JsonAck structure and see all content immediately.

`JsonAck<Binary>` is exactly the same as the ICS-20 ack.

## Comparison with StdAck

## Con

- Slightly incompatible as the `result` field can be any JSON indead of just base64 strings.
- A decoding error of the `result` value leads to a decoding error of the whole document (a consequence of the flattening)
- The `to_binary()` or other serializers return a result because we serialize a generic `T`.

## Pro

- For the smart contract developer, there is only one ack (not an ack inside of an ack)
- Writing integration tests for the ack becomes easier since you only need one decoding step
- Debugging is easier since dumping the outermost ack shows you all the contents
- The encoding is more efficient for JSON payload
- Better type safety for CosmWasm developers