### PR TITLE
Migrate away from loupe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to
 - cosmwasm-vm: Limit number of imports during static validation ([#1629]).
 - cosmwasm-vm: The `check_contract` example was removed. Please use the crate
   [cosmwasm-check](https://crates.io/crates/cosmwasm-check) instead ([#1511]).
+- cosmwasm-vm: Avoid using loupe for getting the `Module` size in the file
+  system cache to prepare for the Wasmer 3 upgrade.
 
 [#1511]: https://github.com/CosmWasm/cosmwasm/issues/1511
 [#1629]: https://github.com/CosmWasm/cosmwasm/pull/1629

--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -262,9 +262,8 @@ where
 
         // Try to get module from file system cache
         let store = make_runtime_store(Some(cache.instance_memory_limit));
-        if let Some(module) = cache.fs_cache.load(checksum, &store)? {
+        if let Some((module, module_size)) = cache.fs_cache.load(checksum, &store)? {
             cache.stats.hits_fs_cache = cache.stats.hits_fs_cache.saturating_add(1);
-            let module_size = loupe::size_of_val(&module);
             return cache
                 .pinned_memory_cache
                 .store(checksum, module, module_size);
@@ -274,8 +273,7 @@ where
         let code = self.load_wasm_with_path(&cache.wasm_path, checksum)?;
         let module = compile(&code, Some(cache.instance_memory_limit), &[])?;
         // Store into the fs cache too
-        cache.fs_cache.store(checksum, &module)?;
-        let module_size = loupe::size_of_val(&module);
+        let module_size = cache.fs_cache.store(checksum, &module)?;
         cache
             .pinned_memory_cache
             .store(checksum, module, module_size)
@@ -334,9 +332,9 @@ where
 
         // Get module from file system cache
         let store = make_runtime_store(Some(cache.instance_memory_limit));
-        if let Some(module) = cache.fs_cache.load(checksum, &store)? {
+        if let Some((module, module_size)) = cache.fs_cache.load(checksum, &store)? {
             cache.stats.hits_fs_cache = cache.stats.hits_fs_cache.saturating_add(1);
-            let module_size = loupe::size_of_val(&module);
+
             cache
                 .memory_cache
                 .store(checksum, module.clone(), module_size)?;
@@ -351,8 +349,8 @@ where
         let wasm = self.load_wasm_with_path(&cache.wasm_path, checksum)?;
         cache.stats.misses = cache.stats.misses.saturating_add(1);
         let module = compile(&wasm, Some(cache.instance_memory_limit), &[])?;
-        cache.fs_cache.store(checksum, &module)?;
-        let module_size = loupe::size_of_val(&module);
+        let module_size = cache.fs_cache.store(checksum, &module)?;
+
         cache
             .memory_cache
             .store(checksum, module.clone(), module_size)?;

--- a/packages/vm/src/modules/file_system_cache.rs
+++ b/packages/vm/src/modules/file_system_cache.rs
@@ -103,13 +103,23 @@ impl FileSystemCache {
 
     /// Loads a serialized module from the file system and returns a module (i.e. artifact + store),
     /// along with the size of the serialized module.
-    pub fn load(&self, checksum: &Checksum, store: &Store) -> VmResult<Option<Module>> {
+    /// The serialized module size is a good approximation (~100.06 %) of the in-memory module size.
+    /// It should not be considered as the exact in-memory module size.
+    pub fn load(&self, checksum: &Checksum, store: &Store) -> VmResult<Option<(Module, usize)>> {
         let filename = checksum.to_hex();
         let file_path = self.latest_modules_path().join(filename);
 
-        let result = unsafe { Module::deserialize_from_file(store, file_path) };
+        let result = unsafe { Module::deserialize_from_file(store, &file_path) };
         match result {
-            Ok(module) => Ok(Some(module)),
+            Ok(module) => {
+                let module_size = file_path
+                    .metadata()
+                    .map_err(|e| {
+                        VmError::cache_err(format!("Error getting module file size: {}", e))
+                    })?
+                    .len();
+                Ok(Some((module, module_size as usize)))
+            }
             Err(DeserializeError::Io(err)) => match err.kind() {
                 io::ErrorKind::NotFound => Ok(None),
                 _ => Err(VmError::cache_err(format!(
@@ -125,7 +135,9 @@ impl FileSystemCache {
     }
 
     /// Stores a serialized module to the file system. Returns the size of the serialized module.
-    pub fn store(&mut self, checksum: &Checksum, module: &Module) -> VmResult<()> {
+    /// The serialized module size is a good approximation (~100.06 %) of the in-memory module size.
+    /// It should not be considered as the exact in-memory module size.
+    pub fn store(&mut self, checksum: &Checksum, module: &Module) -> VmResult<usize> {
         let modules_dir = self.latest_modules_path();
         mkdir_p(&modules_dir)
             .map_err(|_e| VmError::cache_err("Error creating modules directory"))?;
@@ -133,9 +145,13 @@ impl FileSystemCache {
         let filename = checksum.to_hex();
         let path = modules_dir.join(filename);
         module
-            .serialize_to_file(path)
+            .serialize_to_file(path.clone())
             .map_err(|e| VmError::cache_err(format!("Error writing module to disk: {}", e)))?;
-        Ok(())
+        let module_size = path
+            .metadata()
+            .map_err(|e| VmError::cache_err(format!("Error getting module file size: {}", e)))?
+            .len();
+        Ok(module_size as usize)
     }
 
     /// Removes a serialized module from the file system.
@@ -212,7 +228,8 @@ mod tests {
         // Check the returned module is functional.
         // This is not really testing the cache API but better safe than sorry.
         {
-            let cached_module = cached.unwrap();
+            let (cached_module, module_size) = cached.unwrap();
+            assert_eq!(module_size, module.serialize().unwrap().len());
             let import_object = imports! {};
             let instance = WasmerInstance::new(&cached_module, &import_object).unwrap();
             set_remaining_points(&instance, TESTING_GAS_LIMIT);

--- a/packages/vm/src/modules/file_system_cache.rs
+++ b/packages/vm/src/modules/file_system_cache.rs
@@ -129,8 +129,6 @@ impl FileSystemCache {
     }
 
     /// Stores a serialized module to the file system. Returns the size of the serialized module.
-    /// The serialized module size is a good approximation (~100.06 %) of the in-memory module size.
-    /// It should not be considered as the exact in-memory module size.
     pub fn store(&mut self, checksum: &Checksum, module: &Module) -> VmResult<usize> {
         let modules_dir = self.latest_modules_path();
         mkdir_p(&modules_dir)


### PR DESCRIPTION
This reverts https://github.com/CosmWasm/cosmwasm/pull/1041 and prepares the Wasmer 3 upgrade because loupe was refectored aways from Wasmer and is not available anymore.