### PR TITLE
Coin uses same output for Debug as Display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to
 - cosmwasm-vm: Add `.wasm` extension to stored wasm files ([#1686]).
 - cosmwasm-vm: Upgrade Wasmer to version 3.3.0.
 - cosmwasm-check: Update clap dependency to version 4 ([#1677])
-- cosmwasm-std: Coin uses `123ucosm` format for Debug as well as Display
+- cosmwasm-std: Coin uses `Coin { 123 "ucosm" }` format for Debug as well as Display
   ([#1704])
 
 [#1511]: https://github.com/CosmWasm/cosmwasm/issues/1511

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to
 - cosmwasm-vm: Add `.wasm` extension to stored wasm files ([#1686]).
 - cosmwasm-vm: Upgrade Wasmer to version 3.3.0.
 - cosmwasm-check: Update clap dependency to version 4 ([#1677])
-- cosmwasm-std: Coin uses `Coin { 123 "ucosm" }` format for Debug as well as Display
+- cosmwasm-std: Coin uses shorter `Coin { 123 "ucosm" }` format for Debug
   ([#1704])
 
 [#1511]: https://github.com/CosmWasm/cosmwasm/issues/1511

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to
 - cosmwasm-vm: Add `.wasm` extension to stored wasm files ([#1686]).
 - cosmwasm-vm: Upgrade Wasmer to version 3.3.0.
 - cosmwasm-check: Update clap dependency to version 4 ([#1677])
+- cosmwasm-std: Coin uses `123ucosm` format for Debug as well as Display
+  ([#1704])
 
 [#1511]: https://github.com/CosmWasm/cosmwasm/issues/1511
 [#1629]: https://github.com/CosmWasm/cosmwasm/pull/1629
@@ -42,6 +44,7 @@ and this project adheres to
 [#1667]: https://github.com/CosmWasm/cosmwasm/pull/1667
 [#1677]: https://github.com/CosmWasm/cosmwasm/pull/1677
 [#1686]: https://github.com/CosmWasm/cosmwasm/pull/1686
+[#1704]: https://github.com/CosmWasm/cosmwasm/pull/1704
 
 ### Deprecated
 

--- a/packages/std/src/coin.rs
+++ b/packages/std/src/coin.rs
@@ -4,7 +4,7 @@ use std::{fmt, str::FromStr};
 
 use crate::{errors::CoinFromStrError, math::Uint128};
 
-#[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Default, PartialEq, Eq, JsonSchema)]
 pub struct Coin {
     pub denom: String,
     pub amount: Uint128,
@@ -16,6 +16,12 @@ impl Coin {
             amount: Uint128::new(amount),
             denom: denom.into(),
         }
+    }
+}
+
+impl fmt::Debug for Coin {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}{}", self.amount, self.denom)
     }
 }
 
@@ -234,5 +240,11 @@ mod tests {
                 .to_string(),
             "Invalid amount: number too large to fit in target type"
         );
+    }
+
+    #[test]
+    fn debug_coin() {
+        let coin = Coin::new(123, "ucosm");
+        assert_eq!(format!("{:?}", coin), "123ucosm");
     }
 }

--- a/packages/std/src/coin.rs
+++ b/packages/std/src/coin.rs
@@ -21,7 +21,7 @@ impl Coin {
 
 impl fmt::Debug for Coin {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}{}", self.amount, self.denom)
+        write!(f, "Coin {{ {} \"{}\" }}", self.amount, self.denom)
     }
 }
 
@@ -245,6 +245,6 @@ mod tests {
     #[test]
     fn debug_coin() {
         let coin = Coin::new(123, "ucosm");
-        assert_eq!(format!("{:?}", coin), "123ucosm");
+        assert_eq!(format!("{:?}", coin), r#"Coin { 123 "ucosm" }"#);
     }
 }


### PR DESCRIPTION
The Display is now like `123ucosm` while Debug is like `Coin { denom: "ucosm", amount: Uint128(123) }]` (See example here: https://github.com/CosmWasm/cosmwasm/issues/1257).

This is quite annoying when outputing Debug for larger structs that include `Vec<Coin>`. Now the binary fields are well-encoded, this is the ugliest part of debugging view.

This will just align the Debug view with the Display view (as this seems like the canonical encoding format as per https://github.com/CosmWasm/cosmwasm/pull/1684)