### PR TITLE
Add bps conversion to `Decimal` and `Decimal256`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,12 @@ and this project adheres to
   been checked before. This is useful for state-sync where we know the Wasm code
   was checked when it was first uploaded. ([#1635])
 - cosmwasm-std: Add `FromStr` impl for `Coin`. ([#1684])
+- cosmwasm-std: Add `Decimal::bps` and `Decimal256::bps` to create a decimal
+  from a basis point value ([#1715]).
 
 [#1635]: https://github.com/CosmWasm/cosmwasm/pull/1635
 [#1684]: https://github.com/CosmWasm/cosmwasm/pull/1684
+[#1715]: https://github.com/CosmWasm/cosmwasm/pull/1715
 
 ### Changed
 

--- a/packages/std/src/math/decimal.rs
+++ b/packages/std/src/math/decimal.rs
@@ -76,6 +76,11 @@ impl Decimal {
         Self(((x as u128) * 1_000_000_000_000_000).into())
     }
 
+    /// Convert bps (basis points) into Decimal
+    pub fn bps(x: u64) -> Self {
+        Self(((x as u128) * 100_000_000_000_000).into())
+    }
+
     /// Creates a decimal from a number of atomic units and the number
     /// of decimal places. The inputs will be converted internally to form
     /// a decimal with 18 decimal places. So the input 123 and 2 will create
@@ -766,6 +771,12 @@ mod tests {
     fn decimal_permille() {
         let value = Decimal::permille(125);
         assert_eq!(value.0, Decimal::DECIMAL_FRACTIONAL / Uint128::from(8u8));
+    }
+
+    #[test]
+    fn decimal_bps() {
+        let value = Decimal::bps(125);
+        assert_eq!(value.0, Decimal::DECIMAL_FRACTIONAL / Uint128::from(80u8));
     }
 
     #[test]

--- a/packages/std/src/math/decimal.rs
+++ b/packages/std/src/math/decimal.rs
@@ -76,7 +76,7 @@ impl Decimal {
         Self(((x as u128) * 1_000_000_000_000_000).into())
     }
 
-    /// Convert bps (basis points) into Decimal
+    /// Convert basis points (x/10000) into Decimal
     pub fn bps(x: u64) -> Self {
         Self(((x as u128) * 100_000_000_000_000).into())
     }

--- a/packages/std/src/math/decimal256.rs
+++ b/packages/std/src/math/decimal256.rs
@@ -85,7 +85,7 @@ impl Decimal256 {
         Self(Uint256::from(x) * Uint256::from(1_000_000_000_000_000u128))
     }
 
-    /// Convert bps (basis points) into Decimal256
+    /// Convert basis points (x/10000) into Decimal256
     pub fn bps(x: u64) -> Self {
         Self(Uint256::from(x) * Uint256::from(100_000_000_000_000u128))
     }

--- a/packages/std/src/math/decimal256.rs
+++ b/packages/std/src/math/decimal256.rs
@@ -802,7 +802,10 @@ mod tests {
     #[test]
     fn decimal256_bps() {
         let value = Decimal256::bps(125);
-        assert_eq!(value.0, Decimal256::DECIMAL_FRACTIONAL / Uint256::from(80u8));
+        assert_eq!(
+            value.0,
+            Decimal256::DECIMAL_FRACTIONAL / Uint256::from(80u8)
+        );
     }
 
     #[test]

--- a/packages/std/src/math/decimal256.rs
+++ b/packages/std/src/math/decimal256.rs
@@ -85,6 +85,11 @@ impl Decimal256 {
         Self(Uint256::from(x) * Uint256::from(1_000_000_000_000_000u128))
     }
 
+    /// Convert bps (basis points) into Decimal256
+    pub fn bps(x: u64) -> Self {
+        Self(Uint256::from(x) * Uint256::from(100_000_000_000_000u128))
+    }
+
     /// Creates a decimal from a number of atomic units and the number
     /// of decimal places. The inputs will be converted internally to form
     /// a decimal with 18 decimal places. So the input 123 and 2 will create
@@ -792,6 +797,12 @@ mod tests {
     fn decimal256_permille() {
         let value = Decimal256::permille(125);
         assert_eq!(value.0, Decimal256::DECIMAL_FRACTIONAL / Uint256::from(8u8));
+    }
+
+    #[test]
+    fn decimal256_bps() {
+        let value = Decimal256::bps(125);
+        assert_eq!(value.0, Decimal256::DECIMAL_FRACTIONAL / Uint256::from(80u8));
     }
 
     #[test]


### PR DESCRIPTION
Have found a common need to do basis points conversion in financial math. So ideally this should live in the standard lib to prevent conversion errors by contracts.