### PR TITLE
Avoid allocation when converting Uint256 to Uint512

### DIFF
--- a/packages/std/src/math/uint512.rs
+++ b/packages/std/src/math/uint512.rs
@@ -325,9 +325,10 @@ impl Uint512 {
 
 impl From<Uint256> for Uint512 {
     fn from(val: Uint256) -> Self {
-        let bytes = [[0u8; 32], val.to_be_bytes()].concat();
+        let mut bytes = [0u8; 64];
+        bytes[32..].copy_from_slice(&val.to_be_bytes());
 
-        Self::from_be_bytes(bytes.try_into().unwrap())
+        Self::from_be_bytes(bytes)
     }
 }
 


### PR DESCRIPTION
closes #1714 