### PR TITLE
Add backport to mergify config

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -6,27 +6,49 @@ pull_request_rules:
       - "#approved-reviews-by>=1"
       - base=main
       - label=automerge
+      - draft=false
       - label!=WIP
-      # We need to list them all individually. Here is why: https://doc.mergify.io/conditions.html#validating-all-status-check
-      - "status-success=ci/circleci: package_crypto"
-      - "status-success=ci/circleci: package_schema"
-      - "status-success=ci/circleci: package_std"
-      - "status-success=ci/circleci: package_storage"
-      - "status-success=ci/circleci: package_vm"
+      # We need to list them all individually. Here is why: https://docs.mergify.com/conditions/#validating-all-status-checks
+      # Also make sure to update this when the CI names change
+      - "status-success=macOS"
+      - "status-success=Windows"
+      - "status-success=ci/circleci: arm64"
+      - "status-success=ci/circleci: clippy-1.60.0"
+      - "status-success=ci/circleci: clippy-1.68.2"
       - "status-success=ci/circleci: contract_burner"
       - "status-success=ci/circleci: contract_crypto_verify"
+      - "status-success=ci/circleci: contract_cyberpunk"
+      - "status-success=ci/circleci: contract_floaty"
+      - "status-success=ci/circleci: contract_hackatom"
       - "status-success=ci/circleci: contract_hackatom"
       - "status-success=ci/circleci: contract_ibc_reflect"
       - "status-success=ci/circleci: contract_ibc_reflect_send"
-      - "status-success=ci/circleci: contract_floaty"
       - "status-success=ci/circleci: contract_queue"
       - "status-success=ci/circleci: contract_reflect"
       - "status-success=ci/circleci: contract_staking"
+      - "status-success=ci/circleci: contract_virus"
+      - "status-success=ci/circleci: coverage"
       - "status-success=ci/circleci: fmt"
-      - "status-success=ci/circleci: clippy-1.54.0"
-      - "status-success=ci/circleci: clippy-1.58.1"
-      - "status-success=Windows"
-      - "status-success=macOS"
+      - "status-success=ci/circleci: fmt_extra"
+      - "status-success=ci/circleci: package_check"
+      - "status-success=ci/circleci: package_crypto"
+      - "status-success=ci/circleci: package_schema"
+      - "status-success=ci/circleci: package_schema_derive"
+      - "status-success=ci/circleci: package_std"
+      - "status-success=ci/circleci: package_storage"
+      - "status-success=ci/circleci: package_vm"
+      - "status-success=ci/circleci: package_vm_windows"
     actions:
       merge:
         method: merge
+- name: backport PRs to minor version branch
+    conditions:
+      - base=main
+      - label=backport
+    actions:
+      backport:
+        branches:
+          # Update this when going to a new minor version
+          - "1.2"
+        assignees:
+          - "{{ author }}"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -6,7 +6,7 @@ pull_request_rules:
       - "#approved-reviews-by>=1"
       - base=main
       - label=automerge
-      - draft=false
+      - -draft
       - label!=WIP
       # We need to list them all individually. Here is why: https://docs.mergify.com/conditions/#validating-all-status-checks
       # Also make sure to update this when the CI names change
@@ -41,7 +41,7 @@ pull_request_rules:
     actions:
       merge:
         method: merge
-- name: backport PRs to minor version branch
+  - name: backport PRs to minor version branch
     conditions:
       - base=main
       - label=backport


### PR DESCRIPTION
We just need to add a "backport" label (will create that when we merge this) to PRs that go to main. Mergify will then open a PR to 1.2 after the original PR gets merged.
We also need to keep the branch name in the config up-to-date. So, when we create 1.3, we need to update this.

Also updated the ci job names for the automerge. Not sure if that fixes it, since I cannot test it easily.