### PR TITLE
Add `FundCommunityPool` to supported Distribution Msgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+- cosmwasm-std: Add `DistributionMsg::FundCommunityPool` ([#1747])
+
 ### Added
 
 - cosmwasm-std: Implement `BankQuery::AllDenomMetadata` to allow querying all

--- a/packages/std/src/results/cosmos_msg.rs
+++ b/packages/std/src/results/cosmos_msg.rs
@@ -113,6 +113,7 @@ pub enum DistributionMsg {
     },
     /// This is translated to a [[MsgFundCommunityPool](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#LL69C1-L76C2).
     /// `depositor` is automatically filled with the current contract's address.
+    #[cfg(feature = "cosmwasm_1_3")]
     FundCommunityPool {
 		/// The amount to spend
 		amount: Vec<Coin>,

--- a/packages/std/src/results/cosmos_msg.rs
+++ b/packages/std/src/results/cosmos_msg.rs
@@ -111,6 +111,12 @@ pub enum DistributionMsg {
         /// The `validator_address`
         validator: String,
     },
+    /// This is translated to a [[MsgFundCommunityPool](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#LL69C1-L76C2).
+    /// `depositor` is automatically filled with the current contract's address.
+    FundCommunityPool {
+		/// The amount to spend
+		amount: Vec<Coin>,
+	},
 }
 
 fn binary_to_string(data: &Binary, fmt: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
@@ -461,6 +467,44 @@ mod tests {
                 r#"{"instantiate2":{"admin":null,"code_id":7897,"label":"my instance","msg":"eyJjbGFpbSI6e319","funds":[{"denom":"stones","amount":"321"}],"salt":"UkOVazhiwoo="}}"#,
             );
         }
+    }
+    
+    #[test]
+    fn msg_distribution_serializes_to_correct_json() {
+        
+        // FundCommunityPool
+        let fund_coins = vec![
+            coin(200, "feathers"),
+            coin(200, "stones"),
+        ];
+        let fund_msg = DistributionMsg::FundCommunityPool{
+            amount: fund_coins,
+        };
+        let fund_json = to_binary(&fund_msg).unwrap();
+        assert_eq!(
+            String::from_utf8_lossy(&fund_json),
+            r#"{"fund_community_pool":{"amount":[{"denom":"feathers","amount":"200"},{"denom":"stones","amount":"200"}]}}"#,
+        );
+        
+        // SetWithdrawAddress
+        let set_msg = DistributionMsg::SetWithdrawAddress{
+            address: String::from("withdrawer"),
+        };
+        let set_json = to_binary(&set_msg).unwrap();
+        assert_eq!(
+            String::from_utf8_lossy(&set_json),
+            r#"{"set_withdraw_address":{"address":"withdrawer"}}"#,
+        );
+        
+        // WithdrawDelegatorRewards
+        let withdraw_msg = DistributionMsg::WithdrawDelegatorReward{
+            validator: String::from("fancyoperator"),
+        };
+        let withdraw_json = to_binary(&withdraw_msg).unwrap();
+        assert_eq!(
+            String::from_utf8_lossy(&withdraw_json),
+            r#"{"withdraw_delegator_reward":{"validator":"fancyoperator"}}"#
+        );
     }
 
     #[test]


### PR DESCRIPTION
Hello. I politely ask to add `FundCommunityPool` msg to cosmwasm::std, because it is a "hot" feature for Terra Classic smart contract owners. This PR is a third follow-up in a series of follow-ups described by the following issues and PRs:

- https://github.com/CosmWasm/wasmd/pull/1458
- https://github.com/CosmWasm/wasmvm/pull/433
- https://github.com/classic-terra/core/issues/288
- https://github.com/CosmWasm/cosmwasm/issues/1741

The changes include:

- add `FundCommunityPool` to the list of supported/serializable `DistributionMsg`s
- add serialization test
- add serialization test for the other `DistributionMsg` variants (for the sake of completeness)

**Note** that this would likely need to be merged after the above mentioned PRs have been accepted. Thank you for considering this. We appreciate your support.