### PR TITLE
WIP: Add prost support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,6 +163,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
+name = "bytes"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -365,6 +371,7 @@ dependencies = [
  "forward_ref",
  "hex",
  "hex-literal",
+ "prost",
  "schemars",
  "serde",
  "serde-json-wasm",
@@ -1284,6 +1291,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
 dependencies = [
  "unicode-xid",
+]
+
+[[package]]
+name = "prost"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/packages/schema-derive/src/cw_prost.rs
+++ b/packages/schema-derive/src/cw_prost.rs
@@ -1,0 +1,141 @@
+use syn::{parse_quote, DeriveInput};
+
+/// This is only needed for types that do not implement cw_serde.
+/// If they already have cw_serde, just add #[derive(prost::Message)]
+pub fn cw_prost_impl(input: DeriveInput) -> DeriveInput {
+    match input.data {
+        syn::Data::Struct(_) => parse_quote! {
+            #[derive(
+                ::prost::Message,
+                ::std::clone::Clone,
+                ::std::fmt::Debug,
+                ::std::cmp::PartialEq,
+            )]
+            #[allow(clippy::derive_partial_eq_without_eq)] // Allow users of `#[cw_proto]` to not implement Eq without clippy complaining
+            #input
+        },
+        syn::Data::Enum(_) => parse_quote! {
+            #[derive(
+                ::prost::Oneof,
+                ::std::clone::Clone,
+                ::std::fmt::Debug,
+                ::std::cmp::PartialEq,
+            )]
+            #[allow(clippy::derive_partial_eq_without_eq)] // Allow users of `#[cw_serde]` to not implement Eq without clippy complaining
+            #input
+        },
+        syn::Data::Union(_) => panic!("unions are not supported"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn structs() {
+        let expanded = cw_prost_impl(parse_quote! {
+            pub struct InstantiateMsg {
+                #[prost(string, tag="1")]
+                pub verifier: String,
+                #[prost(string, tag="2")]
+                pub beneficiary: String,
+            }
+        });
+
+        let expected = parse_quote! {
+            #[derive(
+                ::prost::Message,
+                ::std::clone::Clone,
+                ::std::fmt::Debug,
+                ::std::cmp::PartialEq,
+            )]
+            #[allow(clippy::derive_partial_eq_without_eq)]
+            pub struct InstantiateMsg {
+                #[prost(string, tag="1")]
+                pub verifier: String,
+                #[prost(string, tag="2")]
+                pub beneficiary: String,
+            }
+        };
+
+        assert_eq!(expanded, expected);
+    }
+
+    #[test]
+    fn empty_struct() {
+        let expanded = cw_prost_impl(parse_quote! {
+            pub struct InstantiateMsg {}
+        });
+
+        let expected = parse_quote! {
+            #[derive(
+                ::prost::Message,
+                ::std::clone::Clone,
+                ::std::fmt::Debug,
+                ::std::cmp::PartialEq,
+            )]
+            #[allow(clippy::derive_partial_eq_without_eq)]
+            pub struct InstantiateMsg {}
+        };
+
+        assert_eq!(expanded, expected);
+    }
+
+    #[test]
+    fn enums() {
+        let expanded = cw_prost_impl(parse_quote! {
+            pub enum SudoMsg {
+                #[prost(message, tag = "1")]
+                StealFunds {
+                    #[prost(string, tag = "1")]
+                    recipient: String,
+                    #[prost(message, repeated, tag = "2")]
+                    amount: Vec<Coin>,
+                },
+            }
+        });
+
+        let expected = parse_quote! {
+            #[derive(
+                ::prost::Oneof,
+                ::std::clone::Clone,
+                ::std::fmt::Debug,
+                ::std::cmp::PartialEq,
+            )]
+            #[allow(clippy::derive_partial_eq_without_eq)]
+            pub enum SudoMsg {
+                #[prost(message, tag = "1")]
+                StealFunds {
+                    #[prost(string, tag = "1")]
+                    recipient: String,
+                    #[prost(message, repeated, tag = "2")]
+                    amount: Vec<Coin>,
+                },
+            }
+        };
+
+        assert_eq!(expanded, expected);
+    }
+
+    #[test]
+    #[should_panic(expected = "unions are not supported")]
+    fn unions() {
+        cw_prost_impl(parse_quote! {
+            pub union SudoMsg {
+                x: u32,
+                y: u32,
+            }
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "expected one of: `struct`, `enum`, `union`")]
+    fn functions() {
+        cw_prost_impl(parse_quote! {
+            pub fn do_stuff(a: i32) -> i32 {
+                a * 3
+            }
+        });
+    }
+}

--- a/packages/schema-derive/src/lib.rs
+++ b/packages/schema-derive/src/lib.rs
@@ -56,3 +56,15 @@ pub fn cw_prost(
 
     proc_macro::TokenStream::from(expanded)
 }
+
+#[proc_macro_attribute]
+pub fn cw_prost_serde(
+    _attr: proc_macro::TokenStream,
+    input: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    let expanded = cw_prost::cw_prost_serde_impl(input).into_token_stream();
+
+    proc_macro::TokenStream::from(expanded)
+}

--- a/packages/schema-derive/src/lib.rs
+++ b/packages/schema-derive/src/lib.rs
@@ -1,3 +1,4 @@
+mod cw_prost;
 mod cw_serde;
 mod generate_api;
 mod query_responses;
@@ -40,6 +41,18 @@ pub fn cw_serde(
     let input = parse_macro_input!(input as DeriveInput);
 
     let expanded = cw_serde::cw_serde_impl(input).into_token_stream();
+
+    proc_macro::TokenStream::from(expanded)
+}
+
+#[proc_macro_attribute]
+pub fn cw_prost(
+    _attr: proc_macro::TokenStream,
+    input: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    let expanded = cw_prost::cw_prost_impl(input).into_token_stream();
 
     proc_macro::TokenStream::from(expanded)
 }

--- a/packages/schema/src/lib.rs
+++ b/packages/schema/src/lib.rs
@@ -11,31 +11,6 @@ pub use query_response::{combine_subqueries, IntegrityError, QueryResponses};
 pub use remove::remove_schemas;
 
 // Re-exports
-/// An attribute macro that annotates types with things they need to be properly (de)serialized
-/// for use in CosmWasm contract messages and/or responses, and also for schema generation.
-///
-/// This derives things like `serde::Serialize` or `schemars::JsonSchema`, makes sure
-/// variants are `snake_case` in the resulting JSON, and so forth.
-///
-/// # Example
-/// ```
-/// use cosmwasm_schema::{cw_serde, QueryResponses};
-///
-/// #[cw_serde]
-/// pub struct InstantiateMsg {
-///     owner: String,
-/// }
-///
-/// #[cw_serde]
-/// #[derive(QueryResponses)]
-/// pub enum QueryMsg {
-///     #[returns(Vec<String>)]
-///     Denoms {},
-///     #[returns(String)]
-///     AccountName { account: String },
-/// }
-/// ```
-pub use cosmwasm_schema_derive::cw_serde;
 /// Generates an [`Api`](crate::Api) for the contract. The body describes the message
 /// types exported in the schema and allows setting contract name and version overrides.
 ///
@@ -92,6 +67,31 @@ pub use cosmwasm_schema_derive::generate_api;
 /// };
 /// ```
 pub use cosmwasm_schema_derive::write_api;
+/// An attribute macro that annotates types with things they need to be properly (de)serialized
+/// for use in CosmWasm contract messages and/or responses, and also for schema generation.
+///
+/// This derives things like `serde::Serialize` or `schemars::JsonSchema`, makes sure
+/// variants are `snake_case` in the resulting JSON, and so forth.
+///
+/// # Example
+/// ```
+/// use cosmwasm_schema::{cw_serde, QueryResponses};
+///
+/// #[cw_serde]
+/// pub struct InstantiateMsg {
+///     owner: String,
+/// }
+///
+/// #[cw_serde]
+/// #[derive(QueryResponses)]
+/// pub enum QueryMsg {
+///     #[returns(Vec<String>)]
+///     Denoms {},
+///     #[returns(String)]
+///     AccountName { account: String },
+/// }
+/// ```
+pub use cosmwasm_schema_derive::{cw_prost, cw_prost_serde, cw_serde};
 
 // For use in macro expansions
 pub use schemars;

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -56,11 +56,14 @@ serde-json-wasm = { version = "0.5.0" }
 thiserror = "1.0.26"
 bnum = "0.7.0"
 
+
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 cosmwasm-crypto = { path = "../crypto", version = "1.3.0-rc.0" }
 
 [dev-dependencies]
 cosmwasm-schema = { path = "../schema" }
+prost = "0.11.9"
+
 # The chrono dependency is only used in an example, which Rust compiles for us. If this causes trouble, remove it.
 chrono = { version = "0.4", default-features = false, features = ["alloc", "std"] }
 hex-literal = "0.3.1"

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -3,6 +3,8 @@
 
 // Exposed on all platforms
 
+mod prost_demo;
+
 mod addresses;
 mod assertions;
 mod binary;

--- a/packages/std/src/prost_demo.rs
+++ b/packages/std/src/prost_demo.rs
@@ -1,0 +1,51 @@
+#[cfg(test)]
+mod tests {
+    use cosmwasm_schema::{cw_prost, cw_prost_serde, cw_serde};
+    use prost::Message;
+
+    // Note: it would be interesting to make this more transparent, using something like
+    // https://docs.rs/autoproto/latest/autoproto/
+    // However, that is 1000+ lines of proc macros with no tests and no commits since 2021.
+    // Anyone want to fork that and maintain it?
+
+    #[cw_prost]
+    pub struct OnlyProto {
+        #[prost(string, tag = "1")]
+        pub name: String,
+        #[prost(uint64, tag = "2")]
+        pub age: u64,
+    }
+
+    #[cw_serde]
+    pub struct OnlySerde {
+        pub name: String,
+        pub age: u64,
+    }
+
+    #[cw_prost_serde]
+    pub struct MultiEncoding {
+        #[prost(string, tag = "1")]
+        pub name: String,
+        #[prost(uint64, tag = "2")]
+        pub age: u64,
+    }
+
+    #[test]
+    fn encode_equivalence() {
+        let orig = OnlyProto {
+            name: "Billy".to_string(),
+            age: 42,
+        };
+        let encoded = orig.encode_to_vec();
+        let multi = MultiEncoding::decode(&*encoded).unwrap();
+
+        assert_eq!(orig.name, multi.name);
+        assert_eq!(orig.age, multi.age);
+
+        let json = crate::to_vec(&multi).unwrap();
+        let serde: OnlySerde = crate::from_slice(&json).unwrap();
+
+        assert_eq!(serde.name, multi.name);
+        assert_eq!(serde.age, multi.age);
+    }
+}

--- a/packages/std/src/prost_demo.rs
+++ b/packages/std/src/prost_demo.rs
@@ -37,12 +37,14 @@ mod basic_tests {
             age: 42,
         };
         let encoded = orig.encode_to_vec();
+        println!("Proto length: {}", encoded.len());
         let multi = MultiEncoding::decode(&*encoded).unwrap();
 
         assert_eq!(orig.name, multi.name);
         assert_eq!(orig.age, multi.age);
 
         let json = crate::to_vec(&multi).unwrap();
+        println!("JSON length: {}", json.len());
         let serde: OnlySerde = crate::from_slice(&json).unwrap();
 
         assert_eq!(serde.name, multi.name);
@@ -51,22 +53,40 @@ mod basic_tests {
 }
 
 #[cfg(test)]
-mod cosmwasm_tests {
-    // cargo expand --tests --lib prost_demo::cosmwasm_tests
+mod newtype_tests {
+    // cargo expand --tests --lib prost_demo::newtype_tests
 
     use cosmwasm_schema::cw_prost;
     use prost::Message;
 
     #[cw_prost]
     pub struct Name {
-        #[prost(string, tag = "1")]
-        pub name: String,
+        // No way to flatten this
+        #[prost(message, required, tag = "1")]
+        pub name: Addr,
         #[prost(uint64, tag = "2")]
         pub age: u64,
     }
 
+    // This wraps a struct, top level
     #[derive(Clone, PartialEq, Debug, Default)]
     pub struct TransparentWrapper(pub Name);
+
+    // This simple prost struct is the same output as the manual Message implementation
+    // for Addr as a newtype
+    #[cw_prost]
+    pub struct Addr {
+        #[prost(string, tag = "1")]
+        str: String,
+    }
+
+    impl Addr {
+        pub fn new(addr: &str) -> Self {
+            Addr {
+                str: addr.to_string(),
+            }
+        }
+    }
 
     // TODO: this needs to be another proc macro, like cw_wrap_proto (along with cw_wrap_proto_serde)
     impl ::prost::Message for TransparentWrapper {
@@ -94,16 +114,160 @@ mod cosmwasm_tests {
         }
     }
 
+    /*
+    // This wraps a primitive and is embedded in a single field in a struct
+    #[derive(Clone, PartialEq, Debug, Default)]
+    pub struct Addr(String);
+
+    // TODO: this needs to be another proc macro, like cw_wrap_proto (along with cw_wrap_proto_serde)
+    impl ::prost::Message for Addr {
+        fn encode_raw<B: ::prost::bytes::BufMut>(&self, buf: &mut B) {
+            self.0.encode_raw(buf)
+        }
+
+        fn clear(&mut self) {
+            self.0.clear()
+        }
+
+        #[inline]
+        fn encoded_len(&self) -> usize {
+            self.0.encoded_len()
+        }
+
+        fn merge_field<B: ::prost::bytes::Buf>(
+            &mut self,
+            tag: u32,
+            wire_type: ::prost::encoding::WireType,
+            buf: &mut B,
+            ctx: ::prost::encoding::DecodeContext,
+        ) -> ::core::result::Result<(), ::prost::DecodeError> {
+            self.0.merge_field(tag, wire_type, buf, ctx)
+        }
+    }
+
+    */
+
+    // check out https://protobuf-decoder.netlify.app with
+    // 0a090a0757696c6c69616d10a50a
+    // (the output with cargo test -- --nocapture)
+    // Both versions above produce the same output
+    // Even when manually doing the wrapper of address it embeds one more layer
+
     #[test]
     fn encode_transparent_wrapper() {
         let name = Name {
-            name: "William".to_string(),
+            name: Addr::new("William"),
             age: 1317,
         };
-        let wrapper = TransparentWrapper(name.clone());
+        let wrapper = TransparentWrapper(name);
         let encoded = wrapper.encode_to_vec();
         let decoded = TransparentWrapper::decode(&*encoded).unwrap();
 
-        assert_eq!(wrapper.0, decoded.0);
+        println!("encoded: {:?}", hex::encode(encoded));
+
+        assert_eq!(wrapper, decoded);
+    }
+}
+
+#[cfg(test)]
+mod u128_tests {
+    use cosmwasm_schema::cw_prost;
+    use prost::Message;
+
+    // cargo expand --tests --lib prost_demo::u128_tests
+
+    // No u128 support in protobuf: https://github.com/protocolbuffers/protobuf/issues/10963
+    // we do it manually
+
+    #[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, Debug, Default, Copy)]
+    struct Uint128(u128);
+
+    impl ::prost::Message for Uint128 {
+        fn encode_raw<B: ::prost::bytes::BufMut>(&self, buf: &mut B) {
+            Uint128Impl::from(*self).encode_raw(buf)
+        }
+
+        fn clear(&mut self) {
+            self.0 = 0u128;
+        }
+
+        #[inline]
+        fn encoded_len(&self) -> usize {
+            Uint128Impl::from(*self).encoded_len()
+        }
+
+        fn merge_field<B: ::prost::bytes::Buf>(
+            &mut self,
+            tag: u32,
+            wire_type: ::prost::encoding::WireType,
+            buf: &mut B,
+            ctx: ::prost::encoding::DecodeContext,
+        ) -> ::core::result::Result<(), ::prost::DecodeError> {
+            let mut encoder = Uint128Impl::from(*self);
+            encoder.merge_field(tag, wire_type, buf, ctx)?;
+            let current = Uint128::from(encoder);
+            *self = current;
+            Ok(())
+        }
+    }
+
+    #[cw_prost]
+    struct Uint128Impl {
+        #[prost(uint64, tag = "1")]
+        pub low: u64,
+        #[prost(uint64, tag = "2")]
+        pub high: u64,
+    }
+
+    impl From<Uint128> for Uint128Impl {
+        fn from(u: Uint128) -> Self {
+            Uint128Impl {
+                low: u.0 as u64,
+                high: (u.0 >> 64) as u64,
+            }
+        }
+    }
+
+    impl From<Uint128Impl> for Uint128 {
+        fn from(u: Uint128Impl) -> Self {
+            Uint128((u.high as u128) << 64 | u.low as u128)
+        }
+    }
+
+    #[test]
+    fn proper_conversion() {
+        let small = Uint128(12345678);
+        let proto = Uint128Impl::from(small);
+        let back = Uint128::from(proto);
+        assert_eq!(small, back);
+
+        let large = Uint128(u128::MAX);
+        let proto = Uint128Impl::from(large);
+        let back = Uint128::from(proto);
+        assert_eq!(large, back);
+    }
+
+    #[test]
+    fn encode_decode_u128() {
+        let mut number = Uint128(123456789012345678901234567890);
+        let encoded = number.encode_to_vec();
+        let decoded = Uint128::decode(&*encoded).unwrap();
+        assert_eq!(number, decoded);
+
+        number.clear();
+        let encoded = number.encode_to_vec();
+        let decoded = Uint128::decode(&*encoded).unwrap();
+        assert_eq!(Uint128(0), decoded);
+    }
+
+    #[test]
+    fn encoding_size() {
+        let number = Uint128(54_300_000);
+        let proto_len = number.encoded_len();
+        let json = crate::to_vec(&number).unwrap();
+        let json_len = json.len();
+
+        println!("proto: {}, json: {}", proto_len, json_len);
+        assert!(proto_len < json_len);
     }
 }


### PR DESCRIPTION
We've had a lot of discussions here about how to add support for protobuf encoding in local contract storage. Forking `cw-storage-plus` is not that hard, but it requires that all core types in `cosmwasm-std` support both `prost` and `serde` encoding. 

This is a demo of nicer apis to generate this alongside `cw_serde` as well as how to handle some patterns we have in the standard library.

It would be great to auto-generate the field tags as well to make this less work. That was demo'd in https://github.com/eira-fransham/autoproto but that code has no commit since 2021 and no tests on many lines of proc macros, so it probably requires a fork and a new maintainer before we could take that approach