### PR TITLE
cosmwasm_std: prefer core and alloc modules to prepare for no_std

### DIFF
--- a/packages/std/src/addresses.rs
+++ b/packages/std/src/addresses.rs
@@ -1,12 +1,12 @@
+use alloc::borrow::Cow;
+use core::fmt;
+use core::ops::Deref;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use sha2::{
     digest::{Digest, Update},
     Sha256,
 };
-use std::borrow::Cow;
-use std::fmt;
-use std::ops::Deref;
 use thiserror::Error;
 
 use crate::{binary::Binary, forward_ref_partial_eq, HexBinary};
@@ -401,7 +401,6 @@ mod tests {
     use super::*;
     use crate::{assert_hash_works, HexBinary};
     use hex_literal::hex;
-    use std::collections::HashSet;
 
     #[test]
     fn addr_unchecked_works() {
@@ -657,6 +656,8 @@ mod tests {
     /// This requires Hash and Eq to be implemented
     #[test]
     fn canonical_addr_can_be_used_in_hash_set() {
+        use std::collections::HashSet;
+
         let alice1 = CanonicalAddr::from([0, 187, 61, 11, 250, 0]);
         let alice2 = CanonicalAddr::from([0, 187, 61, 11, 250, 0]);
         let bob = CanonicalAddr::from([16, 21, 33, 0, 255, 9]);

--- a/packages/std/src/assertions.rs
+++ b/packages/std/src/assertions.rs
@@ -30,7 +30,7 @@
 macro_rules! ensure {
     ($cond:expr, $e:expr) => {
         if !($cond) {
-            return Err(std::convert::From::from($e));
+            return Err(core::convert::From::from($e));
         }
     };
 }
@@ -68,7 +68,7 @@ macro_rules! ensure_eq {
     ($a:expr, $b:expr, $e:expr) => {
         // Not implemented via `ensure!` because the caller would have to import both macros.
         if !($a == $b) {
-            return Err(std::convert::From::from($e));
+            return Err(core::convert::From::from($e));
         }
     };
 }
@@ -100,7 +100,7 @@ macro_rules! ensure_ne {
     ($a:expr, $b:expr, $e:expr) => {
         // Not implemented via `ensure!` because the caller would have to import both macros.
         if !($a != $b) {
-            return Err(std::convert::From::from($e));
+            return Err(core::convert::From::from($e));
         }
     };
 }

--- a/packages/std/src/binary.rs
+++ b/packages/std/src/binary.rs
@@ -1,5 +1,5 @@
-use std::fmt;
-use std::ops::Deref;
+use core::fmt;
+use core::ops::Deref;
 
 use schemars::JsonSchema;
 use serde::{de, ser, Deserialize, Deserializer, Serialize};
@@ -135,7 +135,7 @@ impl From<Binary> for Vec<u8> {
     }
 }
 
-/// Implement `encoding::Binary == std::vec::Vec<u8>`
+/// Implement `encoding::Binary == alloc::vec::Vec<u8>`
 impl PartialEq<Vec<u8>> for Binary {
     fn eq(&self, rhs: &Vec<u8>) -> bool {
         // Use Vec<u8> == Vec<u8>
@@ -143,7 +143,7 @@ impl PartialEq<Vec<u8>> for Binary {
     }
 }
 
-/// Implement `std::vec::Vec<u8> == encoding::Binary`
+/// Implement `alloc::vec::Vec<u8> == encoding::Binary`
 impl PartialEq<Binary> for Vec<u8> {
     fn eq(&self, rhs: &Binary) -> bool {
         // Use Vec<u8> == Vec<u8>
@@ -241,7 +241,6 @@ mod tests {
     use crate::assert_hash_works;
     use crate::errors::StdError;
     use crate::serde::{from_slice, to_vec};
-    use std::collections::HashSet;
 
     #[test]
     fn encode_decode() {
@@ -520,6 +519,8 @@ mod tests {
     /// This requires Hash and Eq to be implemented
     #[test]
     fn binary_can_be_used_in_hash_set() {
+        use std::collections::HashSet;
+
         let a1 = Binary::from([0, 187, 61, 11, 250, 0]);
         let a2 = Binary::from([0, 187, 61, 11, 250, 0]);
         let b = Binary::from([16, 21, 33, 0, 255, 9]);

--- a/packages/std/src/coin.rs
+++ b/packages/std/src/coin.rs
@@ -1,6 +1,6 @@
+use core::{fmt, str::FromStr};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::{fmt, str::FromStr};
 
 use crate::{errors::CoinFromStrError, math::Uint128};
 

--- a/packages/std/src/coins.rs
+++ b/packages/std/src/coins.rs
@@ -1,6 +1,6 @@
-use std::collections::BTreeMap;
-use std::fmt;
-use std::str::FromStr;
+use alloc::collections::BTreeMap;
+use core::fmt;
+use core::str::FromStr;
 
 use crate::{errors::CoinsError, Coin, StdError, StdResult, Uint128};
 use crate::{OverflowError, OverflowOperation};

--- a/packages/std/src/deps.rs
+++ b/packages/std/src/deps.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use crate::query::CustomQuery;
 use crate::results::Empty;

--- a/packages/std/src/errors/recover_pubkey_error.rs
+++ b/packages/std/src/errors/recover_pubkey_error.rs
@@ -1,8 +1,8 @@
+use core::fmt::Debug;
 #[cfg(not(target_arch = "wasm32"))]
 use cosmwasm_crypto::CryptoError;
 #[cfg(feature = "backtraces")]
 use std::backtrace::Backtrace;
-use std::fmt::Debug;
 use thiserror::Error;
 
 #[derive(Error, Debug)]

--- a/packages/std/src/errors/std_error.rs
+++ b/packages/std/src/errors/std_error.rs
@@ -1,6 +1,6 @@
+use core::fmt;
 #[cfg(feature = "backtraces")]
 use std::backtrace::Backtrace;
-use std::fmt;
 use thiserror::Error;
 
 use crate::errors::{RecoverPubkeyError, VerificationError};
@@ -433,14 +433,14 @@ impl PartialEq<StdError> for StdError {
     }
 }
 
-impl From<std::str::Utf8Error> for StdError {
-    fn from(source: std::str::Utf8Error) -> Self {
+impl From<core::str::Utf8Error> for StdError {
+    fn from(source: core::str::Utf8Error) -> Self {
         Self::invalid_utf8(source)
     }
 }
 
-impl From<std::string::FromUtf8Error> for StdError {
-    fn from(source: std::string::FromUtf8Error) -> Self {
+impl From<alloc::string::FromUtf8Error> for StdError {
+    fn from(source: alloc::string::FromUtf8Error) -> Self {
         Self::invalid_utf8(source)
     }
 }
@@ -517,7 +517,7 @@ impl OverflowError {
 /// The error returned by [`TryFrom`] conversions that overflow, for example
 /// when converting from [`Uint256`] to [`Uint128`].
 ///
-/// [`TryFrom`]: std::convert::TryFrom
+/// [`TryFrom`]: core::convert::TryFrom
 /// [`Uint256`]: crate::Uint256
 /// [`Uint128`]: crate::Uint128
 #[derive(Error, Debug, PartialEq, Eq)]
@@ -618,11 +618,11 @@ pub enum CoinFromStrError {
     #[error("Missing amount or non-digit characters in amount")]
     MissingAmount,
     #[error("Invalid amount: {0}")]
-    InvalidAmount(std::num::ParseIntError),
+    InvalidAmount(core::num::ParseIntError),
 }
 
-impl From<std::num::ParseIntError> for CoinFromStrError {
-    fn from(value: std::num::ParseIntError) -> Self {
+impl From<core::num::ParseIntError> for CoinFromStrError {
+    fn from(value: core::num::ParseIntError) -> Self {
         Self::InvalidAmount(value)
     }
 }
@@ -636,7 +636,7 @@ impl From<CoinFromStrError> for StdError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::str;
+    use core::str;
 
     // constructors
 

--- a/packages/std/src/errors/system_error.rs
+++ b/packages/std/src/errors/system_error.rs
@@ -41,8 +41,8 @@ pub enum SystemError {
 
 impl std::error::Error for SystemError {}
 
-impl std::fmt::Display for SystemError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for SystemError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             SystemError::InvalidRequest { error, request } => write!(
                 f,

--- a/packages/std/src/errors/verification_error.rs
+++ b/packages/std/src/errors/verification_error.rs
@@ -1,6 +1,6 @@
+use core::fmt::Debug;
 #[cfg(feature = "backtraces")]
 use std::backtrace::Backtrace;
-use std::fmt::Debug;
 use thiserror::Error;
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/packages/std/src/exports.rs
+++ b/packages/std/src/exports.rs
@@ -7,8 +7,8 @@
 //! and `do_sudo` should be wrapped with a extern "C" entry point including
 //! the contract-specific function pointer. This is done via the `#[entry_point]`
 //! macro attribute from cosmwasm-derive.
-use std::marker::PhantomData;
-use std::vec::Vec;
+use alloc::vec::Vec;
+use core::marker::PhantomData;
 
 use serde::de::DeserializeOwned;
 

--- a/packages/std/src/hex_binary.rs
+++ b/packages/std/src/hex_binary.rs
@@ -1,5 +1,5 @@
-use std::fmt;
-use std::ops::Deref;
+use core::fmt;
+use core::ops::Deref;
 
 use schemars::JsonSchema;
 use serde::{de, ser, Deserialize, Deserializer, Serialize};
@@ -143,7 +143,7 @@ impl From<HexBinary> for Binary {
     }
 }
 
-/// Implement `HexBinary == std::vec::Vec<u8>`
+/// Implement `HexBinary == alloc::vec::Vec<u8>`
 impl PartialEq<Vec<u8>> for HexBinary {
     fn eq(&self, rhs: &Vec<u8>) -> bool {
         // Use Vec<u8> == Vec<u8>
@@ -151,7 +151,7 @@ impl PartialEq<Vec<u8>> for HexBinary {
     }
 }
 
-/// Implement `std::vec::Vec<u8> == HexBinary`
+/// Implement `alloc::vec::Vec<u8> == HexBinary`
 impl PartialEq<HexBinary> for Vec<u8> {
     fn eq(&self, rhs: &HexBinary) -> bool {
         // Use Vec<u8> == Vec<u8>
@@ -248,7 +248,6 @@ mod tests {
     use super::*;
 
     use crate::{assert_hash_works, from_slice, to_vec, StdError};
-    use std::collections::HashSet;
 
     #[test]
     fn from_hex_works() {
@@ -583,6 +582,8 @@ mod tests {
     /// This requires Hash and Eq to be implemented
     #[test]
     fn hex_binary_can_be_used_in_hash_set() {
+        use std::collections::HashSet;
+
         let a1 = HexBinary::from([0, 187, 61, 11, 250, 0]);
         let a2 = HexBinary::from([0, 187, 61, 11, 250, 0]);
         let b = HexBinary::from([16, 21, 33, 0, 255, 9]);

--- a/packages/std/src/ibc.rs
+++ b/packages/std/src/ibc.rs
@@ -2,9 +2,9 @@
 // The CosmosMsg variants are defined in results/cosmos_msg.rs
 // The rest of the IBC related functionality is defined here
 
+use core::cmp::{Ord, Ordering, PartialOrd};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::cmp::{Ord, Ordering, PartialOrd};
 
 #[cfg(feature = "ibc3")]
 use crate::addresses::Addr;

--- a/packages/std/src/imports.rs
+++ b/packages/std/src/imports.rs
@@ -1,4 +1,4 @@
-use std::vec::Vec;
+use alloc::vec::Vec;
 
 use crate::addresses::{Addr, CanonicalAddr};
 use crate::errors::{RecoverPubkeyError, StdError, StdResult, SystemError, VerificationError};

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -1,6 +1,8 @@
 #![cfg_attr(feature = "backtraces", feature(error_generic_member_access))]
 #![cfg_attr(feature = "backtraces", feature(provide_any))]
 
+extern crate alloc;
+
 // Exposed on all platforms
 
 mod addresses;

--- a/packages/std/src/math/decimal.rs
+++ b/packages/std/src/math/decimal.rs
@@ -1,10 +1,10 @@
+use core::cmp::Ordering;
+use core::fmt::{self, Write};
+use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Rem, RemAssign, Sub, SubAssign};
+use core::str::FromStr;
 use forward_ref::{forward_ref_binop, forward_ref_op_assign};
 use schemars::JsonSchema;
 use serde::{de, ser, Deserialize, Deserializer, Serialize};
-use std::cmp::Ordering;
-use std::fmt::{self, Write};
-use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Rem, RemAssign, Sub, SubAssign};
-use std::str::FromStr;
 use thiserror::Error;
 
 use crate::errors::{
@@ -175,7 +175,7 @@ impl Decimal {
     ///
     /// ```
     /// # use cosmwasm_std::{Decimal, Uint128};
-    /// # use std::str::FromStr;
+    /// # use core::str::FromStr;
     /// // Value with whole and fractional part
     /// let a = Decimal::from_str("1.234").unwrap();
     /// assert_eq!(a.decimal_places(), 18);
@@ -385,7 +385,7 @@ impl Decimal {
     /// ## Examples
     ///
     /// ```
-    /// use std::str::FromStr;
+    /// use core::str::FromStr;
     /// use cosmwasm_std::{Decimal, Uint128};
     ///
     /// let d = Decimal::from_str("12.345").unwrap();
@@ -408,7 +408,7 @@ impl Decimal {
     /// ## Examples
     ///
     /// ```
-    /// use std::str::FromStr;
+    /// use core::str::FromStr;
     /// use cosmwasm_std::{Decimal, Uint128};
     ///
     /// let d = Decimal::from_str("12.345").unwrap();
@@ -679,7 +679,7 @@ impl RemAssign<Decimal> for Decimal {
 }
 forward_ref_op_assign!(impl RemAssign, rem_assign for Decimal, Decimal);
 
-impl<A> std::iter::Sum<A> for Decimal
+impl<A> core::iter::Sum<A> for Decimal
 where
     Self: Add<A, Output = Self>,
 {
@@ -1408,7 +1408,7 @@ mod tests {
             (Decimal::permille(6), Decimal::permille(13)),
         ];
 
-        // The regular std::ops::Mul is our source of truth for these tests.
+        // The regular core::ops::Mul is our source of truth for these tests.
         for (x, y) in test_data.into_iter() {
             assert_eq!(x * y, x.checked_mul(y).unwrap());
         }

--- a/packages/std/src/math/decimal256.rs
+++ b/packages/std/src/math/decimal256.rs
@@ -1,10 +1,10 @@
+use core::cmp::Ordering;
+use core::fmt::{self, Write};
+use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Rem, RemAssign, Sub, SubAssign};
+use core::str::FromStr;
 use forward_ref::{forward_ref_binop, forward_ref_op_assign};
 use schemars::JsonSchema;
 use serde::{de, ser, Deserialize, Deserializer, Serialize};
-use std::cmp::Ordering;
-use std::fmt::{self, Write};
-use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Rem, RemAssign, Sub, SubAssign};
-use std::str::FromStr;
 use thiserror::Error;
 
 use crate::errors::{
@@ -187,7 +187,7 @@ impl Decimal256 {
     ///
     /// ```
     /// # use cosmwasm_std::{Decimal256, Uint256};
-    /// # use std::str::FromStr;
+    /// # use core::str::FromStr;
     /// // Value with whole and fractional part
     /// let a = Decimal256::from_str("1.234").unwrap();
     /// assert_eq!(a.decimal_places(), 18);
@@ -401,7 +401,7 @@ impl Decimal256 {
     /// ## Examples
     ///
     /// ```
-    /// use std::str::FromStr;
+    /// use core::str::FromStr;
     /// use cosmwasm_std::{Decimal256, Uint256};
     ///
     /// let d = Decimal256::from_str("12.345").unwrap();
@@ -424,7 +424,7 @@ impl Decimal256 {
     /// ## Examples
     ///
     /// ```
-    /// use std::str::FromStr;
+    /// use core::str::FromStr;
     /// use cosmwasm_std::{Decimal256, Uint256};
     ///
     /// let d = Decimal256::from_str("12.345").unwrap();
@@ -703,7 +703,7 @@ impl RemAssign<Decimal256> for Decimal256 {
 }
 forward_ref_op_assign!(impl RemAssign, rem_assign for Decimal256, Decimal256);
 
-impl<A> std::iter::Sum<A> for Decimal256
+impl<A> core::iter::Sum<A> for Decimal256
 where
     Self: Add<A, Output = Self>,
 {
@@ -1529,7 +1529,7 @@ mod tests {
             (Decimal256::permille(6), Decimal256::permille(13)),
         ];
 
-        // The regular std::ops::Mul is our source of truth for these tests.
+        // The regular core::ops::Mul is our source of truth for these tests.
         for (x, y) in test_data.into_iter() {
             assert_eq!(x * y, x.checked_mul(y).unwrap());
         }

--- a/packages/std/src/math/int128.rs
+++ b/packages/std/src/math/int128.rs
@@ -1,12 +1,12 @@
-use forward_ref::{forward_ref_binop, forward_ref_op_assign};
-use schemars::JsonSchema;
-use serde::{de, ser, Deserialize, Deserializer, Serialize};
-use std::fmt;
-use std::ops::{
+use core::fmt;
+use core::ops::{
     Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Not, Rem, RemAssign, Shl, ShlAssign, Shr,
     ShrAssign, Sub, SubAssign,
 };
-use std::str::FromStr;
+use core::str::FromStr;
+use forward_ref::{forward_ref_binop, forward_ref_op_assign};
+use schemars::JsonSchema;
+use serde::{de, ser, Deserialize, Deserializer, Serialize};
 
 use crate::errors::{DivideByZeroError, DivisionError, OverflowError, OverflowOperation, StdError};
 use crate::{forward_ref_partial_eq, Int64, Uint128, Uint64};
@@ -481,7 +481,7 @@ impl<'de> de::Visitor<'de> for Int128Visitor {
     }
 }
 
-impl<A> std::iter::Sum<A> for Int128
+impl<A> core::iter::Sum<A> for Int128
 where
     Self: Add<A, Output = Self>,
 {
@@ -497,7 +497,7 @@ mod tests {
 
     #[test]
     fn size_of_works() {
-        assert_eq!(std::mem::size_of::<Int128>(), 16);
+        assert_eq!(core::mem::size_of::<Int128>(), 16);
     }
 
     #[test]
@@ -1036,7 +1036,7 @@ mod tests {
         );
         // right shift of MIN value by the maximum shift value should result in -1 (filled with 1s)
         assert_eq!(
-            Int128::MIN >> (std::mem::size_of::<Int128>() as u32 * 8 - 1),
+            Int128::MIN >> (core::mem::size_of::<Int128>() as u32 * 8 - 1),
             -Int128::one()
         );
     }
@@ -1055,7 +1055,7 @@ mod tests {
         );
         // left shift by by the maximum shift value should result in MIN
         assert_eq!(
-            Int128::one() << (std::mem::size_of::<Int128>() as u32 * 8 - 1),
+            Int128::one() << (core::mem::size_of::<Int128>() as u32 * 8 - 1),
             Int128::MIN
         );
     }

--- a/packages/std/src/math/int256.rs
+++ b/packages/std/src/math/int256.rs
@@ -1,12 +1,12 @@
-use forward_ref::{forward_ref_binop, forward_ref_op_assign};
-use schemars::JsonSchema;
-use serde::{de, ser, Deserialize, Deserializer, Serialize};
-use std::fmt;
-use std::ops::{
+use core::fmt;
+use core::ops::{
     Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Not, Rem, RemAssign, Shl, ShlAssign, Shr,
     ShrAssign, Sub, SubAssign,
 };
-use std::str::FromStr;
+use core::str::FromStr;
+use forward_ref::{forward_ref_binop, forward_ref_op_assign};
+use schemars::JsonSchema;
+use serde::{de, ser, Deserialize, Deserializer, Serialize};
 
 use crate::errors::{DivideByZeroError, DivisionError, OverflowError, OverflowOperation, StdError};
 use crate::{forward_ref_partial_eq, Int128, Int64, Uint128, Uint256, Uint64};
@@ -112,7 +112,7 @@ impl Int256 {
             words[1].to_be_bytes(),
             words[0].to_be_bytes(),
         ];
-        unsafe { std::mem::transmute::<[[u8; 8]; 4], [u8; 32]>(words) }
+        unsafe { core::mem::transmute::<[[u8; 8]; 4], [u8; 32]>(words) }
     }
 
     /// Returns a copy of the number as little endian bytes.
@@ -126,7 +126,7 @@ impl Int256 {
             words[2].to_le_bytes(),
             words[3].to_le_bytes(),
         ];
-        unsafe { std::mem::transmute::<[[u8; 8]; 4], [u8; 32]>(words) }
+        unsafe { core::mem::transmute::<[[u8; 8]; 4], [u8; 32]>(words) }
     }
 
     #[must_use]
@@ -553,7 +553,7 @@ impl<'de> de::Visitor<'de> for Int256Visitor {
     }
 }
 
-impl<A> std::iter::Sum<A> for Int256
+impl<A> core::iter::Sum<A> for Int256
 where
     Self: Add<A, Output = Self>,
 {
@@ -569,7 +569,7 @@ mod tests {
 
     #[test]
     fn size_of_works() {
-        assert_eq!(std::mem::size_of::<Int256>(), 32);
+        assert_eq!(core::mem::size_of::<Int256>(), 32);
     }
 
     #[test]
@@ -1121,7 +1121,7 @@ mod tests {
         );
         // right shift of MIN value by the maximum shift value should result in -1 (filled with 1s)
         assert_eq!(
-            Int256::MIN >> (std::mem::size_of::<Int256>() as u32 * 8 - 1),
+            Int256::MIN >> (core::mem::size_of::<Int256>() as u32 * 8 - 1),
             -Int256::one()
         );
     }
@@ -1140,7 +1140,7 @@ mod tests {
         );
         // left shift by by the maximum shift value should result in MIN
         assert_eq!(
-            Int256::one() << (std::mem::size_of::<Int256>() as u32 * 8 - 1),
+            Int256::one() << (core::mem::size_of::<Int256>() as u32 * 8 - 1),
             Int256::MIN
         );
     }

--- a/packages/std/src/math/int512.rs
+++ b/packages/std/src/math/int512.rs
@@ -1,12 +1,12 @@
-use forward_ref::{forward_ref_binop, forward_ref_op_assign};
-use schemars::JsonSchema;
-use serde::{de, ser, Deserialize, Deserializer, Serialize};
-use std::fmt;
-use std::ops::{
+use core::fmt;
+use core::ops::{
     Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Not, Rem, RemAssign, Shl, ShlAssign, Shr,
     ShrAssign, Sub, SubAssign,
 };
-use std::str::FromStr;
+use core::str::FromStr;
+use forward_ref::{forward_ref_binop, forward_ref_op_assign};
+use schemars::JsonSchema;
+use serde::{de, ser, Deserialize, Deserializer, Serialize};
 
 use crate::errors::{DivideByZeroError, DivisionError, OverflowError, OverflowOperation, StdError};
 use crate::{forward_ref_partial_eq, Uint128, Uint256, Uint512, Uint64};
@@ -144,7 +144,7 @@ impl Int512 {
             words[1].to_be_bytes(),
             words[0].to_be_bytes(),
         ];
-        unsafe { std::mem::transmute::<[[u8; 8]; 8], [u8; 64]>(words) }
+        unsafe { core::mem::transmute::<[[u8; 8]; 8], [u8; 64]>(words) }
     }
 
     /// Returns a copy of the number as little endian bytes.
@@ -162,7 +162,7 @@ impl Int512 {
             words[6].to_le_bytes(),
             words[7].to_le_bytes(),
         ];
-        unsafe { std::mem::transmute::<[[u8; 8]; 8], [u8; 64]>(words) }
+        unsafe { core::mem::transmute::<[[u8; 8]; 8], [u8; 64]>(words) }
     }
 
     #[must_use]
@@ -586,7 +586,7 @@ impl<'de> de::Visitor<'de> for Int512Visitor {
     }
 }
 
-impl<A> std::iter::Sum<A> for Int512
+impl<A> core::iter::Sum<A> for Int512
 where
     Self: Add<A, Output = Self>,
 {
@@ -602,7 +602,7 @@ mod tests {
 
     #[test]
     fn size_of_works() {
-        assert_eq!(std::mem::size_of::<Int512>(), 64);
+        assert_eq!(core::mem::size_of::<Int512>(), 64);
     }
 
     #[test]
@@ -1174,7 +1174,7 @@ mod tests {
         );
         // right shift of MIN value by the maximum shift value should result in -1 (filled with 1s)
         assert_eq!(
-            Int512::MIN >> (std::mem::size_of::<Int512>() as u32 * 8 - 1),
+            Int512::MIN >> (core::mem::size_of::<Int512>() as u32 * 8 - 1),
             -Int512::one()
         );
     }
@@ -1193,7 +1193,7 @@ mod tests {
         );
         // left shift by by the maximum shift value should result in MIN
         assert_eq!(
-            Int512::one() << (std::mem::size_of::<Int512>() as u32 * 8 - 1),
+            Int512::one() << (core::mem::size_of::<Int512>() as u32 * 8 - 1),
             Int512::MIN
         );
     }

--- a/packages/std/src/math/int64.rs
+++ b/packages/std/src/math/int64.rs
@@ -1,12 +1,12 @@
-use forward_ref::{forward_ref_binop, forward_ref_op_assign};
-use schemars::JsonSchema;
-use serde::{de, ser, Deserialize, Deserializer, Serialize};
-use std::fmt;
-use std::ops::{
+use core::fmt;
+use core::ops::{
     Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Not, Rem, RemAssign, Shl, ShlAssign, Shr,
     ShrAssign, Sub, SubAssign,
 };
-use std::str::FromStr;
+use core::str::FromStr;
+use forward_ref::{forward_ref_binop, forward_ref_op_assign};
+use schemars::JsonSchema;
+use serde::{de, ser, Deserialize, Deserializer, Serialize};
 
 use crate::errors::{DivideByZeroError, DivisionError, OverflowError, OverflowOperation, StdError};
 use crate::{forward_ref_partial_eq, Uint64};
@@ -457,7 +457,7 @@ impl<'de> de::Visitor<'de> for Int64Visitor {
     }
 }
 
-impl<A> std::iter::Sum<A> for Int64
+impl<A> core::iter::Sum<A> for Int64
 where
     Self: Add<A, Output = Self>,
 {
@@ -473,7 +473,7 @@ mod tests {
 
     #[test]
     fn size_of_works() {
-        assert_eq!(std::mem::size_of::<Int64>(), 8);
+        assert_eq!(core::mem::size_of::<Int64>(), 8);
     }
 
     #[test]
@@ -985,7 +985,7 @@ mod tests {
         assert_eq!(x >> 4, Int64::from(0x0400_0000_0000_0000i64));
         // right shift of MIN value by the maximum shift value should result in -1 (filled with 1s)
         assert_eq!(
-            Int64::MIN >> (std::mem::size_of::<Int64>() as u32 * 8 - 1),
+            Int64::MIN >> (core::mem::size_of::<Int64>() as u32 * 8 - 1),
             -Int64::one()
         );
     }
@@ -998,7 +998,7 @@ mod tests {
         assert_eq!(x << 4, Int64::from(0x0800_0000_0000_0000i64 << 4));
         // left shift by by the maximum shift value should result in MIN
         assert_eq!(
-            Int64::one() << (std::mem::size_of::<Int64>() as u32 * 8 - 1),
+            Int64::one() << (core::mem::size_of::<Int64>() as u32 * 8 - 1),
             Int64::MIN
         );
     }

--- a/packages/std/src/math/isqrt.rs
+++ b/packages/std/src/math/isqrt.rs
@@ -1,4 +1,4 @@
-use std::{cmp, ops};
+use core::{cmp, ops};
 
 use crate::{Uint128, Uint256, Uint512, Uint64};
 

--- a/packages/std/src/math/mod.rs
+++ b/packages/std/src/math/mod.rs
@@ -27,7 +27,7 @@ pub use uint64::Uint64;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::ops::*;
+    use core::ops::*;
 
     /// A trait that ensures other traits are implemented for our number types
     trait AllImpl<'a>:

--- a/packages/std/src/math/uint128.rs
+++ b/packages/std/src/math/uint128.rs
@@ -1,9 +1,9 @@
-use std::fmt::{self};
-use std::ops::{
+use core::fmt::{self};
+use core::ops::{
     Add, AddAssign, Div, DivAssign, Mul, MulAssign, Rem, RemAssign, Shl, ShlAssign, Shr, ShrAssign,
     Sub, SubAssign,
 };
-use std::str::FromStr;
+use core::str::FromStr;
 
 use forward_ref::{forward_ref_binop, forward_ref_op_assign};
 use schemars::JsonSchema;
@@ -586,7 +586,7 @@ impl<'de> de::Visitor<'de> for Uint128Visitor {
     }
 }
 
-impl<A> std::iter::Sum<A> for Uint128
+impl<A> core::iter::Sum<A> for Uint128
 where
     Self: Add<A, Output = Self>,
 {
@@ -604,7 +604,7 @@ mod tests {
 
     #[test]
     fn size_of_works() {
-        assert_eq!(std::mem::size_of::<Uint128>(), 16);
+        assert_eq!(core::mem::size_of::<Uint128>(), 16);
     }
 
     #[test]

--- a/packages/std/src/math/uint256.rs
+++ b/packages/std/src/math/uint256.rs
@@ -1,12 +1,12 @@
-use forward_ref::{forward_ref_binop, forward_ref_op_assign};
-use schemars::JsonSchema;
-use serde::{de, ser, Deserialize, Deserializer, Serialize};
-use std::fmt;
-use std::ops::{
+use core::fmt;
+use core::ops::{
     Add, AddAssign, Div, DivAssign, Mul, MulAssign, Rem, RemAssign, Shl, ShlAssign, Shr, ShrAssign,
     Sub, SubAssign,
 };
-use std::str::FromStr;
+use core::str::FromStr;
+use forward_ref::{forward_ref_binop, forward_ref_op_assign};
+use schemars::JsonSchema;
+use serde::{de, ser, Deserialize, Deserializer, Serialize};
 
 use crate::errors::{
     CheckedMultiplyFractionError, CheckedMultiplyRatioError, ConversionOverflowError,
@@ -135,7 +135,7 @@ impl Uint256 {
             words[1].to_be_bytes(),
             words[0].to_be_bytes(),
         ];
-        unsafe { std::mem::transmute::<[[u8; 8]; 4], [u8; 32]>(words) }
+        unsafe { core::mem::transmute::<[[u8; 8]; 4], [u8; 32]>(words) }
     }
 
     /// Returns a copy of the number as little endian bytes.
@@ -148,7 +148,7 @@ impl Uint256 {
             words[2].to_le_bytes(),
             words[3].to_le_bytes(),
         ];
-        unsafe { std::mem::transmute::<[[u8; 8]; 4], [u8; 32]>(words) }
+        unsafe { core::mem::transmute::<[[u8; 8]; 4], [u8; 32]>(words) }
     }
 
     #[must_use]
@@ -649,7 +649,7 @@ impl<'de> de::Visitor<'de> for Uint256Visitor {
     }
 }
 
-impl<A> std::iter::Sum<A> for Uint256
+impl<A> core::iter::Sum<A> for Uint256
 where
     Self: Add<A, Output = Self>,
 {
@@ -666,7 +666,7 @@ mod tests {
 
     #[test]
     fn size_of_works() {
-        assert_eq!(std::mem::size_of::<Uint256>(), 32);
+        assert_eq!(core::mem::size_of::<Uint256>(), 32);
     }
 
     #[test]

--- a/packages/std/src/math/uint512.rs
+++ b/packages/std/src/math/uint512.rs
@@ -1,12 +1,12 @@
-use forward_ref::{forward_ref_binop, forward_ref_op_assign};
-use schemars::JsonSchema;
-use serde::{de, ser, Deserialize, Deserializer, Serialize};
-use std::fmt;
-use std::ops::{
+use core::fmt;
+use core::ops::{
     Add, AddAssign, Div, DivAssign, Mul, MulAssign, Not, Rem, RemAssign, Shl, ShlAssign, Shr,
     ShrAssign, Sub, SubAssign,
 };
-use std::str::FromStr;
+use core::str::FromStr;
+use forward_ref::{forward_ref_binop, forward_ref_op_assign};
+use schemars::JsonSchema;
+use serde::{de, ser, Deserialize, Deserializer, Serialize};
 
 use crate::errors::{
     ConversionOverflowError, DivideByZeroError, OverflowError, OverflowOperation, StdError,
@@ -159,7 +159,7 @@ impl Uint512 {
             words[1].to_be_bytes(),
             words[0].to_be_bytes(),
         ];
-        unsafe { std::mem::transmute::<[[u8; 8]; 8], [u8; 64]>(words) }
+        unsafe { core::mem::transmute::<[[u8; 8]; 8], [u8; 64]>(words) }
     }
 
     /// Returns a copy of the number as little endian bytes.
@@ -176,7 +176,7 @@ impl Uint512 {
             words[6].to_le_bytes(),
             words[7].to_le_bytes(),
         ];
-        unsafe { std::mem::transmute::<[[u8; 8]; 8], [u8; 64]>(words) }
+        unsafe { core::mem::transmute::<[[u8; 8]; 8], [u8; 64]>(words) }
     }
 
     #[must_use]
@@ -629,7 +629,7 @@ impl<'de> de::Visitor<'de> for Uint512Visitor {
     }
 }
 
-impl<A> std::iter::Sum<A> for Uint512
+impl<A> core::iter::Sum<A> for Uint512
 where
     Self: Add<A, Output = Self>,
 {
@@ -645,7 +645,7 @@ mod tests {
 
     #[test]
     fn size_of_works() {
-        assert_eq!(std::mem::size_of::<Uint512>(), 64);
+        assert_eq!(core::mem::size_of::<Uint512>(), 64);
     }
 
     #[test]

--- a/packages/std/src/math/uint64.rs
+++ b/packages/std/src/math/uint64.rs
@@ -1,11 +1,11 @@
-use forward_ref::{forward_ref_binop, forward_ref_op_assign};
-use schemars::JsonSchema;
-use serde::{de, ser, Deserialize, Deserializer, Serialize};
-use std::fmt::{self};
-use std::ops::{
+use core::fmt::{self};
+use core::ops::{
     Add, AddAssign, Div, DivAssign, Mul, MulAssign, Rem, RemAssign, Shl, ShlAssign, Shr, ShrAssign,
     Sub, SubAssign,
 };
+use forward_ref::{forward_ref_binop, forward_ref_op_assign};
+use schemars::JsonSchema;
+use serde::{de, ser, Deserialize, Deserializer, Serialize};
 
 use crate::errors::{
     CheckedMultiplyFractionError, CheckedMultiplyRatioError, DivideByZeroError, OverflowError,
@@ -537,7 +537,7 @@ impl<'de> de::Visitor<'de> for Uint64Visitor {
     }
 }
 
-impl<A> std::iter::Sum<A> for Uint64
+impl<A> core::iter::Sum<A> for Uint64
 where
     Self: Add<A, Output = Self>,
 {
@@ -554,7 +554,7 @@ mod tests {
 
     #[test]
     fn size_of_works() {
-        assert_eq!(std::mem::size_of::<Uint64>(), 8);
+        assert_eq!(core::mem::size_of::<Uint64>(), 8);
     }
 
     #[test]

--- a/packages/std/src/memory.rs
+++ b/packages/std/src/memory.rs
@@ -1,5 +1,5 @@
-use std::mem;
-use std::vec::Vec;
+use alloc::vec::Vec;
+use core::mem;
 
 /// Describes some data allocated in Wasm's linear memory.
 /// A pointer to an instance of this can be returned over FFI boundaries.

--- a/packages/std/src/results/contract_result.rs
+++ b/packages/std/src/results/contract_result.rs
@@ -1,6 +1,6 @@
+use core::fmt;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::fmt;
 
 /// This is the final result type that is created and serialized in a contract for
 /// every init/execute/migrate call. The VM then deserializes this type to distinguish

--- a/packages/std/src/results/cosmos_msg.rs
+++ b/packages/std/src/results/cosmos_msg.rs
@@ -1,7 +1,7 @@
+use core::fmt;
 use derivative::Derivative;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::fmt;
 
 use crate::binary::Binary;
 use crate::coin::Coin;
@@ -120,10 +120,10 @@ pub enum DistributionMsg {
     },
 }
 
-fn binary_to_string(data: &Binary, fmt: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
-    match std::str::from_utf8(data.as_slice()) {
+fn binary_to_string(data: &Binary, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+    match core::str::from_utf8(data.as_slice()) {
         Ok(s) => fmt.write_str(s),
-        Err(_) => write!(fmt, "{data:?}"),
+        Err(_) => core::fmt::Debug::fmt(data, fmt),
     }
 }
 

--- a/packages/std/src/results/cosmos_msg.rs
+++ b/packages/std/src/results/cosmos_msg.rs
@@ -123,7 +123,7 @@ pub enum DistributionMsg {
 fn binary_to_string(data: &Binary, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
     match core::str::from_utf8(data.as_slice()) {
         Ok(s) => fmt.write_str(s),
-        Err(_) => core::fmt::Debug::fmt(data, fmt),
+        Err(_) => fmt::Debug::fmt(data, fmt),
     }
 }
 

--- a/packages/std/src/results/response.rs
+++ b/packages/std/src/results/response.rs
@@ -239,7 +239,7 @@ mod tests {
 
     #[test]
     fn response_add_attributes_works() {
-        let res = Response::<Empty>::new().add_attributes(std::iter::empty::<Attribute>());
+        let res = Response::<Empty>::new().add_attributes(core::iter::empty::<Attribute>());
         assert_eq!(res.attributes.len(), 0);
 
         let res = Response::<Empty>::new().add_attributes([Attribute::new("test", "ing")]);

--- a/packages/std/src/results/system_result.rs
+++ b/packages/std/src/results/system_result.rs
@@ -1,6 +1,6 @@
+use core::fmt;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::fmt;
 
 use super::super::errors::SystemError;
 

--- a/packages/std/src/serde.rs
+++ b/packages/std/src/serde.rs
@@ -2,8 +2,8 @@
 // The reason is two fold:
 // 1. To easily ensure that all calling libraries use the same version (minimize code size)
 // 2. To allow us to switch out to eg. serde-json-core more easily
+use core::any::type_name;
 use serde::{de::DeserializeOwned, Serialize};
-use std::any::type_name;
 
 use crate::binary::Binary;
 use crate::errors::{StdError, StdResult};

--- a/packages/std/src/storage.rs
+++ b/packages/std/src/storage.rs
@@ -1,9 +1,9 @@
-use std::collections::BTreeMap;
-use std::fmt;
+use alloc::collections::BTreeMap;
+use core::fmt;
 #[cfg(feature = "iterator")]
-use std::iter;
+use core::iter;
 #[cfg(feature = "iterator")]
-use std::ops::{Bound, RangeBounds};
+use core::ops::{Bound, RangeBounds};
 
 #[cfg(feature = "iterator")]
 use crate::iterator::{Order, Record};

--- a/packages/std/src/testing/assertions.rs
+++ b/packages/std/src/testing/assertions.rs
@@ -1,7 +1,7 @@
 use crate::{Decimal, Uint128};
 #[cfg(test)]
 use core::hash::{Hash, Hasher};
-use std::str::FromStr as _;
+use core::str::FromStr as _;
 
 /// Asserts that two expressions are approximately equal to each other.
 ///
@@ -56,7 +56,7 @@ pub fn assert_approx_eq_impl<U: Into<Uint128>>(
     let right = right.into();
     let max_rel_diff = Decimal::from_str(max_rel_diff).unwrap();
 
-    let largest = std::cmp::max(left, right);
+    let largest = core::cmp::max(left, right);
     let rel_diff = Decimal::from_ratio(left.abs_diff(right), largest);
 
     if rel_diff > max_rel_diff {

--- a/packages/std/src/testing/mock.rs
+++ b/packages/std/src/testing/mock.rs
@@ -1,10 +1,11 @@
+use alloc::collections::BTreeMap;
+use core::marker::PhantomData;
+#[cfg(feature = "cosmwasm_1_3")]
+use core::ops::Bound;
 use serde::de::DeserializeOwned;
 #[cfg(feature = "stargate")]
 use serde::Serialize;
-use std::collections::{BTreeMap, HashMap};
-use std::marker::PhantomData;
-#[cfg(feature = "cosmwasm_1_3")]
-use std::ops::Bound;
+use std::collections::HashMap;
 
 use crate::addresses::{Addr, CanonicalAddr};
 use crate::binary::Binary;

--- a/packages/std/src/timestamp.rs
+++ b/packages/std/src/timestamp.rs
@@ -1,6 +1,6 @@
+use core::fmt;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::fmt;
 
 use crate::math::Uint64;
 

--- a/packages/std/src/traits.rs
+++ b/packages/std/src/traits.rs
@@ -1,6 +1,6 @@
+use core::marker::PhantomData;
+use core::ops::Deref;
 use serde::{de::DeserializeOwned, Serialize};
-use std::marker::PhantomData;
-use std::ops::Deref;
 
 use crate::addresses::{Addr, CanonicalAddr};
 use crate::binary::Binary;


### PR DESCRIPTION
To make it easier to implement no_std in cosmwasm_std prefer core and
alloc modules over std module.  std remains used
- for std::backtrace module when backtraces feature is used,
- in testing::mock module for HashMap and
- in tests.

Furthermore, std is forced by some of the dependencies.  Those cases
will be dealt with in another change which will add default std
feature.
