### PR TITLE
cosmwasm_std: simplify ‘T can be used with HashSet’ tests

### DIFF
--- a/packages/std/src/addresses.rs
+++ b/packages/std/src/addresses.rs
@@ -646,31 +646,13 @@ mod tests {
         assert_eq!(canonical_addr_slice, &[0u8, 187, 61, 11, 250, 0]);
     }
 
+    /// Tests that `CanonicalAddr` implements `EQ` and `Hash` correctly and thus
+    /// can be used with hash maps and sets.
     #[test]
-    fn canonical_addr_implements_hash() {
+    fn canonical_addr_implements_hash_eq() {
         let alice = CanonicalAddr::from([0, 187, 61, 11, 250, 0]);
         let bob = CanonicalAddr::from([16, 21, 33, 0, 255, 9]);
         assert_hash_works!(alice, bob);
-    }
-
-    /// This requires Hash and Eq to be implemented
-    #[test]
-    fn canonical_addr_can_be_used_in_hash_set() {
-        use std::collections::HashSet;
-
-        let alice1 = CanonicalAddr::from([0, 187, 61, 11, 250, 0]);
-        let alice2 = CanonicalAddr::from([0, 187, 61, 11, 250, 0]);
-        let bob = CanonicalAddr::from([16, 21, 33, 0, 255, 9]);
-
-        let mut set = HashSet::new();
-        set.insert(alice1.clone());
-        set.insert(alice2.clone());
-        set.insert(bob.clone());
-        assert_eq!(set.len(), 2);
-
-        let set1 = HashSet::<CanonicalAddr>::from_iter(vec![bob.clone(), alice1.clone()]);
-        let set2 = HashSet::from_iter(vec![alice1, alice2, bob]);
-        assert_eq!(set1, set2);
     }
 
     // helper to show we can handle Addr and &Addr equally

--- a/packages/std/src/binary.rs
+++ b/packages/std/src/binary.rs
@@ -509,31 +509,13 @@ mod tests {
         assert_eq!(want, AsRef::<[u8]>::as_ref(&&data));
     }
 
+    /// Tests that `Binary` implements `EQ` and `Hash` correctly and thus can be
+    /// used with hash maps and sets.
     #[test]
-    fn binary_implements_hash() {
+    fn binary_implements_hash_eq() {
         let a = Binary::from([0, 187, 61, 11, 250, 0]);
         let b = Binary::from([16, 21, 33, 0, 255, 9]);
         assert_hash_works!(a, b);
-    }
-
-    /// This requires Hash and Eq to be implemented
-    #[test]
-    fn binary_can_be_used_in_hash_set() {
-        use std::collections::HashSet;
-
-        let a1 = Binary::from([0, 187, 61, 11, 250, 0]);
-        let a2 = Binary::from([0, 187, 61, 11, 250, 0]);
-        let b = Binary::from([16, 21, 33, 0, 255, 9]);
-
-        let mut set = HashSet::new();
-        set.insert(a1.clone());
-        set.insert(a2.clone());
-        set.insert(b.clone());
-        assert_eq!(set.len(), 2);
-
-        let set1 = HashSet::<Binary>::from_iter(vec![b.clone(), a1.clone()]);
-        let set2 = HashSet::from_iter(vec![a1, a2, b]);
-        assert_eq!(set1, set2);
     }
 
     #[test]

--- a/packages/std/src/hex_binary.rs
+++ b/packages/std/src/hex_binary.rs
@@ -572,31 +572,13 @@ mod tests {
         assert_eq!(want, AsRef::<[u8]>::as_ref(&&data));
     }
 
+    /// Tests that `HexBinary` implements `EQ` and `Hash` correctly and thus can
+    /// be used with hash maps and sets.
     #[test]
-    fn hex_binary_implements_hash() {
+    fn hex_binary_implements_hash_eq() {
         let a = HexBinary::from([0, 187, 61, 11, 250, 0]);
         let b = HexBinary::from([16, 21, 33, 0, 255, 9]);
         assert_hash_works!(a, b);
-    }
-
-    /// This requires Hash and Eq to be implemented
-    #[test]
-    fn hex_binary_can_be_used_in_hash_set() {
-        use std::collections::HashSet;
-
-        let a1 = HexBinary::from([0, 187, 61, 11, 250, 0]);
-        let a2 = HexBinary::from([0, 187, 61, 11, 250, 0]);
-        let b = HexBinary::from([16, 21, 33, 0, 255, 9]);
-
-        let mut set = HashSet::new();
-        set.insert(a1.clone());
-        set.insert(a2.clone());
-        set.insert(b.clone());
-        assert_eq!(set.len(), 2);
-
-        let set1 = HashSet::<HexBinary>::from_iter(vec![b.clone(), a1.clone()]);
-        let set2 = HashSet::from_iter(vec![a1, a2, b]);
-        assert_eq!(set1, set2);
     }
 
     #[test]

--- a/packages/std/src/testing/assertions.rs
+++ b/packages/std/src/testing/assertions.rs
@@ -60,29 +60,21 @@ pub fn assert_approx_eq_impl<U: Into<Uint128>>(
     let rel_diff = Decimal::from_ratio(left.abs_diff(right), largest);
 
     if rel_diff > max_rel_diff {
-        match panic_msg {
-            Some(panic_msg) => panic!(
-                "assertion failed: `(left ≈ right)`\nleft: {left}\nright: {right}\nrelative difference: {rel_diff}\nmax allowed relative difference: {max_rel_diff}\n: {panic_msg}"
-            ),
-            None => panic!(
-                "assertion failed: `(left ≈ right)`\nleft: {left}\nright: {right}\nrelative difference: {rel_diff}\nmax allowed relative difference: {max_rel_diff}\n"
-            ),
-        }
+        do_panic(format_args!("assertion failed: `(left ≈ right)`\nleft: {left}\nright: {right}\nrelative difference: {rel_diff}\nmax allowed relative difference: {max_rel_diff}"), panic_msg);
     }
 }
 
-/// Tests that type `T` implements `Hash` trait correctly.
+/// Tests that type `T` implements `Eq` and `Hash` traits correctly.
 ///
 /// `left` and `right` must be unequal objects.
 ///
-/// Some object pairs may produce the same hash causing test failure.
-/// In those cases try different objects. The test uses stable hasher
-/// so once working pair is identified, the test’s going to continue
-/// passing.
+/// Some object pairs may produce the same hash causing test failure.  In those
+/// cases try different objects. The test uses stable hasher so once working
+/// pair is identified, the test’s going to continue passing.
 #[track_caller]
 #[doc(hidden)]
 #[cfg(test)]
-pub fn assert_hash_works_impl<T: Clone + Hash>(left: T, right: T, panic_msg: Option<String>) {
+pub fn assert_hash_works_impl<T: Clone + Eq + Hash>(left: T, right: T, panic_msg: Option<String>) {
     fn hash(value: &impl Hash) -> u64 {
         let mut hasher = crc32fast::Hasher::default();
         value.hash(&mut hasher);
@@ -90,23 +82,35 @@ pub fn assert_hash_works_impl<T: Clone + Hash>(left: T, right: T, panic_msg: Opt
     }
 
     // Check clone
-    if hash(&left) != hash(&left.clone()) {
-        match panic_msg {
-            Some(panic_msg) => {
-                panic!("assertion failed: `hash(left) == hash(left.clone())`\n: {panic_msg}")
-            }
-            None => panic!("assertion failed: `hash(left) == hash(left.clone())`"),
-        }
+    let clone = left.clone();
+    if left != clone {
+        do_panic("assertion failed: `left == left.clone()`", panic_msg);
+    }
+    if hash(&left) != hash(&clone) {
+        do_panic(
+            "assertion failed: `hash(left) == hash(left.clone())`",
+            panic_msg,
+        );
     }
 
     // Check different object
+    if left == right {
+        do_panic("assertion failed: `left != right`", panic_msg);
+    }
     if hash(&left) == hash(&right) {
-        match panic_msg {
-            Some(panic_msg) => {
-                panic!("assertion failed: `hash(left) != hash(right)`\n: {panic_msg}")
-            }
-            None => panic!("assertion failed: `hash(left) != hash(right)`"),
-        }
+        do_panic("assertion failed: `hash(left) != hash(right)`", panic_msg);
+    }
+}
+
+#[track_caller]
+/// Panics concatenating both arguments.
+///
+/// If second argument is `None` panics with just the first argument as message.
+/// Otherwise, formats the panic message as `{reason}:\n{panic_msg}`.
+fn do_panic(reason: impl core::fmt::Display, panic_msg: Option<String>) -> ! {
+    match panic_msg {
+        Some(panic_msg) => panic!("{reason}:\n{panic_msg}"),
+        None => panic!("{reason}"),
     }
 }
 
@@ -140,7 +144,7 @@ mod tests {
 
     #[test]
     #[should_panic(
-        expected = "assertion failed: `(left ≈ right)`\nleft: 8\nright: 10\nrelative difference: 0.2\nmax allowed relative difference: 0.12\n"
+        expected = "assertion failed: `(left ≈ right)`\nleft: 8\nright: 10\nrelative difference: 0.2\nmax allowed relative difference: 0.12"
     )]
     fn assert_approx_fail() {
         assert_approx_eq!(8_u32, 10_u32, "0.12");
@@ -148,7 +152,7 @@ mod tests {
 
     #[test]
     #[should_panic(
-        expected = "assertion failed: `(left ≈ right)`\nleft: 17\nright: 20\nrelative difference: 0.15\nmax allowed relative difference: 0.12\n: some extra info about the error: Foo(8)"
+        expected = "assertion failed: `(left ≈ right)`\nleft: 17\nright: 20\nrelative difference: 0.15\nmax allowed relative difference: 0.12:\nsome extra info about the error: Foo(8)"
     )]
     fn assert_approx_with_custom_panic_msg() {
         let adjective = "extra";


### PR DESCRIPTION
Checking whether a type can be used with a HashSet doesn’t actually
need to involve using the HashSet.  It’s sufficient to check Eq and
Hash traits implementations.

Simplify the tests by extending assert_hash_works macro to also test
Eq trait.

This also helps with eventual no_std support since there’ll be less
need for conditional compilation.
