### PR TITLE
cosmwasm-std: avoid dependency on std::error::Error

### DIFF
--- a/packages/std/src/errors/system_error.rs
+++ b/packages/std/src/errors/system_error.rs
@@ -39,7 +39,11 @@ pub enum SystemError {
     },
 }
 
-impl std::error::Error for SystemError {}
+// We want to support no_std thus we don’t want to reference Error through
+// std::error module.  At the same time we don’t want to use core::error since
+// that’s unstable.  Fortunately, we can take advantage of serde which
+// re-exports the trait as serde::de::StdError.
+impl serde::de::StdError for SystemError {}
 
 impl core::fmt::Display for SystemError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {


### PR DESCRIPTION
`std::error::Error` doesn’t currently have a stable `no_std`
equivalence. `core::error::Error` is a thing but it’s unstable and
thus requires nightly compiler.

There’s one hack we can use.  serde has no_std support and exports
`Error` as `serde::de::StdError`.  This way we hide the need for
nightly compiler to serde.

The two alternatives are:
- require nightly compiler or
- don’t implement std::`error::Error` in `no_std` builds.

Issue: https://github.com/CosmWasm/cosmwasm/issues/1484
