### PR TITLE
Export missing responses & less feature-gating

### DIFF
--- a/packages/std/src/ibc.rs
+++ b/packages/std/src/ibc.rs
@@ -1,4 +1,3 @@
-#![cfg(feature = "stargate")]
 // The CosmosMsg variants are defined in results/cosmos_msg.rs
 // The rest of the IBC related functionality is defined here
 

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -71,6 +71,11 @@ pub use crate::query::{
     AllDelegationsResponse, AllValidatorsResponse, BondedDenomResponse, Delegation,
     DelegationResponse, FullDelegation, StakingQuery, Validator, ValidatorResponse,
 };
+#[cfg(feature = "cosmwasm_1_3")]
+pub use crate::query::{
+    AllDenomMetadataResponse, DelegatorWithdrawAddressResponse, DenomMetadataResponse,
+    DistributionQuery,
+};
 #[cfg(feature = "stargate")]
 pub use crate::query::{ChannelResponse, IbcQuery, ListChannelsResponse, PortIdResponse};
 #[allow(deprecated)]

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -42,7 +42,6 @@ pub use crate::errors::{
     RecoverPubkeyError, StdError, StdResult, SystemError, VerificationError,
 };
 pub use crate::hex_binary::HexBinary;
-#[cfg(feature = "stargate")]
 pub use crate::ibc::{
     Ibc3ChannelOpenResponse, IbcAcknowledgement, IbcBasicResponse, IbcChannel, IbcChannelCloseMsg,
     IbcChannelConnectMsg, IbcChannelOpenMsg, IbcChannelOpenResponse, IbcEndpoint, IbcMsg, IbcOrder,
@@ -58,26 +57,14 @@ pub use crate::math::{
 pub use crate::metadata::{DenomMetadata, DenomUnit};
 pub use crate::never::Never;
 pub use crate::pagination::PageRequest;
-#[cfg(feature = "cosmwasm_1_2")]
-pub use crate::query::CodeInfoResponse;
-#[cfg(feature = "cosmwasm_1_1")]
-pub use crate::query::SupplyResponse;
 pub use crate::query::{
-    AllBalanceResponse, BalanceResponse, BankQuery, ContractInfoResponse, CustomQuery,
-    QueryRequest, WasmQuery,
+    AllBalanceResponse, AllDelegationsResponse, AllDenomMetadataResponse, AllValidatorsResponse,
+    BalanceResponse, BankQuery, BondedDenomResponse, ChannelResponse, CodeInfoResponse,
+    ContractInfoResponse, CustomQuery, Delegation, DelegationResponse,
+    DelegatorWithdrawAddressResponse, DenomMetadataResponse, DistributionQuery, FullDelegation,
+    IbcQuery, ListChannelsResponse, PortIdResponse, QueryRequest, StakingQuery, SupplyResponse,
+    Validator, ValidatorResponse, WasmQuery,
 };
-#[cfg(feature = "staking")]
-pub use crate::query::{
-    AllDelegationsResponse, AllValidatorsResponse, BondedDenomResponse, Delegation,
-    DelegationResponse, FullDelegation, StakingQuery, Validator, ValidatorResponse,
-};
-#[cfg(feature = "cosmwasm_1_3")]
-pub use crate::query::{
-    AllDenomMetadataResponse, DelegatorWithdrawAddressResponse, DenomMetadataResponse,
-    DistributionQuery,
-};
-#[cfg(feature = "stargate")]
-pub use crate::query::{ChannelResponse, IbcQuery, ListChannelsResponse, PortIdResponse};
 #[allow(deprecated)]
 pub use crate::results::SubMsgExecutionResponse;
 #[cfg(all(feature = "stargate", feature = "cosmwasm_1_2"))]

--- a/packages/std/src/query/bank.rs
+++ b/packages/std/src/query/bank.rs
@@ -4,7 +4,8 @@ use serde::{Deserialize, Serialize};
 use crate::Coin;
 
 #[cfg(feature = "cosmwasm_1_3")]
-use crate::{Binary, DenomMetadata, PageRequest};
+use crate::PageRequest;
+use crate::{Binary, DenomMetadata};
 
 use super::query_response::QueryResponseType;
 
@@ -34,7 +35,6 @@ pub enum BankQuery {
     AllDenomMetadata { pagination: Option<PageRequest> },
 }
 
-#[cfg(feature = "cosmwasm_1_1")]
 #[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
@@ -44,10 +44,8 @@ pub struct SupplyResponse {
     pub amount: Coin,
 }
 
-#[cfg(feature = "cosmwasm_1_1")]
 impl_response_constructor!(SupplyResponse, amount: Coin);
 
-#[cfg(feature = "cosmwasm_1_1")]
 impl QueryResponseType for SupplyResponse {}
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq, JsonSchema)]
@@ -73,7 +71,6 @@ impl_response_constructor!(AllBalanceResponse, amount: Vec<Coin>);
 
 impl QueryResponseType for AllBalanceResponse {}
 
-#[cfg(feature = "cosmwasm_1_3")]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
@@ -82,13 +79,10 @@ pub struct DenomMetadataResponse {
     pub metadata: DenomMetadata,
 }
 
-#[cfg(feature = "cosmwasm_1_3")]
 impl_response_constructor!(DenomMetadataResponse, metadata: DenomMetadata);
 
-#[cfg(feature = "cosmwasm_1_3")]
 impl QueryResponseType for DenomMetadataResponse {}
 
-#[cfg(feature = "cosmwasm_1_3")]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
@@ -98,14 +92,12 @@ pub struct AllDenomMetadataResponse {
     pub next_key: Option<Binary>,
 }
 
-#[cfg(feature = "cosmwasm_1_3")]
 impl_response_constructor!(
     AllDenomMetadataResponse,
     metadata: Vec<DenomMetadata>,
     next_key: Option<Binary>
 );
 
-#[cfg(feature = "cosmwasm_1_3")]
 impl QueryResponseType for AllDenomMetadataResponse {}
 
 #[cfg(test)]

--- a/packages/std/src/query/ibc.rs
+++ b/packages/std/src/query/ibc.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "stargate")]
-
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 

--- a/packages/std/src/query/mod.rs
+++ b/packages/std/src/query/mod.rs
@@ -31,23 +31,13 @@ mod query_response;
 mod staking;
 mod wasm;
 
-#[cfg(feature = "cosmwasm_1_1")]
-pub use bank::SupplyResponse;
-pub use bank::{AllBalanceResponse, BalanceResponse, BankQuery};
-#[cfg(feature = "cosmwasm_1_3")]
-pub use bank::{AllDenomMetadataResponse, DenomMetadataResponse};
-#[cfg(feature = "cosmwasm_1_3")]
-pub use distribution::{DelegatorWithdrawAddressResponse, DistributionQuery};
+pub use bank::*;
+pub use distribution::*;
 #[cfg(feature = "stargate")]
-pub use ibc::{ChannelResponse, IbcQuery, ListChannelsResponse, PortIdResponse};
+pub use ibc::*;
 #[cfg(feature = "staking")]
-pub use staking::{
-    AllDelegationsResponse, AllValidatorsResponse, BondedDenomResponse, Delegation,
-    DelegationResponse, FullDelegation, StakingQuery, Validator, ValidatorResponse,
-};
-#[cfg(feature = "cosmwasm_1_2")]
-pub use wasm::CodeInfoResponse;
-pub use wasm::{ContractInfoResponse, WasmQuery};
+pub use staking::*;
+pub use wasm::*;
 
 #[non_exhaustive]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]

--- a/packages/std/src/query/mod.rs
+++ b/packages/std/src/query/mod.rs
@@ -33,9 +33,7 @@ mod wasm;
 
 pub use bank::*;
 pub use distribution::*;
-#[cfg(feature = "stargate")]
 pub use ibc::*;
-#[cfg(feature = "staking")]
 pub use staking::*;
 pub use wasm::*;
 

--- a/packages/std/src/query/staking.rs
+++ b/packages/std/src/query/staking.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "staking")]
-
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 

--- a/packages/std/src/query/wasm.rs
+++ b/packages/std/src/query/wasm.rs
@@ -1,9 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::Binary;
-#[cfg(feature = "cosmwasm_1_2")]
-use crate::HexBinary;
+use crate::{Binary, HexBinary};
 
 use super::query_response::QueryResponseType;
 
@@ -76,7 +74,6 @@ impl ContractInfoResponse {
 /// [CodeInfoResponse]: https://github.com/CosmWasm/wasmd/blob/v0.30.0/proto/cosmwasm/wasm/v1/query.proto#L184-L199
 #[non_exhaustive]
 #[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq, Eq, JsonSchema)]
-#[cfg(feature = "cosmwasm_1_2")]
 pub struct CodeInfoResponse {
     pub code_id: u64,
     /// The address that initially stored the code
@@ -85,7 +82,6 @@ pub struct CodeInfoResponse {
     pub checksum: HexBinary,
 }
 
-#[cfg(feature = "cosmwasm_1_2")]
 impl_response_constructor!(
     CodeInfoResponse,
     code_id: u64,
@@ -93,7 +89,6 @@ impl_response_constructor!(
     checksum: HexBinary
 );
 
-#[cfg(feature = "cosmwasm_1_2")]
 impl QueryResponseType for CodeInfoResponse {}
 
 #[cfg(test)]


### PR DESCRIPTION
All the query responses and related types are now exported irrespective of the enabled features (including the missing ones).
Also using `*`-exports in the query module, so we only need to add the `pub use`s to `lib.rs` for new queries.