### PR TITLE
Update to latest wasmer 4.1.x (4.1.2)

### DIFF
--- a/packages/vm/Cargo.toml
+++ b/packages/vm/Cargo.toml
@@ -48,8 +48,8 @@ serde = { version = "1.0.103", default-features = false, features = ["derive", "
 serde_json = "1.0.40"
 sha2 = "0.10.3"
 thiserror = "1.0.26"
-wasmer = { version = "=4.1.0", default-features = false, features = ["cranelift", "singlepass"] }
-wasmer-middlewares = "=4.1.0"
+wasmer = { version = "=4.1.2", default-features = false, features = ["cranelift", "singlepass"] }
+wasmer-middlewares = "=4.1.2"
 
 # Dependencies that we do not use ourself. We add those entries
 # to bump the min version of them.


### PR DESCRIPTION
Was having some issues when compiling vm with the latest Rust stable (1.72.0)

```
$ ct recovers
    Finished test [unoptimized + debuginfo] target(s) in 0.10s
     Running unittests src/lib.rs (/Users/mauro/work/cosmwasm/target/debug/deps/cosmwasm_vm-70edbccfd7a414dd)

running 1 test
thread 'cache::tests::recovers_from_out_of_gas' panicked at 'misaligned pointer dereference: address must be a multiple of 0x10 but is 0x10849fc18', /Users/mauro/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wasmer-vm-4.1.0/src/trap/traphandlers.rs:219:28
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread caused non-unwinding panic. aborting.
error: test failed, to rerun pass `--lib`

Caused by:
  process didn't exit successfully: `/Users/mauro/work/cosmwasm/target/debug/deps/cosmwasm_vm-70edbccfd7a414dd recovers` (signal: 6, SIGABRT: process abort signal)
$ rustc --version
rustc 1.72.0 (5680fa18f 2023-08-23)
$  
```

['misaligned pointer dereference' in warmer issues](https://github.com/wasmerio/wasmer/issues?q=is%3Aissue+is%3Aopen+misaligned+pointer+dereference).

Upgrading to latest wasmer 4.1.12 solved it.