### PR TITLE
Rename variable _gas_remaining -> _info

### DIFF
--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -99,7 +99,7 @@ where
             let e = Environment::new(backend.api, gas_limit);
             if print_debug {
                 e.set_debug_handler(Some(Rc::new(RefCell::new(
-                    |msg: &str, _gas_remaining: DebugInfo<'_>| {
+                    |msg: &str, _info: DebugInfo<'_>| {
                         eprintln!("{msg}");
                     },
                 ))))


### PR DESCRIPTION
This was missed when we generalized the argument to `DebugInfo`