### PR TITLE
Require cosmwasm-vm and cosmwasm-std to match cosmwasm-check version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- cosmwasm-check: Use "=" for pinning the versions of cosmwasm-vm and
+  cosmwasm-std dependencies. This ensures that you can use an older version of
+  cosmwasm-check together with the VM of the same version by doing
+  `cargo install cosmwasm-check@1.4.1`. A typical use case would be to check a
+  contract with CosmWasm 1.4, 1.5 and 2.0. Note that other dependencies are
+  still upgraded when using `cargo install` which may lead to API, behavioural
+  or compiler incompatibilities. The
+  [--locked](https://doc.rust-lang.org/cargo/commands/cargo-install.html#dealing-with-the-lockfile)
+  feature allows you use the versions locked when the release was created.
+
 ## [1.4.0] - 2023-09-04
 
 ### Added

--- a/packages/check/Cargo.toml
+++ b/packages/check/Cargo.toml
@@ -11,8 +11,8 @@ license = "Apache-2.0"
 anyhow = "1.0.57"
 clap = "4"
 colored = "2"
-cosmwasm-vm = { path = "../vm", version = "1.4.0" }
-cosmwasm-std = { path = "../std", version = "1.4.0" }
+cosmwasm-vm = { path = "../vm", version = "=1.4.0" }
+cosmwasm-std = { path = "../std", version = "=1.4.0" }
 
 [dev-dependencies]
 assert_cmd = "=2.0.10" # 2.0.11+ requires Rust 1.65.0 which we currently don't want to make the minimum if possible


### PR DESCRIPTION
Right now you cannot install older versions of cosmwasm-check dut to breaking changes internally:

```
cargo install --debug cosmwasm-check --version 1.3.1


  Compiling cosmwasm-vm v1.4.0
   Compiling cosmwasm-check v1.3.1
error[E0061]: this function takes 2 arguments but 3 arguments were supplied
  --> /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/cosmwasm-check-1.3.1/src/main.rs:97:5
   |
97 |     compile(&wasm, None, &[])?;
   |     ^^^^^^^ -----  ----  --- unexpected argument of type `&[_; 0]`
   |             |      |
   |             |      unexpected argument of type `Option<_>`
   |             an argument of type `&wasmer::engine::Engine` is missing
   |
note: function defined here
  --> /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/cosmwasm-vm-1.4.0/src/wasm_backend/compile.rs:6:8
   |
6  | pub fn compile(engine: &Engine, code: &[u8]) -> VmResult<Module> {
   |        ^^^^^^^
help: did you mean
   |
97 |     compile(/* &wasmer::engine::Engine */, &wasm)?;
   |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

For more information about this error, try `rustc --explain E0061`.
error: could not compile `cosmwasm-check` (bin "cosmwasm-check") due to previous error
error: failed to compile `cosmwasm-check v1.3.1`, intermediate artifacts can be found at `/tmp/cargo-install4JYgI8`

Exited with code exit status 101
```

Even if that was not the case, you'd still get a 1.4.0 cosmwasm-vm when installing cosmwasm-check 1.3.1. But it would be great to be able to check a contract against a 1.2, 1.3 and 1.4 VM by running different versions of cosmwasm-check.