### PR TITLE
Add missing TryFrom impls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,14 @@ and this project adheres to
 - cosmwasm-std: Add `Int{64,128,256}::{checked_multiply_ratio, full_mul}`
   ([#1866])
 - cosmwasm-std: Add `is_negative` for `Int{64,128,256,512}` ([#1867]).
+- cosmwasm-std: Add `TryFrom<Uint{256,512}> for Uint64` and
+  `TryFrom<Uint{A}> for Int{B}` where `A >= B` ([#1870]).
 
 [#1854]: https://github.com/CosmWasm/cosmwasm/pull/1854
 [#1861]: https://github.com/CosmWasm/cosmwasm/pull/1861
 [#1866]: https://github.com/CosmWasm/cosmwasm/pull/1866
 [#1867]: https://github.com/CosmWasm/cosmwasm/pull/1867
+[#1870]: https://github.com/CosmWasm/cosmwasm/pull/1870
 
 ## [1.4.0] - 2023-09-04
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,6 +502,7 @@ dependencies = [
  "serde-json-wasm",
  "serde_json",
  "sha2 0.10.6",
+ "static_assertions",
  "thiserror",
 ]
 
@@ -2033,6 +2034,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/contracts/burner/Cargo.lock
+++ b/contracts/burner/Cargo.lock
@@ -244,6 +244,7 @@ dependencies = [
  "serde",
  "serde-json-wasm",
  "sha2 0.10.3",
+ "static_assertions",
  "thiserror",
 ]
 
@@ -1406,6 +1407,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/contracts/crypto-verify/Cargo.lock
+++ b/contracts/crypto-verify/Cargo.lock
@@ -233,6 +233,7 @@ dependencies = [
  "serde",
  "serde-json-wasm",
  "sha2 0.10.3",
+ "static_assertions",
  "thiserror",
 ]
 
@@ -1449,6 +1450,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/contracts/cyberpunk/Cargo.lock
+++ b/contracts/cyberpunk/Cargo.lock
@@ -268,6 +268,7 @@ dependencies = [
  "serde",
  "serde-json-wasm",
  "sha2 0.10.3",
+ "static_assertions",
  "thiserror",
 ]
 
@@ -1530,6 +1531,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/contracts/floaty/Cargo.lock
+++ b/contracts/floaty/Cargo.lock
@@ -233,6 +233,7 @@ dependencies = [
  "serde",
  "serde-json-wasm",
  "sha2 0.10.3",
+ "static_assertions",
  "thiserror",
 ]
 
@@ -1407,6 +1408,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/contracts/hackatom/Cargo.lock
+++ b/contracts/hackatom/Cargo.lock
@@ -233,6 +233,7 @@ dependencies = [
  "serde",
  "serde-json-wasm",
  "sha2 0.10.3",
+ "static_assertions",
  "thiserror",
 ]
 
@@ -1408,6 +1409,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/contracts/ibc-reflect-send/Cargo.lock
+++ b/contracts/ibc-reflect-send/Cargo.lock
@@ -233,6 +233,7 @@ dependencies = [
  "serde",
  "serde-json-wasm",
  "sha2 0.10.3",
+ "static_assertions",
  "thiserror",
 ]
 
@@ -1406,6 +1407,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/contracts/ibc-reflect/Cargo.lock
+++ b/contracts/ibc-reflect/Cargo.lock
@@ -233,6 +233,7 @@ dependencies = [
  "serde",
  "serde-json-wasm",
  "sha2 0.10.3",
+ "static_assertions",
  "thiserror",
 ]
 
@@ -1406,6 +1407,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/contracts/queue/Cargo.lock
+++ b/contracts/queue/Cargo.lock
@@ -233,6 +233,7 @@ dependencies = [
  "serde",
  "serde-json-wasm",
  "sha2 0.10.3",
+ "static_assertions",
  "thiserror",
 ]
 
@@ -1406,6 +1407,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/contracts/reflect/Cargo.lock
+++ b/contracts/reflect/Cargo.lock
@@ -233,6 +233,7 @@ dependencies = [
  "serde",
  "serde-json-wasm",
  "sha2 0.10.3",
+ "static_assertions",
  "thiserror",
 ]
 
@@ -1407,6 +1408,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/contracts/staking/Cargo.lock
+++ b/contracts/staking/Cargo.lock
@@ -233,6 +233,7 @@ dependencies = [
  "serde",
  "serde-json-wasm",
  "sha2 0.10.3",
+ "static_assertions",
  "thiserror",
 ]
 
@@ -1434,6 +1435,12 @@ dependencies = [
  "serde",
  "snafu",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/contracts/virus/Cargo.lock
+++ b/contracts/virus/Cargo.lock
@@ -233,6 +233,7 @@ dependencies = [
  "serde",
  "serde-json-wasm",
  "sha2 0.10.3",
+ "static_assertions",
  "thiserror",
 ]
 
@@ -1395,6 +1396,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -61,6 +61,7 @@ serde = { version = "1.0.103", default-features = false, features = ["derive", "
 serde-json-wasm = { version = "0.5.0" }
 thiserror = "1.0.26"
 bnum = "0.8.0"
+static_assertions = "1.1.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 cosmwasm-crypto = { path = "../crypto", version = "1.4.0" }

--- a/packages/std/src/math/conversion.rs
+++ b/packages/std/src/math/conversion.rs
@@ -149,7 +149,7 @@ where
         + core::ops::Add<Output = I>,
     O: TryFrom<I, Error = crate::ConversionOverflowError>
         + From<u32>
-        + NumConsts
+        + super::num_consts::NumConsts
         + core::cmp::PartialEq
         + core::fmt::Debug,
     String: From<I>,
@@ -195,10 +195,15 @@ where
 #[cfg(test)]
 pub(crate) fn test_try_from_int_to_uint<I, O>(input_type: &'static str, output_type: &'static str)
 where
-    I: NumConsts + From<i32> + Copy + TryFrom<O> + core::fmt::Debug + core::ops::Add<Output = I>,
+    I: super::num_consts::NumConsts
+        + From<i32>
+        + Copy
+        + TryFrom<O>
+        + core::fmt::Debug
+        + core::ops::Add<Output = I>,
     O: TryFrom<I, Error = crate::ConversionOverflowError>
         + From<u32>
-        + NumConsts
+        + super::num_consts::NumConsts
         + core::cmp::PartialEq
         + core::fmt::Debug,
     String: From<I>,
@@ -315,8 +320,6 @@ macro_rules! try_from_int_to_uint {
     };
 }
 pub(crate) use try_from_int_to_uint;
-
-use super::num_consts::NumConsts;
 
 #[cfg(test)]
 mod tests {

--- a/packages/std/src/math/int128.rs
+++ b/packages/std/src/math/int128.rs
@@ -10,8 +10,8 @@ use serde::{de, ser, Deserialize, Deserializer, Serialize};
 
 use crate::errors::{DivideByZeroError, DivisionError, OverflowError, OverflowOperation, StdError};
 use crate::{
-    forward_ref_partial_eq, CheckedMultiplyRatioError, ConversionOverflowError, Int256, Int512,
-    Int64, Uint128, Uint256, Uint512, Uint64,
+    forward_ref_partial_eq, CheckedMultiplyRatioError, Int256, Int512, Int64, Uint128, Uint256,
+    Uint512, Uint64,
 };
 
 use super::conversion::{forward_try_from, try_from_int_to_int};

--- a/packages/std/src/math/int128.rs
+++ b/packages/std/src/math/int128.rs
@@ -15,6 +15,7 @@ use crate::{
 };
 
 use super::conversion::{forward_try_from, try_from_int_to_int};
+use super::num_consts::NumConsts;
 
 /// An implementation of i128 that is using strings for JSON encoding/decoding,
 /// such that the full i128 range can be used for clients that convert JSON numbers to floats,
@@ -268,6 +269,13 @@ impl Int128 {
     pub const fn unsigned_abs(self) -> Uint128 {
         Uint128(self.0.unsigned_abs())
     }
+}
+
+impl NumConsts for Int128 {
+    const ZERO: Self = Self::zero();
+    const ONE: Self = Self::one();
+    const MAX: Self = Self::MAX;
+    const MIN: Self = Self::MIN;
 }
 
 // Uint to Int
@@ -562,7 +570,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{from_slice, to_vec};
+    use crate::{from_slice, math::conversion::test_try_from_uint_to_int, to_vec};
 
     #[test]
     fn size_of_works() {
@@ -675,6 +683,13 @@ mod tests {
 
         let result = Int128::try_from("1.23");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn int128_try_from_unsigned_works() {
+        test_try_from_uint_to_int::<Uint128, Int128>("Uint128", "Int128");
+        test_try_from_uint_to_int::<Uint256, Int128>("Uint256", "Int128");
+        test_try_from_uint_to_int::<Uint512, Int128>("Uint512", "Int128");
     }
 
     #[test]

--- a/packages/std/src/math/int256.rs
+++ b/packages/std/src/math/int256.rs
@@ -19,6 +19,7 @@ use crate::{
 use bnum::types::{I256, U256};
 
 use super::conversion::{grow_be_int, try_from_int_to_int, try_from_uint_to_int};
+use super::num_consts::NumConsts;
 
 /// An implementation of i256 that is using strings for JSON encoding/decoding,
 /// such that the full i256 range can be used for clients that convert JSON numbers to floats,
@@ -326,6 +327,13 @@ impl Int256 {
     pub const fn unsigned_abs(self) -> Uint256 {
         Uint256(self.0.unsigned_abs())
     }
+}
+
+impl NumConsts for Int256 {
+    const ZERO: Self = Self::zero();
+    const ONE: Self = Self::one();
+    const MAX: Self = Self::MAX;
+    const MIN: Self = Self::MIN;
 }
 
 // Uint to Int
@@ -637,7 +645,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{from_slice, to_vec};
+    use crate::{from_slice, math::conversion::test_try_from_uint_to_int, to_vec};
 
     #[test]
     fn size_of_works() {
@@ -746,6 +754,12 @@ mod tests {
 
         let result = Int256::try_from("1.23");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn int256_try_from_unsigned_works() {
+        test_try_from_uint_to_int::<Uint256, Int256>("Uint256", "Int256");
+        test_try_from_uint_to_int::<Uint512, Int256>("Uint512", "Int256");
     }
 
     #[test]

--- a/packages/std/src/math/int256.rs
+++ b/packages/std/src/math/int256.rs
@@ -10,8 +10,8 @@ use serde::{de, ser, Deserialize, Deserializer, Serialize};
 
 use crate::errors::{DivideByZeroError, DivisionError, OverflowError, OverflowOperation, StdError};
 use crate::{
-    forward_ref_partial_eq, CheckedMultiplyRatioError, ConversionOverflowError, Int128, Int512,
-    Int64, Uint128, Uint256, Uint512, Uint64,
+    forward_ref_partial_eq, CheckedMultiplyRatioError, Int128, Int512, Int64, Uint128, Uint256,
+    Uint512, Uint64,
 };
 
 /// Used internally - we don't want to leak this type since we might change

--- a/packages/std/src/math/int512.rs
+++ b/packages/std/src/math/int512.rs
@@ -16,6 +16,7 @@ use crate::{forward_ref_partial_eq, Int128, Int256, Int64, Uint128, Uint256, Uin
 use bnum::types::{I512, U512};
 
 use super::conversion::{grow_be_int, try_from_uint_to_int};
+use super::num_consts::NumConsts;
 
 /// An implementation of i512 that is using strings for JSON encoding/decoding,
 /// such that the full i512 range can be used for clients that convert JSON numbers to floats,
@@ -311,6 +312,13 @@ impl Int512 {
     pub const fn unsigned_abs(self) -> Uint512 {
         Uint512(self.0.unsigned_abs())
     }
+}
+
+impl NumConsts for Int512 {
+    const ZERO: Self = Self::zero();
+    const ONE: Self = Self::one();
+    const MAX: Self = Self::MAX;
+    const MIN: Self = Self::MIN;
 }
 
 // Uint to Int
@@ -634,7 +642,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{from_slice, to_vec};
+    use crate::{from_slice, math::conversion::test_try_from_uint_to_int, to_vec};
 
     #[test]
     fn size_of_works() {
@@ -783,6 +791,12 @@ mod tests {
 
         let result = Int512::try_from("1.23");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn int512_try_from_unsigned_works() {
+        test_try_from_uint_to_int::<Uint256, Int256>("Uint256", "Int256");
+        test_try_from_uint_to_int::<Uint512, Int256>("Uint512", "Int256");
     }
 
     #[test]

--- a/packages/std/src/math/int512.rs
+++ b/packages/std/src/math/int512.rs
@@ -1,4 +1,3 @@
-use bnum::prelude::As;
 use core::fmt;
 use core::ops::{
     Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Not, Rem, RemAssign, Shl, ShlAssign, Shr,
@@ -19,7 +18,7 @@ use crate::{
 /// the implementation in the future.
 use bnum::types::{I512, U512};
 
-use super::conversion::grow_be_int;
+use super::conversion::{grow_be_int, try_from_uint_to_int};
 
 /// An implementation of i512 that is using strings for JSON encoding/decoding,
 /// such that the full i512 range can be used for clients that convert JSON numbers to floats,
@@ -46,7 +45,7 @@ use super::conversion::grow_be_int;
 /// assert_eq!(a, b);
 /// ```
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, PartialOrd, Ord, JsonSchema)]
-pub struct Int512(#[schemars(with = "String")] I512);
+pub struct Int512(#[schemars(with = "String")] pub(crate) I512);
 
 forward_ref_partial_eq!(Int512, Int512);
 
@@ -318,19 +317,7 @@ impl Int512 {
 }
 
 // Uint to Int
-impl TryFrom<Uint512> for Int512 {
-    type Error = ConversionOverflowError;
-
-    fn try_from(value: Uint512) -> Result<Self, Self::Error> {
-        // Self::MAX fits into Uint512, so we can just cast it
-        if value.0 > Self::MAX.0.as_() {
-            return Err(ConversionOverflowError::new("Uint512", "Int512", value));
-        }
-
-        // at this point we know it fits
-        Ok(Self(value.0.as_()))
-    }
-}
+try_from_uint_to_int!(Uint512, Int512);
 
 impl From<Uint256> for Int512 {
     fn from(val: Uint256) -> Self {

--- a/packages/std/src/math/int512.rs
+++ b/packages/std/src/math/int512.rs
@@ -9,10 +9,7 @@ use schemars::JsonSchema;
 use serde::{de, ser, Deserialize, Deserializer, Serialize};
 
 use crate::errors::{DivideByZeroError, DivisionError, OverflowError, OverflowOperation, StdError};
-use crate::{
-    forward_ref_partial_eq, ConversionOverflowError, Int128, Int256, Int64, Uint128, Uint256,
-    Uint512, Uint64,
-};
+use crate::{forward_ref_partial_eq, Int128, Int256, Int64, Uint128, Uint256, Uint512, Uint64};
 
 /// Used internally - we don't want to leak this type since we might change
 /// the implementation in the future.

--- a/packages/std/src/math/int64.rs
+++ b/packages/std/src/math/int64.rs
@@ -11,7 +11,7 @@ use serde::{de, ser, Deserialize, Deserializer, Serialize};
 use crate::errors::{DivideByZeroError, DivisionError, OverflowError, OverflowOperation, StdError};
 use crate::{
     forward_ref_partial_eq, CheckedMultiplyRatioError, ConversionOverflowError, Int128, Int256,
-    Int512, Uint64,
+    Int512, Uint128, Uint256, Uint512, Uint64,
 };
 
 use super::conversion::shrink_be_int;
@@ -270,6 +270,7 @@ impl Int64 {
     }
 }
 
+// uint to Int
 impl From<u32> for Int64 {
     fn from(val: u32) -> Self {
         Int64(val.into())
@@ -288,6 +289,7 @@ impl From<u8> for Int64 {
     }
 }
 
+// int to Int
 impl From<i64> for Int64 {
     fn from(val: i64) -> Self {
         Int64(val)
@@ -312,6 +314,7 @@ impl From<i8> for Int64 {
     }
 }
 
+// Int to Int
 impl TryFrom<Int128> for Int64 {
     type Error = ConversionOverflowError;
 
@@ -339,6 +342,55 @@ impl TryFrom<Int512> for Int64 {
         shrink_be_int(value.to_be_bytes())
             .ok_or_else(|| ConversionOverflowError::new("Int512", "Int64", value))
             .map(Self::from_be_bytes)
+    }
+}
+
+// Uint to Int
+impl TryFrom<Uint64> for Int64 {
+    type Error = ConversionOverflowError;
+
+    fn try_from(value: Uint64) -> Result<Self, Self::Error> {
+        value
+            .u64()
+            .try_into() // convert to i64
+            .map(Self::new)
+            .map_err(|_| ConversionOverflowError::new("Uint64", "Int64", value))
+    }
+}
+
+impl TryFrom<Uint128> for Int64 {
+    type Error = ConversionOverflowError;
+
+    fn try_from(value: Uint128) -> Result<Self, Self::Error> {
+        value
+            .u128()
+            .try_into() // convert to i64
+            .map(Self::new)
+            .map_err(|_| ConversionOverflowError::new("Uint64", "Int64", value))
+    }
+}
+
+impl TryFrom<Uint256> for Int64 {
+    type Error = ConversionOverflowError;
+
+    fn try_from(value: Uint256) -> Result<Self, Self::Error> {
+        value
+            .0
+            .try_into()
+            .map(Int64)
+            .map_err(|_| ConversionOverflowError::new("Uint256", "Int64", value))
+    }
+}
+
+impl TryFrom<Uint512> for Int64 {
+    type Error = ConversionOverflowError;
+
+    fn try_from(value: Uint512) -> Result<Self, Self::Error> {
+        value
+            .0
+            .try_into()
+            .map(Int64)
+            .map_err(|_| ConversionOverflowError::new("Uint512", "Int64", value))
     }
 }
 

--- a/packages/std/src/math/int64.rs
+++ b/packages/std/src/math/int64.rs
@@ -10,8 +10,8 @@ use serde::{de, ser, Deserialize, Deserializer, Serialize};
 
 use crate::errors::{DivideByZeroError, DivisionError, OverflowError, OverflowOperation, StdError};
 use crate::{
-    forward_ref_partial_eq, CheckedMultiplyRatioError, ConversionOverflowError, Int128, Int256,
-    Int512, Uint128, Uint256, Uint512, Uint64,
+    forward_ref_partial_eq, CheckedMultiplyRatioError, Int128, Int256, Int512, Uint128, Uint256,
+    Uint512, Uint64,
 };
 
 use super::conversion::{forward_try_from, try_from_int_to_int};

--- a/packages/std/src/math/int64.rs
+++ b/packages/std/src/math/int64.rs
@@ -15,6 +15,7 @@ use crate::{
 };
 
 use super::conversion::{forward_try_from, try_from_int_to_int};
+use super::num_consts::NumConsts;
 
 /// An implementation of i64 that is using strings for JSON encoding/decoding,
 /// such that the full i64 range can be used for clients that convert JSON numbers to floats,
@@ -268,6 +269,13 @@ impl Int64 {
     pub const fn unsigned_abs(self) -> Uint64 {
         Uint64(self.0.unsigned_abs())
     }
+}
+
+impl NumConsts for Int64 {
+    const ZERO: Self = Self::zero();
+    const ONE: Self = Self::one();
+    const MAX: Self = Self::MAX;
+    const MIN: Self = Self::MIN;
 }
 
 // uint to Int
@@ -541,7 +549,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{from_slice, to_vec};
+    use crate::{from_slice, math::conversion::test_try_from_uint_to_int, to_vec};
 
     #[test]
     fn size_of_works() {
@@ -648,6 +656,14 @@ mod tests {
 
         let result = Int64::try_from("1.23");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn int64_try_from_unsigned_works() {
+        test_try_from_uint_to_int::<Uint64, Int64>("Uint64", "Int64");
+        test_try_from_uint_to_int::<Uint128, Int64>("Uint128", "Int64");
+        test_try_from_uint_to_int::<Uint256, Int64>("Uint256", "Int64");
+        test_try_from_uint_to_int::<Uint512, Int64>("Uint512", "Int64");
     }
 
     #[test]

--- a/packages/std/src/math/int64.rs
+++ b/packages/std/src/math/int64.rs
@@ -14,7 +14,7 @@ use crate::{
     Int512, Uint128, Uint256, Uint512, Uint64,
 };
 
-use super::conversion::shrink_be_int;
+use super::conversion::{forward_try_from, try_from_int_to_int};
 
 /// An implementation of i64 that is using strings for JSON encoding/decoding,
 /// such that the full i64 range can be used for clients that convert JSON numbers to floats,
@@ -30,7 +30,7 @@ use super::conversion::shrink_be_int;
 /// assert_eq!(a.i64(), 258);
 /// ```
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, PartialOrd, Ord, JsonSchema)]
-pub struct Int64(#[schemars(with = "String")] i64);
+pub struct Int64(#[schemars(with = "String")] pub(crate) i64);
 
 forward_ref_partial_eq!(Int64, Int64);
 
@@ -315,84 +315,15 @@ impl From<i8> for Int64 {
 }
 
 // Int to Int
-impl TryFrom<Int128> for Int64 {
-    type Error = ConversionOverflowError;
-
-    fn try_from(value: Int128) -> Result<Self, Self::Error> {
-        shrink_be_int(value.to_be_bytes())
-            .ok_or_else(|| ConversionOverflowError::new("Int128", "Int64", value))
-            .map(Self::from_be_bytes)
-    }
-}
-
-impl TryFrom<Int256> for Int64 {
-    type Error = ConversionOverflowError;
-
-    fn try_from(value: Int256) -> Result<Self, Self::Error> {
-        shrink_be_int(value.to_be_bytes())
-            .ok_or_else(|| ConversionOverflowError::new("Int256", "Int64", value))
-            .map(Self::from_be_bytes)
-    }
-}
-
-impl TryFrom<Int512> for Int64 {
-    type Error = ConversionOverflowError;
-
-    fn try_from(value: Int512) -> Result<Self, Self::Error> {
-        shrink_be_int(value.to_be_bytes())
-            .ok_or_else(|| ConversionOverflowError::new("Int512", "Int64", value))
-            .map(Self::from_be_bytes)
-    }
-}
+try_from_int_to_int!(Int128, Int64);
+try_from_int_to_int!(Int256, Int64);
+try_from_int_to_int!(Int512, Int64);
 
 // Uint to Int
-impl TryFrom<Uint64> for Int64 {
-    type Error = ConversionOverflowError;
-
-    fn try_from(value: Uint64) -> Result<Self, Self::Error> {
-        value
-            .u64()
-            .try_into() // convert to i64
-            .map(Self::new)
-            .map_err(|_| ConversionOverflowError::new("Uint64", "Int64", value))
-    }
-}
-
-impl TryFrom<Uint128> for Int64 {
-    type Error = ConversionOverflowError;
-
-    fn try_from(value: Uint128) -> Result<Self, Self::Error> {
-        value
-            .u128()
-            .try_into() // convert to i64
-            .map(Self::new)
-            .map_err(|_| ConversionOverflowError::new("Uint64", "Int64", value))
-    }
-}
-
-impl TryFrom<Uint256> for Int64 {
-    type Error = ConversionOverflowError;
-
-    fn try_from(value: Uint256) -> Result<Self, Self::Error> {
-        value
-            .0
-            .try_into()
-            .map(Int64)
-            .map_err(|_| ConversionOverflowError::new("Uint256", "Int64", value))
-    }
-}
-
-impl TryFrom<Uint512> for Int64 {
-    type Error = ConversionOverflowError;
-
-    fn try_from(value: Uint512) -> Result<Self, Self::Error> {
-        value
-            .0
-            .try_into()
-            .map(Int64)
-            .map_err(|_| ConversionOverflowError::new("Uint512", "Int64", value))
-    }
-}
+forward_try_from!(Uint64, Int64);
+forward_try_from!(Uint128, Int64);
+forward_try_from!(Uint256, Int64);
+forward_try_from!(Uint512, Int64);
 
 impl TryFrom<&str> for Int64 {
     type Error = StdError;

--- a/packages/std/src/math/mod.rs
+++ b/packages/std/src/math/mod.rs
@@ -7,6 +7,7 @@ mod int256;
 mod int512;
 mod int64;
 mod isqrt;
+mod num_consts;
 mod uint128;
 mod uint256;
 mod uint512;
@@ -71,6 +72,7 @@ mod tests {
         + ShrAssign<u32>
         + ShrAssign<&'a u32>
         + Not<Output = Self>
+        + super::num_consts::NumConsts
     {
     }
 

--- a/packages/std/src/math/num_consts.rs
+++ b/packages/std/src/math/num_consts.rs
@@ -1,0 +1,7 @@
+/// Crate internal trait for all our signed and unsigned number types
+pub(crate) trait NumConsts {
+    const MAX: Self;
+    const MIN: Self;
+    const ZERO: Self;
+    const ONE: Self;
+}

--- a/packages/std/src/math/uint128.rs
+++ b/packages/std/src/math/uint128.rs
@@ -15,8 +15,8 @@ use crate::errors::{
     OverflowOperation, StdError,
 };
 use crate::{
-    forward_ref_partial_eq, impl_mul_fraction, ConversionOverflowError, Fraction, Int128, Int256,
-    Int512, Int64, Uint256, Uint64,
+    forward_ref_partial_eq, impl_mul_fraction, Fraction, Int128, Int256, Int512, Int64, Uint256,
+    Uint64,
 };
 
 use super::conversion::forward_try_from;

--- a/packages/std/src/math/uint128.rs
+++ b/packages/std/src/math/uint128.rs
@@ -15,8 +15,11 @@ use crate::errors::{
     OverflowOperation, StdError,
 };
 use crate::{
-    forward_ref_partial_eq, impl_mul_fraction, ConversionOverflowError, Fraction, Uint256, Uint64,
+    forward_ref_partial_eq, impl_mul_fraction, ConversionOverflowError, Fraction, Int128, Int256,
+    Int512, Int64, Uint256, Uint64,
 };
+
+use super::conversion::forward_try_from;
 
 /// A thin wrapper around u128 that is using strings for JSON encoding/decoding,
 /// such that the full u128 range can be used for clients that convert JSON numbers to floats,
@@ -312,15 +315,13 @@ impl From<u8> for Uint128 {
     }
 }
 
-impl TryFrom<Uint128> for Uint64 {
-    type Error = ConversionOverflowError;
+forward_try_from!(Uint128, Uint64);
 
-    fn try_from(value: Uint128) -> Result<Self, Self::Error> {
-        Ok(Uint64::new(value.0.try_into().map_err(|_| {
-            ConversionOverflowError::new("Uint128", "Uint64", value.to_string())
-        })?))
-    }
-}
+// Int to Uint
+forward_try_from!(Int64, Uint128);
+forward_try_from!(Int128, Uint128);
+forward_try_from!(Int256, Uint128);
+forward_try_from!(Int512, Uint128);
 
 impl TryFrom<&str> for Uint128 {
     type Error = StdError;

--- a/packages/std/src/math/uint128.rs
+++ b/packages/std/src/math/uint128.rs
@@ -678,6 +678,18 @@ mod tests {
     }
 
     #[test]
+    fn uint128_try_into() {
+        assert!(Uint64::try_from(Uint128::MAX).is_err());
+
+        assert_eq!(Uint64::try_from(Uint128::zero()), Ok(Uint64::zero()));
+
+        assert_eq!(
+            Uint64::try_from(Uint128::from(42u64)),
+            Ok(Uint64::from(42u64))
+        );
+    }
+
+    #[test]
     fn uint128_implements_display() {
         let a = Uint128(12345);
         assert_eq!(format!("Embedded: {a}"), "Embedded: 12345");

--- a/packages/std/src/math/uint128.rs
+++ b/packages/std/src/math/uint128.rs
@@ -608,7 +608,7 @@ where
 #[cfg(test)]
 mod tests {
     use crate::errors::CheckedMultiplyFractionError::{ConversionOverflow, DivideByZero};
-    use crate::{from_slice, to_vec, Decimal};
+    use crate::{from_slice, to_vec, ConversionOverflowError, Decimal};
 
     use super::*;
 

--- a/packages/std/src/math/uint128.rs
+++ b/packages/std/src/math/uint128.rs
@@ -20,6 +20,7 @@ use crate::{
 };
 
 use super::conversion::forward_try_from;
+use super::num_consts::NumConsts;
 
 /// A thin wrapper around u128 that is using strings for JSON encoding/decoding,
 /// such that the full u128 range can be used for clients that convert JSON numbers to floats,
@@ -270,6 +271,13 @@ impl Uint128 {
             self.0 - other.0
         })
     }
+}
+
+impl NumConsts for Uint128 {
+    const ZERO: Self = Self::zero();
+    const ONE: Self = Self::one();
+    const MAX: Self = Self::MAX;
+    const MIN: Self = Self::MIN;
 }
 
 impl_mul_fraction!(Uint128);
@@ -608,6 +616,7 @@ where
 #[cfg(test)]
 mod tests {
     use crate::errors::CheckedMultiplyFractionError::{ConversionOverflow, DivideByZero};
+    use crate::math::conversion::test_try_from_int_to_uint;
     use crate::{from_slice, to_vec, ConversionOverflowError, Decimal};
 
     use super::*;
@@ -676,6 +685,14 @@ mod tests {
 
         let result = Uint128::try_from("1.23");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn uint128_try_from_signed_works() {
+        test_try_from_int_to_uint::<Int64, Uint128>("Int64", "Uint128");
+        test_try_from_int_to_uint::<Int128, Uint128>("Int128", "Uint128");
+        test_try_from_int_to_uint::<Int256, Uint128>("Int256", "Uint128");
+        test_try_from_int_to_uint::<Int512, Uint128>("Int512", "Uint128");
     }
 
     #[test]

--- a/packages/std/src/math/uint256.rs
+++ b/packages/std/src/math/uint256.rs
@@ -19,6 +19,8 @@ use crate::{forward_ref_partial_eq, impl_mul_fraction, Fraction, Uint128, Uint51
 /// the implementation in the future.
 use bnum::types::U256;
 
+use super::conversion::forward_try_from;
+
 /// An implementation of u256 that is using strings for JSON encoding/decoding,
 /// such that the full u256 range can be used for clients that convert JSON numbers to floats,
 /// like JavaScript and jq.
@@ -379,15 +381,7 @@ impl From<u8> for Uint256 {
     }
 }
 
-impl TryFrom<Uint256> for Uint128 {
-    type Error = ConversionOverflowError;
-
-    fn try_from(value: Uint256) -> Result<Self, Self::Error> {
-        Ok(Uint128::new(value.0.try_into().map_err(|_| {
-            ConversionOverflowError::new("Uint256", "Uint128", value.to_string())
-        })?))
-    }
-}
+forward_try_from!(Uint256, Uint128);
 
 impl TryFrom<Uint256> for Uint64 {
     type Error = ConversionOverflowError;

--- a/packages/std/src/math/uint256.rs
+++ b/packages/std/src/math/uint256.rs
@@ -389,6 +389,16 @@ impl TryFrom<Uint256> for Uint128 {
     }
 }
 
+impl TryFrom<Uint256> for Uint64 {
+    type Error = ConversionOverflowError;
+
+    fn try_from(value: Uint256) -> Result<Self, Self::Error> {
+        Ok(Uint64::new(value.0.try_into().map_err(|_| {
+            ConversionOverflowError::new("Uint256", "Uint64", value.to_string())
+        })?))
+    }
+}
+
 impl TryFrom<&str> for Uint256 {
     type Error = StdError;
 
@@ -1060,6 +1070,24 @@ mod tests {
 
         let result = Uint256::try_from("1.23");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn uint256_try_into() {
+        assert!(Uint64::try_from(Uint256::MAX).is_err());
+        assert!(Uint128::try_from(Uint256::MAX).is_err());
+
+        assert_eq!(Uint64::try_from(Uint256::zero()), Ok(Uint64::zero()));
+        assert_eq!(Uint128::try_from(Uint256::zero()), Ok(Uint128::zero()));
+
+        assert_eq!(
+            Uint64::try_from(Uint256::from(42u64)),
+            Ok(Uint64::from(42u64))
+        );
+        assert_eq!(
+            Uint128::try_from(Uint256::from(42u128)),
+            Ok(Uint128::from(42u128))
+        );
     }
 
     #[test]

--- a/packages/std/src/math/uint256.rs
+++ b/packages/std/src/math/uint256.rs
@@ -23,6 +23,7 @@ use crate::{
 use bnum::types::U256;
 
 use super::conversion::{forward_try_from, try_from_int_to_uint};
+use super::num_consts::NumConsts;
 
 /// An implementation of u256 that is using strings for JSON encoding/decoding,
 /// such that the full u256 range can be used for clients that convert JSON numbers to floats,
@@ -338,6 +339,13 @@ impl Uint256 {
     pub const fn abs_diff(self, other: Self) -> Self {
         Self(self.0.abs_diff(other.0))
     }
+}
+
+impl NumConsts for Uint256 {
+    const ZERO: Self = Self::zero();
+    const ONE: Self = Self::one();
+    const MAX: Self = Self::MAX;
+    const MIN: Self = Self::MIN;
 }
 
 impl_mul_fraction!(Uint256);
@@ -671,6 +679,7 @@ where
 mod tests {
     use super::*;
     use crate::errors::CheckedMultiplyFractionError::{ConversionOverflow, DivideByZero};
+    use crate::math::conversion::test_try_from_int_to_uint;
     use crate::{from_slice, to_vec, Decimal, Decimal256};
 
     #[test]
@@ -1064,6 +1073,14 @@ mod tests {
 
         let result = Uint256::try_from("1.23");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn uint256_try_from_signed_works() {
+        test_try_from_int_to_uint::<Int64, Uint256>("Int64", "Uint256");
+        test_try_from_int_to_uint::<Int128, Uint256>("Int128", "Uint256");
+        test_try_from_int_to_uint::<Int256, Uint256>("Int256", "Uint256");
+        test_try_from_int_to_uint::<Int512, Uint256>("Int512", "Uint256");
     }
 
     #[test]

--- a/packages/std/src/math/uint256.rs
+++ b/packages/std/src/math/uint256.rs
@@ -13,13 +13,16 @@ use crate::errors::{
     CheckedMultiplyFractionError, CheckedMultiplyRatioError, ConversionOverflowError,
     DivideByZeroError, OverflowError, OverflowOperation, StdError,
 };
-use crate::{forward_ref_partial_eq, impl_mul_fraction, Fraction, Uint128, Uint512, Uint64};
+use crate::{
+    forward_ref_partial_eq, impl_mul_fraction, Fraction, Int128, Int256, Int512, Int64, Uint128,
+    Uint512, Uint64,
+};
 
 /// Used internally - we don't want to leak this type since we might change
 /// the implementation in the future.
 use bnum::types::U256;
 
-use super::conversion::forward_try_from;
+use super::conversion::{forward_try_from, try_from_int_to_uint};
 
 /// An implementation of u256 that is using strings for JSON encoding/decoding,
 /// such that the full u256 range can be used for clients that convert JSON numbers to floats,
@@ -382,16 +385,13 @@ impl From<u8> for Uint256 {
 }
 
 forward_try_from!(Uint256, Uint128);
+forward_try_from!(Uint256, Uint64);
 
-impl TryFrom<Uint256> for Uint64 {
-    type Error = ConversionOverflowError;
-
-    fn try_from(value: Uint256) -> Result<Self, Self::Error> {
-        Ok(Uint64::new(value.0.try_into().map_err(|_| {
-            ConversionOverflowError::new("Uint256", "Uint64", value.to_string())
-        })?))
-    }
-}
+// Int to Uint
+try_from_int_to_uint!(Int64, Uint256);
+try_from_int_to_uint!(Int128, Uint256);
+try_from_int_to_uint!(Int256, Uint256);
+try_from_int_to_uint!(Int512, Uint256);
 
 impl TryFrom<&str> for Uint256 {
     type Error = StdError;

--- a/packages/std/src/math/uint512.rs
+++ b/packages/std/src/math/uint512.rs
@@ -11,13 +11,13 @@ use serde::{de, ser, Deserialize, Deserializer, Serialize};
 use crate::errors::{
     ConversionOverflowError, DivideByZeroError, OverflowError, OverflowOperation, StdError,
 };
-use crate::{forward_ref_partial_eq, Uint128, Uint256, Uint64};
+use crate::{forward_ref_partial_eq, Int128, Int256, Int512, Int64, Uint128, Uint256, Uint64};
 
 /// Used internally - we don't want to leak this type since we might change
 /// the implementation in the future.
 use bnum::types::U512;
 
-use super::conversion::forward_try_from;
+use super::conversion::{forward_try_from, try_from_int_to_uint};
 
 /// An implementation of u512 that is using strings for JSON encoding/decoding,
 /// such that the full u512 range can be used for clients that convert JSON numbers to floats,
@@ -373,16 +373,13 @@ impl TryFrom<Uint512> for Uint256 {
 }
 
 forward_try_from!(Uint512, Uint128);
+forward_try_from!(Uint512, Uint64);
 
-impl TryFrom<Uint512> for Uint64 {
-    type Error = ConversionOverflowError;
-
-    fn try_from(value: Uint512) -> Result<Self, Self::Error> {
-        Ok(Uint64::new(value.0.try_into().map_err(|_| {
-            ConversionOverflowError::new("Uint512", "Uint64", value.to_string())
-        })?))
-    }
-}
+// Int to Uint
+try_from_int_to_uint!(Int64, Uint512);
+try_from_int_to_uint!(Int128, Uint512);
+try_from_int_to_uint!(Int256, Uint512);
+try_from_int_to_uint!(Int512, Uint512);
 
 impl TryFrom<&str> for Uint512 {
     type Error = StdError;

--- a/packages/std/src/math/uint512.rs
+++ b/packages/std/src/math/uint512.rs
@@ -18,6 +18,7 @@ use crate::{forward_ref_partial_eq, Int128, Int256, Int512, Int64, Uint128, Uint
 use bnum::types::U512;
 
 use super::conversion::{forward_try_from, try_from_int_to_uint};
+use super::num_consts::NumConsts;
 
 /// An implementation of u512 that is using strings for JSON encoding/decoding,
 /// such that the full u512 range can be used for clients that convert JSON numbers to floats,
@@ -300,6 +301,13 @@ impl Uint512 {
     pub const fn abs_diff(self, other: Self) -> Self {
         Self(self.0.abs_diff(other.0))
     }
+}
+
+impl NumConsts for Uint512 {
+    const ZERO: Self = Self::zero();
+    const ONE: Self = Self::one();
+    const MAX: Self = Self::MAX;
+    const MIN: Self = Self::MIN;
 }
 
 impl From<Uint256> for Uint512 {
@@ -638,7 +646,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{from_slice, to_vec};
+    use crate::{from_slice, math::conversion::test_try_from_int_to_uint, to_vec};
 
     #[test]
     fn size_of_works() {
@@ -747,6 +755,14 @@ mod tests {
 
         let result = Uint512::try_from("1.23");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn uint512_try_from_signed_works() {
+        test_try_from_int_to_uint::<Int64, Uint512>("Int64", "Uint512");
+        test_try_from_int_to_uint::<Int128, Uint512>("Int128", "Uint512");
+        test_try_from_int_to_uint::<Int256, Uint512>("Int256", "Uint512");
+        test_try_from_int_to_uint::<Int512, Uint512>("Int512", "Uint512");
     }
 
     #[test]

--- a/packages/std/src/math/uint512.rs
+++ b/packages/std/src/math/uint512.rs
@@ -17,6 +17,8 @@ use crate::{forward_ref_partial_eq, Uint128, Uint256, Uint64};
 /// the implementation in the future.
 use bnum::types::U512;
 
+use super::conversion::forward_try_from;
+
 /// An implementation of u512 that is using strings for JSON encoding/decoding,
 /// such that the full u512 range can be used for clients that convert JSON numbers to floats,
 /// like JavaScript and jq.
@@ -370,15 +372,7 @@ impl TryFrom<Uint512> for Uint256 {
     }
 }
 
-impl TryFrom<Uint512> for Uint128 {
-    type Error = ConversionOverflowError;
-
-    fn try_from(value: Uint512) -> Result<Self, Self::Error> {
-        Ok(Uint128::new(value.0.try_into().map_err(|_| {
-            ConversionOverflowError::new("Uint512", "Uint128", value.to_string())
-        })?))
-    }
-}
+forward_try_from!(Uint512, Uint128);
 
 impl TryFrom<Uint512> for Uint64 {
     type Error = ConversionOverflowError;

--- a/packages/std/src/math/uint512.rs
+++ b/packages/std/src/math/uint512.rs
@@ -380,6 +380,16 @@ impl TryFrom<Uint512> for Uint128 {
     }
 }
 
+impl TryFrom<Uint512> for Uint64 {
+    type Error = ConversionOverflowError;
+
+    fn try_from(value: Uint512) -> Result<Self, Self::Error> {
+        Ok(Uint64::new(value.0.try_into().map_err(|_| {
+            ConversionOverflowError::new("Uint512", "Uint64", value.to_string())
+        })?))
+    }
+}
+
 impl TryFrom<&str> for Uint512 {
     type Error = StdError;
 
@@ -746,6 +756,30 @@ mod tests {
 
         let result = Uint512::try_from("1.23");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn uint512_try_into() {
+        assert!(Uint64::try_from(Uint512::MAX).is_err());
+        assert!(Uint128::try_from(Uint512::MAX).is_err());
+        assert!(Uint256::try_from(Uint512::MAX).is_err());
+
+        assert_eq!(Uint64::try_from(Uint512::zero()), Ok(Uint64::zero()));
+        assert_eq!(Uint128::try_from(Uint512::zero()), Ok(Uint128::zero()));
+        assert_eq!(Uint256::try_from(Uint512::zero()), Ok(Uint256::zero()));
+
+        assert_eq!(
+            Uint64::try_from(Uint512::from(42u64)),
+            Ok(Uint64::from(42u64))
+        );
+        assert_eq!(
+            Uint128::try_from(Uint512::from(42u128)),
+            Ok(Uint128::from(42u128))
+        );
+        assert_eq!(
+            Uint256::try_from(Uint512::from(42u128)),
+            Ok(Uint256::from(42u128))
+        );
     }
 
     #[test]

--- a/packages/std/src/math/uint64.rs
+++ b/packages/std/src/math/uint64.rs
@@ -12,7 +12,12 @@ use crate::errors::{
     CheckedMultiplyFractionError, CheckedMultiplyRatioError, DivideByZeroError, OverflowError,
     OverflowOperation, StdError,
 };
-use crate::{forward_ref_partial_eq, impl_mul_fraction, Fraction, Uint128};
+use crate::{
+    forward_ref_partial_eq, impl_mul_fraction, ConversionOverflowError, Fraction, Int128, Int256,
+    Int512, Int64, Uint128,
+};
+
+use super::conversion::forward_try_from;
 
 /// A thin wrapper around u64 that is using strings for JSON encoding/decoding,
 /// such that the full u64 range can be used for clients that convert JSON numbers to floats,
@@ -269,6 +274,7 @@ impl_mul_fraction!(Uint64);
 // of the conflict with `TryFrom<&str>` as described here
 // https://stackoverflow.com/questions/63136970/how-do-i-work-around-the-upstream-crates-may-add-a-new-impl-of-trait-error
 
+// uint to Uint
 impl From<u64> for Uint64 {
     fn from(val: u64) -> Self {
         Uint64(val)
@@ -292,6 +298,12 @@ impl From<u8> for Uint64 {
         Uint64(val.into())
     }
 }
+
+// Int to Uint
+forward_try_from!(Int64, Uint64);
+forward_try_from!(Int128, Uint64);
+forward_try_from!(Int256, Uint64);
+forward_try_from!(Int512, Uint64);
 
 impl TryFrom<&str> for Uint64 {
     type Error = StdError;

--- a/packages/std/src/math/uint64.rs
+++ b/packages/std/src/math/uint64.rs
@@ -13,8 +13,7 @@ use crate::errors::{
     OverflowOperation, StdError,
 };
 use crate::{
-    forward_ref_partial_eq, impl_mul_fraction, ConversionOverflowError, Fraction, Int128, Int256,
-    Int512, Int64, Uint128,
+    forward_ref_partial_eq, impl_mul_fraction, Fraction, Int128, Int256, Int512, Int64, Uint128,
 };
 
 use super::conversion::forward_try_from;

--- a/packages/std/src/math/uint64.rs
+++ b/packages/std/src/math/uint64.rs
@@ -17,6 +17,7 @@ use crate::{
 };
 
 use super::conversion::forward_try_from;
+use super::num_consts::NumConsts;
 
 /// A thin wrapper around u64 that is using strings for JSON encoding/decoding,
 /// such that the full u64 range can be used for clients that convert JSON numbers to floats,
@@ -264,6 +265,13 @@ impl Uint64 {
             self.0 - other.0
         })
     }
+}
+
+impl NumConsts for Uint64 {
+    const ZERO: Self = Self::zero();
+    const ONE: Self = Self::one();
+    const MAX: Self = Self::MAX;
+    const MIN: Self = Self::MIN;
 }
 
 impl_mul_fraction!(Uint64);
@@ -570,6 +578,7 @@ where
 mod tests {
     use super::*;
     use crate::errors::CheckedMultiplyFractionError::{ConversionOverflow, DivideByZero};
+    use crate::math::conversion::test_try_from_int_to_uint;
     use crate::{from_slice, to_vec, ConversionOverflowError};
 
     #[test]
@@ -627,6 +636,14 @@ mod tests {
 
         let result = Uint64::try_from("1.23");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn uint64_try_from_signed_works() {
+        test_try_from_int_to_uint::<Int64, Uint64>("Int64", "Uint64");
+        test_try_from_int_to_uint::<Int128, Uint64>("Int128", "Uint64");
+        test_try_from_int_to_uint::<Int256, Uint64>("Int256", "Uint64");
+        test_try_from_int_to_uint::<Int512, Uint64>("Int512", "Uint64");
     }
 
     #[test]


### PR DESCRIPTION
closes #1863 

I also ended up adding the rest of the missing unsigned to signed `TryFrom` impls and signed to unsigned `TryFrom` impls because I needed some more for the `SignedDecimal` PR:
- `Uint{64,128,256,512}` -> `Int64`
- `Uint{128,256,512}` -> `Int128`
- `Uint{256, 512}` -> `Int256`
- `Uint512` -> `Int512`
- `Int{64,128,256,512}` -> `Uint{64,128,256,512}`