### PR TITLE
[2.0] Response changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,10 +34,19 @@ and this project adheres to
 - cosmwasm-std: Upgrade to `serde-json-wasm` 1.0. This means `u128` and `i128`
   are now serialized as numbers instead of strings. Use `Uint128` and `Int128`
   instead. ([#1939])
+- cosmwasm-std: Make `BalanceResponse`, `AllBalanceResponse`,
+  `DelegationRewardsResponse`, `DelegatorReward`, `DelegatorValidatorsResponse`,
+  `PortIdResponse`, `ListChannelsResponse`, `ChannelResponse`,
+  `BondedDenomResponse`, `AllDelegationsResponse`, `Delegation`,
+  `DelegationResponse`, `FullDelegation`, `AllValidatorsResponse`,
+  `ValidatorResponse` and `Validator` non-exhaustive. Add `Validator::create`
+  and `FullDelegation::create` to allow creating them in a stable way. Use
+  `Addr` type for `ContractInfoResponse::{creator, admin}`. ([#1883])
 
 [#1874]: https://github.com/CosmWasm/cosmwasm/pull/1874
 [#1876]: https://github.com/CosmWasm/cosmwasm/pull/1876
 [#1879]: https://github.com/CosmWasm/cosmwasm/pull/1879
+[#1883]: https://github.com/CosmWasm/cosmwasm/pull/1883
 [#1884]: https://github.com/CosmWasm/cosmwasm/pull/1884
 [#1898]: https://github.com/CosmWasm/cosmwasm/pull/1898
 [#1902]: https://github.com/CosmWasm/cosmwasm/pull/1902

--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -2,8 +2,8 @@ use sha2::{Digest, Sha256};
 
 use cosmwasm_std::{
     entry_point, from_json, to_json_binary, to_json_vec, Addr, AllBalanceResponse, Api, BankMsg,
-    CanonicalAddr, Deps, DepsMut, Env, Event, MessageInfo, QueryRequest, QueryResponse, Response,
-    StdError, StdResult, WasmMsg, WasmQuery,
+    BankQuery, CanonicalAddr, Deps, DepsMut, Env, Event, MessageInfo, QueryRequest, QueryResponse,
+    Response, StdError, StdResult, WasmMsg, WasmQuery,
 };
 
 use crate::errors::HackError;
@@ -269,8 +269,8 @@ fn query_verifier(deps: Deps) -> StdResult<VerifierResponse> {
 }
 
 fn query_other_balance(deps: Deps, address: String) -> StdResult<AllBalanceResponse> {
-    let amount = deps.querier.query_all_balances(address)?;
-    Ok(AllBalanceResponse { amount })
+    deps.querier
+        .query(&BankQuery::AllBalances { address }.into())
 }
 
 fn query_recurse(deps: Deps, depth: u32, work: u32, contract: Addr) -> StdResult<RecurseResponse> {

--- a/contracts/staking/Cargo.lock
+++ b/contracts/staking/Cargo.lock
@@ -1475,7 +1475,6 @@ dependencies = [
  "cosmwasm-vm",
  "schemars",
  "serde",
- "serde_json",
  "snafu",
 ]
 

--- a/contracts/staking/Cargo.lock
+++ b/contracts/staking/Cargo.lock
@@ -857,9 +857,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "js-sys"
@@ -1358,9 +1358,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.64"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
 dependencies = [
  "itoa",
  "ryu",
@@ -1475,6 +1475,7 @@ dependencies = [
  "cosmwasm-vm",
  "schemars",
  "serde",
+ "serde_json",
  "snafu",
 ]
 

--- a/contracts/staking/Cargo.toml
+++ b/contracts/staking/Cargo.toml
@@ -40,4 +40,3 @@ snafu = "0.6.6"
 
 [dev-dependencies]
 cosmwasm-vm = { path = "../../packages/vm", default-features = false, features = ["staking"] }
-serde_json = "1.0.107"

--- a/contracts/staking/Cargo.toml
+++ b/contracts/staking/Cargo.toml
@@ -40,3 +40,4 @@ snafu = "0.6.6"
 
 [dev-dependencies]
 cosmwasm-vm = { path = "../../packages/vm", default-features = false, features = ["staking"] }
+serde_json = "1.0.107"

--- a/contracts/staking/src/contract.rs
+++ b/contracts/staking/src/contract.rs
@@ -412,23 +412,24 @@ mod tests {
     use std::str::FromStr;
 
     fn sample_validator(addr: &str) -> Validator {
-        Validator {
-            address: addr.to_owned(),
-            commission: Decimal::percent(3),
-            max_commission: Decimal::percent(10),
-            max_change_rate: Decimal::percent(1),
-        }
+        serde_json::from_value(serde_json::json!({
+            "address": addr.to_owned(),
+            "commission": Decimal::percent(3),
+            "max_commission": Decimal::percent(10),
+            "max_change_rate": Decimal::percent(1),
+        }))
+        .unwrap()
     }
 
     fn sample_delegation(validator_addr: &str, amount: Coin) -> FullDelegation {
-        let can_redelegate = amount.clone();
-        FullDelegation {
-            validator: validator_addr.to_owned(),
-            delegator: Addr::unchecked(MOCK_CONTRACT_ADDR),
-            amount,
-            can_redelegate,
-            accumulated_rewards: Vec::new(),
-        }
+        serde_json::from_value(serde_json::json!({
+            "validator": validator_addr.to_owned(),
+            "delegator": Addr::unchecked(MOCK_CONTRACT_ADDR),
+            "amount": amount,
+            "can_redelegate": amount,
+            "accumulated_rewards": Vec::<Coin>::new(),
+        }))
+        .unwrap()
     }
 
     fn set_validator(querier: &mut MockQuerier) {

--- a/contracts/staking/src/contract.rs
+++ b/contracts/staking/src/contract.rs
@@ -412,24 +412,22 @@ mod tests {
     use std::str::FromStr;
 
     fn sample_validator(addr: &str) -> Validator {
-        serde_json::from_value(serde_json::json!({
-            "address": addr.to_owned(),
-            "commission": Decimal::percent(3),
-            "max_commission": Decimal::percent(10),
-            "max_change_rate": Decimal::percent(1),
-        }))
-        .unwrap()
+        Validator::create(
+            addr.to_owned(),
+            Decimal::percent(3),
+            Decimal::percent(10),
+            Decimal::percent(1),
+        )
     }
 
     fn sample_delegation(validator_addr: &str, amount: Coin) -> FullDelegation {
-        serde_json::from_value(serde_json::json!({
-            "validator": validator_addr.to_owned(),
-            "delegator": Addr::unchecked(MOCK_CONTRACT_ADDR),
-            "amount": amount,
-            "can_redelegate": amount,
-            "accumulated_rewards": Vec::<Coin>::new(),
-        }))
-        .unwrap()
+        FullDelegation::create(
+            Addr::unchecked(MOCK_CONTRACT_ADDR),
+            validator_addr.to_owned(),
+            amount.clone(),
+            amount,
+            vec![],
+        )
     }
 
     fn set_validator(querier: &mut MockQuerier) {

--- a/contracts/staking/tests/integration.rs
+++ b/contracts/staking/tests/integration.rs
@@ -34,12 +34,13 @@ static WASM: &[u8] = include_bytes!("../target/wasm32-unknown-unknown/release/st
 // static WASM: &[u8] = include_bytes!("../contract.wasm");
 
 fn sample_validator(addr: &str) -> Validator {
-    Validator {
-        address: addr.to_owned(),
-        commission: Decimal::percent(3),
-        max_commission: Decimal::percent(10),
-        max_change_rate: Decimal::percent(1),
-    }
+    serde_json::from_value(serde_json::json!({
+        "address": addr.to_owned(),
+        "commission": Decimal::percent(3),
+        "max_commission": Decimal::percent(10),
+        "max_change_rate": Decimal::percent(1),
+    }))
+    .unwrap()
 }
 
 #[test]

--- a/contracts/staking/tests/integration.rs
+++ b/contracts/staking/tests/integration.rs
@@ -34,13 +34,12 @@ static WASM: &[u8] = include_bytes!("../target/wasm32-unknown-unknown/release/st
 // static WASM: &[u8] = include_bytes!("../contract.wasm");
 
 fn sample_validator(addr: &str) -> Validator {
-    serde_json::from_value(serde_json::json!({
-        "address": addr.to_owned(),
-        "commission": Decimal::percent(3),
-        "max_commission": Decimal::percent(10),
-        "max_change_rate": Decimal::percent(1),
-    }))
-    .unwrap()
+    Validator::create(
+        addr.to_owned(),
+        Decimal::percent(3),
+        Decimal::percent(10),
+        Decimal::percent(1),
+    )
 }
 
 #[test]

--- a/packages/std/src/query/bank.rs
+++ b/packages/std/src/query/bank.rs
@@ -35,7 +35,7 @@ pub enum BankQuery {
     AllDenomMetadata { pagination: Option<PageRequest> },
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub struct SupplyResponse {
@@ -48,7 +48,7 @@ impl_response_constructor!(SupplyResponse, amount: Coin);
 
 impl QueryResponseType for SupplyResponse {}
 
-#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub struct BalanceResponse {
@@ -61,7 +61,7 @@ impl_response_constructor!(BalanceResponse, amount: Coin);
 
 impl QueryResponseType for BalanceResponse {}
 
-#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub struct AllBalanceResponse {

--- a/packages/std/src/query/bank.rs
+++ b/packages/std/src/query/bank.rs
@@ -50,6 +50,7 @@ impl QueryResponseType for SupplyResponse {}
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub struct BalanceResponse {
     /// Always returns a Coin with the requested denom.
     /// This may be of 0 amount if no such funds.
@@ -62,6 +63,7 @@ impl QueryResponseType for BalanceResponse {}
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub struct AllBalanceResponse {
     /// Returns all non-zero coins held by this account.
     pub amount: Vec<Coin>,

--- a/packages/std/src/query/distribution.rs
+++ b/packages/std/src/query/distribution.rs
@@ -39,6 +39,7 @@ impl QueryResponseType for DelegatorWithdrawAddressResponse {}
 /// See <https://github.com/cosmos/cosmos-sdk/blob/c74e2887b0b73e81d48c2f33e6b1020090089ee0/proto/cosmos/distribution/v1beta1/query.proto#L169-L178>
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub struct DelegationRewardsResponse {
     pub rewards: Vec<DecCoin>,
 }
@@ -91,13 +92,20 @@ impl_response_constructor!(
 impl QueryResponseType for DelegationTotalRewardsResponse {}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[non_exhaustive]
 pub struct DelegatorReward {
     pub validator_address: String,
     pub reward: Vec<DecCoin>,
 }
+impl_response_constructor!(
+    DelegatorReward,
+    validator_address: String,
+    reward: Vec<DecCoin>
+);
 
 /// See <https://github.com/cosmos/cosmos-sdk/blob/b0acf60e6c39f7ab023841841fc0b751a12c13ff/proto/cosmos/distribution/v1beta1/query.proto#L212-L220>
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[non_exhaustive]
 pub struct DelegatorValidatorsResponse {
     pub validators: Vec<String>,
 }

--- a/packages/std/src/query/ibc.rs
+++ b/packages/std/src/query/ibc.rs
@@ -31,6 +31,7 @@ pub enum IbcQuery {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[non_exhaustive]
 pub struct PortIdResponse {
     pub port_id: String,
 }
@@ -38,6 +39,7 @@ pub struct PortIdResponse {
 impl_response_constructor!(PortIdResponse, port_id: String);
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[non_exhaustive]
 pub struct ListChannelsResponse {
     pub channels: Vec<IbcChannel>,
 }
@@ -45,6 +47,7 @@ pub struct ListChannelsResponse {
 impl_response_constructor!(ListChannelsResponse, channels: Vec<IbcChannel>);
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[non_exhaustive]
 pub struct ChannelResponse {
     pub channel: Option<IbcChannel>,
 }

--- a/packages/std/src/query/staking.rs
+++ b/packages/std/src/query/staking.rs
@@ -36,6 +36,7 @@ pub enum StakingQuery {
 /// BondedDenomResponse is data format returned from StakingRequest::BondedDenom query
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub struct BondedDenomResponse {
     pub denom: String,
 }
@@ -47,6 +48,7 @@ impl_response_constructor!(BondedDenomResponse, denom: String);
 /// DelegationsResponse is data format returned from StakingRequest::AllDelegations query
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub struct AllDelegationsResponse {
     pub delegations: Vec<Delegation>,
 }
@@ -59,6 +61,7 @@ impl_response_constructor!(AllDelegationsResponse, delegations: Vec<Delegation>)
 ///
 /// Instances are created in the querier.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[non_exhaustive]
 pub struct Delegation {
     pub delegator: Addr,
     /// A validator address (e.g. cosmosvaloper1...)
@@ -66,6 +69,13 @@ pub struct Delegation {
     /// How much we have locked in the delegation
     pub amount: Coin,
 }
+
+impl_response_constructor!(
+    Delegation,
+    delegator: Addr,
+    validator: String,
+    amount: Coin
+);
 
 impl From<FullDelegation> for Delegation {
     fn from(full: FullDelegation) -> Self {
@@ -80,6 +90,7 @@ impl From<FullDelegation> for Delegation {
 /// DelegationResponse is data format returned from StakingRequest::Delegation query
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub struct DelegationResponse {
     pub delegation: Option<FullDelegation>,
 }
@@ -93,6 +104,7 @@ impl_response_constructor!(DelegationResponse, delegation: Option<FullDelegation
 ///
 /// Instances are created in the querier.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[non_exhaustive]
 pub struct FullDelegation {
     pub delegator: Addr,
     /// A validator address (e.g. cosmosvaloper1...)
@@ -107,8 +119,18 @@ pub struct FullDelegation {
     pub accumulated_rewards: Vec<Coin>,
 }
 
+impl_response_constructor!(
+    FullDelegation,
+    delegator: Addr,
+    validator: String,
+    amount: Coin,
+    can_redelegate: Coin,
+    accumulated_rewards: Vec<Coin>
+);
+
 /// The data format returned from StakingRequest::AllValidators query
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[non_exhaustive]
 pub struct AllValidatorsResponse {
     pub validators: Vec<Validator>,
 }
@@ -119,6 +141,7 @@ impl_response_constructor!(AllValidatorsResponse, validators: Vec<Validator>);
 
 /// The data format returned from StakingRequest::Validator query
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[non_exhaustive]
 pub struct ValidatorResponse {
     pub validator: Option<Validator>,
 }
@@ -129,6 +152,7 @@ impl_response_constructor!(ValidatorResponse, validator: Option<Validator>);
 
 /// Instances are created in the querier.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[non_exhaustive]
 pub struct Validator {
     /// The operator address of the validator (e.g. cosmosvaloper1...).
     /// See https://github.com/cosmos/cosmos-sdk/blob/v0.47.4/proto/cosmos/staking/v1beta1/staking.proto#L95-L96
@@ -142,3 +166,11 @@ pub struct Validator {
     /// The maximum daily increase of the commission
     pub max_change_rate: Decimal,
 }
+
+impl_response_constructor!(
+    Validator,
+    address: String,
+    commission: Decimal,
+    max_commission: Decimal,
+    max_change_rate: Decimal
+);

--- a/packages/std/src/query/staking.rs
+++ b/packages/std/src/query/staking.rs
@@ -70,12 +70,7 @@ pub struct Delegation {
     pub amount: Coin,
 }
 
-impl_response_constructor!(
-    Delegation,
-    delegator: Addr,
-    validator: String,
-    amount: Coin
-);
+impl_response_constructor!(Delegation, delegator: Addr, validator: String, amount: Coin);
 
 impl From<FullDelegation> for Delegation {
     fn from(full: FullDelegation) -> Self {

--- a/packages/std/src/query/staking.rs
+++ b/packages/std/src/query/staking.rs
@@ -123,6 +123,28 @@ impl_response_constructor!(
     accumulated_rewards: Vec<Coin>
 );
 
+impl FullDelegation {
+    /// Creates a new delegation.
+    ///
+    /// If fields get added to the [`FullDelegation`] struct in the future, this constructor will
+    /// provide default values for them, but these default values may not be sensible.
+    pub fn create(
+        delegator: Addr,
+        validator: String,
+        amount: Coin,
+        can_redelegate: Coin,
+        accumulated_rewards: Vec<Coin>,
+    ) -> Self {
+        Self {
+            delegator,
+            validator,
+            amount,
+            can_redelegate,
+            accumulated_rewards,
+        }
+    }
+}
+
 /// The data format returned from StakingRequest::AllValidators query
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[non_exhaustive]
@@ -169,3 +191,23 @@ impl_response_constructor!(
     max_commission: Decimal,
     max_change_rate: Decimal
 );
+
+impl Validator {
+    /// Creates a new validator.
+    ///
+    /// If fields get added to the [`Validator`] struct in the future, this constructor will
+    /// provide default values for them, but these default values may not be sensible.
+    pub fn create(
+        address: String,
+        commission: Decimal,
+        max_commission: Decimal,
+        max_change_rate: Decimal,
+    ) -> Self {
+        Self {
+            address,
+            commission,
+            max_commission,
+            max_change_rate,
+        }
+    }
+}

--- a/packages/std/src/query/wasm.rs
+++ b/packages/std/src/query/wasm.rs
@@ -1,7 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::{Binary, HexBinary};
+use crate::{Addr, Binary, HexBinary};
 
 use super::query_response::QueryResponseType;
 
@@ -36,9 +36,9 @@ pub enum WasmQuery {
 pub struct ContractInfoResponse {
     pub code_id: u64,
     /// address that instantiated this contract
-    pub creator: String,
+    pub creator: Addr,
     /// admin who can run migrations (if any)
-    pub admin: Option<String>,
+    pub admin: Option<Addr>,
     /// if set, the contract is pinned to the cache, and thus uses less gas when called
     pub pinned: bool,
     /// set if this contract has bound an IBC port
@@ -50,8 +50,8 @@ impl QueryResponseType for ContractInfoResponse {}
 impl_response_constructor!(
     ContractInfoResponse,
     code_id: u64,
-    creator: String,
-    admin: Option<String>,
+    creator: Addr,
+    admin: Option<Addr>,
     pinned: bool,
     ibc_port: Option<String>
 );
@@ -68,7 +68,7 @@ impl_response_constructor!(
 pub struct CodeInfoResponse {
     pub code_id: u64,
     /// The address that initially stored the code
-    pub creator: String,
+    pub creator: Addr,
     /// The hash of the Wasm blob
     pub checksum: HexBinary,
 }
@@ -76,7 +76,7 @@ pub struct CodeInfoResponse {
 impl_response_constructor!(
     CodeInfoResponse,
     code_id: u64,
-    creator: String,
+    creator: Addr,
     checksum: HexBinary
 );
 
@@ -114,8 +114,8 @@ mod tests {
     fn contract_info_response_serialization() {
         let response = ContractInfoResponse {
             code_id: 67,
-            creator: "jane".to_string(),
-            admin: Some("king".to_string()),
+            creator: Addr::unchecked("jane"),
+            admin: Some(Addr::unchecked("king")),
             pinned: true,
             ibc_port: Some("wasm.123".to_string()),
         };
@@ -133,7 +133,7 @@ mod tests {
 
         let response = CodeInfoResponse {
             code_id: 67,
-            creator: "jane".to_string(),
+            creator: Addr::unchecked("jane"),
             checksum: HexBinary::from_hex(
                 "f7bb7b18fb01bbf425cf4ed2cd4b7fb26a019a7fc75a4dc87e8a0b768c501f00",
             )

--- a/packages/std/src/query/wasm.rs
+++ b/packages/std/src/query/wasm.rs
@@ -32,7 +32,7 @@ pub enum WasmQuery {
 }
 
 #[non_exhaustive]
-#[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct ContractInfoResponse {
     pub code_id: u64,
     /// address that instantiated this contract
@@ -64,7 +64,7 @@ impl_response_constructor!(
 /// [CodeInfo]: https://github.com/CosmWasm/wasmd/blob/v0.30.0/proto/cosmwasm/wasm/v1/types.proto#L62-L72
 /// [CodeInfoResponse]: https://github.com/CosmWasm/wasmd/blob/v0.30.0/proto/cosmwasm/wasm/v1/query.proto#L184-L199
 #[non_exhaustive]
-#[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct CodeInfoResponse {
     pub code_id: u64,
     /// The address that initially stored the code

--- a/packages/std/src/testing/mock.rs
+++ b/packages/std/src/testing/mock.rs
@@ -2216,7 +2216,7 @@ mod tests {
                     if addr == constract1 {
                         let response = ContractInfoResponse {
                             code_id: 4,
-                            creator: "lalala".into(),
+                            creator: Addr::unchecked("lalala"),
                             admin: None,
                             pinned: false,
                             ibc_port: None,
@@ -2235,7 +2235,7 @@ mod tests {
                     if code_id == 4 {
                         let response = CodeInfoResponse {
                             code_id,
-                            creator: "lalala".into(),
+                            creator: Addr::unchecked("lalala"),
                             checksum: HexBinary::from_hex(
                                 "84cf20810fd429caf58898c3210fcb71759a27becddae08dbde8668ea2f4725d",
                             )

--- a/packages/std/src/traits.rs
+++ b/packages/std/src/traits.rs
@@ -567,7 +567,7 @@ mod tests {
         fn mock_resp() -> ContractInfoResponse {
             ContractInfoResponse {
                 code_id: 0,
-                creator: "creator".to_string(),
+                creator: Addr::unchecked("creator"),
                 admin: None,
                 pinned: false,
                 ibc_port: None,
@@ -598,7 +598,7 @@ mod tests {
         fn mock_resp() -> ContractInfoResponse {
             ContractInfoResponse {
                 code_id: 0,
-                creator: "creator".to_string(),
+                creator: Addr::unchecked("creator"),
                 admin: None,
                 pinned: false,
                 ibc_port: None,

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -970,7 +970,7 @@ mod tests {
                     .unwrap()
                     .unwrap()
                     .unwrap();
-                let BalanceResponse { amount } = from_json(response).unwrap();
+                let BalanceResponse { amount, .. } = from_json(response).unwrap();
                 assert_eq!(amount.amount.u128(), 8000);
                 assert_eq!(amount.denom, "silver");
                 Ok(())
@@ -991,7 +991,7 @@ mod tests {
                     .unwrap()
                     .unwrap()
                     .unwrap();
-                let AllBalanceResponse { amount } = from_json(response).unwrap();
+                let AllBalanceResponse { amount, .. } = from_json(response).unwrap();
                 assert_eq!(amount.len(), 2);
                 assert_eq!(amount[0].amount.u128(), 10000);
                 assert_eq!(amount[0].denom, "gold");
@@ -1026,7 +1026,7 @@ mod tests {
                     .unwrap()
                     .unwrap()
                     .unwrap();
-                let BalanceResponse { amount } = from_json(response).unwrap();
+                let BalanceResponse { amount, .. } = from_json(response).unwrap();
                 assert_eq!(amount.amount.u128(), 500);
                 Ok(())
             })
@@ -1055,7 +1055,7 @@ mod tests {
                     .unwrap()
                     .unwrap()
                     .unwrap();
-                let BalanceResponse { amount } = from_json(response).unwrap();
+                let BalanceResponse { amount, .. } = from_json(response).unwrap();
                 assert_eq!(amount.amount.u128(), 8000);
                 Ok(())
             })


### PR DESCRIPTION
closes #1559 
closes #1767 
closes #1765 

Not only the responses themselves, but also the structs contained are marked as `non_exhaustive` by this (except `DecCoin` because it seems very unlikely that anything is added here)

I also removed the `Default` impls, changed the address types to `Addr` and replaced the constructor of `ContractInfoResponse` with the macro-generated one.