### PR TITLE
Add `to_json_{vec,binary,string}` and `from_json_{slice,binary,str}` and deprecate old ones

### DIFF
--- a/contracts/crypto-verify/src/contract.rs
+++ b/contracts/crypto-verify/src/contract.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::{
-    entry_point, to_binary, Binary, Deps, DepsMut, Env, MessageInfo, QueryResponse, Response,
+    entry_point, to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, QueryResponse, Response,
     StdError, StdResult, Uint128,
 };
 use sha2::{Digest, Sha256};
@@ -32,7 +32,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<QueryResponse> {
             message,
             signature,
             public_key,
-        } => to_binary(&query_verify_cosmos(
+        } => to_json_binary(&query_verify_cosmos(
             deps,
             &message.0,
             &signature.0,
@@ -42,7 +42,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<QueryResponse> {
             message,
             signature,
             signer_address,
-        } => to_binary(&query_verify_ethereum_text(
+        } => to_json_binary(&query_verify_ethereum_text(
             deps,
             &message,
             &signature,
@@ -60,14 +60,14 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<QueryResponse> {
             r,
             s,
             v,
-        } => to_binary(&query_verify_ethereum_transaction(
+        } => to_json_binary(&query_verify_ethereum_transaction(
             deps, from, to, nonce, gas_limit, gas_price, value, data, chain_id, r, s, v,
         )?),
         QueryMsg::VerifyTendermintSignature {
             message,
             signature,
             public_key,
-        } => to_binary(&query_verify_tendermint(
+        } => to_json_binary(&query_verify_tendermint(
             deps,
             &message.0,
             &signature.0,
@@ -77,13 +77,13 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<QueryResponse> {
             messages,
             signatures,
             public_keys,
-        } => to_binary(&query_verify_tendermint_batch(
+        } => to_json_binary(&query_verify_tendermint_batch(
             deps,
             &messages,
             &signatures,
             &public_keys,
         )?),
-        QueryMsg::ListVerificationSchemes {} => to_binary(&query_list_verifications(deps)?),
+        QueryMsg::ListVerificationSchemes {} => to_json_binary(&query_list_verifications(deps)?),
     }
 }
 
@@ -218,7 +218,7 @@ mod tests {
         mock_dependencies, mock_env, mock_info, MockApi, MockQuerier, MockStorage,
     };
     use cosmwasm_std::{
-        from_slice, Binary, OwnedDeps, RecoverPubkeyError, StdError, VerificationError,
+        from_json_slice, Binary, OwnedDeps, RecoverPubkeyError, StdError, VerificationError,
     };
     use hex_literal::hex;
 
@@ -274,7 +274,7 @@ mod tests {
         };
 
         let raw = query(deps.as_ref(), mock_env(), verify_msg).unwrap();
-        let res: VerifyResponse = from_slice(&raw).unwrap();
+        let res: VerifyResponse = from_json_slice(&raw).unwrap();
 
         assert_eq!(res, VerifyResponse { verifies: true });
     }
@@ -296,7 +296,7 @@ mod tests {
         };
 
         let raw = query(deps.as_ref(), mock_env(), verify_msg).unwrap();
-        let res: VerifyResponse = from_slice(&raw).unwrap();
+        let res: VerifyResponse = from_json_slice(&raw).unwrap();
 
         assert_eq!(res, VerifyResponse { verifies: false });
     }
@@ -339,7 +339,7 @@ mod tests {
             signer_address: signer_address.into(),
         };
         let raw = query(deps.as_ref(), mock_env(), verify_msg).unwrap();
-        let res: VerifyResponse = from_slice(&raw).unwrap();
+        let res: VerifyResponse = from_json_slice(&raw).unwrap();
 
         assert_eq!(res, VerifyResponse { verifies: true });
     }
@@ -360,7 +360,7 @@ mod tests {
         };
 
         let raw = query(deps.as_ref(), mock_env(), verify_msg).unwrap();
-        let res: VerifyResponse = from_slice(&raw).unwrap();
+        let res: VerifyResponse = from_json_slice(&raw).unwrap();
         assert_eq!(res, VerifyResponse { verifies: false });
     }
 
@@ -380,7 +380,7 @@ mod tests {
             signer_address: signer_address.into(),
         };
         let raw = query(deps.as_ref(), mock_env(), verify_msg).unwrap();
-        let res: VerifyResponse = from_slice(&raw).unwrap();
+        let res: VerifyResponse = from_json_slice(&raw).unwrap();
         assert_eq!(res, VerifyResponse { verifies: false });
 
         // Broken signature
@@ -447,7 +447,7 @@ mod tests {
             v,
         };
         let raw = query(deps.as_ref(), mock_env(), msg).unwrap();
-        let res: VerifyResponse = from_slice(&raw).unwrap();
+        let res: VerifyResponse = from_json_slice(&raw).unwrap();
         assert_eq!(res, VerifyResponse { verifies: true });
     }
 
@@ -475,7 +475,7 @@ mod tests {
         };
 
         let raw = query(deps.as_ref(), mock_env(), verify_msg).unwrap();
-        let res: VerifyResponse = from_slice(&raw).unwrap();
+        let res: VerifyResponse = from_json_slice(&raw).unwrap();
 
         assert_eq!(res, VerifyResponse { verifies: true });
     }
@@ -508,7 +508,7 @@ mod tests {
         };
 
         let raw = query(deps.as_ref(), mock_env(), verify_msg).unwrap();
-        let res: VerifyResponse = from_slice(&raw).unwrap();
+        let res: VerifyResponse = from_json_slice(&raw).unwrap();
 
         assert_eq!(res, VerifyResponse { verifies: true });
     }
@@ -542,7 +542,7 @@ mod tests {
         };
 
         let raw = query(deps.as_ref(), mock_env(), verify_msg).unwrap();
-        let res: VerifyResponse = from_slice(&raw).unwrap();
+        let res: VerifyResponse = from_json_slice(&raw).unwrap();
 
         assert_eq!(res, VerifyResponse { verifies: true });
     }
@@ -573,7 +573,7 @@ mod tests {
         };
 
         let raw = query(deps.as_ref(), mock_env(), verify_msg).unwrap();
-        let res: VerifyResponse = from_slice(&raw).unwrap();
+        let res: VerifyResponse = from_json_slice(&raw).unwrap();
 
         assert_eq!(res, VerifyResponse { verifies: false });
     }
@@ -626,7 +626,7 @@ mod tests {
         };
 
         let raw = query(deps.as_ref(), mock_env(), verify_msg).unwrap();
-        let res: VerifyResponse = from_slice(&raw).unwrap();
+        let res: VerifyResponse = from_json_slice(&raw).unwrap();
 
         assert_eq!(res, VerifyResponse { verifies: true });
     }
@@ -648,7 +648,7 @@ mod tests {
         };
 
         let raw = query(deps.as_ref(), mock_env(), verify_msg).unwrap();
-        let res: VerifyResponse = from_slice(&raw).unwrap();
+        let res: VerifyResponse = from_json_slice(&raw).unwrap();
 
         assert_eq!(res, VerifyResponse { verifies: false });
     }
@@ -683,7 +683,7 @@ mod tests {
         let query_msg = QueryMsg::ListVerificationSchemes {};
 
         let raw = query(deps.as_ref(), mock_env(), query_msg).unwrap();
-        let res: ListVerificationsResponse = from_slice(&raw).unwrap();
+        let res: ListVerificationsResponse = from_json_slice(&raw).unwrap();
 
         assert_eq!(
             res,

--- a/contracts/cyberpunk/src/contract.rs
+++ b/contracts/cyberpunk/src/contract.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::{
-    entry_point, to_binary, Api, DenomMetadata, Deps, DepsMut, Empty, Env, MessageInfo,
+    entry_point, to_json_binary, Api, DenomMetadata, Deps, DepsMut, Empty, Env, MessageInfo,
     PageRequest, QueryResponse, Response, StdError, StdResult, WasmMsg,
 };
 
@@ -94,7 +94,7 @@ fn execute_memory_loop() -> Result<Response, ContractError> {
 fn execute_message_loop(env: Env) -> Result<Response, ContractError> {
     let resp = Response::new().add_message(WasmMsg::Execute {
         contract_addr: env.contract.address.into(),
-        msg: to_binary(&ExecuteMsg::MessageLoop {})?,
+        msg: to_json_binary(&ExecuteMsg::MessageLoop {})?,
         funds: vec![],
     });
     Ok(resp)
@@ -148,7 +148,7 @@ fn execute_unreachable() -> Result<Response, ContractError> {
 }
 
 fn execute_mirror_env(env: Env) -> Result<Response, ContractError> {
-    Ok(Response::new().set_data(to_binary(&env)?))
+    Ok(Response::new().set_data(to_json_binary(&env)?))
 }
 
 fn execute_debug(api: &dyn Api) -> Result<Response, ContractError> {
@@ -183,9 +183,9 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<QueryResponse> {
     use QueryMsg::*;
 
     match msg {
-        MirrorEnv {} => to_binary(&query_mirror_env(env)),
-        Denoms {} => to_binary(&query_denoms(deps)?),
-        Denom { denom } => to_binary(&query_denom(deps, denom)?),
+        MirrorEnv {} => to_json_binary(&query_mirror_env(env)),
+        Denoms {} => to_json_binary(&query_denoms(deps)?),
+        Denom { denom } => to_json_binary(&query_denom(deps, denom)?),
     }
 }
 
@@ -226,7 +226,7 @@ mod tests {
     use cosmwasm_std::testing::{
         mock_dependencies, mock_env, mock_info, MockApi, MockQuerier, MockStorage,
     };
-    use cosmwasm_std::{from_binary, DenomMetadata, DenomUnit, OwnedDeps};
+    use cosmwasm_std::{from_json_binary, DenomMetadata, DenomUnit, OwnedDeps};
 
     fn setup() -> OwnedDeps<MockStorage, MockApi, MockQuerier> {
         let mut deps = mock_dependencies();
@@ -274,11 +274,12 @@ mod tests {
         );
 
         let symbols: Vec<DenomMetadata> =
-            from_binary(&query(deps.as_ref(), mock_env(), QueryMsg::Denoms {}).unwrap()).unwrap();
+            from_json_binary(&query(deps.as_ref(), mock_env(), QueryMsg::Denoms {}).unwrap())
+                .unwrap();
 
         assert_eq!(symbols.len(), 98);
 
-        let denom: DenomMetadata = from_binary(
+        let denom: DenomMetadata = from_json_binary(
             &query(
                 deps.as_ref(),
                 mock_env(),

--- a/contracts/cyberpunk/tests/integration.rs
+++ b/contracts/cyberpunk/tests/integration.rs
@@ -17,7 +17,7 @@
 //!      });
 //! 4. Anywhere you see query(&deps, ...) you must replace it with query(&mut deps, ...)
 
-use cosmwasm_std::{from_binary, Empty, Env, Response};
+use cosmwasm_std::{from_json_binary, Empty, Env, Response};
 use cosmwasm_vm::testing::{
     execute, instantiate, mock_env, mock_info, mock_instance, mock_instance_with_gas_limit, query,
 };
@@ -152,13 +152,13 @@ fn test_env() {
     )
     .unwrap();
 
-    let received_env: Env = from_binary(&res.data.unwrap()).unwrap();
+    let received_env: Env = from_json_binary(&res.data.unwrap()).unwrap();
 
     assert_eq!(received_env, env);
 
     let env = mock_env();
     let received_env: Env =
-        from_binary(&query(&mut deps, env.clone(), QueryMsg::MirrorEnv {}).unwrap()).unwrap();
+        from_json_binary(&query(&mut deps, env.clone(), QueryMsg::MirrorEnv {}).unwrap()).unwrap();
 
     assert_eq!(received_env, env);
 }

--- a/contracts/floaty/src/contract.rs
+++ b/contracts/floaty/src/contract.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{
-    entry_point, from_slice, to_binary, to_vec, AllBalanceResponse, BankMsg, Deps, DepsMut, Env,
-    Event, MessageInfo, QueryResponse, Response, StdError, StdResult,
+    entry_point, from_json_slice, to_json_binary, to_json_vec, AllBalanceResponse, BankMsg, Deps,
+    DepsMut, Env, Event, MessageInfo, QueryResponse, Response, StdError, StdResult,
 };
 
 use crate::errors::HackError;
@@ -18,7 +18,7 @@ pub fn instantiate(
 
     deps.storage.set(
         CONFIG_KEY,
-        &to_vec(&State {
+        &to_json_vec(&State {
             verifier: deps.api.addr_validate(&msg.verifier)?,
             beneficiary: deps.api.addr_validate(&msg.beneficiary)?,
             funder: info.sender,
@@ -40,7 +40,7 @@ pub fn execute(
         .storage
         .get(CONFIG_KEY)
         .ok_or_else(|| StdError::not_found("State"))?;
-    let state: State = from_slice(&data)?;
+    let state: State = from_json_slice(&data)?;
 
     if info.sender == state.verifier {
         let to_addr = state.beneficiary;
@@ -67,8 +67,8 @@ pub fn execute(
 
 pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<QueryResponse> {
     match msg {
-        QueryMsg::Verifier {} => to_binary(&query_verifier(deps)?),
-        QueryMsg::OtherBalance { address } => to_binary(&query_other_balance(deps, address)?),
+        QueryMsg::Verifier {} => to_json_binary(&query_verifier(deps)?),
+        QueryMsg::OtherBalance { address } => to_json_binary(&query_other_balance(deps, address)?),
     }
 }
 
@@ -77,7 +77,7 @@ fn query_verifier(deps: Deps) -> StdResult<VerifierResponse> {
         .storage
         .get(CONFIG_KEY)
         .ok_or_else(|| StdError::not_found("State"))?;
-    let state: State = from_slice(&data)?;
+    let state: State = from_json_slice(&data)?;
     Ok(VerifierResponse {
         verifier: state.verifier.into(),
     })
@@ -124,7 +124,7 @@ mod tests {
 
         // it worked, let's check the state
         let data = deps.storage.get(CONFIG_KEY).expect("no data stored");
-        let state: State = from_slice(&data).unwrap();
+        let state: State = from_json_slice(&data).unwrap();
         assert_eq!(state, expected_state);
     }
 
@@ -246,7 +246,7 @@ mod tests {
 
         // state should not change
         let data = deps.storage.get(CONFIG_KEY).expect("no data stored");
-        let state: State = from_slice(&data).unwrap();
+        let state: State = from_json_slice(&data).unwrap();
         assert_eq!(
             state,
             State {

--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -1,9 +1,9 @@
 use sha2::{Digest, Sha256};
 
 use cosmwasm_std::{
-    entry_point, from_slice, to_binary, to_vec, Addr, AllBalanceResponse, Api, BankMsg,
-    CanonicalAddr, Deps, DepsMut, Env, Event, MessageInfo, QueryRequest, QueryResponse, Response,
-    StdError, StdResult, WasmMsg, WasmQuery,
+    entry_point, from_json_slice, to_json_binary, to_json_vec, Addr, AllBalanceResponse, Api,
+    BankMsg, CanonicalAddr, Deps, DepsMut, Env, Event, MessageInfo, QueryRequest, QueryResponse,
+    Response, StdError, StdResult, WasmMsg, WasmQuery,
 };
 
 use crate::errors::HackError;
@@ -24,7 +24,7 @@ pub fn instantiate(
 
     deps.storage.set(
         CONFIG_KEY,
-        &to_vec(&State {
+        &to_json_vec(&State {
             verifier: deps.api.addr_validate(&msg.verifier)?,
             beneficiary: deps.api.addr_validate(&msg.beneficiary)?,
             funder: info.sender,
@@ -41,9 +41,9 @@ pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> Result<Response, Ha
         .storage
         .get(CONFIG_KEY)
         .ok_or_else(|| StdError::not_found("State"))?;
-    let mut config: State = from_slice(&data)?;
+    let mut config: State = from_json_slice(&data)?;
     config.verifier = deps.api.addr_validate(&msg.verifier)?;
-    deps.storage.set(CONFIG_KEY, &to_vec(&config)?);
+    deps.storage.set(CONFIG_KEY, &to_json_vec(&config)?);
 
     Ok(Response::default())
 }
@@ -85,7 +85,7 @@ fn do_release(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response, Ha
         .storage
         .get(CONFIG_KEY)
         .ok_or_else(|| StdError::not_found("State"))?;
-    let state: State = from_slice(&data)?;
+    let state: State = from_json_slice(&data)?;
 
     if info.sender == state.verifier {
         let to_addr = state.beneficiary;
@@ -136,7 +136,7 @@ fn do_memory_loop() -> Result<Response, HackError> {
 fn do_message_loop(env: Env) -> Result<Response, HackError> {
     let resp = Response::new().add_message(WasmMsg::Execute {
         contract_addr: env.contract.address.into(),
-        msg: to_binary(&ExecuteMsg::MessageLoop {})?,
+        msg: to_json_binary(&ExecuteMsg::MessageLoop {})?,
         funds: vec![],
     });
     Ok(resp)
@@ -248,12 +248,12 @@ fn do_user_errors_in_api_calls(api: &dyn Api) -> Result<Response, HackError> {
 #[entry_point]
 pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<QueryResponse> {
     match msg {
-        QueryMsg::Verifier {} => to_binary(&query_verifier(deps)?),
-        QueryMsg::OtherBalance { address } => to_binary(&query_other_balance(deps, address)?),
+        QueryMsg::Verifier {} => to_json_binary(&query_verifier(deps)?),
+        QueryMsg::OtherBalance { address } => to_json_binary(&query_other_balance(deps, address)?),
         QueryMsg::Recurse { depth, work } => {
-            to_binary(&query_recurse(deps, depth, work, env.contract.address)?)
+            to_json_binary(&query_recurse(deps, depth, work, env.contract.address)?)
         }
-        QueryMsg::GetInt {} => to_binary(&query_int()),
+        QueryMsg::GetInt {} => to_json_binary(&query_int()),
     }
 }
 
@@ -262,7 +262,7 @@ fn query_verifier(deps: Deps) -> StdResult<VerifierResponse> {
         .storage
         .get(CONFIG_KEY)
         .ok_or_else(|| StdError::not_found("State"))?;
-    let state: State = from_slice(&data)?;
+    let state: State = from_json_slice(&data)?;
     Ok(VerifierResponse {
         verifier: state.verifier.into(),
     })
@@ -293,7 +293,7 @@ fn query_recurse(deps: Deps, depth: u32, work: u32, contract: Addr) -> StdResult
         };
         let query = QueryRequest::Wasm(WasmQuery::Smart {
             contract_addr: contract.into(),
-            msg: to_binary(&req)?,
+            msg: to_json_binary(&req)?,
         });
         deps.querier.query(&query)
     }
@@ -336,7 +336,7 @@ mod tests {
 
         // it worked, let's check the state
         let data = deps.storage.get(CONFIG_KEY).expect("no data stored");
-        let state: State = from_slice(&data).unwrap();
+        let state: State = from_json_slice(&data).unwrap();
         assert_eq!(state, expected_state);
     }
 
@@ -514,7 +514,7 @@ mod tests {
 
         // state should not change
         let data = deps.storage.get(CONFIG_KEY).expect("no data stored");
-        let state: State = from_slice(&data).unwrap();
+        let state: State = from_json_slice(&data).unwrap();
         assert_eq!(
             state,
             State {

--- a/contracts/hackatom/tests/integration.rs
+++ b/contracts/hackatom/tests/integration.rs
@@ -18,8 +18,8 @@
 //! 4. Anywhere you see query(&deps, ...) you must replace it with query(&mut deps, ...)
 
 use cosmwasm_std::{
-    assert_approx_eq, coins, from_binary, to_vec, Addr, AllBalanceResponse, BankMsg, Binary,
-    ContractResult, Empty, Response, SubMsg,
+    assert_approx_eq, coins, from_json_binary, to_json_vec, Addr, AllBalanceResponse, BankMsg,
+    Binary, ContractResult, Empty, Response, SubMsg,
 };
 use cosmwasm_vm::{
     call_execute, from_slice,
@@ -183,7 +183,7 @@ fn querier_callbacks_work() {
     // querying with balance gets the balance
     let query_msg = QueryMsg::OtherBalance { address: rich_addr };
     let query_response = query(&mut deps, mock_env(), query_msg).unwrap();
-    let bal: AllBalanceResponse = from_binary(&query_response).unwrap();
+    let bal: AllBalanceResponse = from_json_binary(&query_response).unwrap();
     assert_eq!(bal.amount, rich_balance);
 
     // querying other accounts gets none
@@ -191,7 +191,7 @@ fn querier_callbacks_work() {
         address: String::from("someone else"),
     };
     let query_response = query(&mut deps, mock_env(), query_msg).unwrap();
-    let bal: AllBalanceResponse = from_binary(&query_response).unwrap();
+    let bal: AllBalanceResponse = from_json_binary(&query_response).unwrap();
     assert_eq!(bal.amount, vec![]);
 }
 
@@ -322,7 +322,7 @@ fn execute_cpu_loop() {
         &mut deps,
         &mock_env(),
         &execute_info,
-        &to_vec(&ExecuteMsg::CpuLoop {}).unwrap(),
+        &to_json_vec(&ExecuteMsg::CpuLoop {}).unwrap(),
     );
     assert!(execute_res.is_err());
     assert_eq!(deps.get_gas_left(), 0);
@@ -344,7 +344,7 @@ fn execute_storage_loop() {
         &mut deps,
         &mock_env(),
         &execute_info,
-        &to_vec(&ExecuteMsg::StorageLoop {}).unwrap(),
+        &to_json_vec(&ExecuteMsg::StorageLoop {}).unwrap(),
     );
     assert!(execute_res.is_err());
     assert_eq!(deps.get_gas_left(), 0);
@@ -366,7 +366,7 @@ fn execute_memory_loop() {
         &mut deps,
         &mock_env(),
         &execute_info,
-        &to_vec(&ExecuteMsg::MemoryLoop {}).unwrap(),
+        &to_json_vec(&ExecuteMsg::MemoryLoop {}).unwrap(),
     );
     assert!(execute_res.is_err());
     assert_eq!(deps.get_gas_left(), 0);
@@ -448,7 +448,7 @@ fn execute_panic() {
         &mut deps,
         &mock_env(),
         &execute_info,
-        &to_vec(&ExecuteMsg::Panic {}).unwrap(),
+        &to_json_vec(&ExecuteMsg::Panic {}).unwrap(),
     );
     match execute_res.unwrap_err() {
         VmError::RuntimeErr { msg, .. } => {

--- a/contracts/ibc-reflect-send/src/contract.rs
+++ b/contracts/ibc-reflect-send/src/contract.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::{
-    entry_point, to_binary, CosmosMsg, Deps, DepsMut, Env, IbcMsg, MessageInfo, QueryResponse,
+    entry_point, to_json_binary, CosmosMsg, Deps, DepsMut, Env, IbcMsg, MessageInfo, QueryResponse,
     Response, StdError, StdResult,
 };
 
@@ -79,7 +79,7 @@ pub fn handle_send_msgs(
     let packet = PacketMsg::Dispatch { msgs };
     let msg = IbcMsg::SendPacket {
         channel_id,
-        data: to_binary(&packet)?,
+        data: to_json_binary(&packet)?,
         timeout: env.block.time.plus_seconds(PACKET_LIFETIME).into(),
     };
 
@@ -107,7 +107,7 @@ pub fn handle_check_remote_balance(
     let packet = PacketMsg::Balances {};
     let msg = IbcMsg::SendPacket {
         channel_id,
-        data: to_binary(&packet)?,
+        data: to_json_binary(&packet)?,
         timeout: env.block.time.plus_seconds(PACKET_LIFETIME).into(),
     };
 
@@ -168,9 +168,9 @@ pub fn handle_send_funds(
 #[entry_point]
 pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<QueryResponse> {
     match msg {
-        QueryMsg::Admin {} => to_binary(&query_admin(deps)?),
-        QueryMsg::Account { channel_id } => to_binary(&query_account(deps, channel_id)?),
-        QueryMsg::ListAccounts {} => to_binary(&query_list_accounts(deps)?),
+        QueryMsg::Admin {} => to_json_binary(&query_admin(deps)?),
+        QueryMsg::Account { channel_id } => to_json_binary(&query_account(deps, channel_id)?),
+        QueryMsg::ListAccounts {} => to_json_binary(&query_list_accounts(deps)?),
     }
 }
 

--- a/contracts/ibc-reflect-send/src/ibc.rs
+++ b/contracts/ibc-reflect-send/src/ibc.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{
-    entry_point, from_slice, to_binary, DepsMut, Env, IbcBasicResponse, IbcChannelCloseMsg,
-    IbcChannelConnectMsg, IbcChannelOpenMsg, IbcMsg, IbcOrder, IbcPacketAckMsg,
+    entry_point, from_json_slice, to_json_binary, DepsMut, Env, IbcBasicResponse,
+    IbcChannelCloseMsg, IbcChannelConnectMsg, IbcChannelOpenMsg, IbcMsg, IbcOrder, IbcPacketAckMsg,
     IbcPacketReceiveMsg, IbcPacketTimeoutMsg, IbcReceiveResponse, Never, StdError, StdResult,
 };
 
@@ -59,7 +59,7 @@ pub fn ibc_channel_connect(
     let packet = PacketMsg::WhoAmI {};
     let msg = IbcMsg::SendPacket {
         channel_id: channel_id.clone(),
-        data: to_binary(&packet)?,
+        data: to_json_binary(&packet)?,
         timeout: env.block.time.plus_seconds(PACKET_LIFETIME).into(),
     };
 
@@ -108,18 +108,21 @@ pub fn ibc_packet_ack(
     // which local channel was this packet send from
     let caller = msg.original_packet.src.channel_id;
     // we need to parse the ack based on our request
-    let packet: PacketMsg = from_slice(&msg.original_packet.data)?;
+    let packet: PacketMsg = from_json_slice(&msg.original_packet.data)?;
     match packet {
         PacketMsg::Dispatch { .. } => {
-            let res: AcknowledgementMsg<DispatchResponse> = from_slice(&msg.acknowledgement.data)?;
+            let res: AcknowledgementMsg<DispatchResponse> =
+                from_json_slice(&msg.acknowledgement.data)?;
             acknowledge_dispatch(deps, caller, res)
         }
         PacketMsg::WhoAmI {} => {
-            let res: AcknowledgementMsg<WhoAmIResponse> = from_slice(&msg.acknowledgement.data)?;
+            let res: AcknowledgementMsg<WhoAmIResponse> =
+                from_json_slice(&msg.acknowledgement.data)?;
             acknowledge_who_am_i(deps, caller, res)
         }
         PacketMsg::Balances {} => {
-            let res: AcknowledgementMsg<BalancesResponse> = from_slice(&msg.acknowledgement.data)?;
+            let res: AcknowledgementMsg<BalancesResponse> =
+                from_json_slice(&msg.acknowledgement.data)?;
             acknowledge_balances(deps, env, caller, res)
         }
     }
@@ -305,7 +308,7 @@ mod tests {
             channel_id: channel_id.into(),
         };
         let r = query(deps.as_ref(), mock_env(), q).unwrap();
-        let acct: AccountResponse = from_slice(&r).unwrap();
+        let acct: AccountResponse = from_json_slice(&r).unwrap();
         assert!(acct.remote_addr.is_none());
         assert!(acct.remote_balance.is_empty());
         assert_eq!(0, acct.last_update_time.nanos());
@@ -319,7 +322,7 @@ mod tests {
             channel_id: channel_id.into(),
         };
         let r = query(deps.as_ref(), mock_env(), q).unwrap();
-        let acct: AccountResponse = from_slice(&r).unwrap();
+        let acct: AccountResponse = from_json_slice(&r).unwrap();
         assert_eq!(acct.remote_addr.unwrap(), remote_addr);
         assert!(acct.remote_balance.is_empty());
         assert_eq!(0, acct.last_update_time.nanos());

--- a/contracts/ibc-reflect-send/src/state.rs
+++ b/contracts/ibc-reflect-send/src/state.rs
@@ -1,9 +1,9 @@
 use serde::{Deserialize, Serialize};
 
 use cosmwasm_std::{
-    from_slice,
+    from_json_slice,
     storage_keys::{namespace_with_key, to_length_prefixed},
-    to_vec, Addr, Coin, Order, StdError, StdResult, Storage, Timestamp,
+    to_json_vec, Addr, Coin, Order, StdError, StdResult, Storage, Timestamp,
 };
 
 pub const KEY_CONFIG: &[u8] = b"config";
@@ -33,7 +33,7 @@ pub struct AccountData {
 pub fn may_load_account(storage: &dyn Storage, id: &str) -> StdResult<Option<AccountData>> {
     storage
         .get(&namespace_with_key(&[PREFIX_ACCOUNTS], id.as_bytes()))
-        .map(|v| from_slice(&v))
+        .map(|v| from_json_slice(&v))
         .transpose()
 }
 
@@ -44,7 +44,7 @@ pub fn load_account(storage: &dyn Storage, id: &str) -> StdResult<AccountData> {
 pub fn save_account(storage: &mut dyn Storage, id: &str, account: &AccountData) -> StdResult<()> {
     storage.set(
         &namespace_with_key(&[PREFIX_ACCOUNTS], id.as_bytes()),
-        &to_vec(account)?,
+        &to_json_vec(account)?,
     );
     Ok(())
 }
@@ -63,7 +63,7 @@ pub fn range_accounts(
         .map(|(key, val)| {
             Ok((
                 String::from_utf8(key[PREFIX_ACCOUNTS.len() + 2..].to_vec())?,
-                from_slice(&val)?,
+                from_json_slice(&val)?,
             ))
         })
 }
@@ -72,10 +72,10 @@ pub fn load_config(storage: &dyn Storage) -> StdResult<Config> {
     storage
         .get(&to_length_prefixed(KEY_CONFIG))
         .ok_or_else(|| StdError::not_found("config"))
-        .and_then(|v| from_slice(&v))
+        .and_then(|v| from_json_slice(&v))
 }
 
 pub fn save_config(storage: &mut dyn Storage, item: &Config) -> StdResult<()> {
-    storage.set(&to_length_prefixed(KEY_CONFIG), &to_vec(item)?);
+    storage.set(&to_length_prefixed(KEY_CONFIG), &to_json_vec(item)?);
     Ok(())
 }

--- a/contracts/ibc-reflect/src/contract.rs
+++ b/contracts/ibc-reflect/src/contract.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{
-    entry_point, from_slice, to_binary, wasm_execute, BankMsg, Binary, CosmosMsg, Deps, DepsMut,
-    Empty, Env, Event, Ibc3ChannelOpenResponse, IbcBasicResponse, IbcChannelCloseMsg,
+    entry_point, from_json_slice, to_json_binary, wasm_execute, BankMsg, Binary, CosmosMsg, Deps,
+    DepsMut, Empty, Env, Event, Ibc3ChannelOpenResponse, IbcBasicResponse, IbcChannelCloseMsg,
     IbcChannelConnectMsg, IbcChannelOpenMsg, IbcChannelOpenResponse, IbcOrder, IbcPacketAckMsg,
     IbcPacketReceiveMsg, IbcPacketTimeoutMsg, IbcReceiveResponse, MessageInfo, Never,
     QueryResponse, Reply, Response, StdError, StdResult, SubMsg, SubMsgResponse, SubMsgResult,
@@ -91,8 +91,8 @@ pub fn handle_init_callback(deps: DepsMut, response: SubMsgResponse) -> StdResul
 #[entry_point]
 pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<QueryResponse> {
     match msg {
-        QueryMsg::Account { channel_id } => to_binary(&query_account(deps, channel_id)?),
-        QueryMsg::ListAccounts {} => to_binary(&query_list_accounts(deps)?),
+        QueryMsg::Account { channel_id } => to_json_binary(&query_account(deps, channel_id)?),
+        QueryMsg::ListAccounts {} => to_json_binary(&query_list_accounts(deps)?),
     }
 }
 
@@ -224,7 +224,7 @@ pub fn migrate(_deps: DepsMut, _env: Env, _msg: Empty) -> StdResult<Response> {
 // this encode an error or error message into a proper acknowledgement to the recevier
 fn encode_ibc_error(msg: impl Into<String>) -> Binary {
     // this cannot error, unwrap to keep the interface simple
-    to_binary(&AcknowledgementMsg::<()>::Error(msg.into())).unwrap()
+    to_json_binary(&AcknowledgementMsg::<()>::Error(msg.into())).unwrap()
 }
 
 #[entry_point]
@@ -241,7 +241,7 @@ pub fn ibc_packet_receive(
         let packet = msg.packet;
         // which local channel did this packet come on
         let caller = packet.dest.channel_id;
-        let msg: PacketMsg = from_slice(&packet.data)?;
+        let msg: PacketMsg = from_json_slice(&packet.data)?;
         match msg {
             PacketMsg::Dispatch { msgs } => receive_dispatch(deps, caller, msgs),
             PacketMsg::WhoAmI {} => receive_who_am_i(deps, caller),
@@ -267,7 +267,7 @@ fn receive_who_am_i(deps: DepsMut, caller: String) -> StdResult<IbcReceiveRespon
     let response = WhoAmIResponse {
         account: account.into(),
     };
-    let acknowledgement = to_binary(&AcknowledgementMsg::Ok(response))?;
+    let acknowledgement = to_json_binary(&AcknowledgementMsg::Ok(response))?;
     // and we are golden
     Ok(IbcReceiveResponse::new()
         .set_ack(acknowledgement)
@@ -282,7 +282,7 @@ fn receive_balances(deps: DepsMut, caller: String) -> StdResult<IbcReceiveRespon
         account: account.into(),
         balances,
     };
-    let acknowledgement = to_binary(&AcknowledgementMsg::Ok(response))?;
+    let acknowledgement = to_json_binary(&AcknowledgementMsg::Ok(response))?;
     // and we are golden
     Ok(IbcReceiveResponse::new()
         .set_ack(acknowledgement)
@@ -299,7 +299,7 @@ fn receive_dispatch(
     let reflect_addr = load_account(deps.storage, &caller)?;
 
     // let them know we're fine
-    let acknowledgement = to_binary(&AcknowledgementMsg::<DispatchResponse>::Ok(()))?;
+    let acknowledgement = to_json_binary(&AcknowledgementMsg::<DispatchResponse>::Ok(()))?;
     // create the message to re-dispatch to the reflect contract
     let reflect_msg = ReflectExecuteMsg::ReflectMsg { msgs };
     let wasm_msg = wasm_execute(reflect_addr, &reflect_msg, vec![])?;
@@ -322,7 +322,7 @@ fn execute_error(text: String) -> StdResult<IbcReceiveResponse> {
 }
 
 fn execute_return_msgs(msgs: Vec<CosmosMsg>) -> StdResult<IbcReceiveResponse> {
-    let acknowledgement = to_binary(&AcknowledgementMsg::<ReturnMsgsResponse>::Ok(()))?;
+    let acknowledgement = to_json_binary(&AcknowledgementMsg::<ReturnMsgsResponse>::Ok(()))?;
 
     Ok(IbcReceiveResponse::new()
         .set_ack(acknowledgement)
@@ -358,7 +358,7 @@ mod tests {
         mock_ibc_channel_open_init, mock_ibc_channel_open_try, mock_ibc_packet_recv, mock_info,
         mock_wasmd_attr, MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR,
     };
-    use cosmwasm_std::{attr, coin, coins, from_slice, BankMsg, OwnedDeps, WasmMsg};
+    use cosmwasm_std::{attr, coin, coins, from_json_slice, BankMsg, OwnedDeps, WasmMsg};
 
     const CREATOR: &str = "creator";
     // code id of the reflect contract
@@ -482,7 +482,7 @@ mod tests {
 
         // no accounts set yet
         let raw = query(deps.as_ref(), mock_env(), QueryMsg::ListAccounts {}).unwrap();
-        let res: ListAccountsResponse = from_slice(&raw).unwrap();
+        let res: ListAccountsResponse = from_json_slice(&raw).unwrap();
         assert_eq!(0, res.accounts.len());
 
         // fake a reply and ensure this works
@@ -497,7 +497,7 @@ mod tests {
 
         // ensure this is now registered
         let raw = query(deps.as_ref(), mock_env(), QueryMsg::ListAccounts {}).unwrap();
-        let res: ListAccountsResponse = from_slice(&raw).unwrap();
+        let res: ListAccountsResponse = from_json_slice(&raw).unwrap();
         assert_eq!(1, res.accounts.len());
         assert_eq!(
             &res.accounts[0],
@@ -516,7 +516,7 @@ mod tests {
             },
         )
         .unwrap();
-        let res: AccountResponse = from_slice(&raw).unwrap();
+        let res: AccountResponse = from_json_slice(&raw).unwrap();
         assert_eq!(res.account.unwrap(), REFLECT_ADDR);
     }
 
@@ -546,7 +546,8 @@ mod tests {
             res.events[0]
         );
         // acknowledgement is an error
-        let ack: AcknowledgementMsg<DispatchResponse> = from_slice(&res.acknowledgement).unwrap();
+        let ack: AcknowledgementMsg<DispatchResponse> =
+            from_json_slice(&res.acknowledgement).unwrap();
         assert_eq!(
             ack.unwrap_err(),
             "invalid packet: account channel-123 not found"
@@ -560,7 +561,7 @@ mod tests {
         let res = ibc_packet_receive(deps.as_mut(), mock_env(), msg).unwrap();
 
         // assert app-level success
-        let ack: AcknowledgementMsg<()> = from_slice(&res.acknowledgement).unwrap();
+        let ack: AcknowledgementMsg<()> = from_json_slice(&res.acknowledgement).unwrap();
         ack.unwrap();
 
         // and we dispatch the BankMsg via submessage
@@ -577,7 +578,7 @@ mod tests {
             assert_eq!(account, contract_addr.as_str());
             assert_eq!(0, funds.len());
             // parse the message - should callback with proper channel_id
-            let rmsg: ReflectExecuteMsg = from_slice(msg).unwrap();
+            let rmsg: ReflectExecuteMsg = from_json_slice(msg).unwrap();
             assert_eq!(
                 rmsg,
                 ReflectExecuteMsg::ReflectMsg {
@@ -597,7 +598,8 @@ mod tests {
         // we didn't dispatch anything
         assert_eq!(0, res.messages.len());
         // acknowledgement is an error
-        let ack: AcknowledgementMsg<DispatchResponse> = from_slice(&res.acknowledgement).unwrap();
+        let ack: AcknowledgementMsg<DispatchResponse> =
+            from_json_slice(&res.acknowledgement).unwrap();
         assert_eq!(ack.unwrap_err(), "invalid packet: Error parsing into type ibc_reflect::msg::PacketMsg: unknown variant `reflect_code_id`, expected one of `dispatch`, `who_am_i`, `balances`, `panic`, `return_err`, `return_msgs`");
     }
 
@@ -616,7 +618,7 @@ mod tests {
 
         // channel should be listed and have balance
         let raw = query(deps.as_ref(), mock_env(), QueryMsg::ListAccounts {}).unwrap();
-        let res: ListAccountsResponse = from_slice(&raw).unwrap();
+        let res: ListAccountsResponse = from_json_slice(&raw).unwrap();
         assert_eq!(1, res.accounts.len());
         let balance = deps.as_ref().querier.query_all_balances(account).unwrap();
         assert_eq!(funds, balance);
@@ -632,7 +634,7 @@ mod tests {
         }) = &res.messages[0].msg
         {
             assert_eq!(contract_addr.as_str(), account);
-            let reflect: ReflectExecuteMsg = from_slice(msg).unwrap();
+            let reflect: ReflectExecuteMsg = from_json_slice(msg).unwrap();
             match reflect {
                 ReflectExecuteMsg::ReflectMsg { msgs } => {
                     assert_eq!(1, msgs.len());
@@ -652,7 +654,7 @@ mod tests {
 
         // and removes the account lookup
         let raw = query(deps.as_ref(), mock_env(), QueryMsg::ListAccounts {}).unwrap();
-        let res: ListAccountsResponse = from_slice(&raw).unwrap();
+        let res: ListAccountsResponse = from_json_slice(&raw).unwrap();
         assert_eq!(0, res.accounts.len());
     }
 }

--- a/contracts/ibc-reflect/src/state.rs
+++ b/contracts/ibc-reflect/src/state.rs
@@ -1,9 +1,9 @@
 use std::any::type_name;
 
 use cosmwasm_std::{
-    from_slice,
+    from_json_slice,
     storage_keys::{namespace_with_key, to_length_prefixed},
-    to_vec, Addr, Order, StdError, StdResult, Storage,
+    to_json_vec, Addr, Order, StdError, StdResult, Storage,
 };
 use schemars::JsonSchema;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -22,7 +22,7 @@ pub struct Config {
 pub fn may_load_account(storage: &dyn Storage, id: &str) -> StdResult<Option<Addr>> {
     storage
         .get(&namespace_with_key(&[PREFIX_ACCOUNTS], id.as_bytes()))
-        .map(|v| from_slice(&v))
+        .map(|v| from_json_slice(&v))
         .transpose()
 }
 
@@ -33,7 +33,7 @@ pub fn load_account(storage: &dyn Storage, id: &str) -> StdResult<Addr> {
 pub fn save_account(storage: &mut dyn Storage, id: &str, account: &Addr) -> StdResult<()> {
     storage.set(
         &namespace_with_key(&[PREFIX_ACCOUNTS], id.as_bytes()),
-        &to_vec(account)?,
+        &to_json_vec(account)?,
     );
     Ok(())
 }
@@ -52,7 +52,7 @@ pub fn range_accounts(
         .map(|(key, val)| {
             Ok((
                 String::from_utf8(key[PREFIX_ACCOUNTS.len() + 2..].to_vec())?,
-                from_slice(&val)?,
+                from_json_slice(&val)?,
             ))
         })
 }
@@ -61,10 +61,10 @@ pub fn load_item<T: DeserializeOwned>(storage: &dyn Storage, key: &[u8]) -> StdR
     storage
         .get(&to_length_prefixed(key))
         .ok_or_else(|| StdError::not_found(type_name::<T>()))
-        .and_then(|v| from_slice(&v))
+        .and_then(|v| from_json_slice(&v))
 }
 
 pub fn save_item<T: Serialize>(storage: &mut dyn Storage, key: &[u8], item: &T) -> StdResult<()> {
-    storage.set(&to_length_prefixed(key), &to_vec(item)?);
+    storage.set(&to_length_prefixed(key), &to_json_vec(item)?);
     Ok(())
 }

--- a/contracts/queue/src/contract.rs
+++ b/contracts/queue/src/contract.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{
-    entry_point, from_slice, to_binary, to_vec, Binary, Deps, DepsMut, Empty, Env, MessageInfo,
-    Order, QueryResponse, Response, StdResult, Storage,
+    entry_point, from_json_slice, to_json_binary, to_json_vec, Binary, Deps, DepsMut, Empty, Env,
+    MessageInfo, Order, QueryResponse, Response, StdResult, Storage,
 };
 
 use crate::msg::{
@@ -51,7 +51,7 @@ fn enqueue(storage: &mut dyn Storage, value: i32) -> StdResult<()> {
             (last_key + 1).to_be_bytes()
         }
     };
-    let new_value = to_vec(&Item { value })?;
+    let new_value = to_json_vec(&Item { value })?;
 
     storage.set(&new_key, &new_value);
     Ok(())
@@ -92,11 +92,11 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> StdResult<Response
 #[entry_point]
 pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<QueryResponse> {
     match msg {
-        QueryMsg::Count {} => to_binary(&query_count(deps)),
-        QueryMsg::Sum {} => to_binary(&query_sum(deps)?),
-        QueryMsg::Reducer {} => to_binary(&query_reducer(deps)?),
-        QueryMsg::List {} => to_binary(&query_list(deps)),
-        QueryMsg::OpenIterators { count } => to_binary(&query_open_iterators(deps, count)),
+        QueryMsg::Count {} => to_json_binary(&query_count(deps)),
+        QueryMsg::Sum {} => to_json_binary(&query_sum(deps)?),
+        QueryMsg::Reducer {} => to_json_binary(&query_reducer(deps)?),
+        QueryMsg::List {} => to_json_binary(&query_list(deps)),
+        QueryMsg::OpenIterators { count } => to_json_binary(&query_open_iterators(deps, count)),
     }
 }
 
@@ -112,7 +112,7 @@ fn query_sum(deps: Deps) -> StdResult<SumResponse> {
     let values: StdResult<Vec<Item>> = deps
         .storage
         .range_values(None, None, Order::Ascending)
-        .map(|v| from_slice(&v))
+        .map(|v| from_json_slice(&v))
         .collect();
     let sum = values?.iter().fold(0, |s, v| s + v.value);
     Ok(SumResponse { sum })
@@ -124,7 +124,7 @@ fn query_reducer(deps: Deps) -> StdResult<ReducerResponse> {
     for val in deps
         .storage
         .range_values(None, None, Order::Ascending)
-        .map(|v| from_slice::<Item>(&v))
+        .map(|v| from_json_slice::<Item>(&v))
     {
         // this returns error on parse error
         let my_val = val?.value;
@@ -134,7 +134,7 @@ fn query_reducer(deps: Deps) -> StdResult<ReducerResponse> {
             .range_values(None, None, Order::Ascending)
             // get value. ignore parse errors, just count as 0
             .map(|v| {
-                from_slice::<Item>(&v)
+                from_json_slice::<Item>(&v)
                     .map(|v| v.value)
                     .expect("error in item")
             })
@@ -181,7 +181,7 @@ mod tests {
     use cosmwasm_std::testing::{
         mock_dependencies_with_balance, mock_env, mock_info, MockApi, MockQuerier, MockStorage,
     };
-    use cosmwasm_std::{coins, from_binary, OwnedDeps};
+    use cosmwasm_std::{coins, from_json_binary, OwnedDeps};
 
     /// Instantiates a contract with no elements
     fn create_contract() -> (OwnedDeps<MockStorage, MockApi, MockQuerier>, MessageInfo) {
@@ -270,7 +270,7 @@ mod tests {
         // ensure we popped properly
         assert!(res.data.is_some());
         let data = res.data.unwrap();
-        let state: Item = from_slice(data.as_slice()).unwrap();
+        let state: Item = from_json_slice(data.as_slice()).unwrap();
         assert_eq!(state.value, 25);
 
         assert_eq!(get_count(deps.as_ref()), 1);
@@ -340,7 +340,7 @@ mod tests {
 
         let query_msg = QueryMsg::List {};
         let ids: ListResponse =
-            from_binary(&query(deps.as_ref(), mock_env(), query_msg).unwrap()).unwrap();
+            from_json_binary(&query(deps.as_ref(), mock_env(), query_msg).unwrap()).unwrap();
         assert_eq!(ids.empty, Vec::<u32>::new());
         assert_eq!(ids.early, vec![0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f]);
         assert_eq!(ids.late, vec![0x20, 0x21, 0x22, 0x23, 0x24]);

--- a/contracts/queue/tests/integration.rs
+++ b/contracts/queue/tests/integration.rs
@@ -17,7 +17,7 @@
 //!      });
 //! 4. Anywhere you see query(&deps, ...) you must replace it with query(&mut deps, ...)
 
-use cosmwasm_std::{from_binary, from_slice, MessageInfo, Response};
+use cosmwasm_std::{from_json_binary, MessageInfo, Response};
 use cosmwasm_vm::{
     testing::{
         execute, instantiate, migrate, mock_env, mock_info, mock_instance_with_gas_limit, query,
@@ -48,13 +48,13 @@ fn create_contract() -> (Instance<MockApi, MockStorage, MockQuerier>, MessageInf
 
 fn get_count(deps: &mut Instance<MockApi, MockStorage, MockQuerier>) -> u32 {
     let data = query(deps, mock_env(), QueryMsg::Count {}).unwrap();
-    let res: CountResponse = from_binary(&data).unwrap();
+    let res: CountResponse = from_json_binary(&data).unwrap();
     res.count
 }
 
 fn get_sum(deps: &mut Instance<MockApi, MockStorage, MockQuerier>) -> i32 {
     let data = query(deps, mock_env(), QueryMsg::Sum {}).unwrap();
-    let res: SumResponse = from_binary(&data).unwrap();
+    let res: SumResponse = from_json_binary(&data).unwrap();
     res.sum
 }
 
@@ -128,7 +128,7 @@ fn push_and_pop() {
     // ensure we popped properly
     assert!(res.data.is_some());
     let data = res.data.unwrap();
-    let item: Item = from_slice(data.as_slice()).unwrap();
+    let item: Item = from_json_binary(&data).unwrap();
     assert_eq!(item.value, 25);
 
     assert_eq!(get_count(&mut deps), 1);
@@ -169,7 +169,7 @@ fn push_and_reduce() {
     assert_eq!(get_count(&mut deps), 4);
     assert_eq!(get_sum(&mut deps), 130);
     let data = query(&mut deps, mock_env(), QueryMsg::Reducer {}).unwrap();
-    let counters = from_binary::<ReducerResponse>(&data).unwrap().counters;
+    let counters = from_json_binary::<ReducerResponse>(&data).unwrap().counters;
     assert_eq!(counters, vec![(40, 85), (15, 125), (85, 0), (-10, 140)]);
 }
 
@@ -223,7 +223,8 @@ fn query_list() {
     // since we count up to 0x20 in early, we get early and late both with data
 
     let query_msg = QueryMsg::List {};
-    let ids: ListResponse = from_binary(&query(&mut deps, mock_env(), query_msg).unwrap()).unwrap();
+    let ids: ListResponse =
+        from_json_binary(&query(&mut deps, mock_env(), query_msg).unwrap()).unwrap();
     assert_eq!(ids.empty, Vec::<u32>::new());
     assert_eq!(ids.early, vec![0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f]);
     assert_eq!(ids.late, vec![0x20, 0x21, 0x22, 0x23, 0x24]);

--- a/contracts/reflect/src/contract.rs
+++ b/contracts/reflect/src/contract.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{
-    entry_point, to_binary, to_vec, Binary, ContractResult, CosmosMsg, Deps, DepsMut, Env,
-    MessageInfo, QueryRequest, QueryResponse, Reply, Response, StdError, StdResult, SubMsg,
+    entry_point, to_json_binary, to_json_vec, Binary, ContractResult, CosmosMsg, Deps, DepsMut,
+    Env, MessageInfo, QueryRequest, QueryResponse, Reply, Response, StdError, StdResult, SubMsg,
     SystemResult,
 };
 
@@ -119,11 +119,11 @@ pub fn reply(deps: DepsMut<SpecialQuery>, _env: Env, msg: Reply) -> Result<Respo
 #[entry_point]
 pub fn query(deps: Deps<SpecialQuery>, _env: Env, msg: QueryMsg) -> StdResult<QueryResponse> {
     match msg {
-        QueryMsg::Owner {} => to_binary(&query_owner(deps)?),
-        QueryMsg::Capitalized { text } => to_binary(&query_capitalized(deps, text)?),
-        QueryMsg::Chain { request } => to_binary(&query_chain(deps, &request)?),
-        QueryMsg::Raw { contract, key } => to_binary(&query_raw(deps, contract, key)?),
-        QueryMsg::SubMsgResult { id } => to_binary(&query_subcall(deps, id)?),
+        QueryMsg::Owner {} => to_json_binary(&query_owner(deps)?),
+        QueryMsg::Capitalized { text } => to_json_binary(&query_capitalized(deps, text)?),
+        QueryMsg::Chain { request } => to_json_binary(&query_chain(deps, &request)?),
+        QueryMsg::Raw { contract, key } => to_json_binary(&query_raw(deps, contract, key)?),
+        QueryMsg::SubMsgResult { id } => to_json_binary(&query_subcall(deps, id)?),
     }
 }
 
@@ -149,7 +149,7 @@ fn query_chain(
     deps: Deps<SpecialQuery>,
     request: &QueryRequest<SpecialQuery>,
 ) -> StdResult<ChainResponse> {
-    let raw = to_vec(request).map_err(|serialize_err| {
+    let raw = to_json_vec(request).map_err(|serialize_err| {
         StdError::generic_err(format!("Serializing QueryRequest: {serialize_err}"))
     })?;
     match deps.querier.raw_query(&raw) {
@@ -176,7 +176,7 @@ mod tests {
     use crate::testing::mock_dependencies_with_custom_querier;
     use cosmwasm_std::testing::{mock_env, mock_info, MOCK_CONTRACT_ADDR};
     use cosmwasm_std::{
-        coin, coins, from_binary, AllBalanceResponse, BankMsg, BankQuery, Binary, Event,
+        coin, coins, from_json_binary, AllBalanceResponse, BankMsg, BankQuery, Binary, Event,
         StakingMsg, StdError, SubMsgResponse, SubMsgResult,
     };
 
@@ -365,7 +365,7 @@ mod tests {
             text: "demo one".to_string(),
         };
         let response = query(deps.as_ref(), mock_env(), msg).unwrap();
-        let value: CapitalizedResponse = from_binary(&response).unwrap();
+        let value: CapitalizedResponse = from_json_binary(&response).unwrap();
         assert_eq!(value.text, "DEMO ONE");
     }
 
@@ -381,8 +381,8 @@ mod tests {
             .into(),
         };
         let response = query(deps.as_ref(), mock_env(), msg).unwrap();
-        let outer: ChainResponse = from_binary(&response).unwrap();
-        let inner: AllBalanceResponse = from_binary(&outer.data).unwrap();
+        let outer: ChainResponse = from_json_binary(&response).unwrap();
+        let inner: AllBalanceResponse = from_json_binary(&outer.data).unwrap();
         assert_eq!(inner.amount, coins(123, "ucosm"));
 
         // with custom query
@@ -390,8 +390,8 @@ mod tests {
             request: SpecialQuery::Ping {}.into(),
         };
         let response = query(deps.as_ref(), mock_env(), msg).unwrap();
-        let outer: ChainResponse = from_binary(&response).unwrap();
-        let inner: SpecialResponse = from_binary(&outer.data).unwrap();
+        let outer: ChainResponse = from_json_binary(&response).unwrap();
+        let inner: SpecialResponse = from_json_binary(&outer.data).unwrap();
         assert_eq!(inner.msg, "pong");
     }
 
@@ -452,7 +452,7 @@ mod tests {
 
         // query for the real id
         let raw = query(deps.as_ref(), mock_env(), QueryMsg::SubMsgResult { id }).unwrap();
-        let qres: Reply = from_binary(&raw).unwrap();
+        let qres: Reply = from_json_binary(&raw).unwrap();
         assert_eq!(qres.id, id);
         let result = qres.result.unwrap();
         assert_eq!(result.data, Some(data));

--- a/contracts/reflect/src/state.rs
+++ b/contracts/reflect/src/state.rs
@@ -2,9 +2,9 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use cosmwasm_std::{
-    from_slice,
+    from_json_slice,
     storage_keys::{namespace_with_key, to_length_prefixed},
-    to_vec, Addr, Reply, StdError, StdResult, Storage,
+    to_json_vec, Addr, Reply, StdError, StdResult, Storage,
 };
 
 const CONFIG_KEY: &[u8] = b"config";
@@ -19,13 +19,13 @@ pub fn load_reply(storage: &dyn Storage, id: u64) -> StdResult<Reply> {
     storage
         .get(&namespace_with_key(&[RESULT_PREFIX], &id.to_be_bytes()))
         .ok_or_else(|| StdError::not_found(format!("reply {id}")))
-        .and_then(|v| from_slice(&v))
+        .and_then(|v| from_json_slice(&v))
 }
 
 pub fn save_reply(storage: &mut dyn Storage, id: u64, reply: &Reply) -> StdResult<()> {
     storage.set(
         &namespace_with_key(&[RESULT_PREFIX], &id.to_be_bytes()),
-        &to_vec(reply)?,
+        &to_json_vec(reply)?,
     );
     Ok(())
 }
@@ -38,10 +38,10 @@ pub fn load_config(storage: &dyn Storage) -> StdResult<State> {
     storage
         .get(&to_length_prefixed(CONFIG_KEY))
         .ok_or_else(|| StdError::not_found("config"))
-        .and_then(|v| from_slice(&v))
+        .and_then(|v| from_json_slice(&v))
 }
 
 pub fn save_config(storage: &mut dyn Storage, item: &State) -> StdResult<()> {
-    storage.set(&to_length_prefixed(CONFIG_KEY), &to_vec(item)?);
+    storage.set(&to_length_prefixed(CONFIG_KEY), &to_json_vec(item)?);
     Ok(())
 }

--- a/contracts/reflect/src/testing.rs
+++ b/contracts/reflect/src/testing.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use crate::msg::{SpecialQuery, SpecialResponse};
 
 use cosmwasm_std::testing::{MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR};
-use cosmwasm_std::{to_binary, Binary, Coin, ContractResult, OwnedDeps, SystemResult};
+use cosmwasm_std::{to_json_binary, Binary, Coin, ContractResult, OwnedDeps, SystemResult};
 
 /// A drop-in replacement for cosmwasm_std::testing::mock_dependencies
 /// this uses our CustomQuerier.
@@ -26,18 +26,18 @@ pub fn custom_query_execute(query: &SpecialQuery) -> ContractResult<Binary> {
         SpecialQuery::Ping {} => "pong".to_string(),
         SpecialQuery::Capitalized { text } => text.to_uppercase(),
     };
-    to_binary(&SpecialResponse { msg }).into()
+    to_json_binary(&SpecialResponse { msg }).into()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cosmwasm_std::{from_binary, QuerierWrapper, QueryRequest};
+    use cosmwasm_std::{from_json_binary, QuerierWrapper, QueryRequest};
 
     #[test]
     fn custom_query_execute_ping() {
         let res = custom_query_execute(&SpecialQuery::Ping {}).unwrap();
-        let response: SpecialResponse = from_binary(&res).unwrap();
+        let response: SpecialResponse = from_json_binary(&res).unwrap();
         assert_eq!(response.msg, "pong");
     }
 
@@ -47,7 +47,7 @@ mod tests {
             text: "fOObaR".to_string(),
         })
         .unwrap();
-        let response: SpecialResponse = from_binary(&res).unwrap();
+        let response: SpecialResponse = from_json_binary(&res).unwrap();
         assert_eq!(response.msg, "FOOBAR");
     }
 

--- a/contracts/reflect/tests/integration.rs
+++ b/contracts/reflect/tests/integration.rs
@@ -18,7 +18,7 @@
 //! 4. Anywhere you see query(&deps, ...) you must replace it with query(&mut deps, ...)
 
 use cosmwasm_std::{
-    coin, coins, from_binary, BankMsg, BankQuery, Binary, Coin, ContractResult, Event,
+    coin, coins, from_json_binary, BankMsg, BankQuery, Binary, Coin, ContractResult, Event,
     QueryRequest, Reply, Response, StakingMsg, SubMsg, SubMsgResponse, SubMsgResult,
     SupplyResponse, SystemResult,
 };
@@ -83,7 +83,7 @@ fn proper_initialization() {
 
     // it worked, let's query the state
     let res = query(&mut deps, mock_env(), QueryMsg::Owner {}).unwrap();
-    let value: OwnerResponse = from_binary(&res).unwrap();
+    let value: OwnerResponse = from_json_binary(&res).unwrap();
     assert_eq!("creator", value.owner.as_str());
 }
 
@@ -159,7 +159,7 @@ fn transfer() {
     // should change state
     assert_eq!(0, res.messages.len());
     let res = query(&mut deps, mock_env(), QueryMsg::Owner {}).unwrap();
-    let value: OwnerResponse = from_binary(&res).unwrap();
+    let value: OwnerResponse = from_json_binary(&res).unwrap();
     assert_eq!("friend", value.owner.as_str());
 }
 
@@ -203,8 +203,8 @@ fn supply_query() {
     )
     .unwrap();
 
-    let res: ChainResponse = from_binary(&res).unwrap();
-    let res: SupplyResponse = from_binary(&res.data).unwrap();
+    let res: ChainResponse = from_json_binary(&res).unwrap();
+    let res: SupplyResponse = from_json_binary(&res.data).unwrap();
     assert_eq!(res.amount, coin(25, "OSMO"));
 }
 
@@ -225,7 +225,7 @@ fn dispatch_custom_query() {
         },
     )
     .unwrap();
-    let value: CapitalizedResponse = from_binary(&res).unwrap();
+    let value: CapitalizedResponse = from_json_binary(&res).unwrap();
     assert_eq!(value.text, "DEMO ONE");
 }
 
@@ -282,7 +282,7 @@ fn reply_and_query() {
 
     // query for the real id
     let raw = query(&mut deps, mock_env(), QueryMsg::SubMsgResult { id }).unwrap();
-    let qres: Reply = from_binary(&raw).unwrap();
+    let qres: Reply = from_json_binary(&raw).unwrap();
     assert_eq!(qres.id, id);
     let result = qres.result.unwrap();
     assert_eq!(result.data, Some(data));

--- a/contracts/staking/src/contract.rs
+++ b/contracts/staking/src/contract.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::{
-    coin, entry_point, to_binary, BankMsg, Decimal, Deps, DepsMut, DistributionMsg, Env,
+    coin, entry_point, to_json_binary, BankMsg, Decimal, Deps, DepsMut, DistributionMsg, Env,
     MessageInfo, QuerierWrapper, QueryResponse, Response, StakingMsg, StdError, StdResult, Uint128,
     WasmMsg,
 };
@@ -289,7 +289,7 @@ pub fn claim(deps: DepsMut, env: Env, info: MessageInfo) -> StdResult<Response> 
 pub fn reinvest(deps: DepsMut, env: Env, _info: MessageInfo) -> StdResult<Response> {
     let contract_addr = env.contract.address;
     let invest: InvestmentInfo = load_item(deps.storage, KEY_INVESTMENT)?;
-    let msg = to_binary(&ExecuteMsg::_BondAllTokens {})?;
+    let msg = to_json_binary(&ExecuteMsg::_BondAllTokens {})?;
 
     // and bond them to the validator
     let res = Response::new()
@@ -349,10 +349,10 @@ pub fn _bond_all_tokens(
 #[entry_point]
 pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<QueryResponse> {
     match msg {
-        QueryMsg::TokenInfo {} => to_binary(&query_token_info(deps)?),
-        QueryMsg::Investment {} => to_binary(&query_investment(deps)?),
-        QueryMsg::Balance { address } => to_binary(&query_balance(deps, &address)?),
-        QueryMsg::Claims { address } => to_binary(&query_claims(deps, &address)?),
+        QueryMsg::TokenInfo {} => to_json_binary(&query_token_info(deps)?),
+        QueryMsg::Investment {} => to_json_binary(&query_investment(deps)?),
+        QueryMsg::Balance { address } => to_json_binary(&query_balance(deps, &address)?),
+        QueryMsg::Claims { address } => to_json_binary(&query_claims(deps, &address)?),
     }
 }
 

--- a/contracts/staking/src/state.rs
+++ b/contracts/staking/src/state.rs
@@ -4,9 +4,9 @@ use schemars::JsonSchema;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use cosmwasm_std::{
-    from_slice,
+    from_json_slice,
     storage_keys::{namespace_with_key, to_length_prefixed},
-    to_vec, Addr, CanonicalAddr, Decimal, StdError, StdResult, Storage, Uint128,
+    to_json_vec, Addr, CanonicalAddr, Decimal, StdError, StdResult, Storage, Uint128,
 };
 
 pub const KEY_INVESTMENT: &[u8] = b"invest";
@@ -23,7 +23,7 @@ pub fn may_load_map(
 ) -> StdResult<Option<Uint128>> {
     storage
         .get(&namespace_with_key(&[prefix], key))
-        .map(|v| from_slice(&v))
+        .map(|v| from_json_slice(&v))
         .transpose()
 }
 
@@ -33,7 +33,7 @@ pub fn save_map(
     key: &CanonicalAddr,
     value: Uint128,
 ) -> StdResult<()> {
-    storage.set(&namespace_with_key(&[prefix], key), &to_vec(&value)?);
+    storage.set(&namespace_with_key(&[prefix], key), &to_json_vec(&value)?);
     Ok(())
 }
 
@@ -85,11 +85,11 @@ pub fn load_item<T: DeserializeOwned>(storage: &dyn Storage, key: &[u8]) -> StdR
     storage
         .get(&to_length_prefixed(key))
         .ok_or_else(|| StdError::not_found(type_name::<T>()))
-        .and_then(|v| from_slice(&v))
+        .and_then(|v| from_json_slice(&v))
 }
 
 pub fn save_item<T: Serialize>(storage: &mut dyn Storage, key: &[u8], item: &T) -> StdResult<()> {
-    storage.set(&to_length_prefixed(key), &to_vec(item)?);
+    storage.set(&to_length_prefixed(key), &to_json_vec(item)?);
     Ok(())
 }
 

--- a/contracts/staking/tests/integration.rs
+++ b/contracts/staking/tests/integration.rs
@@ -17,7 +17,7 @@
 //!      });
 //! 4. Anywhere you see query(&deps, ...) you must replace it with query(&mut deps, ...)
 
-use cosmwasm_std::{coin, from_binary, ContractResult, Decimal, Response, Uint128, Validator};
+use cosmwasm_std::{coin, from_json_binary, ContractResult, Decimal, Response, Uint128, Validator};
 use cosmwasm_vm::testing::{
     instantiate, mock_backend, mock_env, mock_info, mock_instance_options, query,
 };
@@ -106,7 +106,7 @@ fn proper_initialization() {
 
     // token info is proper
     let res = query(&mut deps, mock_env(), QueryMsg::TokenInfo {}).unwrap();
-    let token: TokenInfoResponse = from_binary(&res).unwrap();
+    let token: TokenInfoResponse = from_json_binary(&res).unwrap();
     assert_eq!(&token.name, &msg.name);
     assert_eq!(&token.symbol, &msg.symbol);
     assert_eq!(token.decimals, msg.decimals);
@@ -120,7 +120,7 @@ fn proper_initialization() {
         },
     )
     .unwrap();
-    let bal: BalanceResponse = from_binary(&res).unwrap();
+    let bal: BalanceResponse = from_json_binary(&res).unwrap();
     assert_eq!(bal.balance, Uint128::new(0));
 
     // no claims
@@ -132,12 +132,12 @@ fn proper_initialization() {
         },
     )
     .unwrap();
-    let claim: ClaimsResponse = from_binary(&res).unwrap();
+    let claim: ClaimsResponse = from_json_binary(&res).unwrap();
     assert_eq!(claim.claims, Uint128::new(0));
 
     // investment info correct
     let res = query(&mut deps, mock_env(), QueryMsg::Investment {}).unwrap();
-    let invest: InvestmentResponse = from_binary(&res).unwrap();
+    let invest: InvestmentResponse = from_json_binary(&res).unwrap();
     assert_eq!(&invest.owner, &creator);
     assert_eq!(&invest.validator, &msg.validator);
     assert_eq!(invest.exit_tax, msg.exit_tax);

--- a/contracts/virus/src/contract.rs
+++ b/contracts/virus/src/contract.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::{
-    entry_point, instantiate2_address, to_binary, Attribute, Binary, CodeInfoResponse,
+    entry_point, instantiate2_address, to_json_binary, Attribute, Binary, CodeInfoResponse,
     ContractInfoResponse, DepsMut, Env, MessageInfo, Response, StdResult, WasmMsg,
 };
 
@@ -72,7 +72,7 @@ pub fn execute_spread(
             admin: None,
             code_id,
             label,
-            msg: to_binary(&InstantiateMsg {})?,
+            msg: to_json_binary(&InstantiateMsg {})?,
             funds: vec![],
             salt,
         });
@@ -80,7 +80,7 @@ pub fn execute_spread(
         // we know the address of the newly instantiated contract, so let's execute it right away
         msgs.push(WasmMsg::Execute {
             contract_addr: address.into(),
-            msg: to_binary(&ExecuteMsg::Spread {
+            msg: to_json_binary(&ExecuteMsg::Spread {
                 parent_path: path,
                 levels: levels - 1,
             })?,

--- a/packages/std/src/binary.rs
+++ b/packages/std/src/binary.rs
@@ -253,7 +253,7 @@ mod tests {
     use super::*;
     use crate::assert_hash_works;
     use crate::errors::StdError;
-    use crate::serde::{from_slice, to_vec};
+    use crate::serde::{from_json_slice, to_json_vec};
 
     #[test]
     fn to_array_works() {
@@ -450,8 +450,8 @@ mod tests {
     fn serialization_works() {
         let binary = Binary(vec![0u8, 187, 61, 11, 250, 0]);
 
-        let json = to_vec(&binary).unwrap();
-        let deserialized: Binary = from_slice(&json).unwrap();
+        let json = to_json_vec(&binary).unwrap();
+        let deserialized: Binary = from_json_slice(&json).unwrap();
 
         assert_eq!(binary, deserialized);
     }
@@ -462,16 +462,16 @@ mod tests {
         // this is the binary behind above string
         let expected = vec![0u8, 187, 61, 11, 250, 0];
 
-        let serialized = to_vec(&b64_str).unwrap();
-        let deserialized: Binary = from_slice(&serialized).unwrap();
+        let serialized = to_json_vec(&b64_str).unwrap();
+        let deserialized: Binary = from_json_slice(&serialized).unwrap();
         assert_eq!(expected, deserialized.as_slice());
     }
 
     #[test]
     fn deserialize_from_invalid_string() {
         let invalid_str = "**BAD!**";
-        let serialized = to_vec(&invalid_str).unwrap();
-        let res = from_slice::<Binary>(&serialized);
+        let serialized = to_json_vec(&invalid_str).unwrap();
+        let res = from_json_slice::<Binary>(&serialized);
         assert!(res.is_err());
     }
 

--- a/packages/std/src/errors/system_error.rs
+++ b/packages/std/src/errors/system_error.rs
@@ -69,7 +69,7 @@ impl core::fmt::Display for SystemError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{from_slice, to_vec};
+    use crate::{from_json_slice, to_json_vec};
 
     #[test]
     fn system_error_no_such_contract_serialization() {
@@ -78,14 +78,14 @@ mod tests {
         };
 
         // ser
-        let json = to_vec(&err).unwrap();
+        let json = to_json_vec(&err).unwrap();
         assert_eq!(
             String::from_utf8_lossy(&json),
             r#"{"no_such_contract":{"addr":"gibtsnicht"}}"#,
         );
 
         // de
-        let err: SystemError = from_slice(br#"{"no_such_contract":{"addr":"nada"}}"#).unwrap();
+        let err: SystemError = from_json_slice(br#"{"no_such_contract":{"addr":"nada"}}"#).unwrap();
         assert_eq!(
             err,
             SystemError::NoSuchContract {
@@ -99,14 +99,14 @@ mod tests {
         let err = SystemError::NoSuchCode { code_id: 13 };
 
         // ser
-        let json = to_vec(&err).unwrap();
+        let json = to_json_vec(&err).unwrap();
         assert_eq!(
             String::from_utf8_lossy(&json),
             r#"{"no_such_code":{"code_id":13}}"#,
         );
 
         // de
-        let err: SystemError = from_slice(br#"{"no_such_code":{"code_id":987}}"#).unwrap();
+        let err: SystemError = from_json_slice(br#"{"no_such_code":{"code_id":987}}"#).unwrap();
         assert_eq!(err, SystemError::NoSuchCode { code_id: 987 },);
     }
 }

--- a/packages/std/src/exports.rs
+++ b/packages/std/src/exports.rs
@@ -25,7 +25,7 @@ use crate::memory::{alloc, consume_region, release_buffer, Region};
 use crate::panic::install_panic_handler;
 use crate::query::CustomQuery;
 use crate::results::{ContractResult, QueryResponse, Reply, Response};
-use crate::serde::{from_slice, to_vec};
+use crate::serde::{from_json_slice, to_json_vec};
 use crate::types::Env;
 use crate::{CustomMsg, Deps, DepsMut, MessageInfo};
 
@@ -120,7 +120,7 @@ where
         info_ptr as *mut Region,
         msg_ptr as *mut Region,
     );
-    let v = to_vec(&res).unwrap();
+    let v = to_json_vec(&res).unwrap();
     release_buffer(v) as u32
 }
 
@@ -150,7 +150,7 @@ where
         info_ptr as *mut Region,
         msg_ptr as *mut Region,
     );
-    let v = to_vec(&res).unwrap();
+    let v = to_json_vec(&res).unwrap();
     release_buffer(v) as u32
 }
 
@@ -174,7 +174,7 @@ where
     #[cfg(feature = "abort")]
     install_panic_handler();
     let res = _do_migrate(migrate_fn, env_ptr as *mut Region, msg_ptr as *mut Region);
-    let v = to_vec(&res).unwrap();
+    let v = to_json_vec(&res).unwrap();
     release_buffer(v) as u32
 }
 
@@ -198,7 +198,7 @@ where
     #[cfg(feature = "abort")]
     install_panic_handler();
     let res = _do_sudo(sudo_fn, env_ptr as *mut Region, msg_ptr as *mut Region);
-    let v = to_vec(&res).unwrap();
+    let v = to_json_vec(&res).unwrap();
     release_buffer(v) as u32
 }
 
@@ -221,7 +221,7 @@ where
     #[cfg(feature = "abort")]
     install_panic_handler();
     let res = _do_reply(reply_fn, env_ptr as *mut Region, msg_ptr as *mut Region);
-    let v = to_vec(&res).unwrap();
+    let v = to_json_vec(&res).unwrap();
     release_buffer(v) as u32
 }
 
@@ -243,7 +243,7 @@ where
     #[cfg(feature = "abort")]
     install_panic_handler();
     let res = _do_query(query_fn, env_ptr as *mut Region, msg_ptr as *mut Region);
-    let v = to_vec(&res).unwrap();
+    let v = to_json_vec(&res).unwrap();
     release_buffer(v) as u32
 }
 
@@ -266,7 +266,7 @@ where
     #[cfg(feature = "abort")]
     install_panic_handler();
     let res = _do_ibc_channel_open(contract_fn, env_ptr as *mut Region, msg_ptr as *mut Region);
-    let v = to_vec(&res).unwrap();
+    let v = to_json_vec(&res).unwrap();
     release_buffer(v) as u32
 }
 
@@ -291,7 +291,7 @@ where
     #[cfg(feature = "abort")]
     install_panic_handler();
     let res = _do_ibc_channel_connect(contract_fn, env_ptr as *mut Region, msg_ptr as *mut Region);
-    let v = to_vec(&res).unwrap();
+    let v = to_json_vec(&res).unwrap();
     release_buffer(v) as u32
 }
 
@@ -316,7 +316,7 @@ where
     #[cfg(feature = "abort")]
     install_panic_handler();
     let res = _do_ibc_channel_close(contract_fn, env_ptr as *mut Region, msg_ptr as *mut Region);
-    let v = to_vec(&res).unwrap();
+    let v = to_json_vec(&res).unwrap();
     release_buffer(v) as u32
 }
 
@@ -342,7 +342,7 @@ where
     #[cfg(feature = "abort")]
     install_panic_handler();
     let res = _do_ibc_packet_receive(contract_fn, env_ptr as *mut Region, msg_ptr as *mut Region);
-    let v = to_vec(&res).unwrap();
+    let v = to_json_vec(&res).unwrap();
     release_buffer(v) as u32
 }
 
@@ -368,7 +368,7 @@ where
     #[cfg(feature = "abort")]
     install_panic_handler();
     let res = _do_ibc_packet_ack(contract_fn, env_ptr as *mut Region, msg_ptr as *mut Region);
-    let v = to_vec(&res).unwrap();
+    let v = to_json_vec(&res).unwrap();
     release_buffer(v) as u32
 }
 
@@ -395,7 +395,7 @@ where
     #[cfg(feature = "abort")]
     install_panic_handler();
     let res = _do_ibc_packet_timeout(contract_fn, env_ptr as *mut Region, msg_ptr as *mut Region);
-    let v = to_vec(&res).unwrap();
+    let v = to_json_vec(&res).unwrap();
     release_buffer(v) as u32
 }
 
@@ -415,9 +415,9 @@ where
     let info: Vec<u8> = unsafe { consume_region(info_ptr) };
     let msg: Vec<u8> = unsafe { consume_region(msg_ptr) };
 
-    let env: Env = try_into_contract_result!(from_slice(&env));
-    let info: MessageInfo = try_into_contract_result!(from_slice(&info));
-    let msg: M = try_into_contract_result!(from_slice(&msg));
+    let env: Env = try_into_contract_result!(from_json_slice(&env));
+    let info: MessageInfo = try_into_contract_result!(from_json_slice(&info));
+    let msg: M = try_into_contract_result!(from_json_slice(&msg));
 
     let mut deps = make_dependencies();
     instantiate_fn(deps.as_mut(), env, info, msg).into()
@@ -439,9 +439,9 @@ where
     let info: Vec<u8> = unsafe { consume_region(info_ptr) };
     let msg: Vec<u8> = unsafe { consume_region(msg_ptr) };
 
-    let env: Env = try_into_contract_result!(from_slice(&env));
-    let info: MessageInfo = try_into_contract_result!(from_slice(&info));
-    let msg: M = try_into_contract_result!(from_slice(&msg));
+    let env: Env = try_into_contract_result!(from_json_slice(&env));
+    let info: MessageInfo = try_into_contract_result!(from_json_slice(&info));
+    let msg: M = try_into_contract_result!(from_json_slice(&msg));
 
     let mut deps = make_dependencies();
     execute_fn(deps.as_mut(), env, info, msg).into()
@@ -461,8 +461,8 @@ where
     let env: Vec<u8> = unsafe { consume_region(env_ptr) };
     let msg: Vec<u8> = unsafe { consume_region(msg_ptr) };
 
-    let env: Env = try_into_contract_result!(from_slice(&env));
-    let msg: M = try_into_contract_result!(from_slice(&msg));
+    let env: Env = try_into_contract_result!(from_json_slice(&env));
+    let msg: M = try_into_contract_result!(from_json_slice(&msg));
 
     let mut deps = make_dependencies();
     migrate_fn(deps.as_mut(), env, msg).into()
@@ -482,8 +482,8 @@ where
     let env: Vec<u8> = unsafe { consume_region(env_ptr) };
     let msg: Vec<u8> = unsafe { consume_region(msg_ptr) };
 
-    let env: Env = try_into_contract_result!(from_slice(&env));
-    let msg: M = try_into_contract_result!(from_slice(&msg));
+    let env: Env = try_into_contract_result!(from_json_slice(&env));
+    let msg: M = try_into_contract_result!(from_json_slice(&msg));
 
     let mut deps = make_dependencies();
     sudo_fn(deps.as_mut(), env, msg).into()
@@ -502,8 +502,8 @@ where
     let env: Vec<u8> = unsafe { consume_region(env_ptr) };
     let msg: Vec<u8> = unsafe { consume_region(msg_ptr) };
 
-    let env: Env = try_into_contract_result!(from_slice(&env));
-    let msg: Reply = try_into_contract_result!(from_slice(&msg));
+    let env: Env = try_into_contract_result!(from_json_slice(&env));
+    let msg: Reply = try_into_contract_result!(from_json_slice(&msg));
 
     let mut deps = make_dependencies();
     reply_fn(deps.as_mut(), env, msg).into()
@@ -522,8 +522,8 @@ where
     let env: Vec<u8> = unsafe { consume_region(env_ptr) };
     let msg: Vec<u8> = unsafe { consume_region(msg_ptr) };
 
-    let env: Env = try_into_contract_result!(from_slice(&env));
-    let msg: M = try_into_contract_result!(from_slice(&msg));
+    let env: Env = try_into_contract_result!(from_json_slice(&env));
+    let msg: M = try_into_contract_result!(from_json_slice(&msg));
 
     let deps = make_dependencies();
     query_fn(deps.as_ref(), env, msg).into()
@@ -542,8 +542,8 @@ where
     let env: Vec<u8> = unsafe { consume_region(env_ptr) };
     let msg: Vec<u8> = unsafe { consume_region(msg_ptr) };
 
-    let env: Env = try_into_contract_result!(from_slice(&env));
-    let msg: IbcChannelOpenMsg = try_into_contract_result!(from_slice(&msg));
+    let env: Env = try_into_contract_result!(from_json_slice(&env));
+    let msg: IbcChannelOpenMsg = try_into_contract_result!(from_json_slice(&msg));
 
     let mut deps = make_dependencies();
     contract_fn(deps.as_mut(), env, msg).into()
@@ -563,8 +563,8 @@ where
     let env: Vec<u8> = unsafe { consume_region(env_ptr) };
     let msg: Vec<u8> = unsafe { consume_region(msg_ptr) };
 
-    let env: Env = try_into_contract_result!(from_slice(&env));
-    let msg: IbcChannelConnectMsg = try_into_contract_result!(from_slice(&msg));
+    let env: Env = try_into_contract_result!(from_json_slice(&env));
+    let msg: IbcChannelConnectMsg = try_into_contract_result!(from_json_slice(&msg));
 
     let mut deps = make_dependencies();
     contract_fn(deps.as_mut(), env, msg).into()
@@ -584,8 +584,8 @@ where
     let env: Vec<u8> = unsafe { consume_region(env_ptr) };
     let msg: Vec<u8> = unsafe { consume_region(msg_ptr) };
 
-    let env: Env = try_into_contract_result!(from_slice(&env));
-    let msg: IbcChannelCloseMsg = try_into_contract_result!(from_slice(&msg));
+    let env: Env = try_into_contract_result!(from_json_slice(&env));
+    let msg: IbcChannelCloseMsg = try_into_contract_result!(from_json_slice(&msg));
 
     let mut deps = make_dependencies();
     contract_fn(deps.as_mut(), env, msg).into()
@@ -605,8 +605,8 @@ where
     let env: Vec<u8> = unsafe { consume_region(env_ptr) };
     let msg: Vec<u8> = unsafe { consume_region(msg_ptr) };
 
-    let env: Env = try_into_contract_result!(from_slice(&env));
-    let msg: IbcPacketReceiveMsg = try_into_contract_result!(from_slice(&msg));
+    let env: Env = try_into_contract_result!(from_json_slice(&env));
+    let msg: IbcPacketReceiveMsg = try_into_contract_result!(from_json_slice(&msg));
 
     let mut deps = make_dependencies();
     contract_fn(deps.as_mut(), env, msg).into()
@@ -626,8 +626,8 @@ where
     let env: Vec<u8> = unsafe { consume_region(env_ptr) };
     let msg: Vec<u8> = unsafe { consume_region(msg_ptr) };
 
-    let env: Env = try_into_contract_result!(from_slice(&env));
-    let msg: IbcPacketAckMsg = try_into_contract_result!(from_slice(&msg));
+    let env: Env = try_into_contract_result!(from_json_slice(&env));
+    let msg: IbcPacketAckMsg = try_into_contract_result!(from_json_slice(&msg));
 
     let mut deps = make_dependencies();
     contract_fn(deps.as_mut(), env, msg).into()
@@ -647,8 +647,8 @@ where
     let env: Vec<u8> = unsafe { consume_region(env_ptr) };
     let msg: Vec<u8> = unsafe { consume_region(msg_ptr) };
 
-    let env: Env = try_into_contract_result!(from_slice(&env));
-    let msg: IbcPacketTimeoutMsg = try_into_contract_result!(from_slice(&msg));
+    let env: Env = try_into_contract_result!(from_json_slice(&env));
+    let msg: IbcPacketTimeoutMsg = try_into_contract_result!(from_json_slice(&msg));
 
     let mut deps = make_dependencies();
     contract_fn(deps.as_mut(), env, msg).into()

--- a/packages/std/src/hex_binary.rs
+++ b/packages/std/src/hex_binary.rs
@@ -247,7 +247,7 @@ impl<'de> de::Visitor<'de> for HexVisitor {
 mod tests {
     use super::*;
 
-    use crate::{assert_hash_works, from_slice, to_vec, StdError};
+    use crate::{assert_hash_works, from_json_slice, to_json_vec, StdError};
 
     #[test]
     fn from_hex_works() {
@@ -376,7 +376,7 @@ mod tests {
     }
 
     #[test]
-    fn from_slice_works() {
+    fn from_json_slice_works() {
         let original: &[u8] = &[0u8, 187, 61, 11, 250, 0];
         let binary: HexBinary = original.into();
         assert_eq!(binary.as_slice(), [0u8, 187, 61, 11, 250, 0]);
@@ -515,8 +515,8 @@ mod tests {
     fn serialization_works() {
         let binary = HexBinary(vec![0u8, 187, 61, 11, 250, 0]);
 
-        let json = to_vec(&binary).unwrap();
-        let deserialized: HexBinary = from_slice(&json).unwrap();
+        let json = to_json_vec(&binary).unwrap();
+        let deserialized: HexBinary = from_json_slice(&json).unwrap();
 
         assert_eq!(binary, deserialized);
     }
@@ -527,16 +527,16 @@ mod tests {
         // this is the binary behind above string
         let expected = vec![0u8, 187, 61, 11, 250, 0];
 
-        let serialized = to_vec(&hex).unwrap();
-        let deserialized: HexBinary = from_slice(&serialized).unwrap();
+        let serialized = to_json_vec(&hex).unwrap();
+        let deserialized: HexBinary = from_json_slice(&serialized).unwrap();
         assert_eq!(expected, deserialized.as_slice());
     }
 
     #[test]
     fn deserialize_from_invalid_string() {
         let invalid_str = "**BAD!**";
-        let serialized = to_vec(&invalid_str).unwrap();
-        let res = from_slice::<HexBinary>(&serialized);
+        let serialized = to_json_vec(&invalid_str).unwrap();
+        let res = from_json_slice::<HexBinary>(&serialized);
         assert!(res.is_err());
     }
 

--- a/packages/std/src/ibc.rs
+++ b/packages/std/src/ibc.rs
@@ -11,7 +11,7 @@ use crate::binary::Binary;
 use crate::coin::Coin;
 use crate::errors::StdResult;
 use crate::results::{Attribute, CosmosMsg, Empty, Event, SubMsg};
-use crate::serde::to_binary;
+use crate::serde::to_json_binary;
 use crate::timestamp::Timestamp;
 
 /// These are messages in the IBC lifecycle. Only usable by IBC-enabled contracts
@@ -240,7 +240,7 @@ impl IbcAcknowledgement {
 
     pub fn encode_json(data: &impl Serialize) -> StdResult<Self> {
         Ok(IbcAcknowledgement {
-            data: to_binary(data)?,
+            data: to_json_binary(data)?,
         })
     }
 }

--- a/packages/std/src/imports.rs
+++ b/packages/std/src/imports.rs
@@ -8,7 +8,7 @@ use crate::results::SystemResult;
 #[cfg(feature = "iterator")]
 use crate::sections::decode_sections2;
 use crate::sections::encode_sections;
-use crate::serde::from_slice;
+use crate::serde::from_json_slice;
 use crate::traits::{Api, Querier, QuerierResult, Storage};
 #[cfg(feature = "iterator")]
 use crate::{
@@ -498,7 +498,7 @@ impl Querier for ExternalQuerier {
         let response_ptr = unsafe { query_chain(request_ptr) };
         let response = unsafe { consume_region(response_ptr as *mut Region) };
 
-        from_slice(&response).unwrap_or_else(|parsing_err| {
+        from_json_slice(&response).unwrap_or_else(|parsing_err| {
             SystemResult::Err(SystemError::InvalidResponse {
                 error: parsing_err.to_string(),
                 response: response.into(),

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -88,7 +88,11 @@ pub use crate::results::{
 pub use crate::results::{DistributionMsg, StakingMsg};
 #[cfg(feature = "stargate")]
 pub use crate::results::{GovMsg, VoteOption};
-pub use crate::serde::{from_binary, from_slice, to_binary, to_vec};
+#[allow(deprecated)]
+pub use crate::serde::{
+    from_binary, from_json_binary, from_json_slice, from_json_str, from_slice, to_binary_replace,
+    to_json_binary, to_json_string, to_json_vec, to_vec,
+};
 pub use crate::stdack::StdAck;
 pub use crate::storage::MemoryStorage;
 pub use crate::timestamp::Timestamp;

--- a/packages/std/src/math/decimal.rs
+++ b/packages/std/src/math/decimal.rs
@@ -781,7 +781,7 @@ impl<'de> de::Visitor<'de> for DecimalVisitor {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{from_slice, to_vec};
+    use crate::{from_json_slice, to_json_vec};
 
     fn dec(input: &str) -> Decimal {
         Decimal::from_str(input).unwrap()
@@ -1908,35 +1908,47 @@ mod tests {
 
     #[test]
     fn decimal_serialize() {
-        assert_eq!(to_vec(&Decimal::zero()).unwrap(), br#""0""#);
-        assert_eq!(to_vec(&Decimal::one()).unwrap(), br#""1""#);
-        assert_eq!(to_vec(&Decimal::percent(8)).unwrap(), br#""0.08""#);
-        assert_eq!(to_vec(&Decimal::percent(87)).unwrap(), br#""0.87""#);
-        assert_eq!(to_vec(&Decimal::percent(876)).unwrap(), br#""8.76""#);
-        assert_eq!(to_vec(&Decimal::percent(8765)).unwrap(), br#""87.65""#);
+        assert_eq!(to_json_vec(&Decimal::zero()).unwrap(), br#""0""#);
+        assert_eq!(to_json_vec(&Decimal::one()).unwrap(), br#""1""#);
+        assert_eq!(to_json_vec(&Decimal::percent(8)).unwrap(), br#""0.08""#);
+        assert_eq!(to_json_vec(&Decimal::percent(87)).unwrap(), br#""0.87""#);
+        assert_eq!(to_json_vec(&Decimal::percent(876)).unwrap(), br#""8.76""#);
+        assert_eq!(to_json_vec(&Decimal::percent(8765)).unwrap(), br#""87.65""#);
     }
 
     #[test]
     fn decimal_deserialize() {
-        assert_eq!(from_slice::<Decimal>(br#""0""#).unwrap(), Decimal::zero());
-        assert_eq!(from_slice::<Decimal>(br#""1""#).unwrap(), Decimal::one());
-        assert_eq!(from_slice::<Decimal>(br#""000""#).unwrap(), Decimal::zero());
-        assert_eq!(from_slice::<Decimal>(br#""001""#).unwrap(), Decimal::one());
+        assert_eq!(
+            from_json_slice::<Decimal>(br#""0""#).unwrap(),
+            Decimal::zero()
+        );
+        assert_eq!(
+            from_json_slice::<Decimal>(br#""1""#).unwrap(),
+            Decimal::one()
+        );
+        assert_eq!(
+            from_json_slice::<Decimal>(br#""000""#).unwrap(),
+            Decimal::zero()
+        );
+        assert_eq!(
+            from_json_slice::<Decimal>(br#""001""#).unwrap(),
+            Decimal::one()
+        );
 
         assert_eq!(
-            from_slice::<Decimal>(br#""0.08""#).unwrap(),
+            from_json_slice::<Decimal>(br#""0.08""#).unwrap(),
             Decimal::percent(8)
         );
         assert_eq!(
-            from_slice::<Decimal>(br#""0.87""#).unwrap(),
+            from_json_slice::<Decimal>(br#""0.87""#).unwrap(),
             Decimal::percent(87)
         );
         assert_eq!(
-            from_slice::<Decimal>(br#""8.76""#).unwrap(),
+            from_json_slice::<Decimal>(br#""8.76""#).unwrap(),
             Decimal::percent(876)
         );
         assert_eq!(
-            from_slice::<Decimal>(br#""87.65""#).unwrap(),
+            from_json_slice::<Decimal>(br#""87.65""#).unwrap(),
             Decimal::percent(8765)
         );
     }

--- a/packages/std/src/math/decimal256.rs
+++ b/packages/std/src/math/decimal256.rs
@@ -797,7 +797,7 @@ impl<'de> de::Visitor<'de> for Decimal256Visitor {
 mod tests {
     use super::*;
     use crate::errors::StdError;
-    use crate::{from_slice, to_vec};
+    use crate::{from_json_slice, to_json_vec};
 
     fn dec(input: &str) -> Decimal256 {
         Decimal256::from_str(input).unwrap()
@@ -2020,47 +2020,53 @@ mod tests {
 
     #[test]
     fn decimal256_serialize() {
-        assert_eq!(to_vec(&Decimal256::zero()).unwrap(), br#""0""#);
-        assert_eq!(to_vec(&Decimal256::one()).unwrap(), br#""1""#);
-        assert_eq!(to_vec(&Decimal256::percent(8)).unwrap(), br#""0.08""#);
-        assert_eq!(to_vec(&Decimal256::percent(87)).unwrap(), br#""0.87""#);
-        assert_eq!(to_vec(&Decimal256::percent(876)).unwrap(), br#""8.76""#);
-        assert_eq!(to_vec(&Decimal256::percent(8765)).unwrap(), br#""87.65""#);
+        assert_eq!(to_json_vec(&Decimal256::zero()).unwrap(), br#""0""#);
+        assert_eq!(to_json_vec(&Decimal256::one()).unwrap(), br#""1""#);
+        assert_eq!(to_json_vec(&Decimal256::percent(8)).unwrap(), br#""0.08""#);
+        assert_eq!(to_json_vec(&Decimal256::percent(87)).unwrap(), br#""0.87""#);
+        assert_eq!(
+            to_json_vec(&Decimal256::percent(876)).unwrap(),
+            br#""8.76""#
+        );
+        assert_eq!(
+            to_json_vec(&Decimal256::percent(8765)).unwrap(),
+            br#""87.65""#
+        );
     }
 
     #[test]
     fn decimal256_deserialize() {
         assert_eq!(
-            from_slice::<Decimal256>(br#""0""#).unwrap(),
+            from_json_slice::<Decimal256>(br#""0""#).unwrap(),
             Decimal256::zero()
         );
         assert_eq!(
-            from_slice::<Decimal256>(br#""1""#).unwrap(),
+            from_json_slice::<Decimal256>(br#""1""#).unwrap(),
             Decimal256::one()
         );
         assert_eq!(
-            from_slice::<Decimal256>(br#""000""#).unwrap(),
+            from_json_slice::<Decimal256>(br#""000""#).unwrap(),
             Decimal256::zero()
         );
         assert_eq!(
-            from_slice::<Decimal256>(br#""001""#).unwrap(),
+            from_json_slice::<Decimal256>(br#""001""#).unwrap(),
             Decimal256::one()
         );
 
         assert_eq!(
-            from_slice::<Decimal256>(br#""0.08""#).unwrap(),
+            from_json_slice::<Decimal256>(br#""0.08""#).unwrap(),
             Decimal256::percent(8)
         );
         assert_eq!(
-            from_slice::<Decimal256>(br#""0.87""#).unwrap(),
+            from_json_slice::<Decimal256>(br#""0.87""#).unwrap(),
             Decimal256::percent(87)
         );
         assert_eq!(
-            from_slice::<Decimal256>(br#""8.76""#).unwrap(),
+            from_json_slice::<Decimal256>(br#""8.76""#).unwrap(),
             Decimal256::percent(876)
         );
         assert_eq!(
-            from_slice::<Decimal256>(br#""87.65""#).unwrap(),
+            from_json_slice::<Decimal256>(br#""87.65""#).unwrap(),
             Decimal256::percent(8765)
         );
     }

--- a/packages/std/src/math/int128.rs
+++ b/packages/std/src/math/int128.rs
@@ -570,7 +570,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{from_slice, math::conversion::test_try_from_uint_to_int, to_vec};
+    use crate::{from_json_slice, math::conversion::test_try_from_uint_to_int, to_json_vec};
 
     #[test]
     fn size_of_works() {
@@ -822,9 +822,9 @@ mod tests {
     #[test]
     fn int128_json() {
         let orig = Int128::from(1234567890987654321i128);
-        let serialized = to_vec(&orig).unwrap();
+        let serialized = to_json_vec(&orig).unwrap();
         assert_eq!(serialized.as_slice(), b"\"1234567890987654321\"");
-        let parsed: Int128 = from_slice(&serialized).unwrap();
+        let parsed: Int128 = from_json_slice(&serialized).unwrap();
         assert_eq!(parsed, orig);
     }
 

--- a/packages/std/src/math/int256.rs
+++ b/packages/std/src/math/int256.rs
@@ -645,7 +645,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{from_slice, math::conversion::test_try_from_uint_to_int, to_vec};
+    use crate::{from_json_slice, math::conversion::test_try_from_uint_to_int, to_json_vec};
 
     #[test]
     fn size_of_works() {
@@ -929,9 +929,9 @@ mod tests {
     #[test]
     fn int256_json() {
         let orig = Int256::from(1234567890987654321u128);
-        let serialized = to_vec(&orig).unwrap();
+        let serialized = to_json_vec(&orig).unwrap();
         assert_eq!(serialized.as_slice(), b"\"1234567890987654321\"");
-        let parsed: Int256 = from_slice(&serialized).unwrap();
+        let parsed: Int256 = from_json_slice(&serialized).unwrap();
         assert_eq!(parsed, orig);
     }
 

--- a/packages/std/src/math/int512.rs
+++ b/packages/std/src/math/int512.rs
@@ -642,7 +642,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{from_slice, math::conversion::test_try_from_uint_to_int, to_vec};
+    use crate::{from_json_slice, math::conversion::test_try_from_uint_to_int, to_json_vec};
 
     #[test]
     fn size_of_works() {
@@ -957,9 +957,9 @@ mod tests {
     #[test]
     fn int512_json() {
         let orig = Int512::from(1234567890987654321u128);
-        let serialized = to_vec(&orig).unwrap();
+        let serialized = to_json_vec(&orig).unwrap();
         assert_eq!(serialized.as_slice(), b"\"1234567890987654321\"");
-        let parsed: Int512 = from_slice(&serialized).unwrap();
+        let parsed: Int512 = from_json_slice(&serialized).unwrap();
         assert_eq!(parsed, orig);
     }
 

--- a/packages/std/src/math/int64.rs
+++ b/packages/std/src/math/int64.rs
@@ -549,7 +549,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{from_slice, math::conversion::test_try_from_uint_to_int, to_vec};
+    use crate::{from_json_slice, math::conversion::test_try_from_uint_to_int, to_json_vec};
 
     #[test]
     fn size_of_works() {
@@ -794,9 +794,9 @@ mod tests {
     #[test]
     fn int64_json() {
         let orig = Int64::from(1234567890987654321i64);
-        let serialized = to_vec(&orig).unwrap();
+        let serialized = to_json_vec(&orig).unwrap();
         assert_eq!(serialized.as_slice(), b"\"1234567890987654321\"");
-        let parsed: Int64 = from_slice(&serialized).unwrap();
+        let parsed: Int64 = from_json_slice(&serialized).unwrap();
         assert_eq!(parsed, orig);
     }
 

--- a/packages/std/src/math/uint128.rs
+++ b/packages/std/src/math/uint128.rs
@@ -617,7 +617,7 @@ where
 mod tests {
     use crate::errors::CheckedMultiplyFractionError::{ConversionOverflow, DivideByZero};
     use crate::math::conversion::test_try_from_int_to_uint;
-    use crate::{from_slice, to_vec, ConversionOverflowError, Decimal};
+    use crate::{from_json_slice, to_json_vec, ConversionOverflowError, Decimal};
 
     use super::*;
 
@@ -789,9 +789,9 @@ mod tests {
     #[test]
     fn uint128_json() {
         let orig = Uint128(1234567890987654321);
-        let serialized = to_vec(&orig).unwrap();
+        let serialized = to_json_vec(&orig).unwrap();
         assert_eq!(serialized.as_slice(), b"\"1234567890987654321\"");
-        let parsed: Uint128 = from_slice(&serialized).unwrap();
+        let parsed: Uint128 = from_json_slice(&serialized).unwrap();
         assert_eq!(parsed, orig);
     }
 

--- a/packages/std/src/math/uint256.rs
+++ b/packages/std/src/math/uint256.rs
@@ -680,7 +680,7 @@ mod tests {
     use super::*;
     use crate::errors::CheckedMultiplyFractionError::{ConversionOverflow, DivideByZero};
     use crate::math::conversion::test_try_from_int_to_uint;
-    use crate::{from_slice, to_vec, Decimal, Decimal256};
+    use crate::{from_json_slice, to_json_vec, Decimal, Decimal256};
 
     #[test]
     fn size_of_works() {
@@ -1306,9 +1306,9 @@ mod tests {
     #[test]
     fn uint256_json() {
         let orig = Uint256::from(1234567890987654321u128);
-        let serialized = to_vec(&orig).unwrap();
+        let serialized = to_json_vec(&orig).unwrap();
         assert_eq!(serialized.as_slice(), b"\"1234567890987654321\"");
-        let parsed: Uint256 = from_slice(&serialized).unwrap();
+        let parsed: Uint256 = from_json_slice(&serialized).unwrap();
         assert_eq!(parsed, orig);
     }
 

--- a/packages/std/src/math/uint512.rs
+++ b/packages/std/src/math/uint512.rs
@@ -646,7 +646,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{from_slice, math::conversion::test_try_from_int_to_uint, to_vec};
+    use crate::{from_json_slice, math::conversion::test_try_from_int_to_uint, to_json_vec};
 
     #[test]
     fn size_of_works() {
@@ -1012,9 +1012,9 @@ mod tests {
     #[test]
     fn uint512_json() {
         let orig = Uint512::from(1234567890987654321u128);
-        let serialized = to_vec(&orig).unwrap();
+        let serialized = to_json_vec(&orig).unwrap();
         assert_eq!(serialized.as_slice(), b"\"1234567890987654321\"");
-        let parsed: Uint512 = from_slice(&serialized).unwrap();
+        let parsed: Uint512 = from_json_slice(&serialized).unwrap();
         assert_eq!(parsed, orig);
     }
 

--- a/packages/std/src/math/uint64.rs
+++ b/packages/std/src/math/uint64.rs
@@ -579,7 +579,7 @@ mod tests {
     use super::*;
     use crate::errors::CheckedMultiplyFractionError::{ConversionOverflow, DivideByZero};
     use crate::math::conversion::test_try_from_int_to_uint;
-    use crate::{from_slice, to_vec, ConversionOverflowError};
+    use crate::{from_json_slice, to_json_vec, ConversionOverflowError};
 
     #[test]
     fn size_of_works() {
@@ -710,9 +710,9 @@ mod tests {
     #[test]
     fn uint64_json() {
         let orig = Uint64(1234567890987654321);
-        let serialized = to_vec(&orig).unwrap();
+        let serialized = to_json_vec(&orig).unwrap();
         assert_eq!(serialized.as_slice(), b"\"1234567890987654321\"");
-        let parsed: Uint64 = from_slice(&serialized).unwrap();
+        let parsed: Uint64 = from_json_slice(&serialized).unwrap();
         assert_eq!(parsed, orig);
     }
 

--- a/packages/std/src/query/wasm.rs
+++ b/packages/std/src/query/wasm.rs
@@ -94,14 +94,14 @@ impl QueryResponseType for CodeInfoResponse {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::to_binary;
+    use crate::to_json_binary;
 
     #[test]
     fn wasm_query_contract_info_serialization() {
         let query = WasmQuery::ContractInfo {
             contract_addr: "aabbccdd456".into(),
         };
-        let json = to_binary(&query).unwrap();
+        let json = to_json_binary(&query).unwrap();
         assert_eq!(
             String::from_utf8_lossy(&json),
             r#"{"contract_info":{"contract_addr":"aabbccdd456"}}"#,
@@ -112,7 +112,7 @@ mod tests {
     #[cfg(feature = "cosmwasm_1_2")]
     fn wasm_query_code_info_serialization() {
         let query = WasmQuery::CodeInfo { code_id: 70 };
-        let json = to_binary(&query).unwrap();
+        let json = to_json_binary(&query).unwrap();
         assert_eq!(
             String::from_utf8_lossy(&json),
             r#"{"code_info":{"code_id":70}}"#,
@@ -128,7 +128,7 @@ mod tests {
             pinned: true,
             ibc_port: Some("wasm.123".to_string()),
         };
-        let json = to_binary(&response).unwrap();
+        let json = to_json_binary(&response).unwrap();
         assert_eq!(
             String::from_utf8_lossy(&json),
             r#"{"code_id":67,"creator":"jane","admin":"king","pinned":true,"ibc_port":"wasm.123"}"#,
@@ -148,7 +148,7 @@ mod tests {
             )
             .unwrap(),
         };
-        let json = to_binary(&response).unwrap();
+        let json = to_json_binary(&response).unwrap();
         assert_eq!(
             String::from_utf8_lossy(&json),
             r#"{"code_id":67,"creator":"jane","checksum":"f7bb7b18fb01bbf425cf4ed2cd4b7fb26a019a7fc75a4dc87e8a0b768c501f00"}"#,

--- a/packages/std/src/results/contract_result.rs
+++ b/packages/std/src/results/contract_result.rs
@@ -88,59 +88,61 @@ impl<S> From<ContractResult<S>> for Result<S, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{from_slice, to_vec, Response, StdError, StdResult};
+    use crate::{from_json_slice, to_json_vec, Response, StdError, StdResult};
 
     #[test]
     fn contract_result_serialization_works() {
         let result = ContractResult::Ok(12);
-        assert_eq!(&to_vec(&result).unwrap(), b"{\"ok\":12}");
+        assert_eq!(&to_json_vec(&result).unwrap(), b"{\"ok\":12}");
 
         let result = ContractResult::Ok("foo");
-        assert_eq!(&to_vec(&result).unwrap(), b"{\"ok\":\"foo\"}");
+        assert_eq!(&to_json_vec(&result).unwrap(), b"{\"ok\":\"foo\"}");
 
         let result: ContractResult<Response> = ContractResult::Ok(Response::default());
         assert_eq!(
-            to_vec(&result).unwrap(),
+            to_json_vec(&result).unwrap(),
             br#"{"ok":{"messages":[],"attributes":[],"events":[],"data":null}}"#
         );
 
         let result: ContractResult<Response> = ContractResult::Err("broken".to_string());
-        assert_eq!(&to_vec(&result).unwrap(), b"{\"error\":\"broken\"}");
+        assert_eq!(&to_json_vec(&result).unwrap(), b"{\"error\":\"broken\"}");
     }
 
     #[test]
     fn contract_result_deserialization_works() {
-        let result: ContractResult<u64> = from_slice(br#"{"ok":12}"#).unwrap();
+        let result: ContractResult<u64> = from_json_slice(br#"{"ok":12}"#).unwrap();
         assert_eq!(result, ContractResult::Ok(12));
 
-        let result: ContractResult<String> = from_slice(br#"{"ok":"foo"}"#).unwrap();
+        let result: ContractResult<String> = from_json_slice(br#"{"ok":"foo"}"#).unwrap();
         assert_eq!(result, ContractResult::Ok("foo".to_string()));
 
         let result: ContractResult<Response> =
-            from_slice(br#"{"ok":{"messages":[],"attributes":[],"events":[],"data":null}}"#)
+            from_json_slice(br#"{"ok":{"messages":[],"attributes":[],"events":[],"data":null}}"#)
                 .unwrap();
         assert_eq!(result, ContractResult::Ok(Response::default()));
 
-        let result: ContractResult<Response> = from_slice(br#"{"error":"broken"}"#).unwrap();
+        let result: ContractResult<Response> = from_json_slice(br#"{"error":"broken"}"#).unwrap();
         assert_eq!(result, ContractResult::Err("broken".to_string()));
 
         // ignores whitespace
-        let result: ContractResult<u64> = from_slice(b" {\n\t  \"ok\": 5898\n}  ").unwrap();
+        let result: ContractResult<u64> = from_json_slice(b" {\n\t  \"ok\": 5898\n}  ").unwrap();
         assert_eq!(result, ContractResult::Ok(5898));
 
         // fails for additional attributes
-        let parse: StdResult<ContractResult<u64>> = from_slice(br#"{"unrelated":321,"ok":4554}"#);
-        match parse.unwrap_err() {
-            StdError::ParseErr { .. } => {}
-            err => panic!("Unexpected error: {err:?}"),
-        }
-        let parse: StdResult<ContractResult<u64>> = from_slice(br#"{"ok":4554,"unrelated":321}"#);
+        let parse: StdResult<ContractResult<u64>> =
+            from_json_slice(br#"{"unrelated":321,"ok":4554}"#);
         match parse.unwrap_err() {
             StdError::ParseErr { .. } => {}
             err => panic!("Unexpected error: {err:?}"),
         }
         let parse: StdResult<ContractResult<u64>> =
-            from_slice(br#"{"ok":4554,"error":"What's up now?"}"#);
+            from_json_slice(br#"{"ok":4554,"unrelated":321}"#);
+        match parse.unwrap_err() {
+            StdError::ParseErr { .. } => {}
+            err => panic!("Unexpected error: {err:?}"),
+        }
+        let parse: StdResult<ContractResult<u64>> =
+            from_json_slice(br#"{"ok":4554,"error":"What's up now?"}"#);
         match parse.unwrap_err() {
             StdError::ParseErr { .. } => {}
             err => panic!("Unexpected error: {err:?}"),

--- a/packages/std/src/results/cosmos_msg.rs
+++ b/packages/std/src/results/cosmos_msg.rs
@@ -8,7 +8,7 @@ use crate::coin::Coin;
 use crate::errors::StdResult;
 #[cfg(feature = "stargate")]
 use crate::ibc::IbcMsg;
-use crate::serde::to_binary;
+use crate::serde::to_json_binary;
 #[cfg(all(feature = "stargate", feature = "cosmwasm_1_2"))]
 use crate::Decimal;
 
@@ -336,7 +336,7 @@ pub fn wasm_instantiate(
     funds: Vec<Coin>,
     label: String,
 ) -> StdResult<WasmMsg> {
-    let payload = to_binary(msg)?;
+    let payload = to_json_binary(msg)?;
     Ok(WasmMsg::Instantiate {
         admin: None,
         code_id,
@@ -352,7 +352,7 @@ pub fn wasm_execute(
     msg: &impl Serialize,
     funds: Vec<Coin>,
 ) -> StdResult<WasmMsg> {
-    let payload = to_binary(msg)?;
+    let payload = to_json_binary(msg)?;
     Ok(WasmMsg::Execute {
         contract_addr: contract_addr.into(),
         msg: payload,
@@ -427,7 +427,7 @@ mod tests {
             funds: vec![],
             label: "my instance".to_string(),
         };
-        let json = to_binary(&msg).unwrap();
+        let json = to_json_binary(&msg).unwrap();
         assert_eq!(
             String::from_utf8_lossy(&json),
             r#"{"instantiate":{"admin":"king","code_id":7897,"msg":"eyJjbGFpbSI6e319","funds":[],"label":"my instance"}}"#,
@@ -441,7 +441,7 @@ mod tests {
             funds: vec![],
             label: "my instance".to_string(),
         };
-        let json = to_binary(&msg).unwrap();
+        let json = to_json_binary(&msg).unwrap();
         assert_eq!(
             String::from_utf8_lossy(&json),
             r#"{"instantiate":{"admin":null,"code_id":7897,"msg":"eyJjbGFpbSI6e319","funds":[],"label":"my instance"}}"#,
@@ -455,7 +455,7 @@ mod tests {
             funds: vec![coin(321, "stones")],
             label: "my instance".to_string(),
         };
-        let json = to_binary(&msg).unwrap();
+        let json = to_json_binary(&msg).unwrap();
         assert_eq!(
             String::from_utf8_lossy(&json),
             r#"{"instantiate":{"admin":null,"code_id":7897,"msg":"eyJjbGFpbSI6e319","funds":[{"denom":"stones","amount":"321"}],"label":"my instance"}}"#,
@@ -472,7 +472,7 @@ mod tests {
                 funds: vec![coin(321, "stones")],
                 salt: Binary::from_base64("UkOVazhiwoo=").unwrap(),
             };
-            let json = to_binary(&msg).unwrap();
+            let json = to_json_binary(&msg).unwrap();
             assert_eq!(
                 String::from_utf8_lossy(&json),
                 r#"{"instantiate2":{"admin":null,"code_id":7897,"label":"my instance","msg":"eyJjbGFpbSI6e319","funds":[{"denom":"stones","amount":"321"}],"salt":"UkOVazhiwoo="}}"#,
@@ -486,7 +486,7 @@ mod tests {
         // FundCommunityPool
         let fund_coins = vec![coin(200, "feathers"), coin(200, "stones")];
         let fund_msg = DistributionMsg::FundCommunityPool { amount: fund_coins };
-        let fund_json = to_binary(&fund_msg).unwrap();
+        let fund_json = to_json_binary(&fund_msg).unwrap();
         assert_eq!(
             String::from_utf8_lossy(&fund_json),
             r#"{"fund_community_pool":{"amount":[{"denom":"feathers","amount":"200"},{"denom":"stones","amount":"200"}]}}"#,
@@ -496,7 +496,7 @@ mod tests {
         let set_msg = DistributionMsg::SetWithdrawAddress {
             address: String::from("withdrawer"),
         };
-        let set_json = to_binary(&set_msg).unwrap();
+        let set_json = to_json_binary(&set_msg).unwrap();
         assert_eq!(
             String::from_utf8_lossy(&set_json),
             r#"{"set_withdraw_address":{"address":"withdrawer"}}"#,
@@ -506,7 +506,7 @@ mod tests {
         let withdraw_msg = DistributionMsg::WithdrawDelegatorReward {
             validator: String::from("fancyoperator"),
         };
-        let withdraw_json = to_binary(&withdraw_msg).unwrap();
+        let withdraw_json = to_json_binary(&withdraw_msg).unwrap();
         assert_eq!(
             String::from_utf8_lossy(&withdraw_json),
             r#"{"withdraw_delegator_reward":{"validator":"fancyoperator"}}"#
@@ -522,7 +522,7 @@ mod tests {
 
         let msg = WasmMsg::Execute {
             contract_addr: "joe".to_string(),
-            msg: to_binary(&ExecuteMsg::Mint {
+            msg: to_json_binary(&ExecuteMsg::Mint {
                 coin: coin(10, "BTC"),
             })
             .unwrap(),
@@ -557,7 +557,7 @@ mod tests {
             proposal_id: 4,
             vote: VoteOption::NoWithVeto,
         };
-        let json = to_binary(&msg).unwrap();
+        let json = to_json_binary(&msg).unwrap();
         assert_eq!(
             String::from_utf8_lossy(&json),
             r#"{"vote":{"proposal_id":4,"vote":"no_with_veto"}}"#,
@@ -584,7 +584,7 @@ mod tests {
                 ],
             };
 
-            let json = to_binary(&msg).unwrap();
+            let json = to_json_binary(&msg).unwrap();
             assert_eq!(
                 String::from_utf8_lossy(&json),
                 r#"{"vote_weighted":{"proposal_id":25,"options":[{"option":"yes","weight":"0.25"},{"option":"no","weight":"0.25"},{"option":"abstain","weight":"0.5"}]}}"#,

--- a/packages/std/src/results/empty.rs
+++ b/packages/std/src/results/empty.rs
@@ -14,7 +14,7 @@ pub struct Empty {}
 mod tests {
     use super::*;
 
-    use crate::serde::{from_slice, to_vec};
+    use crate::serde::{from_json_slice, to_json_vec};
 
     #[test]
     fn empty_can_be_instantiated() {
@@ -25,13 +25,13 @@ mod tests {
     #[test]
     fn empty_can_be_instantiated_serialized_and_deserialized() {
         let instance = Empty {};
-        let serialized = to_vec(&instance).unwrap();
+        let serialized = to_json_vec(&instance).unwrap();
         assert_eq!(serialized, b"{}");
 
-        let deserialized: Empty = from_slice(b"{}").unwrap();
+        let deserialized: Empty = from_json_slice(b"{}").unwrap();
         assert_eq!(deserialized, instance);
 
-        let deserialized: Empty = from_slice(b"{\"stray\":\"data\"}").unwrap();
+        let deserialized: Empty = from_json_slice(b"{\"stray\":\"data\"}").unwrap();
         assert_eq!(deserialized, instance);
     }
 }

--- a/packages/std/src/results/response.rs
+++ b/packages/std/src/results/response.rs
@@ -235,7 +235,7 @@ mod tests {
     use super::super::BankMsg;
     use super::*;
     use crate::results::submessages::{ReplyOn, UNUSED_MSG_ID};
-    use crate::{coins, from_slice, to_vec, ContractResult};
+    use crate::{coins, from_json_slice, to_json_vec, ContractResult};
 
     #[test]
     fn response_add_attributes_works() {
@@ -308,8 +308,8 @@ mod tests {
             events: vec![],
             data: Some(Binary::from([0xAA, 0xBB])),
         };
-        let serialized = to_vec(&original).expect("encode contract result");
-        let deserialized: Response = from_slice(&serialized).expect("decode contract result");
+        let serialized = to_json_vec(&original).expect("encode contract result");
+        let deserialized: Response = from_json_slice(&serialized).expect("decode contract result");
         assert_eq!(deserialized, original);
     }
 

--- a/packages/std/src/results/submessages.rs
+++ b/packages/std/src/results/submessages.rs
@@ -205,7 +205,7 @@ pub type SubMsgExecutionResponse = SubMsgResponse;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{from_slice, to_vec, StdError, StdResult};
+    use crate::{from_json_slice, to_json_vec, StdError, StdResult};
 
     #[test]
     fn sub_msg_result_serialization_works() {
@@ -214,7 +214,7 @@ mod tests {
             events: vec![],
         });
         assert_eq!(
-            &to_vec(&result).unwrap(),
+            &to_json_vec(&result).unwrap(),
             br#"{"ok":{"events":[],"data":null}}"#
         );
 
@@ -223,17 +223,17 @@ mod tests {
             events: vec![Event::new("wasm").add_attribute("fo", "ba")],
         });
         assert_eq!(
-            &to_vec(&result).unwrap(),
+            &to_json_vec(&result).unwrap(),
             br#"{"ok":{"events":[{"type":"wasm","attributes":[{"key":"fo","value":"ba"}]}],"data":"MTIzCg=="}}"#
         );
 
         let result: SubMsgResult = SubMsgResult::Err("broken".to_string());
-        assert_eq!(&to_vec(&result).unwrap(), b"{\"error\":\"broken\"}");
+        assert_eq!(&to_json_vec(&result).unwrap(), b"{\"error\":\"broken\"}");
     }
 
     #[test]
     fn sub_msg_result_deserialization_works() {
-        let result: SubMsgResult = from_slice(br#"{"ok":{"events":[],"data":null}}"#).unwrap();
+        let result: SubMsgResult = from_json_slice(br#"{"ok":{"events":[],"data":null}}"#).unwrap();
         assert_eq!(
             result,
             SubMsgResult::Ok(SubMsgResponse {
@@ -242,7 +242,7 @@ mod tests {
             })
         );
 
-        let result: SubMsgResult = from_slice(
+        let result: SubMsgResult = from_json_slice(
             br#"{"ok":{"events":[{"type":"wasm","attributes":[{"key":"fo","value":"ba"}]}],"data":"MTIzCg=="}}"#).unwrap();
         assert_eq!(
             result,
@@ -252,16 +252,18 @@ mod tests {
             })
         );
 
-        let result: SubMsgResult = from_slice(br#"{"error":"broken"}"#).unwrap();
+        let result: SubMsgResult = from_json_slice(br#"{"error":"broken"}"#).unwrap();
         assert_eq!(result, SubMsgResult::Err("broken".to_string()));
 
         // fails for additional attributes
-        let parse: StdResult<SubMsgResult> = from_slice(br#"{"unrelated":321,"error":"broken"}"#);
+        let parse: StdResult<SubMsgResult> =
+            from_json_slice(br#"{"unrelated":321,"error":"broken"}"#);
         match parse.unwrap_err() {
             StdError::ParseErr { .. } => {}
             err => panic!("Unexpected error: {err:?}"),
         }
-        let parse: StdResult<SubMsgResult> = from_slice(br#"{"error":"broken","unrelated":321}"#);
+        let parse: StdResult<SubMsgResult> =
+            from_json_slice(br#"{"error":"broken","unrelated":321}"#);
         match parse.unwrap_err() {
             StdError::ParseErr { .. } => {}
             err => panic!("Unexpected error: {err:?}"),

--- a/packages/std/src/stdack.rs
+++ b/packages/std/src/stdack.rs
@@ -2,7 +2,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::binary::Binary;
-use crate::to_binary;
+use crate::to_json_binary;
 
 /// This is a standard IBC acknowledgement type. IBC application are free
 /// to use any acknowledgement format they want. However, for compatibility
@@ -94,7 +94,7 @@ impl StdAck {
         // We need a non-failing StdAck -> Binary conversion to allow using StdAck in
         // `impl Into<Binary>` arguments.
         // Pretty sure this cannot fail. If that changes we can create a non-failing implementation here.
-        to_binary(&self).unwrap()
+        to_json_binary(&self).unwrap()
     }
 
     pub fn unwrap(self) -> Binary {

--- a/packages/std/src/testing/mock.rs
+++ b/packages/std/src/testing/mock.rs
@@ -34,7 +34,7 @@ use crate::query::{
 #[cfg(feature = "cosmwasm_1_3")]
 use crate::query::{DelegatorWithdrawAddressResponse, DistributionQuery};
 use crate::results::{ContractResult, Empty, SystemResult};
-use crate::serde::{from_slice, to_binary};
+use crate::serde::{from_json_slice, to_json_binary};
 use crate::storage::MemoryStorage;
 use crate::timestamp::Timestamp;
 use crate::traits::{Api, Querier, QuerierResult};
@@ -360,7 +360,7 @@ pub fn mock_ibc_packet_recv(
 ) -> StdResult<IbcPacketReceiveMsg> {
     Ok(IbcPacketReceiveMsg::new(
         IbcPacket {
-            data: to_binary(data)?,
+            data: to_json_binary(data)?,
             src: IbcEndpoint {
                 port_id: "their-port".to_string(),
                 channel_id: "channel-1234".to_string(),
@@ -387,7 +387,7 @@ pub fn mock_ibc_packet_recv(
 #[cfg(feature = "stargate")]
 fn mock_ibc_packet(my_channel_id: &str, data: &impl Serialize) -> StdResult<IbcPacket> {
     Ok(IbcPacket {
-        data: to_binary(data)?,
+        data: to_json_binary(data)?,
         src: IbcEndpoint {
             port_id: "their-port".to_string(),
             channel_id: my_channel_id.into(),
@@ -561,7 +561,7 @@ impl Default for MockQuerier {
 
 impl<C: CustomQuery + DeserializeOwned> Querier for MockQuerier<C> {
     fn raw_query(&self, bin_request: &[u8]) -> QuerierResult {
-        let request: QueryRequest<C> = match from_slice(bin_request) {
+        let request: QueryRequest<C> = match from_json_slice(bin_request) {
             Ok(v) => v,
             Err(e) => {
                 return SystemResult::Err(SystemError::InvalidRequest {
@@ -717,7 +717,7 @@ impl BankQuerier {
                         denom: denom.to_string(),
                     },
                 };
-                to_binary(&bank_res).into()
+                to_json_binary(&bank_res).into()
             }
             BankQuery::Balance { address, denom } => {
                 // proper error on not found, serialize result on found
@@ -732,14 +732,14 @@ impl BankQuerier {
                         denom: denom.to_string(),
                     },
                 };
-                to_binary(&bank_res).into()
+                to_json_binary(&bank_res).into()
             }
             BankQuery::AllBalances { address } => {
                 // proper error on not found, serialize result on found
                 let bank_res = AllBalanceResponse {
                     amount: self.balances.get(address).cloned().unwrap_or_default(),
                 };
-                to_binary(&bank_res).into()
+                to_json_binary(&bank_res).into()
             }
             #[cfg(feature = "cosmwasm_1_3")]
             BankQuery::DenomMetadata { denom } => {
@@ -749,7 +749,7 @@ impl BankQuerier {
                         let metadata_res = DenomMetadataResponse {
                             metadata: m.clone(),
                         };
-                        to_binary(&metadata_res).into()
+                        to_json_binary(&metadata_res).into()
                     }
                     None => return SystemResult::Err(SystemError::Unknown {}),
                 }
@@ -792,7 +792,7 @@ impl BankQuerier {
                 };
 
                 let metadata_res = AllDenomMetadataResponse { metadata, next_key };
-                to_binary(&metadata_res).into()
+                to_json_binary(&metadata_res).into()
             }
         };
         // system result is always ok in the mock implementation
@@ -837,7 +837,7 @@ impl IbcQuerier {
                     })
                     .cloned();
                 let res = ChannelResponse { channel };
-                to_binary(&res).into()
+                to_json_binary(&res).into()
             }
             IbcQuery::ListChannels { port_id } => {
                 let channels = self
@@ -850,13 +850,13 @@ impl IbcQuerier {
                     .cloned()
                     .collect();
                 let res = ListChannelsResponse { channels };
-                to_binary(&res).into()
+                to_json_binary(&res).into()
             }
             IbcQuery::PortId {} => {
                 let res = PortIdResponse {
                     port_id: self.port_id.clone(),
                 };
-                to_binary(&res).into()
+                to_json_binary(&res).into()
             }
         };
         // system result is always ok in the mock implementation
@@ -888,13 +888,13 @@ impl StakingQuerier {
                 let res = BondedDenomResponse {
                     denom: self.denom.clone(),
                 };
-                to_binary(&res).into()
+                to_json_binary(&res).into()
             }
             StakingQuery::AllValidators {} => {
                 let res = AllValidatorsResponse {
                     validators: self.validators.clone(),
                 };
-                to_binary(&res).into()
+                to_json_binary(&res).into()
             }
             StakingQuery::Validator { address } => {
                 let validator: Option<Validator> = self
@@ -903,7 +903,7 @@ impl StakingQuerier {
                     .find(|validator| validator.address == *address)
                     .cloned();
                 let res = ValidatorResponse { validator };
-                to_binary(&res).into()
+                to_json_binary(&res).into()
             }
             StakingQuery::AllDelegations { delegator } => {
                 let delegations: Vec<_> = self
@@ -914,7 +914,7 @@ impl StakingQuerier {
                     .map(|d| d.into())
                     .collect();
                 let res = AllDelegationsResponse { delegations };
-                to_binary(&res).into()
+                to_json_binary(&res).into()
             }
             StakingQuery::Delegation {
                 delegator,
@@ -927,7 +927,7 @@ impl StakingQuerier {
                 let res = DelegationResponse {
                     delegation: delegation.cloned(),
                 };
-                to_binary(&res).into()
+                to_json_binary(&res).into()
             }
         };
         // system result is always ok in the mock implementation
@@ -1015,7 +1015,7 @@ impl DistributionQuerier {
                             .unwrap_or(delegator_address),
                     ),
                 };
-                to_binary(&res).into()
+                to_json_binary(&res).into()
             }
             #[cfg(feature = "cosmwasm_1_4")]
             DistributionQuery::DelegationRewards {
@@ -1030,7 +1030,7 @@ impl DistributionQuerier {
                         .cloned()
                         .unwrap_or_default(),
                 };
-                to_binary(&res).into()
+                to_json_binary(&res).into()
             }
             #[cfg(feature = "cosmwasm_1_4")]
             DistributionQuery::DelegationTotalRewards { delegator_address } => {
@@ -1056,7 +1056,7 @@ impl DistributionQuerier {
                         .collect(),
                     rewards: validator_rewards,
                 };
-                to_binary(&res).into()
+                to_json_binary(&res).into()
             }
             #[cfg(feature = "cosmwasm_1_4")]
             DistributionQuery::DelegatorValidators { delegator_address } => {
@@ -1067,7 +1067,7 @@ impl DistributionQuerier {
                         .map(|set| set.iter().cloned().collect())
                         .unwrap_or_default(),
                 };
-                to_binary(&res).into()
+                to_json_binary(&res).into()
             }
         };
         // system result is always ok in the mock implementation
@@ -1109,7 +1109,7 @@ mod tests {
     use super::*;
     #[cfg(feature = "cosmwasm_1_3")]
     use crate::DenomUnit;
-    use crate::{coin, coins, from_binary, to_binary, ContractInfoResponse, Response};
+    use crate::{coin, coins, from_json_binary, to_json_binary, ContractInfoResponse, Response};
     #[cfg(feature = "staking")]
     use crate::{Decimal, Delegation};
     use hex_literal::hex;
@@ -1442,7 +1442,7 @@ mod tests {
             })
             .unwrap()
             .unwrap();
-        let res: SupplyResponse = from_binary(&elf).unwrap();
+        let res: SupplyResponse = from_json_binary(&elf).unwrap();
         assert_eq!(res.amount, coin(444, "ELF"));
 
         let fly = bank
@@ -1451,7 +1451,7 @@ mod tests {
             })
             .unwrap()
             .unwrap();
-        let res: SupplyResponse = from_binary(&fly).unwrap();
+        let res: SupplyResponse = from_json_binary(&fly).unwrap();
         assert_eq!(res.amount, coin(777, "FLY"));
 
         // if a denom does not exist, should return zero amount, instead of throwing an error
@@ -1461,7 +1461,7 @@ mod tests {
             })
             .unwrap()
             .unwrap();
-        let res: SupplyResponse = from_binary(&atom).unwrap();
+        let res: SupplyResponse = from_json_binary(&atom).unwrap();
         assert_eq!(res.amount, coin(0, "ATOM"));
     }
 
@@ -1475,7 +1475,7 @@ mod tests {
             .query(&BankQuery::AllBalances { address: addr })
             .unwrap()
             .unwrap();
-        let res: AllBalanceResponse = from_binary(&all).unwrap();
+        let res: AllBalanceResponse = from_json_binary(&all).unwrap();
         assert_eq!(&res.amount, &balance);
     }
 
@@ -1493,7 +1493,7 @@ mod tests {
             })
             .unwrap()
             .unwrap();
-        let res: BalanceResponse = from_binary(&fly).unwrap();
+        let res: BalanceResponse = from_json_binary(&fly).unwrap();
         assert_eq!(res.amount, coin(777, "FLY"));
 
         // missing denom
@@ -1504,7 +1504,7 @@ mod tests {
             })
             .unwrap()
             .unwrap();
-        let res: BalanceResponse = from_binary(&miss).unwrap();
+        let res: BalanceResponse = from_json_binary(&miss).unwrap();
         assert_eq!(res.amount, coin(0, "MISS"));
     }
 
@@ -1521,7 +1521,7 @@ mod tests {
             })
             .unwrap()
             .unwrap();
-        let res: AllBalanceResponse = from_binary(&all).unwrap();
+        let res: AllBalanceResponse = from_json_binary(&all).unwrap();
         assert_eq!(res.amount, vec![]);
 
         // any denom on balances on empty account is empty coin
@@ -1532,7 +1532,7 @@ mod tests {
             })
             .unwrap()
             .unwrap();
-        let res: BalanceResponse = from_binary(&miss).unwrap();
+        let res: BalanceResponse = from_json_binary(&miss).unwrap();
         assert_eq!(res.amount, coin(0, "ELF"));
     }
 
@@ -1570,7 +1570,7 @@ mod tests {
             })
             .unwrap()
             .unwrap();
-        let res: AllDenomMetadataResponse = from_binary(&res).unwrap();
+        let res: AllDenomMetadataResponse = from_json_binary(&res).unwrap();
         assert_eq!(res.metadata.len(), 10);
         assert!(res.next_key.is_some());
 
@@ -1585,7 +1585,7 @@ mod tests {
             })
             .unwrap()
             .unwrap();
-        let res2: AllDenomMetadataResponse = from_binary(&res2).unwrap();
+        let res2: AllDenomMetadataResponse = from_json_binary(&res2).unwrap();
         assert_eq!(res2.metadata.len(), 10);
         assert_ne!(res.metadata.last(), res2.metadata.first());
         // should have no overlap
@@ -1604,7 +1604,7 @@ mod tests {
             })
             .unwrap()
             .unwrap();
-        let res: AllDenomMetadataResponse = from_binary(&res).unwrap();
+        let res: AllDenomMetadataResponse = from_json_binary(&res).unwrap();
         assert_eq!(res.metadata.len(), 100);
         assert!(res.next_key.is_none(), "no more data should be available");
         assert_eq!(res.metadata[0].symbol, "FOO99", "should have been reversed");
@@ -1619,7 +1619,7 @@ mod tests {
             })
             .unwrap()
             .unwrap();
-        let more_res: AllDenomMetadataResponse = from_binary(&more_res).unwrap();
+        let more_res: AllDenomMetadataResponse = from_json_binary(&more_res).unwrap();
         assert_eq!(
             more_res.metadata, res.metadata,
             "should be same as previous query"
@@ -1637,7 +1637,7 @@ mod tests {
         };
 
         let res = distribution.query(&query).unwrap().unwrap();
-        let res: DelegatorWithdrawAddressResponse = from_binary(&res).unwrap();
+        let res: DelegatorWithdrawAddressResponse = from_json_binary(&res).unwrap();
         assert_eq!(res.withdraw_address, "withdraw0");
 
         let query = DistributionQuery::DelegatorWithdrawAddress {
@@ -1645,7 +1645,7 @@ mod tests {
         };
 
         let res = distribution.query(&query).unwrap().unwrap();
-        let res: DelegatorWithdrawAddressResponse = from_binary(&res).unwrap();
+        let res: DelegatorWithdrawAddressResponse = from_json_binary(&res).unwrap();
         assert_eq!(res.withdraw_address, "addr1");
     }
 
@@ -1660,7 +1660,7 @@ mod tests {
         };
 
         let res = distribution.query(&query).unwrap().unwrap();
-        let res: DelegatorValidatorsResponse = from_binary(&res).unwrap();
+        let res: DelegatorValidatorsResponse = from_json_binary(&res).unwrap();
         assert_eq!(res.validators, ["valoper1", "valoper2"]);
 
         let query = DistributionQuery::DelegatorValidators {
@@ -1668,7 +1668,7 @@ mod tests {
         };
 
         let res = distribution.query(&query).unwrap().unwrap();
-        let res: DelegatorValidatorsResponse = from_binary(&res).unwrap();
+        let res: DelegatorValidatorsResponse = from_json_binary(&res).unwrap();
         assert_eq!(res.validators, ([] as [String; 0]));
     }
 
@@ -1690,7 +1690,7 @@ mod tests {
             validator_address: "valoper0".to_string(),
         };
         let res = distribution.query(&query).unwrap().unwrap();
-        let res: DelegationRewardsResponse = from_binary(&res).unwrap();
+        let res: DelegationRewardsResponse = from_json_binary(&res).unwrap();
         assert_eq!(res.rewards, valoper0_rewards);
 
         // delegator does not exist
@@ -1699,7 +1699,7 @@ mod tests {
             validator_address: "valoper0".to_string(),
         };
         let res = distribution.query(&query).unwrap().unwrap();
-        let res: DelegationRewardsResponse = from_binary(&res).unwrap();
+        let res: DelegationRewardsResponse = from_json_binary(&res).unwrap();
         assert_eq!(res.rewards.len(), 0);
 
         // validator does not exist
@@ -1708,7 +1708,7 @@ mod tests {
             validator_address: "valopernonexistent".to_string(),
         };
         let res = distribution.query(&query).unwrap().unwrap();
-        let res: DelegationRewardsResponse = from_binary(&res).unwrap();
+        let res: DelegationRewardsResponse = from_json_binary(&res).unwrap();
         assert_eq!(res.rewards.len(), 0);
 
         // add one more validator
@@ -1720,7 +1720,7 @@ mod tests {
             delegator_address: "addr0".to_string(),
         };
         let res = distribution.query(&query).unwrap().unwrap();
-        let res: DelegationTotalRewardsResponse = from_binary(&res).unwrap();
+        let res: DelegationTotalRewardsResponse = from_json_binary(&res).unwrap();
         assert_eq!(
             res.rewards,
             vec![
@@ -1761,7 +1761,7 @@ mod tests {
             port_id: Some("my_port".to_string()),
         };
         let raw = ibc.query(query).unwrap().unwrap();
-        let chan: ChannelResponse = from_binary(&raw).unwrap();
+        let chan: ChannelResponse = from_json_binary(&raw).unwrap();
         assert_eq!(chan.channel, Some(chan1));
     }
 
@@ -1791,7 +1791,7 @@ mod tests {
             port_id: Some("myport".to_string()),
         };
         let raw = ibc.query(query).unwrap().unwrap();
-        let chan: ChannelResponse = from_binary(&raw).unwrap();
+        let chan: ChannelResponse = from_json_binary(&raw).unwrap();
         assert_eq!(chan.channel, Some(chan1));
     }
 
@@ -1809,7 +1809,7 @@ mod tests {
             port_id: None,
         };
         let raw = ibc.query(query).unwrap().unwrap();
-        let chan: ChannelResponse = from_binary(&raw).unwrap();
+        let chan: ChannelResponse = from_json_binary(&raw).unwrap();
         assert_eq!(chan.channel, None);
     }
 
@@ -1826,7 +1826,7 @@ mod tests {
             port_id: Some("my_port".to_string()),
         };
         let raw = ibc.query(query).unwrap().unwrap();
-        let res: ListChannelsResponse = from_binary(&raw).unwrap();
+        let res: ListChannelsResponse = from_json_binary(&raw).unwrap();
         assert_eq!(res.channels, vec![chan1, chan2]);
     }
 
@@ -1841,7 +1841,7 @@ mod tests {
         // query channels matching "myport" (should be none)
         let query = &IbcQuery::ListChannels { port_id: None };
         let raw = ibc.query(query).unwrap().unwrap();
-        let res: ListChannelsResponse = from_binary(&raw).unwrap();
+        let res: ListChannelsResponse = from_json_binary(&raw).unwrap();
         assert_eq!(res.channels, vec![]);
     }
 
@@ -1855,7 +1855,7 @@ mod tests {
         // query channels matching "myport" (should be none)
         let query = &IbcQuery::PortId {};
         let raw = ibc.query(query).unwrap().unwrap();
-        let res: PortIdResponse = from_binary(&raw).unwrap();
+        let res: PortIdResponse = from_json_binary(&raw).unwrap();
         assert_eq!(res.port_id, "myport");
     }
 
@@ -1882,7 +1882,7 @@ mod tests {
             .query(&StakingQuery::AllValidators {})
             .unwrap()
             .unwrap();
-        let vals: AllValidatorsResponse = from_binary(&raw).unwrap();
+        let vals: AllValidatorsResponse = from_json_binary(&raw).unwrap();
         assert_eq!(vals.validators, vec![val1, val2]);
     }
 
@@ -1913,7 +1913,7 @@ mod tests {
             .query(&StakingQuery::Validator { address: address1 })
             .unwrap()
             .unwrap();
-        let res: ValidatorResponse = from_binary(&raw).unwrap();
+        let res: ValidatorResponse = from_json_binary(&raw).unwrap();
         assert_eq!(res.validator, Some(val1));
 
         // query 2
@@ -1921,7 +1921,7 @@ mod tests {
             .query(&StakingQuery::Validator { address: address2 })
             .unwrap()
             .unwrap();
-        let res: ValidatorResponse = from_binary(&raw).unwrap();
+        let res: ValidatorResponse = from_json_binary(&raw).unwrap();
         assert_eq!(res.validator, Some(val2));
 
         // query non-existent
@@ -1931,7 +1931,7 @@ mod tests {
             })
             .unwrap()
             .unwrap();
-        let res: ValidatorResponse = from_binary(&raw).unwrap();
+        let res: ValidatorResponse = from_json_binary(&raw).unwrap();
         assert_eq!(res.validator, None);
     }
 
@@ -1947,7 +1947,7 @@ mod tests {
             })
             .unwrap()
             .unwrap();
-        let dels: AllDelegationsResponse = from_binary(&raw).unwrap();
+        let dels: AllDelegationsResponse = from_json_binary(&raw).unwrap();
         dels.delegations
     }
 
@@ -1965,7 +1965,7 @@ mod tests {
             })
             .unwrap()
             .unwrap();
-        let dels: DelegationResponse = from_binary(&raw).unwrap();
+        let dels: DelegationResponse = from_json_binary(&raw).unwrap();
         dels.delegation
     }
 
@@ -2130,14 +2130,14 @@ mod tests {
                     if *contract_addr == constract1 {
                         #[derive(Deserialize)]
                         struct MyMsg {}
-                        let _msg: MyMsg = match from_binary(msg) {
+                        let _msg: MyMsg = match from_json_binary(msg) {
                             Ok(msg) => msg,
                             Err(err) => {
                                 return SystemResult::Ok(ContractResult::Err(err.to_string()))
                             }
                         };
                         let response: Response = Response::new().set_data(b"good");
-                        SystemResult::Ok(ContractResult::Ok(to_binary(&response).unwrap()))
+                        SystemResult::Ok(ContractResult::Ok(to_json_binary(&response).unwrap()))
                     } else {
                         SystemResult::Err(SystemError::NoSuchContract {
                             addr: contract_addr.clone(),
@@ -2153,7 +2153,7 @@ mod tests {
                             pinned: false,
                             ibc_port: None,
                         };
-                        SystemResult::Ok(ContractResult::Ok(to_binary(&response).unwrap()))
+                        SystemResult::Ok(ContractResult::Ok(to_json_binary(&response).unwrap()))
                     } else {
                         SystemResult::Err(SystemError::NoSuchContract {
                             addr: contract_addr.clone(),
@@ -2173,7 +2173,7 @@ mod tests {
                             )
                             .unwrap(),
                         };
-                        SystemResult::Ok(ContractResult::Ok(to_binary(&response).unwrap()))
+                        SystemResult::Ok(ContractResult::Ok(to_json_binary(&response).unwrap()))
                     } else {
                         SystemResult::Err(SystemError::NoSuchCode { code_id })
                     }

--- a/packages/storage/src/bucket.rs
+++ b/packages/storage/src/bucket.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 
 use cosmwasm_std::{
     storage_keys::{to_length_prefixed, to_length_prefixed_nested},
-    to_vec, StdError, StdResult, Storage,
+    to_json_vec, StdError, StdResult, Storage,
 };
 #[cfg(feature = "iterator")]
 use cosmwasm_std::{Order, Record};
@@ -72,7 +72,7 @@ where
 
     /// save will serialize the model and store, returns an error on serialization issues
     pub fn save(&mut self, key: &[u8], data: &T) -> StdResult<()> {
-        set_with_prefix(self.storage, &self.prefix, key, &to_vec(data)?);
+        set_with_prefix(self.storage, &self.prefix, key, &to_json_vec(data)?);
         Ok(())
     }
 
@@ -399,7 +399,7 @@ mod tests {
                     return Err(StdError::generic_err("Current age is negative").into());
                 }
                 if data.age > 10 {
-                    to_vec(&data)?; // Uses From to convert StdError to MyError
+                    to_json_vec(&data)?; // Uses From to convert StdError to MyError
                 }
                 data.age += 1;
                 Ok(data)

--- a/packages/storage/src/singleton.rs
+++ b/packages/storage/src/singleton.rs
@@ -1,7 +1,7 @@
 use serde::{de::DeserializeOwned, ser::Serialize};
 use std::marker::PhantomData;
 
-use cosmwasm_std::{storage_keys::to_length_prefixed, to_vec, StdError, StdResult, Storage};
+use cosmwasm_std::{storage_keys::to_length_prefixed, to_json_vec, StdError, StdResult, Storage};
 
 use crate::type_helpers::{may_deserialize, must_deserialize};
 
@@ -58,7 +58,7 @@ where
 
     /// save will serialize the model and store, returns an error on serialization issues
     pub fn save(&mut self, data: &T) -> StdResult<()> {
-        self.storage.set(&self.key, &to_vec(data)?);
+        self.storage.set(&self.key, &to_json_vec(data)?);
         Ok(())
     }
 
@@ -307,7 +307,7 @@ mod tests {
                 return Err(StdError::generic_err("broken stuff").into()); // Uses Into to convert StdError to MyError
             }
             if c.max_tokens > 10 {
-                to_vec(&c)?; // Uses From to convert StdError to MyError
+                to_json_vec(&c)?; // Uses From to convert StdError to MyError
             }
             c.max_tokens += 20;
             Ok(c)

--- a/packages/storage/src/type_helpers.rs
+++ b/packages/storage/src/type_helpers.rs
@@ -36,7 +36,7 @@ pub(crate) fn deserialize_kv<T: DeserializeOwned>(kv: Record<Vec<u8>>) -> StdRes
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cosmwasm_std::{to_vec, StdError};
+    use cosmwasm_std::{to_json_vec, StdError};
     use serde::{Deserialize, Serialize};
 
     #[derive(Serialize, Deserialize, PartialEq, Debug)]
@@ -51,7 +51,7 @@ mod tests {
             name: "Maria".to_string(),
             age: 42,
         };
-        let value = to_vec(&person).unwrap();
+        let value = to_json_vec(&person).unwrap();
 
         let may_parse: Option<Person> = may_deserialize(&Some(value)).unwrap();
         assert_eq!(may_parse, Some(person));
@@ -69,7 +69,7 @@ mod tests {
             name: "Maria".to_string(),
             age: 42,
         };
-        let value = to_vec(&person).unwrap();
+        let value = to_json_vec(&person).unwrap();
         let loaded = Some(value);
 
         let parsed: Person = must_deserialize(&loaded).unwrap();

--- a/packages/vm/src/environment.rs
+++ b/packages/vm/src/environment.rs
@@ -454,7 +454,7 @@ mod tests {
     use crate::testing::{MockApi, MockQuerier, MockStorage};
     use crate::wasm_backend::{compile, make_compiling_engine};
     use cosmwasm_std::{
-        coins, from_binary, to_vec, AllBalanceResponse, BankQuery, Empty, QueryRequest,
+        coins, from_json_binary, to_json_vec, AllBalanceResponse, BankQuery, Empty, QueryRequest,
     };
     use wasmer::{imports, Function, Instance as WasmerInstance, Store};
 
@@ -893,13 +893,13 @@ mod tests {
                     address: INIT_ADDR.to_string(),
                 });
                 let (result, _gas_info) =
-                    querier.query_raw(&to_vec(&req).unwrap(), DEFAULT_QUERY_GAS_LIMIT);
+                    querier.query_raw(&to_json_vec(&req).unwrap(), DEFAULT_QUERY_GAS_LIMIT);
                 Ok(result.unwrap())
             })
             .unwrap()
             .unwrap()
             .unwrap();
-        let balance: AllBalanceResponse = from_binary(&res).unwrap();
+        let balance: AllBalanceResponse = from_json_binary(&res).unwrap();
 
         assert_eq!(balance.amount, coins(INIT_AMOUNT, INIT_DENOM));
     }

--- a/packages/vm/src/imports.rs
+++ b/packages/vm/src/imports.rs
@@ -601,7 +601,7 @@ fn to_low_half(data: u32) -> u64 {
 mod tests {
     use super::*;
     use cosmwasm_std::{
-        coins, from_binary, AllBalanceResponse, BankQuery, Binary, Empty, QueryRequest,
+        coins, from_json_binary, AllBalanceResponse, BankQuery, Binary, Empty, QueryRequest,
         SystemError, SystemResult, WasmQuery,
     };
     use hex_literal::hex;
@@ -1925,7 +1925,7 @@ mod tests {
         let request: QueryRequest<Empty> = QueryRequest::Bank(BankQuery::AllBalances {
             address: INIT_ADDR.to_string(),
         });
-        let request_data = cosmwasm_std::to_vec(&request).unwrap();
+        let request_data = cosmwasm_std::to_json_vec(&request).unwrap();
         let request_ptr = write_data(&mut fe_mut, &request_data);
 
         leave_default_data(&mut fe_mut);
@@ -1934,10 +1934,10 @@ mod tests {
         let response = force_read(&mut fe_mut, response_ptr);
 
         let query_result: cosmwasm_std::QuerierResult =
-            cosmwasm_std::from_slice(&response).unwrap();
+            cosmwasm_std::from_json_slice(&response).unwrap();
         let query_result_inner = query_result.unwrap();
         let query_result_inner_inner = query_result_inner.unwrap();
-        let parsed_again: AllBalanceResponse = from_binary(&query_result_inner_inner).unwrap();
+        let parsed_again: AllBalanceResponse = from_json_binary(&query_result_inner_inner).unwrap();
         assert_eq!(parsed_again.amount, coins(INIT_AMOUNT, INIT_DENOM));
     }
 
@@ -1956,7 +1956,7 @@ mod tests {
         let response = force_read(&mut fe_mut, response_ptr);
 
         let query_result: cosmwasm_std::QuerierResult =
-            cosmwasm_std::from_slice(&response).unwrap();
+            cosmwasm_std::from_json_slice(&response).unwrap();
         match query_result {
             SystemResult::Ok(_) => panic!("This must not succeed"),
             SystemResult::Err(SystemError::InvalidRequest { request: err, .. }) => {
@@ -1976,7 +1976,7 @@ mod tests {
             contract_addr: String::from("non-existent"),
             msg: Binary::from(b"{}" as &[u8]),
         });
-        let request_data = cosmwasm_std::to_vec(&request).unwrap();
+        let request_data = cosmwasm_std::to_json_vec(&request).unwrap();
         let request_ptr = write_data(&mut fe_mut, &request_data);
 
         leave_default_data(&mut fe_mut);
@@ -1985,7 +1985,7 @@ mod tests {
         let response = force_read(&mut fe_mut, response_ptr);
 
         let query_result: cosmwasm_std::QuerierResult =
-            cosmwasm_std::from_slice(&response).unwrap();
+            cosmwasm_std::from_json_slice(&response).unwrap();
         match query_result {
             SystemResult::Ok(_) => panic!("This must not succeed"),
             SystemResult::Err(SystemError::NoSuchContract { addr }) => {

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -515,7 +515,7 @@ mod tests {
         mock_instance_with_options, MockInstanceOptions,
     };
     use cosmwasm_std::{
-        coin, coins, from_binary, AllBalanceResponse, BalanceResponse, BankQuery, Empty,
+        coin, coins, from_json_binary, AllBalanceResponse, BalanceResponse, BankQuery, Empty,
         QueryRequest,
     };
     use wasmer::{FunctionEnv, FunctionEnvMut};
@@ -971,7 +971,7 @@ mod tests {
                     .unwrap()
                     .unwrap()
                     .unwrap();
-                let BalanceResponse { amount } = from_binary(&response).unwrap();
+                let BalanceResponse { amount } = from_json_binary(&response).unwrap();
                 assert_eq!(amount.amount.u128(), 8000);
                 assert_eq!(amount.denom, "silver");
                 Ok(())
@@ -992,7 +992,7 @@ mod tests {
                     .unwrap()
                     .unwrap()
                     .unwrap();
-                let AllBalanceResponse { amount } = from_binary(&response).unwrap();
+                let AllBalanceResponse { amount } = from_json_binary(&response).unwrap();
                 assert_eq!(amount.len(), 2);
                 assert_eq!(amount[0].amount.u128(), 10000);
                 assert_eq!(amount[0].denom, "gold");
@@ -1027,7 +1027,7 @@ mod tests {
                     .unwrap()
                     .unwrap()
                     .unwrap();
-                let BalanceResponse { amount } = from_binary(&response).unwrap();
+                let BalanceResponse { amount } = from_json_binary(&response).unwrap();
                 assert_eq!(amount.amount.u128(), 500);
                 Ok(())
             })
@@ -1056,7 +1056,7 @@ mod tests {
                     .unwrap()
                     .unwrap()
                     .unwrap();
-                let BalanceResponse { amount } = from_binary(&response).unwrap();
+                let BalanceResponse { amount } = from_json_binary(&response).unwrap();
                 assert_eq!(amount.amount.u128(), 8000);
                 Ok(())
             })

--- a/packages/vm/src/testing/querier.rs
+++ b/packages/vm/src/testing/querier.rs
@@ -2,7 +2,7 @@ use serde::de::DeserializeOwned;
 
 use cosmwasm_std::testing::{MockQuerier as StdMockQuerier, MockQuerierCustomHandlerResult};
 use cosmwasm_std::{
-    to_binary, to_vec, Binary, Coin, ContractResult, CustomQuery, Empty, Querier as _,
+    to_json_binary, to_json_vec, Binary, Coin, ContractResult, CustomQuery, Empty, Querier as _,
     QueryRequest, SystemError, SystemResult,
 };
 
@@ -72,7 +72,7 @@ impl<C: CustomQuery + DeserializeOwned> Querier for MockQuerier<C> {
             GAS_COST_QUERY_FLAT
                 + (GAS_COST_QUERY_REQUEST_MULTIPLIER * (bin_request.len() as u64))
                 + (GAS_COST_QUERY_RESPONSE_MULTIPLIER
-                    * (to_binary(&response).unwrap().len() as u64)),
+                    * (to_json_binary(&response).unwrap().len() as u64)),
         );
 
         // In a production implementation, this should stop the query execution in the middle of the computation.
@@ -93,7 +93,7 @@ impl MockQuerier {
         gas_limit: u64,
     ) -> BackendResult<SystemResult<ContractResult<Binary>>> {
         // encode the request, then call raw_query
-        let request_binary = match to_vec(request) {
+        let request_binary = match to_json_vec(request) {
             Ok(raw) => raw,
             Err(err) => {
                 let gas_info = GasInfo::with_externally_used(err.to_string().len() as u64);
@@ -113,7 +113,9 @@ impl MockQuerier {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cosmwasm_std::{coin, from_binary, AllBalanceResponse, BalanceResponse, BankQuery, Empty};
+    use cosmwasm_std::{
+        coin, from_json_binary, AllBalanceResponse, BalanceResponse, BankQuery, Empty,
+    };
 
     const DEFAULT_QUERY_GAS_LIMIT: u64 = 300_000;
 
@@ -147,7 +149,7 @@ mod tests {
             .unwrap()
             .unwrap()
             .unwrap();
-        let res: AllBalanceResponse = from_binary(&all).unwrap();
+        let res: AllBalanceResponse = from_json_binary(&all).unwrap();
         assert_eq!(&res.amount, &balance);
     }
 
@@ -171,7 +173,7 @@ mod tests {
             .unwrap()
             .unwrap()
             .unwrap();
-        let res: BalanceResponse = from_binary(&fly).unwrap();
+        let res: BalanceResponse = from_json_binary(&fly).unwrap();
         assert_eq!(res.amount, coin(777, "FLY"));
 
         // missing denom
@@ -188,7 +190,7 @@ mod tests {
             .unwrap()
             .unwrap()
             .unwrap();
-        let res: BalanceResponse = from_binary(&miss).unwrap();
+        let res: BalanceResponse = from_json_binary(&miss).unwrap();
         assert_eq!(res.amount, coin(0, "MISS"));
     }
 
@@ -211,7 +213,7 @@ mod tests {
             .unwrap()
             .unwrap()
             .unwrap();
-        let res: AllBalanceResponse = from_binary(&all).unwrap();
+        let res: AllBalanceResponse = from_json_binary(&all).unwrap();
         assert_eq!(res.amount, vec![]);
 
         // any denom on balances on empty account is empty coin
@@ -228,7 +230,7 @@ mod tests {
             .unwrap()
             .unwrap()
             .unwrap();
-        let res: BalanceResponse = from_binary(&miss).unwrap();
+        let res: BalanceResponse = from_json_binary(&miss).unwrap();
         assert_eq!(res.amount, coin(0, "ELF"));
     }
 }


### PR DESCRIPTION
closes #1885