### PR TITLE
Improve write limit error message

### DIFF
--- a/packages/vm/src/errors/vm_error.rs
+++ b/packages/vm/src/errors/vm_error.rs
@@ -29,6 +29,14 @@ pub enum VmError {
         #[cfg(feature = "backtraces")]
         backtrace: Backtrace,
     },
+    #[error("{kind} too big. Tried to write {length} bytes to storage, limit is {max_length}")]
+    WriteTooBig {
+        kind: &'static str,
+        length: usize,
+        max_length: usize,
+        #[cfg(feature = "backtraces")]
+        backtrace: Backtrace,
+    },
     #[error("Error in guest/host communication: {source}")]
     CommunicationErr {
         #[from]

--- a/packages/vm/src/errors/vm_error.rs
+++ b/packages/vm/src/errors/vm_error.rs
@@ -29,14 +29,6 @@ pub enum VmError {
         #[cfg(feature = "backtraces")]
         backtrace: Backtrace,
     },
-    #[error("{kind} too big. Tried to write {length} bytes to storage, limit is {max_length}")]
-    WriteTooBig {
-        kind: &'static str,
-        length: usize,
-        max_length: usize,
-        #[cfg(feature = "backtraces")]
-        backtrace: Backtrace,
-    },
     #[error("Error in guest/host communication: {source}")]
     CommunicationErr {
         #[from]

--- a/packages/vm/src/imports.rs
+++ b/packages/vm/src/imports.rs
@@ -106,10 +106,10 @@ pub fn do_db_write<A: BackendApi + 'static, S: Storage + 'static, Q: Querier + '
             backtrace,
         } = e
         {
-            VmError::WriteTooBig {
-                kind,
-                length,
-                max_length,
+            VmError::GenericErr {
+                msg: format!(
+                "{kind} too big. Tried to write {length} bytes to storage, limit is {max_length}"
+            ),
                 #[cfg(feature = "backtraces")]
                 backtrace,
             }
@@ -906,15 +906,7 @@ mod tests {
         leave_default_data(&mut fe_mut);
 
         let result = do_db_write(fe_mut, key_ptr, value_ptr);
-        assert!(matches!(
-            result,
-            Err(VmError::WriteTooBig {
-                kind: "Key",
-                length: KEY_SIZE,
-                max_length: MAX_LENGTH_DB_KEY,
-                ..
-            })
-        ));
+        assert_eq!(result.unwrap_err().to_string(), format!("Generic error: Key too big. Tried to write {KEY_SIZE} bytes to storage, limit is {MAX_LENGTH_DB_KEY}"));
     }
 
     #[test]
@@ -930,15 +922,7 @@ mod tests {
         leave_default_data(&mut fe_mut);
 
         let result = do_db_write(fe_mut, key_ptr, value_ptr);
-        assert!(matches!(
-            result,
-            Err(VmError::WriteTooBig {
-                kind: "Value",
-                length: VAL_SIZE,
-                max_length: MAX_LENGTH_DB_VALUE,
-                ..
-            })
-        ));
+        assert_eq!(result.unwrap_err().to_string(), format!("Generic error: Value too big. Tried to write {VAL_SIZE} bytes to storage, limit is {MAX_LENGTH_DB_VALUE}"));
     }
 
     #[test]

--- a/packages/vm/src/imports.rs
+++ b/packages/vm/src/imports.rs
@@ -106,7 +106,7 @@ pub fn do_db_write<A: BackendApi + 'static, S: Storage + 'static, Q: Querier + '
         } = e
         {
             VmError::generic_err(format!(
-                "{kind} too big. Tried to write {length} bytes to storage, limit is {max_length}"
+                "{kind} too big. Tried to write {length} bytes to storage, limit is {max_length}."
             ))
         } else {
             e
@@ -901,7 +901,7 @@ mod tests {
         leave_default_data(&mut fe_mut);
 
         let result = do_db_write(fe_mut, key_ptr, value_ptr);
-        assert_eq!(result.unwrap_err().to_string(), format!("Generic error: Key too big. Tried to write {KEY_SIZE} bytes to storage, limit is {MAX_LENGTH_DB_KEY}"));
+        assert_eq!(result.unwrap_err().to_string(), format!("Generic error: Key too big. Tried to write {KEY_SIZE} bytes to storage, limit is {MAX_LENGTH_DB_KEY}."));
     }
 
     #[test]
@@ -917,7 +917,7 @@ mod tests {
         leave_default_data(&mut fe_mut);
 
         let result = do_db_write(fe_mut, key_ptr, value_ptr);
-        assert_eq!(result.unwrap_err().to_string(), format!("Generic error: Value too big. Tried to write {VAL_SIZE} bytes to storage, limit is {MAX_LENGTH_DB_VALUE}"));
+        assert_eq!(result.unwrap_err().to_string(), format!("Generic error: Value too big. Tried to write {VAL_SIZE} bytes to storage, limit is {MAX_LENGTH_DB_VALUE}."));
     }
 
     #[test]

--- a/packages/vm/src/imports.rs
+++ b/packages/vm/src/imports.rs
@@ -102,17 +102,12 @@ pub fn do_db_write<A: BackendApi + 'static, S: Storage + 'static, Q: Querier + '
     fn convert_error(e: VmError, kind: &'static str) -> VmError {
         if let VmError::CommunicationErr {
             source: CommunicationError::RegionLengthTooBig { length, max_length },
-            #[cfg(feature = "backtraces")]
-            backtrace,
+            ..
         } = e
         {
-            VmError::GenericErr {
-                msg: format!(
+            VmError::generic_err(format!(
                 "{kind} too big. Tried to write {length} bytes to storage, limit is {max_length}"
-            ),
-                #[cfg(feature = "backtraces")]
-                backtrace,
-            }
+            ))
         } else {
             e
         }


### PR DESCRIPTION
closes #1853 

Not sure if this is the cleanest solution, but changing the fields of `RegionLengthTooBig` would be breaking,
so this is the only way I could come up with.