### PR TITLE
[2.0] Remove mixed uint decimal arithmetic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,12 @@ and this project adheres to
   constructor, remove `SubMsgExecutionResponse` (Use `SubMsgResponse` instead)
   and remove `PartialEq<&str> for Addr` (validate the address and use
   `PartialEq<Addr> for Addr` instead). ([#1879])
+- cosmwasm-std: Remove `Mul<Decimal> for Uint128` and
+  `Mul<Decimal256> for Uint256`. Use `Uint{128,256}::mul_floor` instead.
+  ([#1890])
 
 [#1879]: https://github.com/CosmWasm/cosmwasm/pull/1879
+[#1890]: https://github.com/CosmWasm/cosmwasm/pull/1890
 
 ## [1.5.0-rc.0]
 

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -54,6 +54,14 @@ major releases of `cosmwasm`. Note that you can also view the
 
   But keep in mind that this is case sensitive (while addresses are not).
 
+- Replace all uses of `Mul<Decimal> for Uint128` and
+  `Mul<Decimal256> for Uint256` with `Uint{128,256}::mul_floor`:
+
+  ```diff
+  -Uint128::new(123456) * Decimal::percent(1);
+  +Uint128::new(123456).mul_floor(Decimal::percent(1));
+  ```
+
 ## 1.4.x -> 1.5.0
 
 - Update `cosmwasm-*` dependencies in Cargo.toml (skip the ones you don't use):

--- a/contracts/staking/src/contract.rs
+++ b/contracts/staking/src/contract.rs
@@ -154,7 +154,7 @@ pub fn bond(deps: DepsMut, env: Env, info: MessageInfo) -> StdResult<Response> {
     // TODO: this is just temporary check - we should use dynamic query or have a way to recover
     assert_bonds(&supply, bonded)?;
     let to_mint = if supply.issued.is_zero() || bonded.is_zero() {
-        FALLBACK_RATIO * payment.amount
+        payment.amount.mul_floor(FALLBACK_RATIO)
     } else {
         payment.amount.multiply_ratio(supply.issued, bonded)
     };
@@ -193,7 +193,7 @@ pub fn unbond(deps: DepsMut, env: Env, info: MessageInfo, amount: Uint128) -> St
     let owner_raw = deps.api.addr_canonicalize(invest.owner.as_str())?;
 
     // calculate tax and remainer to unbond
-    let tax = amount * invest.exit_tax;
+    let tax = amount.mul_floor(invest.exit_tax);
 
     // deduct all from the account
     let balance = may_load_map(deps.storage, PREFIX_BALANCE, &sender_raw)?.unwrap_or_default();


### PR DESCRIPTION
closes #1485

This removes the mixed-type `Mul` impls.

I noticed we currently do not have the `impl_mul_fraction` for signed integers. Is that something we want to implement?