### PR TITLE
Floaty contract cleanup

### DIFF
--- a/contracts/floaty/src/contract.rs
+++ b/contracts/floaty/src/contract.rs
@@ -33,6 +33,7 @@ pub fn query(_deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<QueryResponse> 
     }
 }
 
+#[cfg_attr(not(target_arch = "wasm32"), allow(unused_variables))]
 fn query_run(instruction: &str, args: Vec<Value>) -> StdResult<Value> {
     #[cfg(not(target_arch = "wasm32"))]
     panic!();

--- a/contracts/floaty/src/instructions.rs
+++ b/contracts/floaty/src/instructions.rs
@@ -4,6 +4,7 @@ use rand_chacha::rand_core::RngCore;
 use crate::floats::{random_f32, random_f64};
 
 /// Not intended for direct usage
+#[cfg_attr(not(target_arch = "wasm32"), allow(unused_macros))]
 macro_rules! run_instr {
     ($instr:expr, $input:expr, $input_ty:ty, $return_ty:ty) => {{
         let input: $input_ty = $input;
@@ -23,9 +24,11 @@ macro_rules! run_instr {
         ret
     }};
 }
+#[cfg_attr(not(target_arch = "wasm32"), allow(unused_imports))]
 pub(crate) use run_instr;
 
 /// Helper to run a single WebAssembly instruction in a type-safe way
+#[cfg_attr(not(target_arch = "wasm32"), allow(unused_macros))]
 macro_rules! run {
     ("f32.eq", $input1:expr, $input2:expr) => {
         $crate::instructions::run_instr!("f32.eq", $input1, f32, $input2, f32, u32)
@@ -244,6 +247,7 @@ macro_rules! run {
         $crate::instructions::run_instr!("i64.trunc_sat_f64_u", $input, f64, u64)
     };
 }
+#[cfg_attr(not(target_arch = "wasm32"), allow(unused_imports))]
 pub(crate) use run;
 
 #[cw_serde]
@@ -471,7 +475,7 @@ pub fn random_args_for(instr: &str, rng: &mut impl RngCore) -> Vec<Value> {
     }
 }
 
-pub const FLOAT_INSTRUCTIONS: [&'static str; 70] = [
+pub const FLOAT_INSTRUCTIONS: [&str; 70] = [
     "f32.eq",
     "f32.ne",
     "f32.lt",

--- a/devtools/check_contracts_full.sh
+++ b/devtools/check_contracts_full.sh
@@ -2,6 +2,7 @@
 set -o errexit -o nounset -o pipefail
 command -v shellcheck >/dev/null && shellcheck "$0"
 
+GLOBIGNORE="contracts/floaty/"
 for contract_dir in contracts/*/; do
   (
     cd "$contract_dir"

--- a/devtools/check_contracts_medium.sh
+++ b/devtools/check_contracts_medium.sh
@@ -2,6 +2,7 @@
 set -o errexit -o nounset -o pipefail
 command -v shellcheck >/dev/null && shellcheck "$0"
 
+GLOBIGNORE="contracts/floaty/"
 for contract_dir in contracts/*/; do
   (
     cd "$contract_dir"


### PR DESCRIPTION
Another follow-up to #1864 

I excluded the floaty contract from the devtools scripts, as it needs nightly to compile to wasm.
Also fixed some warnings that occur when not compiled on wasm32.