### PR TITLE
Set the minimum `ecdsa` version to v0.16.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,6 +438,7 @@ version = "1.4.0"
 dependencies = [
  "criterion",
  "digest 0.10.6",
+ "ecdsa",
  "ed25519-zebra",
  "english-numbers",
  "hex",

--- a/contracts/burner/Cargo.lock
+++ b/contracts/burner/Cargo.lock
@@ -196,6 +196,7 @@ name = "cosmwasm-crypto"
 version = "1.4.0"
 dependencies = [
  "digest 0.10.7",
+ "ecdsa",
  "ed25519-zebra",
  "k256",
  "rand_core 0.6.4",

--- a/contracts/crypto-verify/Cargo.lock
+++ b/contracts/crypto-verify/Cargo.lock
@@ -185,6 +185,7 @@ name = "cosmwasm-crypto"
 version = "1.4.0"
 dependencies = [
  "digest 0.10.7",
+ "ecdsa",
  "ed25519-zebra",
  "k256",
  "rand_core 0.6.4",

--- a/contracts/cyberpunk/Cargo.lock
+++ b/contracts/cyberpunk/Cargo.lock
@@ -220,6 +220,7 @@ name = "cosmwasm-crypto"
 version = "1.4.0"
 dependencies = [
  "digest 0.10.7",
+ "ecdsa",
  "ed25519-zebra",
  "k256",
  "rand_core 0.6.4",

--- a/contracts/floaty/Cargo.lock
+++ b/contracts/floaty/Cargo.lock
@@ -185,6 +185,7 @@ name = "cosmwasm-crypto"
 version = "1.4.0"
 dependencies = [
  "digest 0.10.7",
+ "ecdsa",
  "ed25519-zebra",
  "k256",
  "rand_core 0.6.4",

--- a/contracts/hackatom/Cargo.lock
+++ b/contracts/hackatom/Cargo.lock
@@ -185,6 +185,7 @@ name = "cosmwasm-crypto"
 version = "1.4.0"
 dependencies = [
  "digest 0.10.7",
+ "ecdsa",
  "ed25519-zebra",
  "k256",
  "rand_core 0.6.4",

--- a/contracts/ibc-reflect-send/Cargo.lock
+++ b/contracts/ibc-reflect-send/Cargo.lock
@@ -185,6 +185,7 @@ name = "cosmwasm-crypto"
 version = "1.4.0"
 dependencies = [
  "digest 0.10.7",
+ "ecdsa",
  "ed25519-zebra",
  "k256",
  "rand_core 0.6.4",

--- a/contracts/ibc-reflect/Cargo.lock
+++ b/contracts/ibc-reflect/Cargo.lock
@@ -185,6 +185,7 @@ name = "cosmwasm-crypto"
 version = "1.4.0"
 dependencies = [
  "digest 0.10.7",
+ "ecdsa",
  "ed25519-zebra",
  "k256",
  "rand_core 0.6.4",

--- a/contracts/queue/Cargo.lock
+++ b/contracts/queue/Cargo.lock
@@ -185,6 +185,7 @@ name = "cosmwasm-crypto"
 version = "1.4.0"
 dependencies = [
  "digest 0.10.7",
+ "ecdsa",
  "ed25519-zebra",
  "k256",
  "rand_core 0.6.4",

--- a/contracts/reflect/Cargo.lock
+++ b/contracts/reflect/Cargo.lock
@@ -185,6 +185,7 @@ name = "cosmwasm-crypto"
 version = "1.4.0"
 dependencies = [
  "digest 0.10.7",
+ "ecdsa",
  "ed25519-zebra",
  "k256",
  "rand_core 0.6.4",

--- a/contracts/staking/Cargo.lock
+++ b/contracts/staking/Cargo.lock
@@ -185,6 +185,7 @@ name = "cosmwasm-crypto"
 version = "1.4.0"
 dependencies = [
  "digest 0.10.7",
+ "ecdsa",
  "ed25519-zebra",
  "k256",
  "rand_core 0.6.4",

--- a/contracts/virus/Cargo.lock
+++ b/contracts/virus/Cargo.lock
@@ -185,6 +185,7 @@ name = "cosmwasm-crypto"
 version = "1.4.0"
 dependencies = [
  "digest 0.10.7",
+ "ecdsa",
  "ed25519-zebra",
  "k256",
  "rand_core 0.6.4",

--- a/packages/crypto/Cargo.toml
+++ b/packages/crypto/Cargo.toml
@@ -20,6 +20,7 @@ bench = false
 
 [dependencies]
 k256 = { version = "0.13.1", features = ["ecdsa"] }
+ecdsa = "0.16.2"
 ed25519-zebra = "3"
 digest = "0.10"
 rand_core = { version = "0.6", features = ["getrandom"] }

--- a/packages/crypto/Cargo.toml
+++ b/packages/crypto/Cargo.toml
@@ -20,11 +20,12 @@ bench = false
 
 [dependencies]
 k256 = { version = "0.13.1", features = ["ecdsa"] }
-ecdsa = "0.16.2"
 ed25519-zebra = "3"
 digest = "0.10"
 rand_core = { version = "0.6", features = ["getrandom"] }
 thiserror = "1.0.38"
+# Not used directly, but needed to bump transitive dependency, see: https://github.com/CosmWasm/cosmwasm/pull/1899 for details.
+ecdsa = "0.16.2"
 
 [dev-dependencies]
 criterion = "0.4"


### PR DESCRIPTION
`cosmwasm-crypto` crate does not compile with `-Zminimal-versions` option because of improper dependency to `ecdsa` in `k256` crate. To reproduce the problem, run:
```
cargo clean && rm Cargo.lock && cargo +nightly build -Zminimal-versions -p cosmwasm-crypto
```
The result will be:
```
   Compiling elliptic-curve v0.13.0
   Compiling ecdsa v0.16.0 <-----------------------------------------|
   Compiling k256 v0.13.1
   Compiling ed25519-zebra v3.0.0
   Compiling cosmwasm-crypto v1.4.0 (/home/confio/Work/CosmWasm/cosmwasm/packages/crypto)
error[E0599]: no function or associated item named `from_bytes` found for struct `ecdsa::Signature` in the current scope
  --> packages/crypto/src/secp256k1.rs:53:36
   |
53 |     let mut signature = Signature::from_bytes(&signature.into())
   |                                    ^^^^^^^^^^
   |                                    |
   |                                    function or associated item not found in `Signature<Secp256k1>`
   |                                    help: there is a method with a similar name: `to_bytes`

error[E0599]: no function or associated item named `from_bytes` found for struct `ecdsa::Signature` in the current scope
   --> packages/crypto/src/secp256k1.rs:115:32
    |
115 |     let signature = Signature::from_bytes(&signature.into())
    |                                ^^^^^^^^^^
    |                                |
    |                                function or associated item not found in `Signature<Secp256k1>`
    |                                help: there is a method with a similar name: `to_bytes`

For more information about this error, try `rustc --explain E0599`.
error: could not compile `cosmwasm-crypto` (lib) due to 2 previous errors

```
The newest version of `ecdsa` crate is 0.16.8 but is not compatible with version 0.16.0. So specifying `-Zminimal-versions` uses 0.16.0 version and our code does not compile anymore. The minimum `ecdsa` version needed to compile `cosmwams-crypto` is 0.16.2.

This change adds minimum `ecdsa` dependendency set to 0.16.2.
Now the compilation is successful:
```
cargo clean && rm Cargo.lock && cargo +nightly build -Zminimal-versions -p cosmwasm-crypto
```
```
   Compiling serde_derive v1.0.103
   Compiling elliptic-curve v0.13.2
   Compiling ecdsa v0.16.2 <-----------------------------------------|
   Compiling k256 v0.13.1
   Compiling ed25519-zebra v3.0.0
   Compiling cosmwasm-crypto v1.4.0 (/home/confio/Work/CosmWasm/cosmwasm/packages/crypto)
    Finished dev [unoptimized + debuginfo] target(s) in 8.21s
```
I hope that after this change, all our crates that use `cosmwasm-crypto` directly or indirectly via `cosmwasm-std` will not have to fix `ecdsa` dependency in `Cargo.toml`s.