### PR TITLE
Fixed clippy warnings.

### DIFF
--- a/packages/std/src/errors/std_error.rs
+++ b/packages/std/src/errors/std_error.rs
@@ -888,7 +888,7 @@ mod tests {
     }
 
     #[test]
-    fn from_std_string_fromutf8error_works() {
+    fn from_std_string_from_utf8error_works() {
         let error: StdError = String::from_utf8(b"Hello \xF0\x90\x80World".to_vec())
             .unwrap_err()
             .into();

--- a/packages/std/src/math/isqrt.rs
+++ b/packages/std/src/math/isqrt.rs
@@ -59,19 +59,19 @@ mod tests {
     #[test]
     fn isqrt_primitives() {
         // Let's check correctness.
-        assert_eq!(0u8.isqrt(), 0);
-        assert_eq!(1u8.isqrt(), 1);
-        assert_eq!(24u8.isqrt(), 4);
-        assert_eq!(25u8.isqrt(), 5);
-        assert_eq!(26u8.isqrt(), 5);
-        assert_eq!(36u8.isqrt(), 6);
+        assert_eq!(super::Isqrt::isqrt(0u8), 0);
+        assert_eq!(super::Isqrt::isqrt(1u8), 1);
+        assert_eq!(super::Isqrt::isqrt(24u8), 4);
+        assert_eq!(super::Isqrt::isqrt(25u8), 5);
+        assert_eq!(super::Isqrt::isqrt(26u8), 5);
+        assert_eq!(super::Isqrt::isqrt(36u8), 6);
 
         // Let's also check different types.
-        assert_eq!(26u8.isqrt(), 5);
-        assert_eq!(26u16.isqrt(), 5);
-        assert_eq!(26u32.isqrt(), 5);
-        assert_eq!(26u64.isqrt(), 5);
-        assert_eq!(26u128.isqrt(), 5);
+        assert_eq!(super::Isqrt::isqrt(26u8), 5);
+        assert_eq!(super::Isqrt::isqrt(26u16), 5);
+        assert_eq!(super::Isqrt::isqrt(26u32), 5);
+        assert_eq!(super::Isqrt::isqrt(26u64), 5);
+        assert_eq!(super::Isqrt::isqrt(26u128), 5);
     }
 
     #[test]

--- a/packages/vm/src/calls.rs
+++ b/packages/vm/src/calls.rs
@@ -769,7 +769,7 @@ mod tests {
         let contract_result = call_query(&mut instance, &mock_env(), msg)
             .unwrap()
             .unwrap();
-        let instructions: Vec<String> = from_json(&contract_result).unwrap();
+        let instructions: Vec<String> = from_json(contract_result).unwrap();
         // little sanity check
         assert_eq!(instructions.len(), 70);
 


### PR DESCRIPTION
Fixed warnings reported by 1.72.1 nightly, but do not affect any functionality, used in tests.