### PR TITLE
Fix usage of Wasmer Module when recompiling Wasm (regression bug 1.3.x -> 1.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to
 
 ## [Unreleased]
 
+## Fixed
+
+- cosmwasm-vm: Fix a 1.3.x -> 1.4.0 regression bug leading to a _Wasmer runtime
+  error: RuntimeError: out of bounds memory access_ in cases when the Wasm file
+  is re-compiled and used right away. ([#1907])
+
+[#1907]: https://github.com/CosmWasm/cosmwasm/pull/1907
+
 ### Changed
 
 - cosmwasm-check: Use "=" for pinning the versions of cosmwasm-vm and

--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -543,6 +543,30 @@ mod tests {
         }
     }
 
+    /// Takes an instance and executes it
+    fn test_hackatom_instance_execution<A, S, Q>(instance: &mut Instance<A, S, Q>)
+    where
+        A: BackendApi + 'static,
+        S: Storage + 'static,
+        Q: Querier + 'static,
+    {
+        // instantiate
+        let info = mock_info("creator", &coins(1000, "earth"));
+        let msg = br#"{"verifier": "verifies", "beneficiary": "benefits"}"#;
+        let response = call_instantiate::<_, _, _, Empty>(instance, &mock_env(), &info, msg)
+            .unwrap()
+            .unwrap();
+        assert_eq!(response.messages.len(), 0);
+
+        // execute
+        let info = mock_info("verifies", &coins(15, "earth"));
+        let msg = br#"{"release":{}}"#;
+        let response = call_execute::<_, _, _, Empty>(instance, &mock_env(), &info, msg)
+            .unwrap()
+            .unwrap();
+        assert_eq!(response.messages.len(), 1);
+    }
+
     #[test]
     fn new_base_dir_will_be_created() {
         let my_base_dir = TempDir::new()
@@ -1025,22 +1049,7 @@ mod tests {
         assert_eq!(cache.stats().hits_memory_cache, 0);
         assert_eq!(cache.stats().hits_fs_cache, 0);
         assert_eq!(cache.stats().misses, 1);
-
-        // instantiate
-        let info = mock_info("creator", &coins(1000, "earth"));
-        let msg = br#"{"verifier": "verifies", "beneficiary": "benefits"}"#;
-        let response = call_instantiate::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg)
-            .unwrap()
-            .unwrap();
-        assert_eq!(response.messages.len(), 0);
-
-        // execute
-        let info = mock_info("verifies", &coins(15, "earth"));
-        let msg = br#"{"release":{}}"#;
-        let response = call_execute::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg)
-            .unwrap()
-            .unwrap();
-        assert_eq!(response.messages.len(), 1);
+        test_hackatom_instance_execution(&mut instance);
     }
 
     #[test]

--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -1286,13 +1286,14 @@ mod tests {
 
         // check not pinned
         let backend = mock_backend(&[]);
-        let _instance = cache
+        let mut instance = cache
             .get_instance(&checksum, backend, TESTING_OPTIONS)
             .unwrap();
         assert_eq!(cache.stats().hits_pinned_memory_cache, 0);
         assert_eq!(cache.stats().hits_memory_cache, 0);
         assert_eq!(cache.stats().hits_fs_cache, 1);
         assert_eq!(cache.stats().misses, 0);
+        test_hackatom_instance_execution(&mut instance);
 
         // first pin hits file system cache
         cache.pin(&checksum).unwrap();
@@ -1310,26 +1311,28 @@ mod tests {
 
         // check pinned
         let backend = mock_backend(&[]);
-        let _instance = cache
+        let mut instance = cache
             .get_instance(&checksum, backend, TESTING_OPTIONS)
             .unwrap();
         assert_eq!(cache.stats().hits_pinned_memory_cache, 1);
         assert_eq!(cache.stats().hits_memory_cache, 0);
         assert_eq!(cache.stats().hits_fs_cache, 2);
         assert_eq!(cache.stats().misses, 0);
+        test_hackatom_instance_execution(&mut instance);
 
         // unpin
         cache.unpin(&checksum).unwrap();
 
         // verify unpinned
         let backend = mock_backend(&[]);
-        let _instance = cache
+        let mut instance = cache
             .get_instance(&checksum, backend, TESTING_OPTIONS)
             .unwrap();
         assert_eq!(cache.stats().hits_pinned_memory_cache, 1);
         assert_eq!(cache.stats().hits_memory_cache, 1);
         assert_eq!(cache.stats().hits_fs_cache, 2);
         assert_eq!(cache.stats().misses, 0);
+        test_hackatom_instance_execution(&mut instance);
 
         // unpin again has no effect
         cache.unpin(&checksum).unwrap();

--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -1361,13 +1361,14 @@ mod tests {
 
         // After the compilation in pin, the module can be used from pinned memory cache
         let backend = mock_backend(&[]);
-        let _ = cache
+        let mut instance = cache
             .get_instance(&checksum, backend, TESTING_OPTIONS)
             .unwrap();
         assert_eq!(cache.stats().hits_pinned_memory_cache, 1);
         assert_eq!(cache.stats().hits_memory_cache, 0);
         assert_eq!(cache.stats().hits_fs_cache, 0);
         assert_eq!(cache.stats().misses, 1);
+        test_hackatom_instance_execution(&mut instance);
     }
 
     #[test]

--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -854,7 +854,7 @@ mod tests {
             assert_eq!(cache.stats().hits_fs_cache, 1);
             assert_eq!(cache.stats().misses, 0);
 
-            // init
+            // instantiate
             let info = mock_info("creator", &coins(1000, "earth"));
             let msg = br#"{"verifier": "verifies", "beneficiary": "benefits"}"#;
             let res =
@@ -873,7 +873,7 @@ mod tests {
             assert_eq!(cache.stats().hits_fs_cache, 1);
             assert_eq!(cache.stats().misses, 0);
 
-            // init
+            // instantiate
             let info = mock_info("creator", &coins(1000, "earth"));
             let msg = br#"{"verifier": "verifies", "beneficiary": "benefits"}"#;
             let res =
@@ -894,7 +894,7 @@ mod tests {
             assert_eq!(cache.stats().hits_fs_cache, 2);
             assert_eq!(cache.stats().misses, 0);
 
-            // init
+            // instantiate
             let info = mock_info("creator", &coins(1000, "earth"));
             let msg = br#"{"verifier": "verifies", "beneficiary": "benefits"}"#;
             let res =
@@ -919,7 +919,7 @@ mod tests {
             assert_eq!(cache.stats().hits_fs_cache, 1);
             assert_eq!(cache.stats().misses, 0);
 
-            // init
+            // instantiate
             let info = mock_info("creator", &coins(1000, "earth"));
             let msg = br#"{"verifier": "verifies", "beneficiary": "benefits"}"#;
             let response =
@@ -947,7 +947,7 @@ mod tests {
             assert_eq!(cache.stats().hits_fs_cache, 1);
             assert_eq!(cache.stats().misses, 0);
 
-            // init
+            // instantiate
             let info = mock_info("creator", &coins(1000, "earth"));
             let msg = br#"{"verifier": "verifies", "beneficiary": "benefits"}"#;
             let response =
@@ -977,7 +977,7 @@ mod tests {
             assert_eq!(cache.stats().hits_fs_cache, 2);
             assert_eq!(cache.stats().misses, 0);
 
-            // init
+            // instantiate
             let info = mock_info("creator", &coins(1000, "earth"));
             let msg = br#"{"verifier": "verifies", "beneficiary": "benefits"}"#;
             let response =
@@ -1005,7 +1005,7 @@ mod tests {
         let backend1 = mock_backend(&[]);
         let backend2 = mock_backend(&[]);
 
-        // init instance 1
+        // instantiate instance 1
         let mut instance = cache
             .get_instance(&checksum, backend1, TESTING_OPTIONS)
             .unwrap();
@@ -1017,7 +1017,7 @@ mod tests {
         assert_eq!(msgs.len(), 0);
         let backend1 = instance.recycle().unwrap();
 
-        // init instance 2
+        // instantiate instance 2
         let mut instance = cache
             .get_instance(&checksum, backend2, TESTING_OPTIONS)
             .unwrap();

--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -292,12 +292,22 @@ where
         // Re-compile from original Wasm bytecode
         let wasm = self.load_wasm_with_path(&cache.wasm_path, checksum)?;
         cache.stats.misses = cache.stats.misses.saturating_add(1);
-        // Module will run with a different engine, so we can set memory limit to None
-        let compiling_engine = make_compiling_engine(None);
-        // This module cannot be executed directly as it was not created with the runtime engine
-        let module = compile(&compiling_engine, &wasm)?;
-        // Store into the fs cache too
-        let module_size = cache.fs_cache.store(checksum, &module)?;
+        {
+            // Module will run with a different engine, so we can set memory limit to None
+            let compiling_engine = make_compiling_engine(None);
+            // This module cannot be executed directly as it was not created with the runtime engine
+            let module = compile(&compiling_engine, &wasm)?;
+            cache.fs_cache.store(checksum, &module)?;
+        }
+
+        // This time we'll hit the file-system cache.
+        let Some((module, module_size)) = cache.fs_cache.load(checksum, &cache.runtime_engine)?
+        else {
+            return Err(VmError::generic_err(
+                "Can't load module from file system cache after storing it to file system cache (pin)",
+            ));
+        };
+
         cache
             .pinned_memory_cache
             .store(checksum, module, module_size)
@@ -391,7 +401,7 @@ where
         let Some((module, module_size)) = cache.fs_cache.load(checksum, &cache.runtime_engine)?
         else {
             return Err(VmError::generic_err(
-                "Can't load module from file system cache after storing it to file system cache",
+                "Can't load module from file system cache after storing it to file system cache (get_module)",
             ));
         };
         cache


### PR DESCRIPTION
The upgrade [CosmWasm 1.3 -> 1.4.0](https://github.com/CosmWasm/cosmwasm/compare/v1.3.3...v1.4.0) contains a  big [upgrade of Wasmer from 2.3 to version 4](https://github.com/CosmWasm/cosmwasm/issues?q=label%3Awasmer3%2F4). This led to large refactorings in our usage of the Wasmer API. To a large degree this improved the integration. E.g. cached modules in memory are now much smaller because we don't need to cache a Store anymore. However, we made one mistake in some code paths when using Wasmer: When we recompile a module from the Wasm file to the node's architecture we use an engine with a singlepass compiler attached. But for running modules we use a different engine that does not have a compiler. This is nice as the engine running contracts is lightweight and reusable. Now the regression was introduced by creating a Wasmer `Module` instance with one engine but run it with a different engine. The type system and Wasmer API allows you to do that, but it seems to be an invalid usage of Wasmer due to how Modules, Artifacts and Engines work internally. The resulting error message we get is:

> Wasmer runtime error: RuntimeError: out of bounds memory access

This PR fixes the issue by ensuring the compiling engine and the Module instance are not used to instantiate and execute the Module. Instead the Module is serialized to the file system cache and read from there.

We also increase our test coverage for the affected cases. Before we just checked the instance was created. Now we also test that the created instances can be executed.