### PR TITLE
Fixed doc warnings

### DIFF
--- a/contracts/crypto-verify/schema/crypto-verify.json
+++ b/contracts/crypto-verify/schema/crypto-verify.json
@@ -268,7 +268,7 @@
     ],
     "definitions": {
       "Binary": {
-        "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+        "description": "Binary is a wrapper around `Vec<u8>` to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for `Vec<u8>`. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
         "type": "string"
       },
       "Uint128": {

--- a/contracts/cyberpunk/schema/cyberpunk.json
+++ b/contracts/cyberpunk/schema/cyberpunk.json
@@ -5,7 +5,7 @@
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "InstantiateMsg",
-    "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressable in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
+    "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressable in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (<https://github.com/CosmWasm/cosmwasm/issues/451>)",
     "type": "object"
   },
   "execute": {

--- a/packages/crypto/src/secp256k1.rs
+++ b/packages/crypto/src/secp256k1.rs
@@ -75,7 +75,7 @@ pub fn secp256k1_verify(
 /// are not stored on chain directly.
 ///
 /// `recovery_param` must be 0 or 1. The values 2 and 3 are unsupported by this implementation,
-/// which is the same restriction as Ethereum has (https://github.com/ethereum/go-ethereum/blob/v1.9.25/internal/ethapi/api.go#L466-L469).
+/// which is the same restriction as Ethereum has <https://github.com/ethereum/go-ethereum/blob/v1.9.25/internal/ethapi/api.go#L466-L469>.
 /// All other values are invalid.
 ///
 /// Returns the recovered pubkey in compressed form, which can be used

--- a/packages/schema/src/lib.rs
+++ b/packages/schema/src/lib.rs
@@ -36,13 +36,13 @@ pub use remove::remove_schemas;
 /// }
 /// ```
 pub use cosmwasm_schema_derive::cw_serde;
-/// Generates an [`Api`](crate::Api) for the contract. The body describes the message
+/// Generates an [Api] for the contract. The body describes the message
 /// types exported in the schema and allows setting contract name and version overrides.
 ///
 /// The only obligatory field is `instantiate` - to set the InstantiateMsg type.
 ///
 /// # Available fields
-/// See [`write_api`](crate::write_api).
+/// See [write_api].
 ///
 /// # Example
 /// ```

--- a/packages/std/src/addresses.rs
+++ b/packages/std/src/addresses.rs
@@ -90,7 +90,7 @@ impl AsRef<str> for Addr {
 /// Implement `Addr == &str`
 ///
 /// Deprecated. This comparison unsafe. Convert both sides to Addr first.
-/// Will be removed soon: https://github.com/CosmWasm/cosmwasm/issues/1669
+/// Will be removed soon: <https://github.com/CosmWasm/cosmwasm/issues/1669>.
 impl PartialEq<&str> for Addr {
     fn eq(&self, rhs: &&str) -> bool {
         self.0 == *rhs
@@ -100,7 +100,7 @@ impl PartialEq<&str> for Addr {
 /// Implement `&str == Addr`
 ///
 /// Deprecated. This comparison unsafe. Convert both sides to Addr first.
-/// Will be removed soon: https://github.com/CosmWasm/cosmwasm/issues/1669
+/// Will be removed soon: <https://github.com/CosmWasm/cosmwasm/issues/1669>.
 impl PartialEq<Addr> for &str {
     fn eq(&self, rhs: &Addr) -> bool {
         *self == rhs.0
@@ -110,7 +110,7 @@ impl PartialEq<Addr> for &str {
 /// Implement `Addr == String`
 ///
 /// Deprecated. This comparison unsafe. Convert both sides to Addr first.
-/// Will be removed soon: https://github.com/CosmWasm/cosmwasm/issues/1669
+/// Will be removed soon: <https://github.com/CosmWasm/cosmwasm/issues/1669>.
 impl PartialEq<String> for Addr {
     fn eq(&self, rhs: &String) -> bool {
         &self.0 == rhs
@@ -120,7 +120,7 @@ impl PartialEq<String> for Addr {
 /// Implement `String == Addr`
 ///
 /// Deprecated. This comparison unsafe. Convert both sides to Addr first.
-/// Will be removed soon: https://github.com/CosmWasm/cosmwasm/issues/1669
+/// Will be removed soon: <https://github.com/CosmWasm/cosmwasm/issues/1669>.
 impl PartialEq<Addr> for String {
     fn eq(&self, rhs: &Addr) -> bool {
         self == &rhs.0
@@ -262,7 +262,7 @@ impl From<CanonicalAddr> for HexBinary {
     }
 }
 
-/// Just like Vec<u8>, CanonicalAddr is a smart pointer to [u8].
+/// Just like `Vec<u8>`, CanonicalAddr is a smart pointer to [u8].
 /// This implements `*canonical_address` for us and allows us to
 /// do `&*canonical_address`, returning a `&[u8]` from a `&CanonicalAddr`.
 /// With [deref coercions](https://doc.rust-lang.org/1.22.1/book/first-edition/deref-coercions.html#deref-coercions),
@@ -390,7 +390,7 @@ fn instantiate2_address_impl(
 }
 
 /// The "Basic Address" Hash from
-/// https://github.com/cosmos/cosmos-sdk/blob/v0.45.8/docs/architecture/adr-028-public-key-addresses.md
+/// <https://github.com/cosmos/cosmos-sdk/blob/v0.45.8/docs/architecture/adr-028-public-key-addresses.md>.
 fn hash(ty: &str, key: &[u8]) -> Vec<u8> {
     let inner = Sha256::digest(ty.as_bytes());
     Sha256::new().chain(inner).chain(key).finalize().to_vec()

--- a/packages/std/src/binary.rs
+++ b/packages/std/src/binary.rs
@@ -7,10 +7,10 @@ use serde::{de, ser, Deserialize, Deserializer, Serialize};
 
 use crate::errors::{StdError, StdResult};
 
-/// Binary is a wrapper around Vec<u8> to add base64 de/serialization
+/// Binary is a wrapper around `Vec<u8>` to add base64 de/serialization
 /// with serde. It also adds some helper methods to help encode inline.
 ///
-/// This is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>.
+/// This is only needed as serde-json-{core,wasm} has a horrible encoding for `Vec<u8>`.
 /// See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.
 #[derive(Clone, Default, PartialEq, Eq, Hash, PartialOrd, Ord, JsonSchema)]
 pub struct Binary(#[schemars(with = "String")] pub Vec<u8>);
@@ -96,7 +96,7 @@ impl fmt::Debug for Binary {
     }
 }
 
-/// Just like Vec<u8>, Binary is a smart pointer to [u8].
+/// Just like `Vec<u8>`, Binary is a smart pointer to [u8].
 /// This implements `*binary` for us and allows us to
 /// do `&*binary`, returning a `&[u8]` from a `&Binary`.
 /// With [deref coercions](https://doc.rust-lang.org/1.22.1/book/first-edition/deref-coercions.html#deref-coercions),

--- a/packages/std/src/coins.rs
+++ b/packages/std/src/coins.rs
@@ -18,7 +18,7 @@ use crate::{
 #[derive(Clone, Default, Debug, PartialEq, Eq)]
 pub struct Coins(BTreeMap<String, Coin>);
 
-/// Casting a Vec<Coin> to Coins.
+/// Casting a `Vec<Coin>` to Coins.
 /// The Vec can be out of order, but must not contain duplicate denoms.
 /// If you want to sum up duplicates, create an empty instance using `Coins::default` and
 /// use `Coins::add` to add your coins.
@@ -101,7 +101,7 @@ impl fmt::Display for Coins {
 }
 
 impl Coins {
-    /// Conversion to Vec<Coin>, while NOT consuming the original object.
+    /// Conversion to `Vec<Coin>`, while NOT consuming the original object.
     ///
     /// This produces a vector of coins that is sorted alphabetically by denom with
     /// no duplicate denoms.
@@ -109,7 +109,7 @@ impl Coins {
         self.0.values().cloned().collect()
     }
 
-    /// Conversion to Vec<Coin>, consuming the original object.
+    /// Conversion to `Vec<Coin>`, consuming the original object.
     ///
     /// This produces a vector of coins that is sorted alphabetically by denom with
     /// no duplicate denoms.

--- a/packages/std/src/errors/system_error.rs
+++ b/packages/std/src/errors/system_error.rs
@@ -5,7 +5,7 @@ use crate::Binary;
 
 /// SystemError is used for errors inside the VM and is API friendly (i.e. serializable).
 ///
-/// This is used on return values for Querier as a nested result: Result<StdResult<T>, SystemError>
+/// This is used on return values for Querier as a nested result: `Result<StdResult<T>, SystemError>`
 /// The first wrap (SystemError) will trigger if the contract address doesn't exist,
 /// the QueryRequest is malformed, etc. The second wrap will be an error message from
 /// the contract itself.

--- a/packages/std/src/hex_binary.rs
+++ b/packages/std/src/hex_binary.rs
@@ -6,7 +6,7 @@ use serde::{de, ser, Deserialize, Deserializer, Serialize};
 
 use crate::{Binary, StdError, StdResult};
 
-/// This is a wrapper around Vec<u8> to add hex de/serialization
+/// This is a wrapper around `Vec<u8>` to add hex de/serialization
 /// with serde. It also adds some helper methods to help encode inline.
 ///
 /// This is similar to `cosmwasm_std::Binary` but uses hex.
@@ -79,7 +79,7 @@ impl fmt::Debug for HexBinary {
     }
 }
 
-/// Just like Vec<u8>, HexBinary is a smart pointer to [u8].
+/// Just like `Vec<u8>`, HexBinary is a smart pointer to [u8].
 /// This implements `*data` for us and allows us to
 /// do `&*data`, returning a `&[u8]` from a `&HexBinary`.
 /// With [deref coercions](https://doc.rust-lang.org/1.22.1/book/first-edition/deref-coercions.html#deref-coercions),

--- a/packages/std/src/ibc.rs
+++ b/packages/std/src/ibc.rs
@@ -31,7 +31,7 @@ pub enum IbcMsg {
         /// address on the remote chain to receive these tokens
         to_address: String,
         /// packet data only supports one coin
-        /// https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/ibc/applications/transfer/v1/transfer.proto#L11-L20
+        /// <https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/ibc/applications/transfer/v1/transfer.proto#L11-L20>
         amount: Coin,
         /// when packet times out, measured on remote chain
         timeout: IbcTimeout,
@@ -147,7 +147,7 @@ impl IbcChannel {
 }
 
 /// IbcOrder defines if a channel is ORDERED or UNORDERED
-/// Values come from https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/ibc/core/channel/v1/channel.proto#L69-L80
+/// Values come from <https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/ibc/core/channel/v1/channel.proto#L69-L80>.
 /// Naming comes from the protobuf files and go translations.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub enum IbcOrder {
@@ -249,9 +249,9 @@ impl IbcAcknowledgement {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum IbcChannelOpenMsg {
-    /// The ChanOpenInit step from https://github.com/cosmos/ibc/tree/master/spec/core/ics-004-channel-and-packet-semantics#channel-lifecycle-management
+    /// The ChanOpenInit step from <https://github.com/cosmos/ibc/tree/master/spec/core/ics-004-channel-and-packet-semantics#channel-lifecycle-management>.
     OpenInit { channel: IbcChannel },
-    /// The ChanOpenTry step from https://github.com/cosmos/ibc/tree/master/spec/core/ics-004-channel-and-packet-semantics#channel-lifecycle-management
+    /// The ChanOpenTry step from <https://github.com/cosmos/ibc/tree/master/spec/core/ics-004-channel-and-packet-semantics#channel-lifecycle-management>.
     OpenTry {
         channel: IbcChannel,
         counterparty_version: String,
@@ -314,12 +314,12 @@ pub struct Ibc3ChannelOpenResponse {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum IbcChannelConnectMsg {
-    /// The ChanOpenAck step from https://github.com/cosmos/ibc/tree/master/spec/core/ics-004-channel-and-packet-semantics#channel-lifecycle-management
+    /// The ChanOpenAck step from <https://github.com/cosmos/ibc/tree/master/spec/core/ics-004-channel-and-packet-semantics#channel-lifecycle-management>.
     OpenAck {
         channel: IbcChannel,
         counterparty_version: String,
     },
-    /// The ChanOpenConfirm step from https://github.com/cosmos/ibc/tree/master/spec/core/ics-004-channel-and-packet-semantics#channel-lifecycle-management
+    /// The ChanOpenConfirm step from <https://github.com/cosmos/ibc/tree/master/spec/core/ics-004-channel-and-packet-semantics#channel-lifecycle-management>.
     OpenConfirm { channel: IbcChannel },
 }
 
@@ -366,9 +366,9 @@ impl From<IbcChannelConnectMsg> for IbcChannel {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum IbcChannelCloseMsg {
-    /// The ChanCloseInit step from https://github.com/cosmos/ibc/tree/master/spec/core/ics-004-channel-and-packet-semantics#channel-lifecycle-management
+    /// The ChanCloseInit step from <https://github.com/cosmos/ibc/tree/master/spec/core/ics-004-channel-and-packet-semantics#channel-lifecycle-management>.
     CloseInit { channel: IbcChannel },
-    /// The ChanCloseConfirm step from https://github.com/cosmos/ibc/tree/master/spec/core/ics-004-channel-and-packet-semantics#channel-lifecycle-management
+    /// The ChanCloseConfirm step from <https://github.com/cosmos/ibc/tree/master/spec/core/ics-004-channel-and-packet-semantics#channel-lifecycle-management>.
     CloseConfirm { channel: IbcChannel }, // pub channel: IbcChannel,
 }
 

--- a/packages/std/src/query/distribution.rs
+++ b/packages/std/src/query/distribution.rs
@@ -50,8 +50,8 @@ impl QueryResponseType for DelegationRewardsResponse {}
 /// Modeled after the Cosmos SDK's [DecCoin] type.
 /// However, in contrast to the Cosmos SDK the `amount` string MUST always have a dot at JSON level,
 /// see <https://github.com/cosmos/cosmos-sdk/issues/10863>.
-/// Also if Cosmos SDK choses to migrate away from fixed point decimals
-/// (as shown [here](https://github.com/cosmos/cosmos-sdk/blob/v0.47.4/x/group/internal/math/dec.go#L13-L21 and discussed [here](https://github.com/cosmos/cosmos-sdk/issues/11783)),
+/// Also if Cosmos SDK chooses to migrate away from fixed point decimals
+/// (as shown [here](https://github.com/cosmos/cosmos-sdk/blob/v0.47.4/x/group/internal/math/dec.go#L13-L21) and discussed [here](https://github.com/cosmos/cosmos-sdk/issues/11783)),
 /// wasmd needs to truncate the decimal places to 18.
 ///
 /// [DecCoin]: (https://github.com/cosmos/cosmos-sdk/blob/v0.47.4/proto/cosmos/base/v1beta1/coin.proto#L28-L38)

--- a/packages/std/src/query/staking.rs
+++ b/packages/std/src/query/staking.rs
@@ -131,7 +131,7 @@ impl_response_constructor!(ValidatorResponse, validator: Option<Validator>);
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct Validator {
     /// The operator address of the validator (e.g. cosmosvaloper1...).
-    /// See https://github.com/cosmos/cosmos-sdk/blob/v0.47.4/proto/cosmos/staking/v1beta1/staking.proto#L95-L96
+    /// See <https://github.com/cosmos/cosmos-sdk/blob/v0.47.4/proto/cosmos/staking/v1beta1/staking.proto#L95-L96>.
     /// for more information.
     ///
     /// This uses `String` instead of `Addr` since the bech32 address prefix is different from

--- a/packages/std/src/results/cosmos_msg.rs
+++ b/packages/std/src/results/cosmos_msg.rs
@@ -49,7 +49,7 @@ pub enum CosmosMsg<T = Empty> {
 
 /// The message types of the bank module.
 ///
-/// See https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto
+/// See <https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto>.
 #[non_exhaustive]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
@@ -70,7 +70,7 @@ pub enum BankMsg {
 
 /// The message types of the staking module.
 ///
-/// See https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto
+/// See <https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto>.
 #[cfg(feature = "staking")]
 #[non_exhaustive]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
@@ -93,7 +93,7 @@ pub enum StakingMsg {
 
 /// The message types of the distribution module.
 ///
-/// See https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto
+/// See <https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto>.
 #[cfg(feature = "staking")]
 #[non_exhaustive]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
@@ -129,7 +129,7 @@ fn binary_to_string(data: &Binary, fmt: &mut core::fmt::Formatter) -> core::fmt:
 
 /// The message types of the wasm module.
 ///
-/// See https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto
+/// See <https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto>.
 #[non_exhaustive]
 #[derive(Serialize, Deserialize, Clone, Derivative, PartialEq, Eq, JsonSchema)]
 #[derivative(Debug)]
@@ -172,7 +172,7 @@ pub enum WasmMsg {
     },
     /// Instantiates a new contracts from previously uploaded Wasm code
     /// using a predictable address derivation algorithm implemented in
-    /// [`cosmwasm_std::instantiate2_address`].
+    /// [instantiate2_address](crate::addresses::instantiate2_address).
     ///
     /// This is translated to a [MsgInstantiateContract2](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L73-L96).
     /// `sender` is automatically filled with the current contract's address.

--- a/packages/std/src/results/empty.rs
+++ b/packages/std/src/results/empty.rs
@@ -4,9 +4,9 @@ use serde::{Deserialize, Serialize};
 /// An empty struct that serves as a placeholder in different places,
 /// such as contracts that don't set a custom message.
 ///
-/// It is designed to be expressable in correct JSON and JSON Schema but
+/// It is designed to be expressible in correct JSON and JSON Schema but
 /// contains no meaningful data. Previously we used enums without cases,
-/// but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)
+/// but those cannot represented as valid JSON Schema (<https://github.com/CosmWasm/cosmwasm/issues/451>).
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema, Default)]
 pub struct Empty {}
 

--- a/packages/std/src/sections.rs
+++ b/packages/std/src/sections.rs
@@ -17,7 +17,7 @@ pub fn decode_sections2(data: Vec<u8>) -> (Vec<u8>, Vec<u8>) {
 ///
 /// The resulting data looks like this:
 ///
-/// ```ignore
+/// ```text
 /// section1 || section1_len || section2 || section2_len || section3 || section3_len || …
 /// ```
 #[allow(dead_code)] // used in Wasm and tests only

--- a/packages/std/src/storage.rs
+++ b/packages/std/src/storage.rs
@@ -96,7 +96,7 @@ fn range_bounds(start: Option<&[u8]>, end: Option<&[u8]>) -> impl RangeBounds<Ve
 }
 
 #[cfg(feature = "iterator")]
-/// The BTreeMap specific key-value pair reference type, as returned by BTreeMap<Vec<u8>, Vec<u8>>::range.
+/// The BTreeMap specific key-value pair reference type, as returned by `BTreeMap<Vec<u8>, Vec<u8>>::range`.
 /// This is internal as it can change any time if the map implementation is swapped out.
 type BTreeMapRecordRef<'a> = (&'a Vec<u8>, &'a Vec<u8>);
 

--- a/packages/std/src/storage_keys/length_prefixed.rs
+++ b/packages/std/src/storage_keys/length_prefixed.rs
@@ -1,11 +1,11 @@
 //! This module is an implemention of a namespacing scheme described
-//! in https://github.com/webmaster128/key-namespacing#length-prefixed-keys
+//! in <https://github.com/webmaster128/key-namespacing#length-prefixed-keys>.
 //!
 //! Everything in this file is only responsible for building such keys
 //! and is in no way specific to any kind of storage.
 
 /// Calculates the raw key prefix for a given namespace as documented
-/// in https://github.com/webmaster128/key-namespacing#length-prefixed-keys
+/// in <https://github.com/webmaster128/key-namespacing#length-prefixed-keys>.
 pub fn to_length_prefixed(namespace_component: &[u8]) -> Vec<u8> {
     let mut out = Vec::with_capacity(namespace_component.len() + 2);
     out.extend_from_slice(&encode_length(namespace_component));
@@ -14,7 +14,7 @@ pub fn to_length_prefixed(namespace_component: &[u8]) -> Vec<u8> {
 }
 
 /// Calculates the raw key prefix for a given nested namespace
-/// as documented in https://github.com/webmaster128/key-namespacing#nesting
+/// as documented in <https://github.com/webmaster128/key-namespacing#nesting>
 pub fn to_length_prefixed_nested(namespace: &[&[u8]]) -> Vec<u8> {
     let mut size = 0;
     for component in namespace {

--- a/packages/std/src/testing/mock.rs
+++ b/packages/std/src/testing/mock.rs
@@ -709,7 +709,7 @@ pub struct BankQuerier {
     supplies: HashMap<String, Uint128>,
     /// HashMap<address, coins>
     balances: HashMap<String, Vec<Coin>>,
-    /// Vec<Metadata>
+    /// `Vec<Metadata>`
     denom_metadata: BTreeMap<Vec<u8>, DenomMetadata>,
 }
 

--- a/packages/std/src/testing/shuffle.rs
+++ b/packages/std/src/testing/shuffle.rs
@@ -1,7 +1,7 @@
 /// Performs a perfect shuffle (in shuffle)
 ///
-/// https://en.wikipedia.org/wiki/Riffle_shuffle_permutation#Perfect_shuffles
-/// https://en.wikipedia.org/wiki/In_shuffle
+/// <https://en.wikipedia.org/wiki/Riffle_shuffle_permutation#Perfect_shuffles>
+/// <https://en.wikipedia.org/wiki/In_shuffle>
 ///
 /// The number of shuffles required to restore the original order are listed in
 /// <https://oeis.org/A002326> and <https://oeis.org/A002326/list>, e.g.:

--- a/packages/std/src/traits.rs
+++ b/packages/std/src/traits.rs
@@ -34,8 +34,8 @@ use crate::{DenomMetadata, PageRequest};
 /// Storage provides read and write access to a persistent storage.
 /// If you only want to provide read access, provide `&Storage`
 pub trait Storage {
-    /// Returns None when key does not exist.
-    /// Returns Some(Vec<u8>) when key exists.
+    /// Returns `None` when key does not exist.
+    /// Returns `Some(Vec<u8>)` when key exists.
     ///
     /// Note: Support for differentiating between a non-existent key and a key with empty value
     /// is not great yet and might not be possible in all backends. But we're trying to get there.
@@ -92,7 +92,7 @@ pub trait Storage {
     /// Removes a database entry at `key`.
     ///
     /// The current interface does not allow to differentiate between a key that existed
-    /// before and one that didn't exist. See https://github.com/CosmWasm/cosmwasm/issues/290
+    /// before and one that didn't exist. See <https://github.com/CosmWasm/cosmwasm/issues/290>.
     fn remove(&mut self, key: &[u8]);
 }
 

--- a/packages/storage/src/type_helpers.rs
+++ b/packages/storage/src/type_helpers.rs
@@ -7,7 +7,7 @@ use cosmwasm_std::{from_slice, StdError, StdResult};
 
 /// may_deserialize parses json bytes from storage (Option), returning Ok(None) if no data present
 ///
-/// value is an odd type, but this is meant to be easy to use with output from storage.get (Option<Vec<u8>>)
+/// value is an odd type, but this is meant to be easy to use with output from storage.get (`Option<Vec<u8>>`)
 /// and value.map(|s| s.as_slice()) seems trickier than &value
 pub(crate) fn may_deserialize<T: DeserializeOwned>(
     value: &Option<Vec<u8>>,

--- a/packages/vm/src/backend.rs
+++ b/packages/vm/src/backend.rs
@@ -86,16 +86,16 @@ pub struct Backend<A: BackendApi, S: Storage, Q: Querier> {
 
 /// Access to the VM's backend storage, i.e. the chain
 pub trait Storage {
-    /// Returns Err on error.
-    /// Returns Ok(None) when key does not exist.
-    /// Returns Ok(Some(Vec<u8>)) when key exists.
+    /// Returns `Err` on error.
+    /// Returns `Ok(None)` when key does not exist.
+    /// Returns `Ok(Some(Vec<u8>))` when key exists.
     ///
     /// Note: Support for differentiating between a non-existent key and a key with empty value
     /// is not great yet and might not be possible in all backends. But we're trying to get there.
     fn get(&self, key: &[u8]) -> BackendResult<Option<Vec<u8>>>;
 
     /// Allows iteration over a set of key/value pairs, either forwards or backwards.
-    /// Returns an interator ID that is unique within the Storage instance.
+    /// Returns an iterator ID that is unique within the Storage instance.
     ///
     /// The bound `start` is inclusive and `end` is exclusive.
     ///
@@ -155,7 +155,7 @@ pub trait Storage {
     /// Removes a database entry at `key`.
     ///
     /// The current interface does not allow to differentiate between a key that existed
-    /// before and one that didn't exist. See https://github.com/CosmWasm/cosmwasm/issues/290
+    /// before and one that didn't exist. See <https://github.com/CosmWasm/cosmwasm/issues/290>
     fn remove(&mut self, key: &[u8]) -> BackendResult<()>;
 }
 

--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -181,10 +181,10 @@ where
 
     /// Takes a Wasm bytecode and stores it to the cache.
     ///
-    /// This performs static checks, compiles the bytescode to a module and
+    /// This performs static checks, compiles the bytecode to a module and
     /// stores the Wasm file on disk.
     ///
-    /// This does the same as [`save_wasm_unchecked`] plus the static checks.
+    /// This does the same as [save_wasm_unchecked](Self::save_wasm_unchecked) plus the static checks.
     /// When a Wasm blob is stored the first time, use this function.
     pub fn save_wasm(&self, wasm: &[u8]) -> VmResult<Checksum> {
         check_wasm(wasm, &self.available_capabilities)?;
@@ -193,10 +193,10 @@ where
 
     /// Takes a Wasm bytecode and stores it to the cache.
     ///
-    /// This compiles the bytescode to a module and
+    /// This compiles the bytecode to a module and
     /// stores the Wasm file on disk.
     ///
-    /// This does the same as [`save_wasm`] but without the static checks.
+    /// This does the same as [save_wasm](Self::save_wasm) but without the static checks.
     /// When a Wasm blob is stored which was previously checked (e.g. as part of state sync),
     /// use this function.
     pub fn save_wasm_unchecked(&self, wasm: &[u8]) -> VmResult<Checksum> {
@@ -218,7 +218,7 @@ where
     pub fn remove_wasm(&self, checksum: &Checksum) -> VmResult<()> {
         let mut cache = self.inner.lock().unwrap();
 
-        // Remove compiled moduled from disk (if it exists).
+        // Remove compiled module from disk (if it exists).
         // Here we could also delete from memory caches but this is not really
         // necessary as they are pushed out from the LRU over time or disappear
         // when the node process restarts.
@@ -250,7 +250,7 @@ where
 
     /// Performs static anlyzation on this Wasm without compiling or instantiating it.
     ///
-    /// Once the contract was stored via [`save_wasm`], this can be called at any point in time.
+    /// Once the contract was stored via [save_wasm](Self::save_wasm), this can be called at any point in time.
     /// It does not depend on any caching of the contract.
     pub fn analyze(&self, checksum: &Checksum) -> VmResult<AnalysisReport> {
         // Here we could use a streaming deserializer to slightly improve performance. However, this way it is DRYer.
@@ -420,7 +420,7 @@ fn save_wasm_to_disk(dir: impl Into<PathBuf>, wasm: &[u8]) -> VmResult<Checksum>
     let filepath = dir.into().join(filename).with_extension("wasm");
 
     // write data to file
-    // Since the same filename (a collision resistent hash) cannot be generated from two different byte codes
+    // Since the same filename (a collision resistant hash) cannot be generated from two different byte codes
     // (even if a malicious actor tried), it is safe to override.
     let mut file = OpenOptions::new()
         .write(true)

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -49,7 +49,7 @@ pub struct InstanceOptions {
 pub struct Instance<A: BackendApi, S: Storage, Q: Querier> {
     /// We put this instance in a box to maintain a constant memory address for the entire
     /// lifetime of the instance in the cache. This is needed e.g. when linking the wasmer
-    /// instance to a context. See also https://github.com/CosmWasm/cosmwasm/pull/245.
+    /// instance to a context. See also: <https://github.com/CosmWasm/cosmwasm/pull/245>.
     ///
     /// This instance should only be accessed via the Environment, which provides safe access.
     _inner: Box<WasmerInstance>,
@@ -350,7 +350,7 @@ where
     /// Returns the size of the default memory in pages.
     /// This provides a rough idea of the peak memory consumption. Note that
     /// Wasm memory always grows in 64 KiB steps (pages) and can never shrink
-    /// (https://github.com/WebAssembly/design/issues/1300#issuecomment-573867836).
+    /// <https://github.com/WebAssembly/design/issues/1300#issuecomment-573867836>.
     pub fn memory_pages(&mut self) -> usize {
         let mut fe_mut = self.fe.clone().into_mut(&mut self.store);
         let (env, store) = fe_mut.data_and_store_mut();

--- a/packages/vm/src/modules/file_system_cache.rs
+++ b/packages/vm/src/modules/file_system_cache.rs
@@ -17,10 +17,10 @@ use crate::modules::current_wasmer_module_version;
 /// This needs to be done e.g. when switching between the jit/native engine.
 ///
 /// The string is used as a folder and should be named in a way that is
-/// easy to interprete for system admins. It should allow easy clearing
+/// easy to interpret for system admins. It should allow easy clearing
 /// of old versions.
 ///
-/// See https://github.com/wasmerio/wasmer/issues/2781 for more information
+/// See <https://github.com/wasmerio/wasmer/issues/2781> for more information
 /// on Wasmer's module stability concept.
 ///
 /// ## Version history:

--- a/packages/vm/src/sections.rs
+++ b/packages/vm/src/sections.rs
@@ -33,7 +33,7 @@ pub fn decode_sections(data: &[u8]) -> Vec<&[u8]> {
 ///
 /// The resulting data looks like this:
 ///
-/// ```ignore
+/// ```text
 /// section1 || section1_len || section2 || section2_len || section3 || section3_len || …
 /// ```
 #[allow(dead_code)]

--- a/packages/vm/src/testing/storage.rs
+++ b/packages/vm/src/testing/storage.rs
@@ -146,7 +146,7 @@ fn range_bounds(start: Option<&[u8]>, end: Option<&[u8]>) -> impl RangeBounds<Ve
 }
 
 #[cfg(feature = "iterator")]
-/// The BTreeMap specific key-value pair reference type, as returned by BTreeMap<Vec<u8>, Vec<u8>>::range.
+/// The BTreeMap specific key-value pair reference type, as returned by `BTreeMap<Vec<u8>, Vec<u8>>::range`.
 /// This is internal as it can change any time if the map implementation is swapped out.
 type BTreeMapRecordRef<'a> = (&'a Vec<u8>, &'a Vec<u8>);
 

--- a/packages/vm/src/wasm_backend/engine.rs
+++ b/packages/vm/src/wasm_backend/engine.rs
@@ -17,7 +17,7 @@ use super::limiting_tunables::LimitingTunables;
 /// WebAssembly linear memory objects have sizes measured in pages. Each page
 /// is 65536 (2^16) bytes. In WebAssembly version 1, a linear memory can have at
 /// most 65536 pages, for a total of 2^32 bytes (4 gibibytes).
-/// https://github.com/WebAssembly/memory64/blob/master/proposals/memory64/Overview.md
+/// <https://github.com/WebAssembly/memory64/blob/master/proposals/memory64/Overview.md>
 const MAX_WASM_PAGES: u32 = 65536;
 
 fn cost(_operator: &Operator) -> u64 {


### PR DESCRIPTION
This PR fixes doc warnings generated by the command:
```
$ cargo +stable doc --no-deps --workspace --features cosmwasm_1_4
```
plus few spelling corrections.

This is quite handy, when the cargo doc does not generate any warnings, then during developing a new code, just introduced errors are reported. I find it quite useful and time saving.