### PR TITLE
Make GasConfig non_exhaustive

### DIFF
--- a/packages/vm/src/environment.rs
+++ b/packages/vm/src/environment.rs
@@ -28,6 +28,7 @@ pub enum Never {}
 /** gas config data */
 
 #[derive(Clone, PartialEq, Eq, Debug)]
+#[non_exhaustive]
 pub struct GasConfig {
     /// Gas costs of VM (not Backend) provided functionality
     /// secp256k1 signature verification cost


### PR DESCRIPTION
GasConfig is currently not exported, making this a non-breaking change. But we want to be prepared to add more crypto algorithms with their gas configuration.