### PR TITLE
Test zero-size InMemoryCache

### DIFF
--- a/packages/vm/src/modules/in_memory_cache.rs
+++ b/packages/vm/src/modules/in_memory_cache.rs
@@ -117,6 +117,28 @@ mod tests {
     // Based on `examples/module_size.sh`
     const TESTING_WASM_SIZE_FACTOR: usize = 18;
 
+    const WAT1: &str = r#"(module
+        (type $t0 (func (param i32) (result i32)))
+        (func $add_one (export "add_one") (type $t0) (param $p0 i32) (result i32)
+            get_local $p0
+            i32.const 1
+            i32.add)
+        )"#;
+    const WAT2: &str = r#"(module
+        (type $t0 (func (param i32) (result i32)))
+        (func $add_one (export "add_two") (type $t0) (param $p0 i32) (result i32)
+            get_local $p0
+            i32.const 2
+            i32.add)
+        )"#;
+    const WAT3: &str = r#"(module
+        (type $t0 (func (param i32) (result i32)))
+        (func $add_one (export "add_three") (type $t0) (param $p0 i32) (result i32)
+            get_local $p0
+            i32.const 3
+            i32.add)
+        )"#;
+
     #[test]
     fn check_element_sizes() {
         let key_size = mem::size_of::<Checksum>();
@@ -135,16 +157,7 @@ mod tests {
         let mut cache = InMemoryCache::new(Size::mebi(200));
 
         // Create module
-        let wasm = wat::parse_str(
-            r#"(module
-            (type $t0 (func (param i32) (result i32)))
-            (func $add_one (export "add_one") (type $t0) (param $p0 i32) (result i32)
-                get_local $p0
-                i32.const 1
-                i32.add)
-            )"#,
-        )
-        .unwrap();
+        let wasm = wat::parse_str(WAT1).unwrap();
         let checksum = Checksum::generate(&wasm);
 
         // Module does not exist
@@ -188,38 +201,11 @@ mod tests {
         let mut cache = InMemoryCache::new(Size::mebi(2));
 
         // Create module
-        let wasm1 = wat::parse_str(
-            r#"(module
-            (type $t0 (func (param i32) (result i32)))
-            (func $add_one (export "add_one") (type $t0) (param $p0 i32) (result i32)
-                get_local $p0
-                i32.const 1
-                i32.add)
-            )"#,
-        )
-        .unwrap();
+        let wasm1 = wat::parse_str(WAT1).unwrap();
         let checksum1 = Checksum::generate(&wasm1);
-        let wasm2 = wat::parse_str(
-            r#"(module
-            (type $t0 (func (param i32) (result i32)))
-            (func $add_one (export "add_two") (type $t0) (param $p0 i32) (result i32)
-                get_local $p0
-                i32.const 2
-                i32.add)
-            )"#,
-        )
-        .unwrap();
+        let wasm2 = wat::parse_str(WAT2).unwrap();
         let checksum2 = Checksum::generate(&wasm2);
-        let wasm3 = wat::parse_str(
-            r#"(module
-            (type $t0 (func (param i32) (result i32)))
-            (func $add_one (export "add_three") (type $t0) (param $p0 i32) (result i32)
-                get_local $p0
-                i32.const 3
-                i32.add)
-            )"#,
-        )
-        .unwrap();
+        let wasm3 = wat::parse_str(WAT3).unwrap();
         let checksum3 = Checksum::generate(&wasm3);
 
         assert_eq!(cache.len(), 0);
@@ -248,38 +234,11 @@ mod tests {
         let mut cache = InMemoryCache::new(Size::mebi(2));
 
         // Create module
-        let wasm1 = wat::parse_str(
-            r#"(module
-            (type $t0 (func (param i32) (result i32)))
-            (func $add_one (export "add_one") (type $t0) (param $p0 i32) (result i32)
-                get_local $p0
-                i32.const 1
-                i32.add)
-            )"#,
-        )
-        .unwrap();
+        let wasm1 = wat::parse_str(WAT1).unwrap();
         let checksum1 = Checksum::generate(&wasm1);
-        let wasm2 = wat::parse_str(
-            r#"(module
-            (type $t0 (func (param i32) (result i32)))
-            (func $add_one (export "add_two") (type $t0) (param $p0 i32) (result i32)
-                get_local $p0
-                i32.const 2
-                i32.add)
-            )"#,
-        )
-        .unwrap();
+        let wasm2 = wat::parse_str(WAT2).unwrap();
         let checksum2 = Checksum::generate(&wasm2);
-        let wasm3 = wat::parse_str(
-            r#"(module
-            (type $t0 (func (param i32) (result i32)))
-            (func $add_one (export "add_three") (type $t0) (param $p0 i32) (result i32)
-                get_local $p0
-                i32.const 3
-                i32.add)
-            )"#,
-        )
-        .unwrap();
+        let wasm3 = wat::parse_str(WAT3).unwrap();
         let checksum3 = Checksum::generate(&wasm3);
 
         assert_eq!(cache.size(), 0);


### PR DESCRIPTION
Being able to set the in-memory cache size to 0 is relevant for the Wasm light client, which pins all codes anyways and should not waste and additional memory in this cache.