### PR TITLE
Add `SubMsg::reply_never()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to
   `Decimal256`. ([#1902])
 - cosmwasm-std: Remove operand strings from `OverflowError`,
   `ConversionOverflowError` and `DivideByZeroError`. ([#1896])
+- cosmwasm-std: Add `SubMsg:reply_never` constructor ([#1929])
 
 [#1874]: https://github.com/CosmWasm/cosmwasm/pull/1874
 [#1879]: https://github.com/CosmWasm/cosmwasm/pull/1879
@@ -31,6 +32,7 @@ and this project adheres to
 [#1896]: https://github.com/CosmWasm/cosmwasm/pull/1896
 [#1898]: https://github.com/CosmWasm/cosmwasm/pull/1898
 [#1902]: https://github.com/CosmWasm/cosmwasm/pull/1902
+[#1929]: https://github.com/CosmWasm/cosmwasm/pull/1929
 
 ## [1.5.0-rc.0]
 

--- a/packages/std/src/results/submessages.rs
+++ b/packages/std/src/results/submessages.rs
@@ -67,6 +67,11 @@ impl<T> SubMsg<T> {
         Self::reply_on(msg.into(), id, ReplyOn::Always)
     }
 
+    /// create a `SubMsg` that will never `reply`. This is equivalent to standard message semantics.
+    pub fn reply_never(msg: impl Into<CosmosMsg<T>>, id: u64) -> Self {
+        Self::reply_on(msg.into(), id, ReplyOn::Never)
+    }
+
     /// Add a gas limit to the message.
     /// This gas limit measured in [Cosmos SDK gas](https://github.com/CosmWasm/cosmwasm/blob/main/docs/GAS.md).
     ///

--- a/packages/std/src/results/submessages.rs
+++ b/packages/std/src/results/submessages.rs
@@ -44,12 +44,7 @@ pub const UNUSED_MSG_ID: u64 = 0;
 impl<T> SubMsg<T> {
     /// new creates a "fire and forget" message with the pre-0.14 semantics
     pub fn new(msg: impl Into<CosmosMsg<T>>) -> Self {
-        SubMsg {
-            id: UNUSED_MSG_ID,
-            msg: msg.into(),
-            reply_on: ReplyOn::Never,
-            gas_limit: None,
-        }
+        Self::reply_never(msg)
     }
 
     /// create a `SubMsg` that will provide a `reply` with the given id if the message returns `Ok`
@@ -68,8 +63,8 @@ impl<T> SubMsg<T> {
     }
 
     /// create a `SubMsg` that will never `reply`. This is equivalent to standard message semantics.
-    pub fn reply_never(msg: impl Into<CosmosMsg<T>>, id: u64) -> Self {
-        Self::reply_on(msg.into(), id, ReplyOn::Never)
+    pub fn reply_never(msg: impl Into<CosmosMsg<T>>) -> Self {
+        Self::reply_on(msg.into(), UNUSED_MSG_ID, ReplyOn::Never)
     }
 
     /// Add a gas limit to the message.


### PR DESCRIPTION
Just thought this should be an explicit constructor, even though the `::new()` constructs a `ReplyOn::Never` msg, it might make it less confusing and more consistent to also explicitly have this method.