### PR TITLE
Update WAT format in several test cases

### DIFF
--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -542,7 +542,7 @@ mod tests {
     static INVALID_CONTRACT_WAT: &str = r#"(module
         (type $t0 (func (param i32) (result i32)))
         (func $add_one (export "add_one") (type $t0) (param $p0 i32) (result i32)
-            get_local $p0
+            local.get $p0
             i32.const 1
             i32.add))
     "#;

--- a/packages/vm/src/modules/file_system_cache.rs
+++ b/packages/vm/src/modules/file_system_cache.rs
@@ -237,7 +237,7 @@ mod tests {
     const SOME_WAT: &str = r#"(module
         (type $t0 (func (param i32) (result i32)))
         (func $add_one (export "add_one") (type $t0) (param $p0 i32) (result i32)
-            get_local $p0
+            local.get $p0
             i32.const 1
             i32.add))
     "#;

--- a/packages/vm/src/modules/in_memory_cache.rs
+++ b/packages/vm/src/modules/in_memory_cache.rs
@@ -120,21 +120,21 @@ mod tests {
     const WAT1: &str = r#"(module
         (type $t0 (func (param i32) (result i32)))
         (func $add_one (export "add_one") (type $t0) (param $p0 i32) (result i32)
-            get_local $p0
+            local.get $p0
             i32.const 1
             i32.add)
         )"#;
     const WAT2: &str = r#"(module
         (type $t0 (func (param i32) (result i32)))
         (func $add_one (export "add_two") (type $t0) (param $p0 i32) (result i32)
-            get_local $p0
+            local.get $p0
             i32.const 2
             i32.add)
         )"#;
     const WAT3: &str = r#"(module
         (type $t0 (func (param i32) (result i32)))
         (func $add_one (export "add_three") (type $t0) (param $p0 i32) (result i32)
-            get_local $p0
+            local.get $p0
             i32.const 3
             i32.add)
         )"#;

--- a/packages/vm/src/modules/pinned_memory_cache.rs
+++ b/packages/vm/src/modules/pinned_memory_cache.rs
@@ -92,7 +92,7 @@ mod tests {
             r#"(module
             (type $t0 (func (param i32) (result i32)))
             (func $add_one (export "add_one") (type $t0) (param $p0 i32) (result i32)
-                get_local $p0
+                local.get $p0
                 i32.const 1
                 i32.add)
             )"#,
@@ -144,7 +144,7 @@ mod tests {
             r#"(module
             (type $t0 (func (param i32) (result i32)))
             (func $add_one (export "add_one") (type $t0) (param $p0 i32) (result i32)
-                get_local $p0
+                local.get $p0
                 i32.const 1
                 i32.add)
             )"#,
@@ -176,7 +176,7 @@ mod tests {
             r#"(module
             (type $t0 (func (param i32) (result i32)))
             (func $add_one (export "add_one") (type $t0) (param $p0 i32) (result i32)
-                get_local $p0
+                local.get $p0
                 i32.const 1
                 i32.add)
             )"#,
@@ -208,7 +208,7 @@ mod tests {
             r#"(module
             (type $t0 (func (param i32) (result i32)))
             (func $add_one (export "add_one") (type $t0) (param $p0 i32) (result i32)
-                get_local $p0
+                local.get $p0
                 i32.const 1
                 i32.add)
             )"#,
@@ -219,7 +219,7 @@ mod tests {
             r#"(module
             (type $t0 (func (param i32) (result i32)))
             (func $add_one (export "add_two") (type $t0) (param $p0 i32) (result i32)
-                get_local $p0
+                local.get $p0
                 i32.const 2
                 i32.add)
             )"#,

--- a/packages/vm/src/wasm_backend/gatekeeper.rs
+++ b/packages/vm/src/wasm_backend/gatekeeper.rs
@@ -710,8 +710,8 @@ mod tests {
             r#"
             (module
                 (func (export "sum") (param i32 i32) (result i32)
-                    get_local 0
-                    get_local 1
+                    local.get 0
+                    local.get 1
                     i32.add
                 ))
             "#,
@@ -732,8 +732,8 @@ mod tests {
             r#"
             (module
                 (func $to_float (param i32) (result f32)
-                    get_local 0
-                    f32.convert_u/i32
+                    local.get 0
+                    f32.convert_i32_u
                 ))
             "#,
         )


### PR DESCRIPTION
In cosmwasm-vm, several WAT testdata include deprecated instruction names. For example `get_local` is now `local.get`. See: https://github.com/WebAssembly/spec/issues/884

Recently, the Rust library `wat` dropped support for these deprecated instruction names: https://github.com/bytecodealliance/wasm-tools/pull/1184. This repo currently uses wat `1.0.64`, but if you upgrade to `>=1.0.72` the tests will fail:

```plain
---- cache::tests::save_wasm_rejects_invalid_contract stdout ----
thread 'cache::tests::save_wasm_rejects_invalid_contract' panicked at packages/vm/src/cache.rs:631:57:
called `Result::unwrap()` on an `Err` value: Error { kind: Wast(Error { inner: ErrorInner { text: Some(Text { line: 3, col: 12, snippet: "            get_local $p0" }), file: None, span: Span { offset: 153 }, kind: Custom("unknown operator or unexpected token") } }) }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

These PR updates the instruction names to the standard ones.