### PR TITLE
Remove backtraces feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,12 @@ and this project adheres to
   `AnalysisReport::required_capabilities` a `BTreeSet`. ([#1949])
 - cosmwasm-std: Add `Checksum` type and change type of
   `CodeInfoResponse::checksum` to that. ([#1944])
+- cosmwasm-std: Removed `backtraces` feature, use the `RUST_BACKTRACE=1` env
+  variable instead. Error variants that previously only contained a `backtrace`
+  field with the feature enabled now always contain it. ([#1967])
+- cosmwasm-vm: Removed `backtraces` feature, use the `RUST_BACKTRACE=1` env
+  variable instead. All `VmError` variants now have a `backtrace` field.
+  ([#1967])
 
 [#1874]: https://github.com/CosmWasm/cosmwasm/pull/1874
 [#1876]: https://github.com/CosmWasm/cosmwasm/pull/1876
@@ -73,6 +79,7 @@ and this project adheres to
 [#1941]: https://github.com/CosmWasm/cosmwasm/pull/1941
 [#1944]: https://github.com/CosmWasm/cosmwasm/pull/1944
 [#1949]: https://github.com/CosmWasm/cosmwasm/pull/1949
+[#1967]: https://github.com/CosmWasm/cosmwasm/pull/1967
 
 ### Removed
 

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -125,6 +125,14 @@ major releases of `cosmwasm`. Note that you can also view the
   +CosmosMsg::Any(AnyMsg { type_url, value })
   ```
 
+- Replace all direct construction of `StdError` with use of the corresponding
+  constructor:
+
+  ```diff
+  -StdError::GenericErr { msg }
+  +StdError::generic_err(msg)
+  ```
+
 ## 1.4.x -> 1.5.0
 
 - Update `cosmwasm-*` dependencies in Cargo.toml (skip the ones you don't use):

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -21,7 +21,9 @@ major releases of `cosmwasm`. Note that you can also view the
 
   If you were using cosmwasm-std's `ibc3` feature, you can remove it, as it is
   the default now. Depending on your usage, you might have to enable the
-  `stargate` feature instead, since it was previously implied by `ibc3`.
+  `stargate` feature instead, since it was previously implied by `ibc3`. Also
+  remove any uses of the `backtraces` feature. You can use a `RUST_BACKTRACE=1`
+  env variable for this now.
 
 - `ContractInfoResponse::new` now takes all fields of the response as
   parameters:

--- a/contracts/burner/Cargo.toml
+++ b/contracts/burner/Cargo.toml
@@ -27,9 +27,7 @@ overflow-checks = true
 default = []
 # Use cranelift backend instead of singlepass. This is required for development on 32 bit or ARM machines.
 cranelift = ["cosmwasm-vm/cranelift"]
-# for quicker tests, cargo test --lib
-# for more explicit tests, cargo test --features=backtraces
-backtraces = ["cosmwasm-vm/backtraces"]
+
 
 [dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }

--- a/contracts/burner/Cargo.toml
+++ b/contracts/burner/Cargo.toml
@@ -29,7 +29,7 @@ default = []
 cranelift = ["cosmwasm-vm/cranelift"]
 # for quicker tests, cargo test --lib
 # for more explicit tests, cargo test --features=backtraces
-backtraces = ["cosmwasm-std/backtraces", "cosmwasm-vm/backtraces"]
+backtraces = ["cosmwasm-vm/backtraces"]
 
 [dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }

--- a/contracts/crypto-verify/Cargo.toml
+++ b/contracts/crypto-verify/Cargo.toml
@@ -29,7 +29,7 @@ default = []
 cranelift = ["cosmwasm-vm/cranelift"]
 # for quicker tests, cargo test --lib
 # for more explicit tests, cargo test --features=backtraces
-backtraces = ["cosmwasm-std/backtraces", "cosmwasm-vm/backtraces"]
+backtraces = ["cosmwasm-vm/backtraces"]
 
 [dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }

--- a/contracts/crypto-verify/Cargo.toml
+++ b/contracts/crypto-verify/Cargo.toml
@@ -27,9 +27,6 @@ overflow-checks = true
 default = []
 # Use cranelift backend instead of singlepass. This is required for development on 32 bit or ARM machines.
 cranelift = ["cosmwasm-vm/cranelift"]
-# for quicker tests, cargo test --lib
-# for more explicit tests, cargo test --features=backtraces
-backtraces = ["cosmwasm-vm/backtraces"]
 
 [dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }

--- a/contracts/crypto-verify/src/contract.rs
+++ b/contracts/crypto-verify/src/contract.rs
@@ -317,12 +317,13 @@ mod tests {
 
         let res = query(deps.as_ref(), mock_env(), verify_msg);
         assert!(res.is_err());
-        assert_eq!(
+        assert!(matches!(
             res.unwrap_err(),
             StdError::VerificationErr {
-                source: VerificationError::InvalidPubkeyFormat
+                source: VerificationError::InvalidPubkeyFormat,
+                ..
             }
-        )
+        ))
     }
 
     #[test]
@@ -605,12 +606,13 @@ mod tests {
         };
         let res = query(deps.as_ref(), mock_env(), verify_msg);
         assert!(res.is_err());
-        assert_eq!(
+        assert!(matches!(
             res.unwrap_err(),
             StdError::VerificationErr {
                 source: VerificationError::InvalidPubkeyFormat,
+                ..
             }
-        )
+        ))
     }
 
     #[test]
@@ -670,12 +672,13 @@ mod tests {
         };
         let res = query(deps.as_ref(), mock_env(), verify_msg);
         assert!(res.is_err());
-        assert_eq!(
+        assert!(matches!(
             res.unwrap_err(),
             StdError::VerificationErr {
-                source: VerificationError::InvalidPubkeyFormat
+                source: VerificationError::InvalidPubkeyFormat,
+                ..
             }
-        )
+        ))
     }
 
     #[test]

--- a/contracts/cyberpunk/Cargo.toml
+++ b/contracts/cyberpunk/Cargo.toml
@@ -25,8 +25,6 @@ overflow-checks = true
 default = []
 # Use cranelift backend instead of singlepass. This is required for development on 32 bit or ARM machines.
 cranelift = ["cosmwasm-vm/cranelift"]
-# For quicker tests, cargo test --lib. for more explicit tests, cargo test --features=backtraces
-backtraces = ["cosmwasm-vm/backtraces"]
 
 [dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }

--- a/contracts/cyberpunk/Cargo.toml
+++ b/contracts/cyberpunk/Cargo.toml
@@ -26,7 +26,7 @@ default = []
 # Use cranelift backend instead of singlepass. This is required for development on 32 bit or ARM machines.
 cranelift = ["cosmwasm-vm/cranelift"]
 # For quicker tests, cargo test --lib. for more explicit tests, cargo test --features=backtraces
-backtraces = ["cosmwasm-std/backtraces", "cosmwasm-vm/backtraces"]
+backtraces = ["cosmwasm-vm/backtraces"]
 
 [dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }

--- a/contracts/empty/Cargo.toml
+++ b/contracts/empty/Cargo.toml
@@ -29,7 +29,7 @@ default = []
 cranelift = ["cosmwasm-vm/cranelift"]
 # for quicker tests, cargo test --lib
 # for more explicit tests, cargo test --features=backtraces
-backtraces = ["cosmwasm-std/backtraces", "cosmwasm-vm/backtraces"]
+backtraces = ["cosmwasm-vm/backtraces"]
 
 [dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }

--- a/contracts/empty/Cargo.toml
+++ b/contracts/empty/Cargo.toml
@@ -27,9 +27,6 @@ overflow-checks = true
 default = []
 # Use cranelift backend instead of singlepass. This is required for development on 32 bit or ARM machines.
 cranelift = ["cosmwasm-vm/cranelift"]
-# for quicker tests, cargo test --lib
-# for more explicit tests, cargo test --features=backtraces
-backtraces = ["cosmwasm-vm/backtraces"]
 
 [dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }

--- a/contracts/floaty/Cargo.toml
+++ b/contracts/floaty/Cargo.toml
@@ -28,7 +28,7 @@ default = []
 # Use cranelift backend instead of singlepass. This is required for development on 32 bit or ARM machines.
 cranelift = ["cosmwasm-vm/cranelift"]
 # For quicker tests, cargo test --lib. for more explicit tests, cargo test --features=backtraces
-backtraces = ["cosmwasm-std/backtraces", "cosmwasm-vm/backtraces"]
+backtraces = ["cosmwasm-vm/backtraces"]
 
 [dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }

--- a/contracts/floaty/Cargo.toml
+++ b/contracts/floaty/Cargo.toml
@@ -27,8 +27,6 @@ overflow-checks = true
 default = []
 # Use cranelift backend instead of singlepass. This is required for development on 32 bit or ARM machines.
 cranelift = ["cosmwasm-vm/cranelift"]
-# For quicker tests, cargo test --lib. for more explicit tests, cargo test --features=backtraces
-backtraces = ["cosmwasm-vm/backtraces"]
 
 [dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }

--- a/contracts/hackatom/Cargo.toml
+++ b/contracts/hackatom/Cargo.toml
@@ -28,7 +28,7 @@ default = []
 # Use cranelift backend instead of singlepass. This is required for development on 32 bit or ARM machines.
 cranelift = ["cosmwasm-vm/cranelift"]
 # For quicker tests, cargo test --lib. for more explicit tests, cargo test --features=backtraces
-backtraces = ["cosmwasm-std/backtraces", "cosmwasm-vm/backtraces"]
+backtraces = ["cosmwasm-vm/backtraces"]
 
 [dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }

--- a/contracts/hackatom/Cargo.toml
+++ b/contracts/hackatom/Cargo.toml
@@ -27,8 +27,6 @@ overflow-checks = true
 default = []
 # Use cranelift backend instead of singlepass. This is required for development on 32 bit or ARM machines.
 cranelift = ["cosmwasm-vm/cranelift"]
-# For quicker tests, cargo test --lib. for more explicit tests, cargo test --features=backtraces
-backtraces = ["cosmwasm-vm/backtraces"]
 
 [dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }

--- a/contracts/ibc-reflect-send/Cargo.toml
+++ b/contracts/ibc-reflect-send/Cargo.toml
@@ -29,7 +29,7 @@ default = []
 cranelift = ["cosmwasm-vm/cranelift"]
 # for quicker tests, cargo test --lib
 # for more explicit tests, cargo test --features=backtraces
-backtraces = ["cosmwasm-std/backtraces", "cosmwasm-vm/backtraces"]
+backtraces = ["cosmwasm-vm/backtraces"]
 
 [dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }

--- a/contracts/ibc-reflect-send/Cargo.toml
+++ b/contracts/ibc-reflect-send/Cargo.toml
@@ -27,9 +27,6 @@ overflow-checks = true
 default = []
 # Use cranelift backend instead of singlepass. This is required for development on 32 bit or ARM machines.
 cranelift = ["cosmwasm-vm/cranelift"]
-# for quicker tests, cargo test --lib
-# for more explicit tests, cargo test --features=backtraces
-backtraces = ["cosmwasm-vm/backtraces"]
 
 [dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }

--- a/contracts/ibc-reflect/Cargo.toml
+++ b/contracts/ibc-reflect/Cargo.toml
@@ -29,7 +29,7 @@ default = []
 cranelift = ["cosmwasm-vm/cranelift"]
 # for quicker tests, cargo test --lib
 # for more explicit tests, cargo test --features=backtraces
-backtraces = ["cosmwasm-std/backtraces", "cosmwasm-vm/backtraces"]
+backtraces = ["cosmwasm-vm/backtraces"]
 
 [dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }

--- a/contracts/ibc-reflect/Cargo.toml
+++ b/contracts/ibc-reflect/Cargo.toml
@@ -27,9 +27,6 @@ overflow-checks = true
 default = []
 # Use cranelift backend instead of singlepass. This is required for development on 32 bit or ARM machines.
 cranelift = ["cosmwasm-vm/cranelift"]
-# for quicker tests, cargo test --lib
-# for more explicit tests, cargo test --features=backtraces
-backtraces = ["cosmwasm-vm/backtraces"]
 
 [dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }

--- a/contracts/queue/Cargo.toml
+++ b/contracts/queue/Cargo.toml
@@ -28,7 +28,7 @@ default = []
 # Use cranelift backend instead of singlepass. This is required for development on 32 bit or ARM machines.
 cranelift = ["cosmwasm-vm/cranelift"]
 # For quicker tests, cargo test --lib. for more explicit tests, cargo test --features=backtraces
-backtraces = ["cosmwasm-std/backtraces", "cosmwasm-vm/backtraces"]
+backtraces = ["cosmwasm-vm/backtraces"]
 # this is to demonstrate conditional entry-points for cosmwasm-plus style
 library = []
 
@@ -40,4 +40,4 @@ schemars = "0.8.3"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
-cosmwasm-vm = { path = "../../packages/vm", default-features = false, features = ["iterator"]  }
+cosmwasm-vm = { path = "../../packages/vm", default-features = false, features = ["iterator"] }

--- a/contracts/queue/Cargo.toml
+++ b/contracts/queue/Cargo.toml
@@ -27,8 +27,6 @@ overflow-checks = true
 default = []
 # Use cranelift backend instead of singlepass. This is required for development on 32 bit or ARM machines.
 cranelift = ["cosmwasm-vm/cranelift"]
-# For quicker tests, cargo test --lib. for more explicit tests, cargo test --features=backtraces
-backtraces = ["cosmwasm-vm/backtraces"]
 # this is to demonstrate conditional entry-points for cosmwasm-plus style
 library = []
 

--- a/contracts/reflect/Cargo.toml
+++ b/contracts/reflect/Cargo.toml
@@ -28,9 +28,6 @@ overflow-checks = true
 default = []
 # Use cranelift backend instead of singlepass. This is required for development on 32 bit or ARM machines.
 cranelift = ["cosmwasm-vm/cranelift"]
-# for quicker tests, cargo test --lib
-# for more explicit tests, cargo test --features=backtraces
-backtraces = ["cosmwasm-vm/backtraces"]
 
 [dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }

--- a/contracts/reflect/Cargo.toml
+++ b/contracts/reflect/Cargo.toml
@@ -30,7 +30,7 @@ default = []
 cranelift = ["cosmwasm-vm/cranelift"]
 # for quicker tests, cargo test --lib
 # for more explicit tests, cargo test --features=backtraces
-backtraces = ["cosmwasm-std/backtraces", "cosmwasm-vm/backtraces"]
+backtraces = ["cosmwasm-vm/backtraces"]
 
 [dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }

--- a/contracts/staking/Cargo.toml
+++ b/contracts/staking/Cargo.toml
@@ -29,7 +29,7 @@ default = []
 cranelift = ["cosmwasm-vm/cranelift"]
 # for quicker tests, cargo test --lib
 # for more explicit tests, cargo test --features=backtraces
-backtraces = ["cosmwasm-std/backtraces", "cosmwasm-vm/backtraces"]
+backtraces = ["cosmwasm-vm/backtraces"]
 
 [dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }

--- a/contracts/staking/Cargo.toml
+++ b/contracts/staking/Cargo.toml
@@ -27,9 +27,6 @@ overflow-checks = true
 default = []
 # Use cranelift backend instead of singlepass. This is required for development on 32 bit or ARM machines.
 cranelift = ["cosmwasm-vm/cranelift"]
-# for quicker tests, cargo test --lib
-# for more explicit tests, cargo test --features=backtraces
-backtraces = ["cosmwasm-vm/backtraces"]
 
 [dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }

--- a/contracts/virus/Cargo.toml
+++ b/contracts/virus/Cargo.toml
@@ -29,7 +29,7 @@ default = []
 cranelift = ["cosmwasm-vm/cranelift"]
 # for quicker tests, cargo test --lib
 # for more explicit tests, cargo test --features=backtraces
-backtraces = ["cosmwasm-std/backtraces", "cosmwasm-vm/backtraces"]
+backtraces = ["cosmwasm-vm/backtraces"]
 
 [dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }

--- a/contracts/virus/Cargo.toml
+++ b/contracts/virus/Cargo.toml
@@ -27,9 +27,6 @@ overflow-checks = true
 default = []
 # Use cranelift backend instead of singlepass. This is required for development on 32 bit or ARM machines.
 cranelift = ["cosmwasm-vm/cranelift"]
-# for quicker tests, cargo test --lib
-# for more explicit tests, cargo test --features=backtraces
-backtraces = ["cosmwasm-vm/backtraces"]
 
 [dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }

--- a/docs/USING_COSMWASM_STD.md
+++ b/docs/USING_COSMWASM_STD.md
@@ -32,7 +32,7 @@ in the dependency tree. Otherwise conflicting C exports are created.
 
 ## cosmwasm-std features
 
-The libarary comes with the following features:
+The library comes with the following features:
 
 | Feature      | Enabled by default | Description                                                               |
 | ------------ | ------------------ | ------------------------------------------------------------------------- |
@@ -40,7 +40,6 @@ The libarary comes with the following features:
 | abort        | x                  | A panic handler that aborts the contract execution with a helpful message |
 | stargate     |                    | Cosmos SDK 0.40+ features and IBC                                         |
 | staking      |                    | Access to the staking module                                              |
-| backtraces   |                    | Add backtraces to errors (for unit testing)                               |
 | cosmwasm_1_1 |                    | Features that require CosmWasm 1.1+ on the chain                          |
 | cosmwasm_1_2 |                    | Features that require CosmWasm 1.2+ on the chain                          |
 | cosmwasm_1_3 |                    | Features that require CosmWasm 1.3+ on the chain                          |

--- a/packages/crypto/Cargo.toml
+++ b/packages/crypto/Cargo.toml
@@ -9,10 +9,6 @@ license = "Apache-2.0"
 
 [features]
 default = []
-# backtraces provides much better context at runtime errors (in non-wasm code)
-# at the cost of a bit of code size and performance.
-# This feature requires Rust nightly because it depends on the unstable backtrace feature.
-backtraces = []
 
 [lib]
 # See https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options

--- a/packages/crypto/src/backtrace.rs
+++ b/packages/crypto/src/backtrace.rs
@@ -1,0 +1,26 @@
+use core::fmt::{Debug, Display, Formatter, Result};
+use std::backtrace::Backtrace;
+
+/// This wraps an actual backtrace to achieve two things:
+/// - being able to fill this with a stub implementation in `no_std` environments
+/// - being able to use this in conjunction with [`thiserror::Error`]
+pub struct BT(Backtrace);
+
+impl BT {
+    #[track_caller]
+    pub fn capture() -> Self {
+        BT(Backtrace::capture())
+    }
+}
+
+impl Debug for BT {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        Debug::fmt(&self.0, f)
+    }
+}
+
+impl Display for BT {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        Display::fmt(&self.0, f)
+    }
+}

--- a/packages/crypto/src/errors.rs
+++ b/packages/crypto/src/errors.rs
@@ -1,5 +1,4 @@
-#[cfg(feature = "backtraces")]
-use std::backtrace::Backtrace;
+use crate::BT;
 use std::fmt::Debug;
 use thiserror::Error;
 
@@ -8,81 +7,55 @@ pub type CryptoResult<T> = core::result::Result<T, CryptoError>;
 #[derive(Error, Debug)]
 pub enum CryptoError {
     #[error("Batch verify error: {msg}")]
-    BatchErr {
-        msg: String,
-        #[cfg(feature = "backtraces")]
-        backtrace: Backtrace,
-    },
+    BatchErr { msg: String, backtrace: BT },
     #[error("Crypto error: {msg}")]
-    GenericErr {
-        msg: String,
-        #[cfg(feature = "backtraces")]
-        backtrace: Backtrace,
-    },
+    GenericErr { msg: String, backtrace: BT },
     #[error("Invalid hash format")]
-    InvalidHashFormat {
-        #[cfg(feature = "backtraces")]
-        backtrace: Backtrace,
-    },
+    InvalidHashFormat { backtrace: BT },
     #[error("Invalid public key format")]
-    InvalidPubkeyFormat {
-        #[cfg(feature = "backtraces")]
-        backtrace: Backtrace,
-    },
+    InvalidPubkeyFormat { backtrace: BT },
     #[error("Invalid signature format")]
-    InvalidSignatureFormat {
-        #[cfg(feature = "backtraces")]
-        backtrace: Backtrace,
-    },
+    InvalidSignatureFormat { backtrace: BT },
     #[error("Invalid recovery parameter. Supported values: 0 and 1.")]
-    InvalidRecoveryParam {
-        #[cfg(feature = "backtraces")]
-        backtrace: Backtrace,
-    },
+    InvalidRecoveryParam { backtrace: BT },
 }
 
 impl CryptoError {
     pub fn batch_err(msg: impl Into<String>) -> Self {
         CryptoError::BatchErr {
             msg: msg.into(),
-            #[cfg(feature = "backtraces")]
-            backtrace: Backtrace::capture(),
+            backtrace: BT::capture(),
         }
     }
 
     pub fn generic_err(msg: impl Into<String>) -> Self {
         CryptoError::GenericErr {
             msg: msg.into(),
-            #[cfg(feature = "backtraces")]
-            backtrace: Backtrace::capture(),
+            backtrace: BT::capture(),
         }
     }
 
     pub fn invalid_hash_format() -> Self {
         CryptoError::InvalidHashFormat {
-            #[cfg(feature = "backtraces")]
-            backtrace: Backtrace::capture(),
+            backtrace: BT::capture(),
         }
     }
 
     pub fn invalid_pubkey_format() -> Self {
         CryptoError::InvalidPubkeyFormat {
-            #[cfg(feature = "backtraces")]
-            backtrace: Backtrace::capture(),
+            backtrace: BT::capture(),
         }
     }
 
     pub fn invalid_signature_format() -> Self {
         CryptoError::InvalidSignatureFormat {
-            #[cfg(feature = "backtraces")]
-            backtrace: Backtrace::capture(),
+            backtrace: BT::capture(),
         }
     }
 
     pub fn invalid_recovery_param() -> Self {
         CryptoError::InvalidRecoveryParam {
-            #[cfg(feature = "backtraces")]
-            backtrace: Backtrace::capture(),
+            backtrace: BT::capture(),
         }
     }
 

--- a/packages/crypto/src/lib.rs
+++ b/packages/crypto/src/lib.rs
@@ -2,9 +2,7 @@
 //! Please don't use any of these types directly, as
 //! they might change frequently, or be removed in the future.
 //! This crate does not adhere to semantic versioning.
-#![cfg_attr(feature = "backtraces", feature(error_generic_member_access))]
-#![cfg_attr(feature = "backtraces", feature(provide_any))]
-
+mod backtrace;
 mod ed25519;
 mod errors;
 mod identity_digest;
@@ -20,3 +18,4 @@ pub use crate::errors::{CryptoError, CryptoResult};
 pub use crate::secp256k1::{secp256k1_recover_pubkey, secp256k1_verify};
 #[doc(hidden)]
 pub use crate::secp256k1::{ECDSA_PUBKEY_MAX_LEN, ECDSA_SIGNATURE_LEN, MESSAGE_HASH_MAX_LEN};
+pub(crate) use backtrace::BT;

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -23,10 +23,6 @@ iterator = []
 # CosmosMsg types, and new QueryRequest types. This should only be enabled on contracts
 # that require these types, so other contracts can be used on systems with eg. PoA consensus
 staking = []
-# backtraces provides much better context at runtime errors (in non-wasm code)
-# at the cost of a bit of code size and performance.
-# This feature requires Rust nightly because it depends on the unstable backtrace feature.
-backtraces = []
 # stargate enables stargate-dependent messages and queries, like raw protobuf messages
 # as well as ibc-related functionality
 stargate = []
@@ -54,10 +50,7 @@ forward_ref = "1"
 hex = "0.4"
 schemars = "0.8.3"
 sha2 = "0.10.3"
-serde = { version = "1.0.103", default-features = false, features = [
-  "derive",
-  "alloc",
-] }
+serde = { version = "1.0.103", default-features = false, features = ["derive", "alloc"] }
 serde-json-wasm = { version = "1.0.0" }
 thiserror = "1.0.26"
 bnum = "0.8.0"
@@ -70,10 +63,7 @@ cosmwasm-crypto = { path = "../crypto", version = "1.5.0" }
 [dev-dependencies]
 cosmwasm-schema = { path = "../schema" }
 # The chrono dependency is only used in an example, which Rust compiles for us. If this causes trouble, remove it.
-chrono = { version = "0.4", default-features = false, features = [
-  "alloc",
-  "std",
-] }
+chrono = { version = "0.4", default-features = false, features = ["alloc", "std"] }
 crc32fast = "1.3.2"
 hex-literal = "0.3.1"
 serde_json = "1.0.81"

--- a/packages/std/src/binary.rs
+++ b/packages/std/src/binary.rs
@@ -335,7 +335,7 @@ mod tests {
             ("cmFuZ", "Encoded text cannot have a 6-bit remainder."),
         ] {
             match Binary::from_base64(invalid_base64) {
-                Err(StdError::InvalidBase64 { msg }) => assert_eq!(want, msg),
+                Err(StdError::InvalidBase64 { msg, .. }) => assert_eq!(want, msg),
                 result => panic!("Unexpected result: {result:?}"),
             }
         }

--- a/packages/std/src/errors/backtrace.rs
+++ b/packages/std/src/errors/backtrace.rs
@@ -1,0 +1,48 @@
+use core::fmt::{Debug, Display, Formatter, Result};
+use thiserror::Error;
+
+/// This wraps an actual backtrace to achieve two things:
+/// - being able to fill this with a stub implementation in `no_std` environments
+/// - being able to use this in conjunction with [`thiserror::Error`]
+#[derive(Error)]
+pub struct BT(Box<dyn Printable>);
+
+impl BT {
+    #[track_caller]
+    pub fn capture() -> Self {
+        BT(Box::new(std::backtrace::Backtrace::capture()))
+    }
+}
+
+trait Printable: Debug + Display {}
+impl<T> Printable for T where T: Debug + Display {}
+
+impl Debug for BT {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        Debug::fmt(&self.0, f)
+    }
+}
+
+impl Display for BT {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        Display::fmt(&self.0, f)
+    }
+}
+
+/// This macro implements `From` for a given error type to a given error type where
+/// the target error has a `backtrace` field.
+/// This is meant as a replacement for `thiserror`'s `#[from]` attribute, which does not
+/// work with our custom backtrace wrapper.
+macro_rules! impl_from_err {
+    ($from:ty, $to:ty, $map:path) => {
+        impl From<$from> for $to {
+            fn from(err: $from) -> Self {
+                $map {
+                    source: err,
+                    backtrace: $crate::errors::backtrace::BT::capture(),
+                }
+            }
+        }
+    };
+}
+pub(crate) use impl_from_err;

--- a/packages/std/src/errors/backtrace.rs
+++ b/packages/std/src/errors/backtrace.rs
@@ -10,7 +10,10 @@ pub struct BT(Box<dyn Printable>);
 impl BT {
     #[track_caller]
     pub fn capture() -> Self {
-        BT(Box::new(std::backtrace::Backtrace::capture()))
+        #[cfg(target_arch = "wasm32")]
+        return BT(Box::new(std::backtrace::Backtrace::disabled()));
+        #[cfg(not(target_arch = "wasm32"))]
+        return BT(Box::new(std::backtrace::Backtrace::capture()));
     }
 }
 

--- a/packages/std/src/errors/backtrace.rs
+++ b/packages/std/src/errors/backtrace.rs
@@ -1,10 +1,8 @@
 use core::fmt::{Debug, Display, Formatter, Result};
-use thiserror::Error;
 
 /// This wraps an actual backtrace to achieve two things:
 /// - being able to fill this with a stub implementation in `no_std` environments
 /// - being able to use this in conjunction with [`thiserror::Error`]
-#[derive(Error)]
 pub struct BT(Box<dyn Printable>);
 
 impl BT {

--- a/packages/std/src/errors/backtrace.rs
+++ b/packages/std/src/errors/backtrace.rs
@@ -8,6 +8,7 @@ pub struct BT(Box<dyn Printable>);
 impl BT {
     #[track_caller]
     pub fn capture() -> Self {
+        // in case of no_std, we can fill with a stub here
         #[cfg(target_arch = "wasm32")]
         return BT(Box::new(std::backtrace::Backtrace::disabled()));
         #[cfg(not(target_arch = "wasm32"))]
@@ -47,3 +48,22 @@ macro_rules! impl_from_err {
     };
 }
 pub(crate) use impl_from_err;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bt_works_without_std() {
+        #[derive(Debug)]
+        struct BacktraceStub;
+
+        impl Display for BacktraceStub {
+            fn fmt(&self, _f: &mut Formatter<'_>) -> Result {
+                Ok(())
+            }
+        }
+
+        _ = BT(Box::new(BacktraceStub));
+    }
+}

--- a/packages/std/src/errors/mod.rs
+++ b/packages/std/src/errors/mod.rs
@@ -1,8 +1,10 @@
+mod backtrace;
 mod recover_pubkey_error;
 mod std_error;
 mod system_error;
 mod verification_error;
 
+pub(crate) use backtrace::{impl_from_err, BT};
 pub use recover_pubkey_error::RecoverPubkeyError;
 pub use std_error::{
     CheckedFromRatioError, CheckedMultiplyFractionError, CheckedMultiplyRatioError,

--- a/packages/std/src/errors/recover_pubkey_error.rs
+++ b/packages/std/src/errors/recover_pubkey_error.rs
@@ -1,8 +1,8 @@
 use core::fmt::Debug;
 #[cfg(not(target_arch = "wasm32"))]
 use cosmwasm_crypto::CryptoError;
-#[cfg(feature = "backtraces")]
-use std::backtrace::Backtrace;
+
+use super::BT;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -14,19 +14,15 @@ pub enum RecoverPubkeyError {
     #[error("Invalid recovery parameter. Supported values: 0 and 1.")]
     InvalidRecoveryParam,
     #[error("Unknown error: {error_code}")]
-    UnknownErr {
-        error_code: u32,
-        #[cfg(feature = "backtraces")]
-        backtrace: Backtrace,
-    },
+    UnknownErr { error_code: u32, backtrace: BT },
 }
 
 impl RecoverPubkeyError {
     pub fn unknown_err(error_code: u32) -> Self {
         RecoverPubkeyError::UnknownErr {
             error_code,
-            #[cfg(feature = "backtraces")]
-            backtrace: Backtrace::capture(),
+
+            backtrace: BT::capture(),
         }
     }
 }

--- a/packages/std/src/errors/std_error.rs
+++ b/packages/std/src/errors/std_error.rs
@@ -1,6 +1,6 @@
 use core::fmt;
-#[cfg(feature = "backtraces")]
-use std::backtrace::Backtrace;
+
+use super::{impl_from_err, BT};
 use thiserror::Error;
 
 use crate::errors::{RecoverPubkeyError, VerificationError};
@@ -25,121 +25,94 @@ pub enum StdError {
     #[error("Verification error: {source}")]
     VerificationErr {
         source: VerificationError,
-        #[cfg(feature = "backtraces")]
-        backtrace: Backtrace,
+        backtrace: BT,
     },
     #[error("Recover pubkey error: {source}")]
     RecoverPubkeyErr {
         source: RecoverPubkeyError,
-        #[cfg(feature = "backtraces")]
-        backtrace: Backtrace,
+        backtrace: BT,
     },
     /// Whenever there is no specific error type available
     #[error("Generic error: {msg}")]
-    GenericErr {
-        msg: String,
-        #[cfg(feature = "backtraces")]
-        backtrace: Backtrace,
-    },
+    GenericErr { msg: String, backtrace: BT },
     #[error("Invalid Base64 string: {msg}")]
-    InvalidBase64 {
-        msg: String,
-        #[cfg(feature = "backtraces")]
-        backtrace: Backtrace,
-    },
+    InvalidBase64 { msg: String, backtrace: BT },
     #[error("Invalid data size: expected={expected} actual={actual}")]
     InvalidDataSize {
         expected: u64,
         actual: u64,
-        #[cfg(feature = "backtraces")]
-        backtrace: Backtrace,
+        backtrace: BT,
     },
     #[error("Invalid hex string: {msg}")]
-    InvalidHex {
-        msg: String,
-        #[cfg(feature = "backtraces")]
-        backtrace: Backtrace,
-    },
+    InvalidHex { msg: String, backtrace: BT },
     /// Whenever UTF-8 bytes cannot be decoded into a unicode string, e.g. in String::from_utf8 or str::from_utf8.
     #[error("Cannot decode UTF8 bytes into string: {msg}")]
-    InvalidUtf8 {
-        msg: String,
-        #[cfg(feature = "backtraces")]
-        backtrace: Backtrace,
-    },
+    InvalidUtf8 { msg: String, backtrace: BT },
     #[error("{kind} not found")]
-    NotFound {
-        kind: String,
-        #[cfg(feature = "backtraces")]
-        backtrace: Backtrace,
-    },
+    NotFound { kind: String, backtrace: BT },
     #[error("Error parsing into type {target_type}: {msg}")]
     ParseErr {
         /// the target type that was attempted
         target_type: String,
         msg: String,
-        #[cfg(feature = "backtraces")]
-        backtrace: Backtrace,
+        backtrace: BT,
     },
     #[error("Error serializing type {source_type}: {msg}")]
     SerializeErr {
         /// the source type that was attempted
         source_type: String,
         msg: String,
-        #[cfg(feature = "backtraces")]
-        backtrace: Backtrace,
+        backtrace: BT,
     },
     #[error("Overflow: {source}")]
     Overflow {
         source: OverflowError,
-        #[cfg(feature = "backtraces")]
-        backtrace: Backtrace,
+        backtrace: BT,
     },
     #[error("Divide by zero: {source}")]
     DivideByZero {
         source: DivideByZeroError,
-        #[cfg(feature = "backtraces")]
-        backtrace: Backtrace,
+        backtrace: BT,
     },
     #[error("Conversion error: ")]
     ConversionOverflow {
-        #[from]
         source: ConversionOverflowError,
-        #[cfg(feature = "backtraces")]
-        backtrace: Backtrace,
+        backtrace: BT,
     },
 }
+
+impl_from_err!(
+    ConversionOverflowError,
+    StdError,
+    StdError::ConversionOverflow
+);
 
 impl StdError {
     pub fn verification_err(source: VerificationError) -> Self {
         StdError::VerificationErr {
             source,
-            #[cfg(feature = "backtraces")]
-            backtrace: Backtrace::capture(),
+            backtrace: BT::capture(),
         }
     }
 
     pub fn recover_pubkey_err(source: RecoverPubkeyError) -> Self {
         StdError::RecoverPubkeyErr {
             source,
-            #[cfg(feature = "backtraces")]
-            backtrace: Backtrace::capture(),
+            backtrace: BT::capture(),
         }
     }
 
     pub fn generic_err(msg: impl Into<String>) -> Self {
         StdError::GenericErr {
             msg: msg.into(),
-            #[cfg(feature = "backtraces")]
-            backtrace: Backtrace::capture(),
+            backtrace: BT::capture(),
         }
     }
 
     pub fn invalid_base64(msg: impl ToString) -> Self {
         StdError::InvalidBase64 {
             msg: msg.to_string(),
-            #[cfg(feature = "backtraces")]
-            backtrace: Backtrace::capture(),
+            backtrace: BT::capture(),
         }
     }
 
@@ -148,32 +121,28 @@ impl StdError {
             // Cast is safe because usize is 32 or 64 bit large in all environments we support
             expected: expected as u64,
             actual: actual as u64,
-            #[cfg(feature = "backtraces")]
-            backtrace: Backtrace::capture(),
+            backtrace: BT::capture(),
         }
     }
 
     pub fn invalid_hex(msg: impl ToString) -> Self {
         StdError::InvalidHex {
             msg: msg.to_string(),
-            #[cfg(feature = "backtraces")]
-            backtrace: Backtrace::capture(),
+            backtrace: BT::capture(),
         }
     }
 
     pub fn invalid_utf8(msg: impl ToString) -> Self {
         StdError::InvalidUtf8 {
             msg: msg.to_string(),
-            #[cfg(feature = "backtraces")]
-            backtrace: Backtrace::capture(),
+            backtrace: BT::capture(),
         }
     }
 
     pub fn not_found(kind: impl Into<String>) -> Self {
         StdError::NotFound {
             kind: kind.into(),
-            #[cfg(feature = "backtraces")]
-            backtrace: Backtrace::capture(),
+            backtrace: BT::capture(),
         }
     }
 
@@ -181,8 +150,7 @@ impl StdError {
         StdError::ParseErr {
             target_type: target.into(),
             msg: msg.to_string(),
-            #[cfg(feature = "backtraces")]
-            backtrace: Backtrace::capture(),
+            backtrace: BT::capture(),
         }
     }
 
@@ -190,24 +158,21 @@ impl StdError {
         StdError::SerializeErr {
             source_type: source.into(),
             msg: msg.to_string(),
-            #[cfg(feature = "backtraces")]
-            backtrace: Backtrace::capture(),
+            backtrace: BT::capture(),
         }
     }
 
     pub fn overflow(source: OverflowError) -> Self {
         StdError::Overflow {
             source,
-            #[cfg(feature = "backtraces")]
-            backtrace: Backtrace::capture(),
+            backtrace: BT::capture(),
         }
     }
 
     pub fn divide_by_zero(source: DivideByZeroError) -> Self {
         StdError::DivideByZero {
             source,
-            #[cfg(feature = "backtraces")]
-            backtrace: Backtrace::capture(),
+            backtrace: BT::capture(),
         }
     }
 }
@@ -217,13 +182,11 @@ impl PartialEq<StdError> for StdError {
         match self {
             StdError::VerificationErr {
                 source,
-                #[cfg(feature = "backtraces")]
-                    backtrace: _,
+                backtrace: _,
             } => {
                 if let StdError::VerificationErr {
                     source: rhs_source,
-                    #[cfg(feature = "backtraces")]
-                        backtrace: _,
+                    backtrace: _,
                 } = rhs
                 {
                     source == rhs_source
@@ -233,13 +196,11 @@ impl PartialEq<StdError> for StdError {
             }
             StdError::RecoverPubkeyErr {
                 source,
-                #[cfg(feature = "backtraces")]
-                    backtrace: _,
+                backtrace: _,
             } => {
                 if let StdError::RecoverPubkeyErr {
                     source: rhs_source,
-                    #[cfg(feature = "backtraces")]
-                        backtrace: _,
+                    backtrace: _,
                 } = rhs
                 {
                     source == rhs_source
@@ -247,15 +208,10 @@ impl PartialEq<StdError> for StdError {
                     false
                 }
             }
-            StdError::GenericErr {
-                msg,
-                #[cfg(feature = "backtraces")]
-                    backtrace: _,
-            } => {
+            StdError::GenericErr { msg, backtrace: _ } => {
                 if let StdError::GenericErr {
                     msg: rhs_msg,
-                    #[cfg(feature = "backtraces")]
-                        backtrace: _,
+                    backtrace: _,
                 } = rhs
                 {
                     msg == rhs_msg
@@ -263,15 +219,10 @@ impl PartialEq<StdError> for StdError {
                     false
                 }
             }
-            StdError::InvalidBase64 {
-                msg,
-                #[cfg(feature = "backtraces")]
-                    backtrace: _,
-            } => {
+            StdError::InvalidBase64 { msg, backtrace: _ } => {
                 if let StdError::InvalidBase64 {
                     msg: rhs_msg,
-                    #[cfg(feature = "backtraces")]
-                        backtrace: _,
+                    backtrace: _,
                 } = rhs
                 {
                     msg == rhs_msg
@@ -282,14 +233,12 @@ impl PartialEq<StdError> for StdError {
             StdError::InvalidDataSize {
                 expected,
                 actual,
-                #[cfg(feature = "backtraces")]
-                    backtrace: _,
+                backtrace: _,
             } => {
                 if let StdError::InvalidDataSize {
                     expected: rhs_expected,
                     actual: rhs_actual,
-                    #[cfg(feature = "backtraces")]
-                        backtrace: _,
+                    backtrace: _,
                 } = rhs
                 {
                     expected == rhs_expected && actual == rhs_actual
@@ -297,15 +246,10 @@ impl PartialEq<StdError> for StdError {
                     false
                 }
             }
-            StdError::InvalidHex {
-                msg,
-                #[cfg(feature = "backtraces")]
-                    backtrace: _,
-            } => {
+            StdError::InvalidHex { msg, backtrace: _ } => {
                 if let StdError::InvalidHex {
                     msg: rhs_msg,
-                    #[cfg(feature = "backtraces")]
-                        backtrace: _,
+                    backtrace: _,
                 } = rhs
                 {
                     msg == rhs_msg
@@ -313,15 +257,10 @@ impl PartialEq<StdError> for StdError {
                     false
                 }
             }
-            StdError::InvalidUtf8 {
-                msg,
-                #[cfg(feature = "backtraces")]
-                    backtrace: _,
-            } => {
+            StdError::InvalidUtf8 { msg, backtrace: _ } => {
                 if let StdError::InvalidUtf8 {
                     msg: rhs_msg,
-                    #[cfg(feature = "backtraces")]
-                        backtrace: _,
+                    backtrace: _,
                 } = rhs
                 {
                     msg == rhs_msg
@@ -329,15 +268,10 @@ impl PartialEq<StdError> for StdError {
                     false
                 }
             }
-            StdError::NotFound {
-                kind,
-                #[cfg(feature = "backtraces")]
-                    backtrace: _,
-            } => {
+            StdError::NotFound { kind, backtrace: _ } => {
                 if let StdError::NotFound {
                     kind: rhs_kind,
-                    #[cfg(feature = "backtraces")]
-                        backtrace: _,
+                    backtrace: _,
                 } = rhs
                 {
                     kind == rhs_kind
@@ -348,14 +282,12 @@ impl PartialEq<StdError> for StdError {
             StdError::ParseErr {
                 target_type,
                 msg,
-                #[cfg(feature = "backtraces")]
-                    backtrace: _,
+                backtrace: _,
             } => {
                 if let StdError::ParseErr {
                     target_type: rhs_target_type,
                     msg: rhs_msg,
-                    #[cfg(feature = "backtraces")]
-                        backtrace: _,
+                    backtrace: _,
                 } = rhs
                 {
                     target_type == rhs_target_type && msg == rhs_msg
@@ -366,14 +298,12 @@ impl PartialEq<StdError> for StdError {
             StdError::SerializeErr {
                 source_type,
                 msg,
-                #[cfg(feature = "backtraces")]
-                    backtrace: _,
+                backtrace: _,
             } => {
                 if let StdError::SerializeErr {
                     source_type: rhs_source_type,
                     msg: rhs_msg,
-                    #[cfg(feature = "backtraces")]
-                        backtrace: _,
+                    backtrace: _,
                 } = rhs
                 {
                     source_type == rhs_source_type && msg == rhs_msg
@@ -383,13 +313,11 @@ impl PartialEq<StdError> for StdError {
             }
             StdError::Overflow {
                 source,
-                #[cfg(feature = "backtraces")]
-                    backtrace: _,
+                backtrace: _,
             } => {
                 if let StdError::Overflow {
                     source: rhs_source,
-                    #[cfg(feature = "backtraces")]
-                        backtrace: _,
+                    backtrace: _,
                 } = rhs
                 {
                     source == rhs_source
@@ -399,13 +327,11 @@ impl PartialEq<StdError> for StdError {
             }
             StdError::DivideByZero {
                 source,
-                #[cfg(feature = "backtraces")]
-                    backtrace: _,
+                backtrace: _,
             } => {
                 if let StdError::DivideByZero {
                     source: rhs_source,
-                    #[cfg(feature = "backtraces")]
-                        backtrace: _,
+                    backtrace: _,
                 } = rhs
                 {
                     source == rhs_source
@@ -415,13 +341,11 @@ impl PartialEq<StdError> for StdError {
             }
             StdError::ConversionOverflow {
                 source,
-                #[cfg(feature = "backtraces")]
-                    backtrace: _,
+                backtrace: _,
             } => {
                 if let StdError::ConversionOverflow {
                     source: rhs_source,
-                    #[cfg(feature = "backtraces")]
-                        backtrace: _,
+                    backtrace: _,
                 } = rhs
                 {
                     source == rhs_source
@@ -811,9 +735,6 @@ mod tests {
     fn implements_debug() {
         let error: StdError = StdError::from(OverflowError::new(OverflowOperation::Sub));
         let embedded = format!("Debug: {error:?}");
-        #[cfg(not(feature = "backtraces"))]
-        let expected = r#"Debug: Overflow { source: OverflowError { operation: Sub } }"#;
-        #[cfg(feature = "backtraces")]
         let expected = r#"Debug: Overflow { source: OverflowError { operation: Sub }, backtrace: <disabled> }"#;
         assert_eq!(embedded, expected);
     }

--- a/packages/std/src/errors/verification_error.rs
+++ b/packages/std/src/errors/verification_error.rs
@@ -1,6 +1,6 @@
 use core::fmt::Debug;
-#[cfg(feature = "backtraces")]
-use std::backtrace::Backtrace;
+
+use super::BT;
 use thiserror::Error;
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -21,19 +21,15 @@ pub enum VerificationError {
     #[error("Invalid recovery parameter. Supported values: 0 and 1.")]
     InvalidRecoveryParam,
     #[error("Unknown error: {error_code}")]
-    UnknownErr {
-        error_code: u32,
-        #[cfg(feature = "backtraces")]
-        backtrace: Backtrace,
-    },
+    UnknownErr { error_code: u32, backtrace: BT },
 }
 
 impl VerificationError {
     pub fn unknown_err(error_code: u32) -> Self {
         VerificationError::UnknownErr {
             error_code,
-            #[cfg(feature = "backtraces")]
-            backtrace: Backtrace::capture(),
+
+            backtrace: BT::capture(),
         }
     }
 }

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -1,6 +1,3 @@
-#![cfg_attr(feature = "backtraces", feature(error_generic_member_access))]
-#![cfg_attr(feature = "backtraces", feature(provide_any))]
-
 extern crate alloc;
 
 // Exposed on all platforms

--- a/packages/vm/Cargo.toml
+++ b/packages/vm/Cargo.toml
@@ -9,10 +9,6 @@ license = "Apache-2.0"
 
 [features]
 default = ["staking", "iterator"]
-# backtraces provides much better context at runtime errors (in non-wasm code)
-# at the cost of a bit of code size and performance.
-# This feature requires Rust nightly because it depends on the unstable backtrace feature.
-backtraces = []
 # iterator allows us to iterate over all DB items in a given range
 # this must be enabled to support cosmwasm contracts compiled with the 'iterator' feature
 # optional as some merkle stores (like tries) don't support this

--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -1287,7 +1287,7 @@ mod tests {
         // removing again fails
 
         match remove_wasm_from_disk(path, &checksum).unwrap_err() {
-            VmError::CacheErr { msg } => assert_eq!(msg, "Wasm file does not exist"),
+            VmError::CacheErr { msg, .. } => assert_eq!(msg, "Wasm file does not exist"),
             err => panic!("Unexpected error: {err:?}"),
         }
     }

--- a/packages/vm/src/calls.rs
+++ b/packages/vm/src/calls.rs
@@ -669,7 +669,7 @@ mod tests {
         let msg = br#"{"cpu_loop":{}}"#;
         let err =
             call_execute::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg).unwrap_err();
-        assert!(matches!(err, VmError::GasDepletion {}));
+        assert!(matches!(err, VmError::GasDepletion { .. }));
     }
 
     #[test]
@@ -687,7 +687,7 @@ mod tests {
         let err =
             call_execute::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg).unwrap_err();
         match err {
-            VmError::RuntimeErr { msg } => {
+            VmError::RuntimeErr { msg, .. } => {
                 assert!(msg.contains(
                     "RuntimeError: Aborted: panicked at 'This page intentionally faulted'"
                 ))
@@ -711,7 +711,7 @@ mod tests {
         let err =
             call_execute::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg).unwrap_err();
         match err {
-            VmError::RuntimeErr { msg } => {
+            VmError::RuntimeErr { msg, .. } => {
                 assert!(msg.contains("RuntimeError: unreachable"))
             }
             err => panic!("Unexpected error: {err:?}"),

--- a/packages/vm/src/errors/backtrace.rs
+++ b/packages/vm/src/errors/backtrace.rs
@@ -1,9 +1,7 @@
 use core::fmt::{Debug, Display, Formatter, Result};
 use std::backtrace::Backtrace;
 
-/// This wraps an actual backtrace to achieve two things:
-/// - being able to fill this with a stub implementation in `no_std` environments
-/// - being able to use this in conjunction with [`thiserror::Error`]
+/// This wraps an actual backtrace to allow us to use this in conjunction with [`thiserror::Error`]
 pub struct BT(Box<Backtrace>);
 
 impl BT {

--- a/packages/vm/src/errors/backtrace.rs
+++ b/packages/vm/src/errors/backtrace.rs
@@ -1,0 +1,44 @@
+use core::fmt::{Debug, Display, Formatter, Result};
+use std::backtrace::Backtrace;
+
+/// This wraps an actual backtrace to achieve two things:
+/// - being able to fill this with a stub implementation in `no_std` environments
+/// - being able to use this in conjunction with [`thiserror::Error`]
+pub struct BT(Backtrace);
+
+impl BT {
+    #[track_caller]
+    pub fn capture() -> Self {
+        BT(Backtrace::capture())
+    }
+}
+
+impl Debug for BT {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        Debug::fmt(&self.0, f)
+    }
+}
+
+impl Display for BT {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        Display::fmt(&self.0, f)
+    }
+}
+
+/// This macro implements `From` for a given error type to a given error type where
+/// the target error has a `backtrace` field.
+/// This is meant as a replacement for `thiserror`'s `#[from]` attribute, which does not
+/// work with our custom backtrace wrapper.
+macro_rules! impl_from_err {
+    ($from:ty, $to:ty, $map:path) => {
+        impl From<$from> for $to {
+            fn from(err: $from) -> Self {
+                $map {
+                    source: err,
+                    backtrace: $crate::errors::backtrace::BT::capture(),
+                }
+            }
+        }
+    };
+}
+pub(crate) use impl_from_err;

--- a/packages/vm/src/errors/backtrace.rs
+++ b/packages/vm/src/errors/backtrace.rs
@@ -4,12 +4,12 @@ use std::backtrace::Backtrace;
 /// This wraps an actual backtrace to achieve two things:
 /// - being able to fill this with a stub implementation in `no_std` environments
 /// - being able to use this in conjunction with [`thiserror::Error`]
-pub struct BT(Backtrace);
+pub struct BT(Box<Backtrace>);
 
 impl BT {
     #[track_caller]
     pub fn capture() -> Self {
-        BT(Backtrace::capture())
+        BT(Box::new(Backtrace::capture()))
     }
 }
 

--- a/packages/vm/src/errors/mod.rs
+++ b/packages/vm/src/errors/mod.rs
@@ -1,7 +1,9 @@
+mod backtrace;
 mod communication_error;
 mod region_validation_error;
 mod vm_error;
 
+pub(crate) use backtrace::{impl_from_err, BT};
 pub use communication_error::CommunicationError;
 pub use region_validation_error::RegionValidationError;
 pub use vm_error::VmError;

--- a/packages/vm/src/lib.rs
+++ b/packages/vm/src/lib.rs
@@ -1,6 +1,3 @@
-#![cfg_attr(feature = "backtraces", feature(error_generic_member_access))]
-#![cfg_attr(feature = "backtraces", feature(provide_any))]
-
 mod backend;
 mod cache;
 mod calls;


### PR DESCRIPTION
closes #1760 

We cannot use the `#[from]` annotation anymore, so I added an internal macro for that (currently we only use it for one variant).