### PR TITLE
Fix panic test

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ This code is compiled into Wasm bytecode as part of the smart contract.
   some given source code, allowing a
   [similar contract verification algorithm](https://medium.com/coinmonks/how-to-verify-and-publish-on-etherscan-52cf25312945)
   as Etherscan.
+
+  Building locally instead of using the docker image can
+  [leak some information about the directory structure of your system](https://github.com/CosmWasm/cosmwasm/issues/1918)
+  and makes the build non-reproducible.
+
 - [serde-json-wasm](https://github.com/CosmWasm/serde-json-wasm) - A custom json
   library, forked from `serde-json-core`. This provides an interface similar to
   `serde-json`, but without any floating-point instructions (non-deterministic)

--- a/contracts/hackatom/tests/integration.rs
+++ b/contracts/hackatom/tests/integration.rs
@@ -453,7 +453,8 @@ fn execute_panic() {
     match execute_res.unwrap_err() {
         VmError::RuntimeErr { msg, .. } => {
             assert!(
-                msg.contains("Aborted: panicked at 'This page intentionally faulted'"),
+                msg.contains("Aborted: panicked")
+                    && msg.contains("This page intentionally faulted"),
                 "Must contain panic message"
             );
             assert!(msg.contains("contract.rs:"), "Must contain file and line");


### PR DESCRIPTION
related to #1918 

This started to become annoying because the test always failed locally. This version will work both on CI and with more recent Rust versions.
As discussed in the issue, I also added a notice about the information leakage to the readme.
Manually creating the panic message is currently not really possible on stable rust (see my comment on the issue)