### PR TITLE
Add `std` feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ and this project adheres to
 - cosmwasm-vm: Replace `MockApi` with bech32 implementation. ([#1914])
 - cosmwasm-std: Make `IbcReceiveResponse::acknowledgement` optional and add
   `IbcReceiveResponse::without_ack` constructor. ([#1892])
+- cosmwasm-std: Add `std` feature and make it a default feature. ([#1971])
 
 [#1874]: https://github.com/CosmWasm/cosmwasm/pull/1874
 [#1876]: https://github.com/CosmWasm/cosmwasm/pull/1876
@@ -86,6 +87,7 @@ and this project adheres to
 [#1944]: https://github.com/CosmWasm/cosmwasm/pull/1944
 [#1949]: https://github.com/CosmWasm/cosmwasm/pull/1949
 [#1967]: https://github.com/CosmWasm/cosmwasm/pull/1967
+[#1971]: https://github.com/CosmWasm/cosmwasm/pull/1971
 
 ### Removed
 

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -21,9 +21,18 @@ major releases of `cosmwasm`. Note that you can also view the
 
   If you were using cosmwasm-std's `ibc3` feature, you can remove it, as it is
   the default now. Depending on your usage, you might have to enable the
-  `stargate` feature instead, since it was previously implied by `ibc3`. Also
-  remove any uses of the `backtraces` feature. You can use a `RUST_BACKTRACE=1`
-  env variable for this now.
+  `stargate` feature instead, since it was previously implied by `ibc3`.
+
+  Also remove any uses of the `backtraces` feature. You can use a
+  `RUST_BACKTRACE=1` env variable for this now.
+
+  If you were using `cosmwasm-std` with `default-features = false`, you probably
+  want to enable the `std` feature now, as we might move certain existing
+  functionality to that feature in the future to support no_std environments:
+
+  ```toml
+  cosmwasm-std = { version = "2.0.0", default-features = false, features = ["std", ...] }
+  ```
 
 - `ContractInfoResponse::new` now takes all fields of the response as
   parameters:

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -30,8 +30,9 @@ major releases of `cosmwasm`. Note that you can also view the
   want to enable the `std` feature now, as we might move certain existing
   functionality to that feature in the future to support no_std environments:
 
-  ```toml
-  cosmwasm-std = { version = "2.0.0", default-features = false, features = ["std", ...] }
+  ```diff
+  -cosmwasm-std = { version = "2.0.0", default-features = false, features = [...] }
+  +cosmwasm-std = { version = "2.0.0", default-features = false, features = ["std", ...] }
   ```
 
 - `ContractInfoResponse::new` now takes all fields of the response as

--- a/docs/USING_COSMWASM_STD.md
+++ b/docs/USING_COSMWASM_STD.md
@@ -74,7 +74,8 @@ there it becomes impossible to use the contract in chains with lower CosmWasm
 versions. If you add `abort`, it becomes impossible for the contract developer
 to opt out of the abort feature due to your library. Since this affects the
 default features `abort` and `iterator`, you should always disable default
-features.
+features. However, you should make sure to keep the `std` feature enabled, as we
+might move certain existing functionality to that feature in the future.
 
 Also libraries should define a loose version range that allows the contract
 developer to control which cosmwasm-std version they want to use in the final
@@ -85,5 +86,6 @@ A typical dependency then looks like this:
 
 ```toml
 # We really need `stargate` here as this is an IBC related library. `abort` and `iterator` are not needed.
-cosmwasm-std = { version = "1.0.1", default-features = false, features = ["stargate"] }
+# `std` should always stay enabled.
+cosmwasm-std = { version = "1.0.1", default-features = false, features = ["std", "stargate"] }
 ```

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -12,8 +12,13 @@ readme = "README.md"
 features = ["abort", "stargate", "staking", "cosmwasm_1_4"]
 
 [features]
-default = ["iterator", "abort"]
+default = ["iterator", "abort", "std"]
 abort = []
+# This feature is currently unused, but might be used in the future to replace internal
+# implementation details with no_std compatible ones or feature-gate functionality
+# that is only available in std environments.
+# You probably want to keep this enabled for now to avoid breaking changes later.
+std = []
 # iterator allows us to iterate over all DB items in a given range
 # optional as some merkle stores (like tries) don't support this
 # given Ethereum 1.0, 2.0, Substrate, and other major projects use Tries

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -14,11 +14,11 @@ features = ["abort", "stargate", "staking", "cosmwasm_1_4"]
 [features]
 default = ["iterator", "abort", "std"]
 abort = []
-# This feature is currently unused, but might be used in the future to replace internal
-# implementation details with no_std compatible ones or feature-gate functionality
-# that is only available in std environments.
-# You probably want to keep this enabled for now to avoid breaking changes later.
-std = []
+# This feature can be used in the future to provide support for no_std environments,
+# but disabling it will not provide any benefit at the moment. Even with this feature disabled,
+# we currently require an std environment.
+# You probably want to keep this enabled for now to avoid possible breaking changes later.
+std = ["serde/std", "serde-json-wasm/std"]
 # iterator allows us to iterate over all DB items in a given range
 # optional as some merkle stores (like tries) don't support this
 # given Ethereum 1.0, 2.0, Substrate, and other major projects use Tries
@@ -50,13 +50,13 @@ cosmwasm_1_4 = ["cosmwasm_1_3"]
 [dependencies]
 base64 = "0.21.0"
 cosmwasm-derive = { path = "../derive", version = "1.5.0" }
-derivative = "2"
+derivative = { version = "2", features = ["use_core"] }
 forward_ref = "1"
 hex = "0.4"
 schemars = "0.8.3"
 sha2 = "0.10.3"
 serde = { version = "1.0.103", default-features = false, features = ["derive", "alloc"] }
-serde-json-wasm = { version = "1.0.0" }
+serde-json-wasm = { version = "1.0.0", default-features = false }
 thiserror = "1.0.26"
 bnum = "0.8.0"
 static_assertions = "1.1.0"

--- a/packages/std/src/addresses.rs
+++ b/packages/std/src/addresses.rs
@@ -9,6 +9,7 @@ use sha2::{
 };
 use thiserror::Error;
 
+use crate::prelude::*;
 use crate::{binary::Binary, forward_ref_partial_eq, HexBinary};
 
 /// A human readable address.

--- a/packages/std/src/binary.rs
+++ b/packages/std/src/binary.rs
@@ -6,6 +6,7 @@ use schemars::JsonSchema;
 use serde::{de, ser, Deserialize, Deserializer, Serialize};
 
 use crate::errors::{StdError, StdResult};
+use crate::prelude::*;
 
 /// Binary is a wrapper around Vec<u8> to add base64 de/serialization
 /// with serde. It also adds some helper methods to help encode inline.

--- a/packages/std/src/checksum.rs
+++ b/packages/std/src/checksum.rs
@@ -5,6 +5,7 @@ use serde::{de, ser, Deserialize, Deserializer, Serialize};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
 
+use crate::prelude::*;
 use crate::{StdError, StdResult};
 
 /// A SHA-256 checksum of a Wasm blob, used to identify a Wasm code.

--- a/packages/std/src/coin.rs
+++ b/packages/std/src/coin.rs
@@ -2,6 +2,7 @@ use core::{fmt, str::FromStr};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use crate::prelude::*;
 use crate::{errors::CoinFromStrError, math::Uint128};
 
 #[derive(Serialize, Deserialize, Clone, Default, PartialEq, Eq, JsonSchema)]

--- a/packages/std/src/coins.rs
+++ b/packages/std/src/coins.rs
@@ -2,6 +2,7 @@ use alloc::collections::BTreeMap;
 use core::fmt;
 use core::str::FromStr;
 
+use crate::prelude::*;
 use crate::{
     errors::CoinsError, Coin, OverflowError, OverflowOperation, StdError, StdResult, Uint128,
 };

--- a/packages/std/src/errors/backtrace.rs
+++ b/packages/std/src/errors/backtrace.rs
@@ -1,5 +1,7 @@
 use core::fmt::{Debug, Display, Formatter, Result};
 
+use crate::prelude::*;
+
 /// This wraps an actual backtrace to achieve two things:
 /// - being able to fill this with a stub implementation in `no_std` environments
 /// - being able to use this in conjunction with [`thiserror::Error`]
@@ -9,10 +11,17 @@ impl BT {
     #[track_caller]
     pub fn capture() -> Self {
         // in case of no_std, we can fill with a stub here
-        #[cfg(target_arch = "wasm32")]
-        return BT(Box::new(std::backtrace::Backtrace::disabled()));
-        #[cfg(not(target_arch = "wasm32"))]
-        return BT(Box::new(std::backtrace::Backtrace::capture()));
+        #[cfg(feature = "std")]
+        {
+            #[cfg(target_arch = "wasm32")]
+            return BT(Box::new(std::backtrace::Backtrace::disabled()));
+            #[cfg(not(target_arch = "wasm32"))]
+            return BT(Box::new(std::backtrace::Backtrace::capture()));
+        }
+        #[cfg(not(feature = "std"))]
+        {
+            BT(Box::new(Stub))
+        }
     }
 }
 
@@ -28,6 +37,23 @@ impl Debug for BT {
 impl Display for BT {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         Display::fmt(&self.0, f)
+    }
+}
+
+#[cfg(not(feature = "std"))]
+struct Stub;
+
+#[cfg(not(feature = "std"))]
+impl Debug for Stub {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "<disabled>")
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl Display for Stub {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "<disabled>")
     }
 }
 

--- a/packages/std/src/errors/backtrace.rs
+++ b/packages/std/src/errors/backtrace.rs
@@ -40,17 +40,15 @@ impl Display for BT {
     }
 }
 
-#[cfg(not(feature = "std"))]
+#[allow(unused)]
 struct Stub;
 
-#[cfg(not(feature = "std"))]
 impl Debug for Stub {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(f, "<disabled>")
     }
 }
 
-#[cfg(not(feature = "std"))]
 impl Display for Stub {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(f, "<disabled>")

--- a/packages/std/src/errors/std_error.rs
+++ b/packages/std/src/errors/std_error.rs
@@ -4,6 +4,7 @@ use super::{impl_from_err, BT};
 use thiserror::Error;
 
 use crate::errors::{RecoverPubkeyError, VerificationError};
+use crate::prelude::*;
 
 /// Structured error type for init, execute and query.
 ///

--- a/packages/std/src/errors/system_error.rs
+++ b/packages/std/src/errors/system_error.rs
@@ -1,6 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use crate::prelude::*;
 use crate::Binary;
 
 /// SystemError is used for errors inside the VM and is API friendly (i.e. serializable).
@@ -39,6 +40,7 @@ pub enum SystemError {
     },
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for SystemError {}
 
 impl core::fmt::Display for SystemError {

--- a/packages/std/src/hex_binary.rs
+++ b/packages/std/src/hex_binary.rs
@@ -4,6 +4,7 @@ use core::ops::Deref;
 use schemars::JsonSchema;
 use serde::{de, ser, Deserialize, Deserializer, Serialize};
 
+use crate::prelude::*;
 use crate::{Binary, StdError, StdResult};
 
 /// This is a wrapper around Vec<u8> to add hex de/serialization

--- a/packages/std/src/ibc.rs
+++ b/packages/std/src/ibc.rs
@@ -9,6 +9,7 @@ use crate::addresses::Addr;
 use crate::binary::Binary;
 use crate::coin::Coin;
 use crate::errors::StdResult;
+use crate::prelude::*;
 use crate::results::{Attribute, CosmosMsg, Empty, Event, SubMsg};
 use crate::serde::to_json_binary;
 use crate::timestamp::Timestamp;

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -1,5 +1,3 @@
-// #![cfg_attr(not(feature = "std"), no_std)]
-
 extern crate alloc;
 
 // Exposed on all platforms

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -1,3 +1,5 @@
+// #![cfg_attr(not(feature = "std"), no_std)]
+
 extern crate alloc;
 
 // Exposed on all platforms
@@ -31,6 +33,9 @@ mod storage;
 mod timestamp;
 mod traits;
 mod types;
+
+/// This module is to simplify no_std imports
+pub(crate) mod prelude;
 
 /// This modules is very advanced and will not be used directly by the vast majority of users.
 /// We want to offer it to ensure a stable storage key composition system but don't encourage

--- a/packages/std/src/math/decimal.rs
+++ b/packages/std/src/math/decimal.rs
@@ -11,6 +11,7 @@ use crate::errors::{
     CheckedFromRatioError, CheckedMultiplyRatioError, DivideByZeroError, OverflowError,
     OverflowOperation, RoundUpOverflowError, StdError,
 };
+use crate::prelude::*;
 use crate::{forward_ref_partial_eq, Decimal256, SignedDecimal, SignedDecimal256};
 
 use super::Fraction;

--- a/packages/std/src/math/decimal256.rs
+++ b/packages/std/src/math/decimal256.rs
@@ -11,6 +11,7 @@ use crate::errors::{
     CheckedFromRatioError, CheckedMultiplyRatioError, DivideByZeroError, OverflowError,
     OverflowOperation, RoundUpOverflowError, StdError,
 };
+use crate::prelude::*;
 use crate::{forward_ref_partial_eq, Decimal, SignedDecimal, SignedDecimal256, Uint512};
 
 use super::Fraction;

--- a/packages/std/src/math/int128.rs
+++ b/packages/std/src/math/int128.rs
@@ -9,6 +9,7 @@ use schemars::JsonSchema;
 use serde::{de, ser, Deserialize, Deserializer, Serialize};
 
 use crate::errors::{DivideByZeroError, DivisionError, OverflowError, OverflowOperation, StdError};
+use crate::prelude::*;
 use crate::{
     forward_ref_partial_eq, CheckedMultiplyRatioError, Int256, Int512, Int64, Uint128, Uint256,
     Uint512, Uint64,

--- a/packages/std/src/math/int256.rs
+++ b/packages/std/src/math/int256.rs
@@ -9,6 +9,7 @@ use schemars::JsonSchema;
 use serde::{de, ser, Deserialize, Deserializer, Serialize};
 
 use crate::errors::{DivideByZeroError, DivisionError, OverflowError, OverflowOperation, StdError};
+use crate::prelude::*;
 use crate::{
     forward_ref_partial_eq, CheckedMultiplyRatioError, Int128, Int512, Int64, Uint128, Uint256,
     Uint512, Uint64,

--- a/packages/std/src/math/int512.rs
+++ b/packages/std/src/math/int512.rs
@@ -9,6 +9,7 @@ use schemars::JsonSchema;
 use serde::{de, ser, Deserialize, Deserializer, Serialize};
 
 use crate::errors::{DivideByZeroError, DivisionError, OverflowError, OverflowOperation, StdError};
+use crate::prelude::*;
 use crate::{forward_ref_partial_eq, Int128, Int256, Int64, Uint128, Uint256, Uint512, Uint64};
 
 /// Used internally - we don't want to leak this type since we might change

--- a/packages/std/src/math/int64.rs
+++ b/packages/std/src/math/int64.rs
@@ -9,6 +9,7 @@ use schemars::JsonSchema;
 use serde::{de, ser, Deserialize, Deserializer, Serialize};
 
 use crate::errors::{DivideByZeroError, DivisionError, OverflowError, OverflowOperation, StdError};
+use crate::prelude::*;
 use crate::{
     forward_ref_partial_eq, CheckedMultiplyRatioError, Int128, Int256, Int512, Uint128, Uint256,
     Uint512, Uint64,

--- a/packages/std/src/math/signed_decimal.rs
+++ b/packages/std/src/math/signed_decimal.rs
@@ -13,6 +13,7 @@ use crate::errors::{
     CheckedFromRatioError, CheckedMultiplyRatioError, DivideByZeroError, OverflowError,
     OverflowOperation, RoundDownOverflowError, RoundUpOverflowError, StdError,
 };
+use crate::prelude::*;
 use crate::{forward_ref_partial_eq, Decimal, Decimal256, Int256, SignedDecimal256};
 
 use super::Fraction;

--- a/packages/std/src/math/signed_decimal_256.rs
+++ b/packages/std/src/math/signed_decimal_256.rs
@@ -13,6 +13,7 @@ use crate::errors::{
     CheckedFromRatioError, CheckedMultiplyRatioError, DivideByZeroError, OverflowError,
     OverflowOperation, RoundDownOverflowError, RoundUpOverflowError, StdError,
 };
+use crate::prelude::*;
 use crate::{forward_ref_partial_eq, Decimal, Decimal256, Int512, SignedDecimal};
 
 use super::Fraction;

--- a/packages/std/src/math/uint128.rs
+++ b/packages/std/src/math/uint128.rs
@@ -1,10 +1,9 @@
-use core::fmt::{self};
+use core::fmt;
 use core::ops::{
-    Add, AddAssign, Div, DivAssign, Mul, MulAssign, Rem, RemAssign, Shl, ShlAssign, Shr, ShrAssign,
-    Sub, SubAssign,
+    Add, AddAssign, Div, DivAssign, Mul, MulAssign, Not, Rem, RemAssign, Shl, ShlAssign, Shr,
+    ShrAssign, Sub, SubAssign,
 };
 use core::str::FromStr;
-use std::ops::Not;
 
 use forward_ref::{forward_ref_binop, forward_ref_op_assign};
 use schemars::JsonSchema;
@@ -14,6 +13,7 @@ use crate::errors::{
     CheckedMultiplyFractionError, CheckedMultiplyRatioError, DivideByZeroError, OverflowError,
     OverflowOperation, StdError,
 };
+use crate::prelude::*;
 use crate::{
     forward_ref_partial_eq, impl_mul_fraction, Fraction, Int128, Int256, Int512, Int64, Uint256,
     Uint64,

--- a/packages/std/src/math/uint256.rs
+++ b/packages/std/src/math/uint256.rs
@@ -1,18 +1,18 @@
 use core::fmt;
 use core::ops::{
-    Add, AddAssign, Div, DivAssign, Mul, MulAssign, Rem, RemAssign, Shl, ShlAssign, Shr, ShrAssign,
-    Sub, SubAssign,
+    Add, AddAssign, Div, DivAssign, Mul, MulAssign, Not, Rem, RemAssign, Shl, ShlAssign, Shr,
+    ShrAssign, Sub, SubAssign,
 };
 use core::str::FromStr;
 use forward_ref::{forward_ref_binop, forward_ref_op_assign};
 use schemars::JsonSchema;
 use serde::{de, ser, Deserialize, Deserializer, Serialize};
-use std::ops::Not;
 
 use crate::errors::{
     CheckedMultiplyFractionError, CheckedMultiplyRatioError, ConversionOverflowError,
     DivideByZeroError, OverflowError, OverflowOperation, StdError,
 };
+use crate::prelude::*;
 use crate::{
     forward_ref_partial_eq, impl_mul_fraction, Fraction, Int128, Int256, Int512, Int64, Uint128,
     Uint512, Uint64,

--- a/packages/std/src/math/uint512.rs
+++ b/packages/std/src/math/uint512.rs
@@ -11,6 +11,7 @@ use serde::{de, ser, Deserialize, Deserializer, Serialize};
 use crate::errors::{
     ConversionOverflowError, DivideByZeroError, OverflowError, OverflowOperation, StdError,
 };
+use crate::prelude::*;
 use crate::{forward_ref_partial_eq, Int128, Int256, Int512, Int64, Uint128, Uint256, Uint64};
 
 /// Used internally - we don't want to leak this type since we might change

--- a/packages/std/src/math/uint64.rs
+++ b/packages/std/src/math/uint64.rs
@@ -1,17 +1,17 @@
-use core::fmt::{self};
+use core::fmt;
 use core::ops::{
-    Add, AddAssign, Div, DivAssign, Mul, MulAssign, Rem, RemAssign, Shl, ShlAssign, Shr, ShrAssign,
-    Sub, SubAssign,
+    Add, AddAssign, Div, DivAssign, Mul, MulAssign, Not, Rem, RemAssign, Shl, ShlAssign, Shr,
+    ShrAssign, Sub, SubAssign,
 };
 use forward_ref::{forward_ref_binop, forward_ref_op_assign};
 use schemars::JsonSchema;
 use serde::{de, ser, Deserialize, Deserializer, Serialize};
-use std::ops::Not;
 
 use crate::errors::{
     CheckedMultiplyFractionError, CheckedMultiplyRatioError, DivideByZeroError, OverflowError,
     OverflowOperation, StdError,
 };
+use crate::prelude::*;
 use crate::{
     forward_ref_partial_eq, impl_mul_fraction, Fraction, Int128, Int256, Int512, Int64, Uint128,
 };

--- a/packages/std/src/metadata.rs
+++ b/packages/std/src/metadata.rs
@@ -1,6 +1,8 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use crate::prelude::*;
+
 /// Replicates the cosmos-sdk bank module Metadata type
 #[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq, Eq, JsonSchema)]
 pub struct DenomMetadata {

--- a/packages/std/src/pagination.rs
+++ b/packages/std/src/pagination.rs
@@ -1,6 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use crate::prelude::*;
 use crate::Binary;
 
 /// Simplified version of the PageRequest type for pagination from the cosmos-sdk

--- a/packages/std/src/prelude.rs
+++ b/packages/std/src/prelude.rs
@@ -1,0 +1,6 @@
+pub use alloc::boxed::Box;
+pub use alloc::format;
+pub use alloc::string::{String, ToString};
+pub use alloc::vec;
+pub use alloc::vec::Vec;
+pub use core::option::Option::{self, None, Some};

--- a/packages/std/src/query/bank.rs
+++ b/packages/std/src/query/bank.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::Coin;
 
+use crate::prelude::*;
 #[cfg(feature = "cosmwasm_1_3")]
 use crate::PageRequest;
 use crate::{Binary, DenomMetadata};

--- a/packages/std/src/query/distribution.rs
+++ b/packages/std/src/query/distribution.rs
@@ -1,6 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use crate::prelude::*;
 use crate::{Addr, Decimal256};
 
 use super::query_response::QueryResponseType;

--- a/packages/std/src/query/ibc.rs
+++ b/packages/std/src/query/ibc.rs
@@ -2,6 +2,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::ibc::IbcChannel;
+use crate::prelude::*;
 
 /// These are queries to the various IBC modules to see the state of the contract's
 /// IBC connection. These will return errors if the contract is not "ibc enabled"

--- a/packages/std/src/query/mod.rs
+++ b/packages/std/src/query/mod.rs
@@ -1,6 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use crate::prelude::*;
 #[cfg(feature = "stargate")]
 use crate::Binary;
 use crate::Empty;

--- a/packages/std/src/query/query_response.rs
+++ b/packages/std/src/query/query_response.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 use serde::de::DeserializeOwned;
 

--- a/packages/std/src/query/staking.rs
+++ b/packages/std/src/query/staking.rs
@@ -1,6 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use crate::prelude::*;
 use crate::{Addr, Coin, Decimal};
 
 use super::query_response::QueryResponseType;

--- a/packages/std/src/query/wasm.rs
+++ b/packages/std/src/query/wasm.rs
@@ -1,6 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use crate::prelude::*;
 use crate::{Addr, Binary, Checksum};
 
 use super::query_response::QueryResponseType;

--- a/packages/std/src/results/contract_result.rs
+++ b/packages/std/src/results/contract_result.rs
@@ -2,6 +2,8 @@ use core::fmt;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use crate::prelude::*;
+
 /// This is the final result type that is created and serialized in a contract for
 /// every init/execute/migrate call. The VM then deserializes this type to distinguish
 /// between successful and failed executions.

--- a/packages/std/src/results/cosmos_msg.rs
+++ b/packages/std/src/results/cosmos_msg.rs
@@ -8,6 +8,7 @@ use crate::coin::Coin;
 use crate::errors::StdResult;
 #[cfg(feature = "stargate")]
 use crate::ibc::IbcMsg;
+use crate::prelude::*;
 use crate::serde::to_json_binary;
 #[cfg(all(feature = "stargate", feature = "cosmwasm_1_2"))]
 use crate::Decimal;

--- a/packages/std/src/results/empty.rs
+++ b/packages/std/src/results/empty.rs
@@ -1,6 +1,8 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use crate::prelude::*;
+
 /// An empty struct that serves as a placeholder in different places,
 /// such as contracts that don't set a custom message.
 ///

--- a/packages/std/src/results/events.rs
+++ b/packages/std/src/results/events.rs
@@ -2,6 +2,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::forward_ref_partial_eq;
+use crate::prelude::*;
 
 /// A full [*Cosmos SDK* event].
 ///

--- a/packages/std/src/results/response.rs
+++ b/packages/std/src/results/response.rs
@@ -1,6 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use crate::prelude::*;
 use crate::Binary;
 
 use super::{Attribute, CosmosMsg, Empty, Event, SubMsg};

--- a/packages/std/src/results/submessages.rs
+++ b/packages/std/src/results/submessages.rs
@@ -1,6 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use crate::prelude::*;
 use crate::Binary;
 
 use super::{CosmosMsg, Empty, Event};

--- a/packages/std/src/results/system_result.rs
+++ b/packages/std/src/results/system_result.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 
 use super::super::errors::SystemError;
 
+use crate::prelude::*;
+
 /// This is the outer result type returned by a querier to the contract.
 ///
 /// We use a custom type here instead of Rust's Result because we want to be able to

--- a/packages/std/src/sections.rs
+++ b/packages/std/src/sections.rs
@@ -1,4 +1,5 @@
 use crate::conversion::force_to_u32;
+use crate::prelude::*;
 
 /// A sections decoder for the special case of two elements
 #[allow(dead_code)] // used in Wasm and tests only

--- a/packages/std/src/serde.rs
+++ b/packages/std/src/serde.rs
@@ -7,6 +7,7 @@ use serde::{de::DeserializeOwned, Serialize};
 
 use crate::binary::Binary;
 use crate::errors::{StdError, StdResult};
+use crate::prelude::*;
 
 #[deprecated = "use from_json instead"]
 pub fn from_slice<T: DeserializeOwned>(value: &[u8]) -> StdResult<T> {

--- a/packages/std/src/stdack.rs
+++ b/packages/std/src/stdack.rs
@@ -2,6 +2,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::binary::Binary;
+use crate::prelude::*;
 use crate::to_json_binary;
 
 /// This is a standard IBC acknowledgement type. IBC application are free

--- a/packages/std/src/storage.rs
+++ b/packages/std/src/storage.rs
@@ -7,6 +7,7 @@ use core::ops::{Bound, RangeBounds};
 
 #[cfg(feature = "iterator")]
 use crate::iterator::{Order, Record};
+use crate::prelude::*;
 use crate::traits::Storage;
 
 #[derive(Default)]

--- a/packages/std/src/storage_keys/length_prefixed.rs
+++ b/packages/std/src/storage_keys/length_prefixed.rs
@@ -4,6 +4,8 @@
 //! Everything in this file is only responsible for building such keys
 //! and is in no way specific to any kind of storage.
 
+use crate::prelude::*;
+
 /// Calculates the raw key prefix for a given namespace as documented
 /// in https://github.com/webmaster128/key-namespacing#length-prefixed-keys
 pub fn to_length_prefixed(namespace_component: &[u8]) -> Vec<u8> {

--- a/packages/std/src/testing/assertions.rs
+++ b/packages/std/src/testing/assertions.rs
@@ -1,3 +1,4 @@
+use crate::prelude::*;
 use crate::{Decimal, Uint128};
 #[cfg(test)]
 use core::hash::{Hash, Hasher};

--- a/packages/std/src/testing/mock.rs
+++ b/packages/std/src/testing/mock.rs
@@ -202,12 +202,10 @@ impl Api for MockApi {
         )?)
     }
 
-    #[cfg(feature = "std")]
-    fn debug(&self, message: &str) {
+    fn debug(&self, #[allow(unused)] message: &str) {
+        #[cfg(feature = "std")]
         println!("{message}");
     }
-    #[cfg(not(feature = "std"))]
-    fn debug(&self, _message: &str) {}
 }
 
 impl MockApi {

--- a/packages/std/src/timestamp.rs
+++ b/packages/std/src/timestamp.rs
@@ -3,6 +3,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::math::Uint64;
+use crate::prelude::*;
 
 /// A point in time in nanosecond precision.
 ///

--- a/packages/std/src/traits.rs
+++ b/packages/std/src/traits.rs
@@ -8,6 +8,7 @@ use crate::coin::Coin;
 use crate::errors::{RecoverPubkeyError, StdError, StdResult, VerificationError};
 #[cfg(feature = "iterator")]
 use crate::iterator::{Order, Record};
+use crate::prelude::*;
 #[cfg(feature = "cosmwasm_1_2")]
 use crate::query::CodeInfoResponse;
 #[cfg(feature = "cosmwasm_1_1")]

--- a/packages/std/src/types.rs
+++ b/packages/std/src/types.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::addresses::Addr;
 use crate::coin::Coin;
+use crate::prelude::*;
 use crate::timestamp::Timestamp;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]


### PR DESCRIPTION
regarding #1484 

This adds the `std` feature as a default and replaces the most obvious usages of `std`.
It does not provide full `no_std` support.

Some notes for anyone tackling full `no_std` support in the future:
The next big problem is `thiserror`. It should be possible to only enable it when `std` is enabled and provide alternative Display / Debug implementations otherwise.
The `JsonSchema` derive macro also would need to be patched to use core / alloc instead of std, but that should be straightforward.
Apart from that, some of our dependencies are likely not `no_std`, so changes might be needed there.