### PR TITLE
Add `QueryRequest::Grpc`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@ and this project adheres to
 - cosmwasm-std: Make `IbcReceiveResponse::acknowledgement` optional and add
   `IbcReceiveResponse::without_ack` constructor. ([#1892])
 - cosmwasm-std: Add `std` feature and make it a default feature. ([#1971])
+- cosmwasm-std: Add `QueryRequest::Grpc` and deprecate `QueryRequest::Stargate`.
+  ([#1973])
 
 [#1874]: https://github.com/CosmWasm/cosmwasm/pull/1874
 [#1876]: https://github.com/CosmWasm/cosmwasm/pull/1876
@@ -91,6 +93,7 @@ and this project adheres to
 [#1949]: https://github.com/CosmWasm/cosmwasm/pull/1949
 [#1967]: https://github.com/CosmWasm/cosmwasm/pull/1967
 [#1971]: https://github.com/CosmWasm/cosmwasm/pull/1971
+[#1973]: https://github.com/CosmWasm/cosmwasm/pull/1973
 
 ### Removed
 

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -189,6 +189,23 @@ major releases of `cosmwasm`. Note that you can also view the
   +};
   ```
 
+- If you were using `QueryRequest::Stargate`, you might want to enable the
+  `cosmwasm_2_0` cargo feature and migrate to `QueryRequest::Grpc` instead.
+  While the stargate query sometimes returns protobuf encoded data and sometimes
+  JSON encoded data, depending on the chain, the gRPC query always returns
+  protobuf encoded data.
+
+  ```diff
+  -deps.querier.query(&QueryRequest::Stargate {
+  -    path: "/service.Path/ServiceMethod".to_string(),
+  -    data: Binary::new(b"DATA"),
+  -})?;
+  +deps.querier.query(&QueryRequest::Grpc(GrpcQuery {
+  +    path: "/service.Path/ServiceMethod".to_string(),
+  +    data: Binary::new(b"DATA"),
+  +}))?;
+  ```
+
 ## 1.4.x -> 1.5.0
 
 - Update `cosmwasm-*` dependencies in Cargo.toml (skip the ones you don't use):

--- a/contracts/reflect/schema/raw/query.json
+++ b/contracts/reflect/schema/raw/query.json
@@ -324,6 +324,28 @@
         }
       ]
     },
+    "GrpcQuery": {
+      "description": "Queries the chain using a grpc query. This allows to query information that is not exposed in our API. The chain needs to whitelist the supported queries. The drawback of this query is that you have to handle the protobuf encoding and decoding yourself.\n\nThe returned data is protobuf encoded. The protobuf type depends on the query.",
+      "type": "object",
+      "required": [
+        "data",
+        "path"
+      ],
+      "properties": {
+        "data": {
+          "description": "The expected protobuf message type (not any), binary encoded",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Binary"
+            }
+          ]
+        },
+        "path": {
+          "description": "The fully qualified service path used for routing, eg. \"custom/cosmos_sdk.x.bank.v1.Query/QueryBalance\"",
+          "type": "string"
+        }
+      }
+    },
     "IbcQuery": {
       "description": "These are queries to the various IBC modules to see the state of the contract's IBC connection. These will return errors if the contract is not \"ibc enabled\"",
       "oneOf": [
@@ -519,6 +541,18 @@
           "properties": {
             "wasm": {
               "$ref": "#/definitions/WasmQuery"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "grpc"
+          ],
+          "properties": {
+            "grpc": {
+              "$ref": "#/definitions/GrpcQuery"
             }
           },
           "additionalProperties": false

--- a/contracts/reflect/schema/raw/query.json
+++ b/contracts/reflect/schema/raw/query.json
@@ -324,28 +324,6 @@
         }
       ]
     },
-    "GrpcQuery": {
-      "description": "Queries the chain using a grpc query. This allows to query information that is not exposed in our API. The chain needs to allowlist the supported queries. The drawback of this query is that you have to handle the protobuf encoding and decoding yourself.\n\nThe returned data is protobuf encoded. The protobuf type depends on the query.\n\nTo find the path, as well as the request and response types, you can query the chain's gRPC endpoint using a tool like [grpcurl](https://github.com/fullstorydev/grpcurl).",
-      "type": "object",
-      "required": [
-        "data",
-        "path"
-      ],
-      "properties": {
-        "data": {
-          "description": "The expected protobuf message type (not [Any](https://protobuf.dev/programming-guides/proto3/#any)), binary encoded",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Binary"
-            }
-          ]
-        },
-        "path": {
-          "description": "The fully qualified endpoint path used for routing. It follows the format `/service_path/method_name`, eg. \"/cosmos.authz.v1beta1.Query/Grants\"",
-          "type": "string"
-        }
-      }
-    },
     "IbcQuery": {
       "description": "These are queries to the various IBC modules to see the state of the contract's IBC connection. These will return errors if the contract is not \"ibc enabled\"",
       "oneOf": [
@@ -542,18 +520,6 @@
           "properties": {
             "wasm": {
               "$ref": "#/definitions/WasmQuery"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "required": [
-            "grpc"
-          ],
-          "properties": {
-            "grpc": {
-              "$ref": "#/definitions/GrpcQuery"
             }
           },
           "additionalProperties": false

--- a/contracts/reflect/schema/raw/query.json
+++ b/contracts/reflect/schema/raw/query.json
@@ -325,7 +325,7 @@
       ]
     },
     "GrpcQuery": {
-      "description": "Queries the chain using a grpc query. This allows to query information that is not exposed in our API. The chain needs to whitelist the supported queries. The drawback of this query is that you have to handle the protobuf encoding and decoding yourself.\n\nThe returned data is protobuf encoded. The protobuf type depends on the query.",
+      "description": "Queries the chain using a grpc query. This allows to query information that is not exposed in our API. The chain needs to allowlist the supported queries. The drawback of this query is that you have to handle the protobuf encoding and decoding yourself.\n\nThe returned data is protobuf encoded. The protobuf type depends on the query.\n\nTo find the path, as well as the request and response types, you can query the chain's gRPC endpoint using a tool like [grpcurl](https://github.com/fullstorydev/grpcurl).",
       "type": "object",
       "required": [
         "data",
@@ -333,7 +333,7 @@
       ],
       "properties": {
         "data": {
-          "description": "The expected protobuf message type (not any), binary encoded",
+          "description": "The expected protobuf message type (not [Any](https://protobuf.dev/programming-guides/proto3/#any)), binary encoded",
           "allOf": [
             {
               "$ref": "#/definitions/Binary"
@@ -341,7 +341,7 @@
           ]
         },
         "path": {
-          "description": "The fully qualified service path used for routing, eg. \"custom/cosmos_sdk.x.bank.v1.Query/QueryBalance\"",
+          "description": "The fully qualified endpoint path used for routing. It follows the format `/service_path/method_name`, eg. \"/cosmos.authz.v1beta1.Query/Grants\"",
           "type": "string"
         }
       }
@@ -492,6 +492,7 @@
         },
         {
           "description": "A Stargate query is encoded the same way as abci_query, with path and protobuf encoded request data. The format is defined in [ADR-21](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-021-protobuf-query-encoding.md). The response is protobuf encoded data directly without a JSON response wrapper. The caller is responsible for compiling the proper protobuf definitions for both requests and responses.",
+          "deprecated": true,
           "type": "object",
           "required": [
             "stargate"
@@ -513,7 +514,7 @@
                   ]
                 },
                 "path": {
-                  "description": "this is the fully qualified service path used for routing, eg. custom/cosmos_sdk.x.bank.v1.Query/QueryBalance",
+                  "description": "this is the fully qualified service path used for routing, eg. \"/cosmos_sdk.x.bank.v1.Query/QueryBalance\"",
                   "type": "string"
                 }
               }

--- a/contracts/reflect/schema/reflect.json
+++ b/contracts/reflect/schema/reflect.json
@@ -1327,28 +1327,6 @@
           }
         ]
       },
-      "GrpcQuery": {
-        "description": "Queries the chain using a grpc query. This allows to query information that is not exposed in our API. The chain needs to allowlist the supported queries. The drawback of this query is that you have to handle the protobuf encoding and decoding yourself.\n\nThe returned data is protobuf encoded. The protobuf type depends on the query.\n\nTo find the path, as well as the request and response types, you can query the chain's gRPC endpoint using a tool like [grpcurl](https://github.com/fullstorydev/grpcurl).",
-        "type": "object",
-        "required": [
-          "data",
-          "path"
-        ],
-        "properties": {
-          "data": {
-            "description": "The expected protobuf message type (not [Any](https://protobuf.dev/programming-guides/proto3/#any)), binary encoded",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Binary"
-              }
-            ]
-          },
-          "path": {
-            "description": "The fully qualified endpoint path used for routing. It follows the format `/service_path/method_name`, eg. \"/cosmos.authz.v1beta1.Query/Grants\"",
-            "type": "string"
-          }
-        }
-      },
       "IbcQuery": {
         "description": "These are queries to the various IBC modules to see the state of the contract's IBC connection. These will return errors if the contract is not \"ibc enabled\"",
         "oneOf": [
@@ -1545,18 +1523,6 @@
             "properties": {
               "wasm": {
                 "$ref": "#/definitions/WasmQuery"
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "grpc"
-            ],
-            "properties": {
-              "grpc": {
-                "$ref": "#/definitions/GrpcQuery"
               }
             },
             "additionalProperties": false

--- a/contracts/reflect/schema/reflect.json
+++ b/contracts/reflect/schema/reflect.json
@@ -1328,7 +1328,7 @@
         ]
       },
       "GrpcQuery": {
-        "description": "Queries the chain using a grpc query. This allows to query information that is not exposed in our API. The chain needs to whitelist the supported queries. The drawback of this query is that you have to handle the protobuf encoding and decoding yourself.\n\nThe returned data is protobuf encoded. The protobuf type depends on the query.",
+        "description": "Queries the chain using a grpc query. This allows to query information that is not exposed in our API. The chain needs to allowlist the supported queries. The drawback of this query is that you have to handle the protobuf encoding and decoding yourself.\n\nThe returned data is protobuf encoded. The protobuf type depends on the query.\n\nTo find the path, as well as the request and response types, you can query the chain's gRPC endpoint using a tool like [grpcurl](https://github.com/fullstorydev/grpcurl).",
         "type": "object",
         "required": [
           "data",
@@ -1336,7 +1336,7 @@
         ],
         "properties": {
           "data": {
-            "description": "The expected protobuf message type (not any), binary encoded",
+            "description": "The expected protobuf message type (not [Any](https://protobuf.dev/programming-guides/proto3/#any)), binary encoded",
             "allOf": [
               {
                 "$ref": "#/definitions/Binary"
@@ -1344,7 +1344,7 @@
             ]
           },
           "path": {
-            "description": "The fully qualified service path used for routing, eg. \"custom/cosmos_sdk.x.bank.v1.Query/QueryBalance\"",
+            "description": "The fully qualified endpoint path used for routing. It follows the format `/service_path/method_name`, eg. \"/cosmos.authz.v1beta1.Query/Grants\"",
             "type": "string"
           }
         }
@@ -1495,6 +1495,7 @@
           },
           {
             "description": "A Stargate query is encoded the same way as abci_query, with path and protobuf encoded request data. The format is defined in [ADR-21](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-021-protobuf-query-encoding.md). The response is protobuf encoded data directly without a JSON response wrapper. The caller is responsible for compiling the proper protobuf definitions for both requests and responses.",
+            "deprecated": true,
             "type": "object",
             "required": [
               "stargate"
@@ -1516,7 +1517,7 @@
                     ]
                   },
                   "path": {
-                    "description": "this is the fully qualified service path used for routing, eg. custom/cosmos_sdk.x.bank.v1.Query/QueryBalance",
+                    "description": "this is the fully qualified service path used for routing, eg. \"/cosmos_sdk.x.bank.v1.Query/QueryBalance\"",
                     "type": "string"
                   }
                 }

--- a/contracts/reflect/schema/reflect.json
+++ b/contracts/reflect/schema/reflect.json
@@ -1327,6 +1327,28 @@
           }
         ]
       },
+      "GrpcQuery": {
+        "description": "Queries the chain using a grpc query. This allows to query information that is not exposed in our API. The chain needs to whitelist the supported queries. The drawback of this query is that you have to handle the protobuf encoding and decoding yourself.\n\nThe returned data is protobuf encoded. The protobuf type depends on the query.",
+        "type": "object",
+        "required": [
+          "data",
+          "path"
+        ],
+        "properties": {
+          "data": {
+            "description": "The expected protobuf message type (not any), binary encoded",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Binary"
+              }
+            ]
+          },
+          "path": {
+            "description": "The fully qualified service path used for routing, eg. \"custom/cosmos_sdk.x.bank.v1.Query/QueryBalance\"",
+            "type": "string"
+          }
+        }
+      },
       "IbcQuery": {
         "description": "These are queries to the various IBC modules to see the state of the contract's IBC connection. These will return errors if the contract is not \"ibc enabled\"",
         "oneOf": [
@@ -1522,6 +1544,18 @@
             "properties": {
               "wasm": {
                 "$ref": "#/definitions/WasmQuery"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "grpc"
+            ],
+            "properties": {
+              "grpc": {
+                "$ref": "#/definitions/GrpcQuery"
               }
             },
             "additionalProperties": false

--- a/docs/CAPABILITIES-BUILT-IN.md
+++ b/docs/CAPABILITIES-BUILT-IN.md
@@ -23,5 +23,5 @@ might define others.
   `DistributionQuery::DelegationTotalRewards` and
   `DistributionQuery::DelegatorValidators` queries. Only chains running CosmWasm
   `1.4.0` or higher support this.
-- `cosmwasm_2_0` enables `CosmosMsg::Any`. Only chains running CosmWasm `2.0.0`
-  or higher support this.
+- `cosmwasm_2_0` enables `CosmosMsg::Any` and `QueryRequest::Grpc`. Only chains
+  running CosmWasm `2.0.0` or higher support this.

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -47,7 +47,7 @@ cosmwasm_1_3 = ["cosmwasm_1_2"]
 # It requires the host blockchain to run CosmWasm `1.4.0` or higher.
 cosmwasm_1_4 = ["cosmwasm_1_3"]
 # This enables functionality that is only available on 2.0 chains.
-# It adds `CosmosMsg::Any`, replacing `CosmosMsg::Stargate`.
+# It adds `CosmosMsg::Any`, replacing `CosmosMsg::Stargate`. It also adds `QueryRequest::Grpc`.
 cosmwasm_2_0 = ["cosmwasm_1_4"]
 
 [dependencies]

--- a/packages/std/src/query/mod.rs
+++ b/packages/std/src/query/mod.rs
@@ -131,6 +131,12 @@ impl<C: CustomQuery> From<WasmQuery> for QueryRequest<C> {
     }
 }
 
+impl<C: CustomQuery> From<GrpcQuery> for QueryRequest<C> {
+    fn from(msg: GrpcQuery) -> Self {
+        QueryRequest::Grpc(msg)
+    }
+}
+
 #[cfg(feature = "stargate")]
 impl<C: CustomQuery> From<IbcQuery> for QueryRequest<C> {
     fn from(msg: IbcQuery) -> Self {

--- a/packages/std/src/query/mod.rs
+++ b/packages/std/src/query/mod.rs
@@ -66,6 +66,7 @@ pub enum QueryRequest<C> {
     #[cfg(feature = "stargate")]
     Ibc(IbcQuery),
     Wasm(WasmQuery),
+    #[cfg(feature = "cosmwasm_2_0")]
     Grpc(GrpcQuery),
 }
 
@@ -139,6 +140,7 @@ impl<C: CustomQuery> From<WasmQuery> for QueryRequest<C> {
     }
 }
 
+#[cfg(feature = "cosmwasm_2_0")]
 impl<C: CustomQuery> From<GrpcQuery> for QueryRequest<C> {
     fn from(msg: GrpcQuery) -> Self {
         QueryRequest::Grpc(msg)

--- a/packages/std/src/query/mod.rs
+++ b/packages/std/src/query/mod.rs
@@ -76,7 +76,7 @@ pub struct GrpcQuery {
     /// The fully qualified service path used for routing,
     /// eg. "custom/cosmos_sdk.x.bank.v1.Query/QueryBalance"
     path: String,
-    /// The expected protobuf message type (not any), binary encoded
+    /// The expected protobuf message type (not [Any](https://protobuf.dev/programming-guides/proto3/#any)), binary encoded
     data: Binary,
 }
 

--- a/packages/std/src/query/mod.rs
+++ b/packages/std/src/query/mod.rs
@@ -52,6 +52,7 @@ pub enum QueryRequest<C> {
     /// The response is protobuf encoded data directly without a JSON response wrapper.
     /// The caller is responsible for compiling the proper protobuf definitions for both requests and responses.
     #[cfg(feature = "stargate")]
+    #[deprecated = "Please use the GrpcQuery instead"]
     Stargate {
         /// this is the fully qualified service path used for routing,
         /// eg. custom/cosmos_sdk.x.bank.v1.Query/QueryBalance

--- a/packages/std/src/query/mod.rs
+++ b/packages/std/src/query/mod.rs
@@ -72,10 +72,14 @@ pub enum QueryRequest<C> {
 /// The drawback of this query is that you have to handle the protobuf encoding and decoding yourself.
 ///
 /// The returned data is protobuf encoded. The protobuf type depends on the query.
+///
+/// To find the path, as well as the request and response types,
+/// you can query the chain's gRPC endpoint using a tool like
+/// [grpcurl](https://github.com/fullstorydev/grpcurl).
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct GrpcQuery {
-    /// The fully qualified service path used for routing,
-    /// eg. "custom/cosmos_sdk.x.bank.v1.Query/QueryBalance"
+    /// The fully qualified endpoint path used for routing,
+    /// eg. "cosmos.authz.v1beta1.Query.Grants"
     path: String,
     /// The expected protobuf message type (not [Any](https://protobuf.dev/programming-guides/proto3/#any)), binary encoded
     data: Binary,

--- a/packages/std/src/query/mod.rs
+++ b/packages/std/src/query/mod.rs
@@ -67,7 +67,7 @@ pub enum QueryRequest<C> {
 
 /// Queries the chain using a grpc query.
 /// This allows to query information that is not exposed in our API.
-/// The chain needs to whitelist the supported queries.
+/// The chain needs to allowlist the supported queries.
 /// The drawback of this query is that you have to handle the protobuf encoding and decoding yourself.
 ///
 /// The returned data is protobuf encoded. The protobuf type depends on the query.

--- a/packages/std/src/query/mod.rs
+++ b/packages/std/src/query/mod.rs
@@ -85,9 +85,9 @@ pub struct GrpcQuery {
     /// The fully qualified endpoint path used for routing.
     /// It follows the format `/service_path/method_name`,
     /// eg. "/cosmos.authz.v1beta1.Query/Grants"
-    path: String,
+    pub path: String,
     /// The expected protobuf message type (not [Any](https://protobuf.dev/programming-guides/proto3/#any)), binary encoded
-    data: Binary,
+    pub data: Binary,
 }
 
 /// A trait that is required to avoid conflicts with other query types like BankQuery and WasmQuery

--- a/packages/std/src/query/mod.rs
+++ b/packages/std/src/query/mod.rs
@@ -1,3 +1,6 @@
+// needed because the derive macros on QueryRequest use the deprecated `Stargate` variant
+#![allow(deprecated)]
+
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 

--- a/packages/std/src/query/mod.rs
+++ b/packages/std/src/query/mod.rs
@@ -58,7 +58,7 @@ pub enum QueryRequest<C> {
     #[deprecated = "Please use the GrpcQuery instead"]
     Stargate {
         /// this is the fully qualified service path used for routing,
-        /// eg. custom/cosmos_sdk.x.bank.v1.Query/QueryBalance
+        /// eg. "/cosmos_sdk.x.bank.v1.Query/QueryBalance"
         path: String,
         /// this is the expected protobuf message type (not any), binary encoded
         data: Binary,
@@ -81,8 +81,9 @@ pub enum QueryRequest<C> {
 /// [grpcurl](https://github.com/fullstorydev/grpcurl).
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct GrpcQuery {
-    /// The fully qualified endpoint path used for routing,
-    /// eg. "cosmos.authz.v1beta1.Query.Grants"
+    /// The fully qualified endpoint path used for routing.
+    /// It follows the format `/service_path/method_name`,
+    /// eg. "/cosmos.authz.v1beta1.Query/Grants"
     path: String,
     /// The expected protobuf message type (not [Any](https://protobuf.dev/programming-guides/proto3/#any)), binary encoded
     data: Binary,

--- a/packages/std/src/query/mod.rs
+++ b/packages/std/src/query/mod.rs
@@ -2,7 +2,6 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::prelude::*;
-#[cfg(feature = "stargate")]
 use crate::Binary;
 use crate::Empty;
 
@@ -63,6 +62,22 @@ pub enum QueryRequest<C> {
     #[cfg(feature = "stargate")]
     Ibc(IbcQuery),
     Wasm(WasmQuery),
+    Grpc(GrpcQuery),
+}
+
+/// Queries the chain using a grpc query.
+/// This allows to query information that is not exposed in our API.
+/// The chain needs to whitelist the supported queries.
+/// The drawback of this query is that you have to handle the protobuf encoding and decoding yourself.
+///
+/// The returned data is protobuf encoded. The protobuf type depends on the query.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+pub struct GrpcQuery {
+    /// The fully qualified service path used for routing,
+    /// eg. "custom/cosmos_sdk.x.bank.v1.Query/QueryBalance"
+    path: String,
+    /// The expected protobuf message type (not any), binary encoded
+    data: Binary,
 }
 
 /// A trait that is required to avoid conflicts with other query types like BankQuery and WasmQuery

--- a/packages/std/src/testing/mock.rs
+++ b/packages/std/src/testing/mock.rs
@@ -602,6 +602,7 @@ impl<C: CustomQuery + DeserializeOwned> MockQuerier<C> {
             }
             QueryRequest::Wasm(msg) => self.wasm.query(msg),
             #[cfg(feature = "stargate")]
+            #[allow(deprecated)]
             QueryRequest::Stargate { .. } => SystemResult::Err(SystemError::UnsupportedRequest {
                 kind: "Stargate".to_string(),
             }),

--- a/packages/std/src/testing/mock.rs
+++ b/packages/std/src/testing/mock.rs
@@ -606,6 +606,7 @@ impl<C: CustomQuery + DeserializeOwned> MockQuerier<C> {
             QueryRequest::Stargate { .. } => SystemResult::Err(SystemError::UnsupportedRequest {
                 kind: "Stargate".to_string(),
             }),
+            #[cfg(feature = "cosmwasm_2_0")]
             QueryRequest::Grpc(_) => SystemResult::Err(SystemError::UnsupportedRequest {
                 kind: "GRPC".to_string(),
             }),

--- a/packages/std/src/testing/mock.rs
+++ b/packages/std/src/testing/mock.rs
@@ -605,6 +605,9 @@ impl<C: CustomQuery + DeserializeOwned> MockQuerier<C> {
             QueryRequest::Stargate { .. } => SystemResult::Err(SystemError::UnsupportedRequest {
                 kind: "Stargate".to_string(),
             }),
+            QueryRequest::Grpc(_) => SystemResult::Err(SystemError::UnsupportedRequest {
+                kind: "GRPC".to_string(),
+            }),
             #[cfg(feature = "stargate")]
             QueryRequest::Ibc(msg) => self.ibc.query(msg),
         }


### PR DESCRIPTION
closes #1966

Do we also want to remove / deprecate the Stargate query? Only on the contract side ofc, since we need to continue supporting it in wasmd for 1.x compatibility.