### PR TITLE
Require cosmwasm-vm and cosmwasm-std to match cosmwasm-check version (backport 1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- cosmwasm-check: Use "=" for pinning the versions of cosmwasm-vm and
+  cosmwasm-std dependencies. This ensures that you can use an older version of
+  cosmwasm-check together with the VM of the same version by doing
+  `cargo install cosmwasm-check@1.2.8`. A typical use case would be to check a
+  contract with CosmWasm 1.2, 1.3, 1.4, 1.5 and 2.0. Note that other
+  dependencies are still upgraded when using `cargo install` which may lead to
+  API, behavioural or compiler incompatibilities. The
+  [--locked](https://doc.rust-lang.org/cargo/commands/cargo-install.html#dealing-with-the-lockfile)
+  feature allows you use the versions locked when the release was created.
+
 ## [1.2.7] - 2023-06-19
 
 ### Added

--- a/packages/check/Cargo.toml
+++ b/packages/check/Cargo.toml
@@ -11,5 +11,5 @@ license = "Apache-2.0"
 anyhow = "1.0.57"
 clap = "2"
 colored = "2"
-cosmwasm-vm = { path = "../vm", version = "1.2.7" }
-cosmwasm-std = { path = "../std", version = "1.2.7" }
+cosmwasm-vm = { path = "../vm", version = "=1.2.7" }
+cosmwasm-std = { path = "../std", version = "=1.2.7" }


### PR DESCRIPTION
Backport to 1.2
See also https://github.com/CosmWasm/cosmwasm/pull/1860