### PR TITLE
feat: schema: feature-gate deny_unknown_fields

### DIFF
--- a/packages/schema-derive/Cargo.toml
+++ b/packages/schema-derive/Cargo.toml
@@ -16,4 +16,5 @@ syn = { version = "1", features = ["full", "printing", "extra-traits"] }
 proc-macro = true
 
 [features]
-allow-unknown-fields = []
+default = ["deny-unknown-fields"]
+deny-unknown-fields = []

--- a/packages/schema-derive/Cargo.toml
+++ b/packages/schema-derive/Cargo.toml
@@ -14,3 +14,6 @@ syn = { version = "1", features = ["full", "printing", "extra-traits"] }
 
 [lib]
 proc-macro = true
+
+[features]
+allow-unknown-fields = []

--- a/packages/schema-derive/src/cw_serde.rs
+++ b/packages/schema-derive/src/cw_serde.rs
@@ -73,6 +73,7 @@ mod tests {
                 ::cosmwasm_schema::schemars::JsonSchema
             )]
             #[allow(clippy::derive_partial_eq_without_eq)]
+            #[serde(crate = "::cosmwasm_schema::serde")]
             #unknown_fields
             #[schemars(crate = "::cosmwasm_schema::schemars")]
             pub struct InstantiateMsg {
@@ -102,6 +103,7 @@ mod tests {
                 ::cosmwasm_schema::schemars::JsonSchema
             )]
             #[allow(clippy::derive_partial_eq_without_eq)]
+            #[serde(crate = "::cosmwasm_schema::serde")]
             #unknown_fields
             #[schemars(crate = "::cosmwasm_schema::schemars")]
             pub struct InstantiateMsg {}

--- a/packages/schema-derive/src/cw_serde.rs
+++ b/packages/schema-derive/src/cw_serde.rs
@@ -12,7 +12,7 @@ pub fn cw_serde_impl(input: DeriveInput) -> DeriveInput {
                 ::cosmwasm_schema::schemars::JsonSchema
             )]
             #[allow(clippy::derive_partial_eq_without_eq)] // Allow users of `#[cw_serde]` to not implement Eq without clippy complaining
-            #[serde(deny_unknown_fields, crate = "::cosmwasm_schema::serde")]
+            #[cfg_attr(not(feature = "allow-unknown-fields"), serde(deny_unknown_fields, crate = "::cosmwasm_schema::serde"))]
             #[schemars(crate = "::cosmwasm_schema::schemars")]
             #input
         },
@@ -26,7 +26,8 @@ pub fn cw_serde_impl(input: DeriveInput) -> DeriveInput {
                 ::cosmwasm_schema::schemars::JsonSchema
             )]
             #[allow(clippy::derive_partial_eq_without_eq)] // Allow users of `#[cw_serde]` to not implement Eq without clippy complaining
-            #[serde(deny_unknown_fields, rename_all = "snake_case", crate = "::cosmwasm_schema::serde")]
+            #[serde(rename_all = "snake_case", crate = "::cosmwasm_schema::serde")]
+            #[cfg_attr(not(feature = "allow-unknown-fields"), serde(deny_unknown_fields))]
             #[schemars(crate = "::cosmwasm_schema::schemars")]
             #input
         },
@@ -57,7 +58,7 @@ mod tests {
                 ::cosmwasm_schema::schemars::JsonSchema
             )]
             #[allow(clippy::derive_partial_eq_without_eq)]
-            #[serde(deny_unknown_fields, crate = "::cosmwasm_schema::serde")]
+            #[cfg_attr(not(feature = "allow-unknown-fields"), serde(deny_unknown_fields, crate = "::cosmwasm_schema::serde"))]
             #[schemars(crate = "::cosmwasm_schema::schemars")]
             pub struct InstantiateMsg {
                 pub verifier: String,
@@ -84,7 +85,7 @@ mod tests {
                 ::cosmwasm_schema::schemars::JsonSchema
             )]
             #[allow(clippy::derive_partial_eq_without_eq)]
-            #[serde(deny_unknown_fields, crate = "::cosmwasm_schema::serde")]
+            #[cfg_attr(not(feature = "allow-unknown-fields"), serde(deny_unknown_fields, crate = "::cosmwasm_schema::serde"))]
             #[schemars(crate = "::cosmwasm_schema::schemars")]
             pub struct InstantiateMsg {}
         };
@@ -113,7 +114,8 @@ mod tests {
                 ::cosmwasm_schema::schemars::JsonSchema
             )]
             #[allow(clippy::derive_partial_eq_without_eq)]
-            #[serde(deny_unknown_fields, rename_all = "snake_case", crate = "::cosmwasm_schema::serde")]
+            #[serde(rename_all = "snake_case", crate = "::cosmwasm_schema::serde")]
+            #[cfg_attr(not(feature = "allow-unknown-fields"), serde(deny_unknown_fields))]
             #[schemars(crate = "::cosmwasm_schema::schemars")]
             pub enum SudoMsg {
                 StealFunds {

--- a/packages/schema-derive/src/cw_serde.rs
+++ b/packages/schema-derive/src/cw_serde.rs
@@ -1,11 +1,11 @@
 use syn::{parse_quote, DeriveInput};
 
-#[cfg(not(feature = "allow-unknown-fields"))]
+#[cfg(feature = "deny-unknown-fields")]
 pub(crate) fn serde_unknown_fields() -> proc_macro2::TokenStream {
     quote::quote!(#[serde(deny_unknown_fields)])
 }
 
-#[cfg(feature = "allow-unknown-fields")]
+#[cfg(not(feature = "deny-unknown-fields"))]
 pub(crate) fn serde_unknown_fields() -> proc_macro2::TokenStream {
     quote::quote!()
 }

--- a/packages/schema/Cargo.toml
+++ b/packages/schema/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/CosmWasm/cosmwasm/tree/main/packages/schema"
 license = "Apache-2.0"
 
 [dependencies]
-cosmwasm-schema-derive = { version = "=2.0.0-beta.1", path = "../schema-derive" }
+cosmwasm-schema-derive = { version = "=2.0.0-beta.1", path = "../schema-derive", default-features = false}
 schemars = "0.8.3"
 serde = "1.0"
 serde_json = "1.0.40"
@@ -21,4 +21,5 @@ semver = "1"
 tempfile = "3"
 
 [features]
-allow-unknown-fields = ["cosmwasm-schema-derive/allow-unknown-fields"]
+default = ["deny-unknown-fields"]
+deny-unknown-fields = ["cosmwasm-schema-derive/deny-unknown-fields"]

--- a/packages/schema/Cargo.toml
+++ b/packages/schema/Cargo.toml
@@ -19,3 +19,6 @@ anyhow = "1.0.57"
 cosmwasm-std = { version = "2.0.0-beta.1", path = "../std" }
 semver = "1"
 tempfile = "3"
+
+[features]
+allow-unknown-fields = []

--- a/packages/schema/Cargo.toml
+++ b/packages/schema/Cargo.toml
@@ -21,4 +21,4 @@ semver = "1"
 tempfile = "3"
 
 [features]
-allow-unknown-fields = []
+allow-unknown-fields = ["cosmwasm-schema-derive/allow-unknown-fields"]

--- a/packages/schema/tests/idl.rs
+++ b/packages/schema/tests/idl.rs
@@ -284,3 +284,33 @@ fn nested_name_collision_caught() {
         query: NestedNameCollision,
     };
 }
+
+#[test]
+#[cfg(feature = "allow-unknown-fields")]
+fn test_allow_unknown_fields() {
+    #[cw_serde]
+    struct Expanded {
+        foo: String,
+        bar: String,
+    }
+
+    impl Default for Expanded {
+        fn default() -> Self {
+            Expanded {
+                foo: "hello".to_string(),
+                bar: "world".to_string(),
+            }
+        }
+    }
+
+    #[cw_serde]
+    struct Minimal {
+        foo: String,
+    }
+
+    let expanded_str = serde_json::to_string(&Expanded::default()).unwrap();
+    let expanded: Expanded = serde_json::from_str(&expanded_str).unwrap();
+    let minimal: Minimal = serde_json::from_str(&expanded_str).unwrap();
+
+    assert_eq!(expanded.foo, minimal.foo);
+}

--- a/packages/schema/tests/idl.rs
+++ b/packages/schema/tests/idl.rs
@@ -286,7 +286,7 @@ fn nested_name_collision_caught() {
 }
 
 #[test]
-#[cfg(feature = "allow-unknown-fields")]
+#[cfg(not(feature = "deny-unknown-fields"))]
 fn test_allow_unknown_fields() {
     #[cw_serde]
     struct Expanded {


### PR DESCRIPTION
This is a backwards-compatible change to the `schema` package which makes `serde(deny_unknown_fields)` optional.

It's feature-gated and _not_ set by default.

`cargo test --features allow-unknown-fields` will run the new `test_allow_unknown_fields()`. 

I believe this test illustrates the use-case clearly in code, but a bit more explanation: this has been a real-world problem for us (Levana) - we have bots which are written in Rust and consume messages from contracts. They do share the same "message" library code, but oftentimes we need to stagger their deployment (e.g. deploy contracts with new fields for the frontend, and we do not want to immediately deploy new bots or indexer services). `deny_unknown_fields` causes the bots to then break, since they are unaware of the new fields - but they don't need or use those new fields at all. We want to allow it.

Tbh I'm a bit surprised this hasn't come up more in the wild, but that may be due to most clients using languages other than Rust which are not bound by the serde constraints (such as Typescript which does _not_ error out on unknown fields.)