### PR TITLE
Added Sync + Send to Printable used in BT

### DIFF
--- a/packages/std/src/errors/backtrace.rs
+++ b/packages/std/src/errors/backtrace.rs
@@ -5,7 +5,7 @@ use crate::prelude::*;
 /// This wraps an actual backtrace to achieve two things:
 /// - being able to fill this with a stub implementation in `no_std` environments
 /// - being able to use this in conjunction with [`thiserror::Error`]
-pub struct BT(Box<dyn Printable>);
+pub struct BT(Box<dyn Printable + Sync + Send>);
 
 impl BT {
     #[track_caller]


### PR DESCRIPTION
In `cw-multi-test` and `cw-plus` are multiple conversions to anyhow::Result that fail without Sync+Send.