### PR TITLE
Update cosmwasm-check capabilities

### DIFF
--- a/packages/check/src/main.rs
+++ b/packages/check/src/main.rs
@@ -11,7 +11,7 @@ use cosmwasm_vm::capabilities_from_csv;
 use cosmwasm_vm::internals::{check_wasm, compile, make_compiling_engine};
 
 const DEFAULT_AVAILABLE_CAPABILITIES: &str =
-    "iterator,staking,stargate,cosmwasm_1_1,cosmwasm_1_2,cosmwasm_1_3,cosmwasm_1_4";
+    "iterator,staking,stargate,cosmwasm_1_1,cosmwasm_1_2,cosmwasm_1_3,cosmwasm_1_4,cosmwasm_2_0";
 
 pub fn main() {
     let matches = Command::new("Contract checking")


### PR DESCRIPTION
The last [CI build of contracts](https://circleci.com/gh/CosmWasm/cosmwasm/97965) for the 2.0.0-rc.1 release failed because of this.