### PR TITLE
fix: update broken links to docs

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -44,7 +44,7 @@ Introducing the development contracts in the order they were created.
 ## Optimized builds
 
 Those development contracts are used for testing in other repos, e.g. in
-[wasmvm](https://github.com/CosmWasm/wasmvm/tree/master/api/testdata) or
+[wasmvm](https://github.com/CosmWasm/wasmvm/tree/main/testdata) or
 [cosmjs](https://github.com/cosmos/cosmjs/tree/main/scripts/wasmd/contracts).
 
 They are [built and deployed](https://github.com/CosmWasm/cosmwasm/releases) by

--- a/contracts/reflect/README.md
+++ b/contracts/reflect/README.md
@@ -63,9 +63,8 @@ be done simply by running `cargo check` or `cargo unit-test`
 
 Once you have your custom repo, you should check out
 [Developing](./Developing.md) to explain more on how to run tests and develop
-code. Or go through the
-[online tutorial](https://book.cosmwasm.com/index.html) to get a
-better feel of how to develop.
+code. Or go through the [online tutorial](https://book.cosmwasm.com/index.html)
+to get a better feel of how to develop.
 
 [Publishing](./Publishing.md) contains useful information on how to publish your
 contract to the world, once you are ready to deploy it on a running blockchain.

--- a/contracts/reflect/README.md
+++ b/contracts/reflect/README.md
@@ -64,7 +64,7 @@ be done simply by running `cargo check` or `cargo unit-test`
 Once you have your custom repo, you should check out
 [Developing](./Developing.md) to explain more on how to run tests and develop
 code. Or go through the
-[online tutorial](https://www.cosmwasm.com/docs/getting-started/intro) to get a
+[online tutorial](https://book.cosmwasm.com/index.html) to get a
 better feel of how to develop.
 
 [Publishing](./Publishing.md) contains useful information on how to publish your

--- a/contracts/staking/README.md
+++ b/contracts/staking/README.md
@@ -28,5 +28,5 @@ transferred to the owners account. (The ownership can also be transferred).
 
 You should check out [Developing](./Developing.md) to explain more on how to run
 tests and develop code. Or go through the
-[online tutorial](https://book.cosmwasm.com/index.html) to get a
-better feel of how to develop.
+[online tutorial](https://book.cosmwasm.com/index.html) to get a better feel of
+how to develop.

--- a/contracts/staking/README.md
+++ b/contracts/staking/README.md
@@ -28,5 +28,5 @@ transferred to the owners account. (The ownership can also be transferred).
 
 You should check out [Developing](./Developing.md) to explain more on how to run
 tests and develop code. Or go through the
-[online tutorial](https://www.cosmwasm.com/docs/getting-started/intro) to get a
+[online tutorial](https://book.cosmwasm.com/index.html) to get a
 better feel of how to develop.


### PR DESCRIPTION
Hello, I've found several broken links. Some of them are pointing to deprecated docs, I'm replacing them with alternative to cosmwasm book.