### PR TITLE
Go-gen improvements

### DIFF
--- a/packages/go-gen/src/main.rs
+++ b/packages/go-gen/src/main.rs
@@ -251,7 +251,7 @@ mod tests {
                 Binary []byte `json:"binary"`
                 Checksum Checksum `json:"checksum"`
                 HexBinary string `json:"hex_binary"`
-                NestedBinary []*[]byte `json:"nested_binary"`
+                NestedBinary Array[*[]byte] `json:"nested_binary"`
                 Uint128 string `json:"uint128"`
             }"#,
         );
@@ -456,7 +456,7 @@ mod tests {
             code,
             r#"
             type A struct {
-                A [][][]*B `json:"a"`
+                A Array[Array[Array[*B]]] `json:"a"`
             }
             type B struct { }"#,
         );
@@ -470,7 +470,7 @@ mod tests {
             code,
             r#"
             type C struct {
-                C [][][]*string `json:"c"`
+                C Array[Array[Array[*string]]] `json:"c"`
             }"#,
         );
     }

--- a/packages/go-gen/src/main.rs
+++ b/packages/go-gen/src/main.rs
@@ -151,7 +151,7 @@ pub fn build_enum_variant(
     // we are not interested in that case, so we error out
     if let Some(values) = &schema.enum_values {
         bail!(
-            "enum variants {} without inner data not supported",
+            "enum variant {} without inner data not supported",
             values
                 .iter()
                 .map(|v| v.to_string())
@@ -436,7 +436,7 @@ mod tests {
         compare_codes!(cosmwasm_std::DistributionMsg);
         compare_codes!(cosmwasm_std::IbcMsg);
         compare_codes!(cosmwasm_std::WasmMsg);
-        // compare_codes!(cosmwasm_std::GovMsg); // TODO: currently fails because of VoteOption
+        compare_codes!(cosmwasm_std::GovMsg);
     }
 
     #[test]

--- a/packages/go-gen/src/main.rs
+++ b/packages/go-gen/src/main.rs
@@ -473,6 +473,21 @@ mod tests {
                 C Array[Array[Array[*string]]] `json:"c"`
             }"#,
         );
+
+        #[cw_serde]
+        struct D {
+            d: Option<Vec<String>>,
+            nested: Vec<Option<Vec<String>>>,
+        }
+        let code = generate_go(cosmwasm_schema::schema_for!(D)).unwrap();
+        assert_code_eq(
+            code,
+            r#"
+            type D struct {
+                D *[]string `json:"d,omitempty"`
+                Nested Array[*[]string] `json:"nested"`
+            }"#,
+        );
     }
 
     #[test]

--- a/packages/go-gen/src/schema.rs
+++ b/packages/go-gen/src/schema.rs
@@ -4,7 +4,7 @@ use inflector::Inflector;
 use schemars::schema::{InstanceType, Schema, SchemaObject, SingleOrVec};
 
 use crate::{
-    go::{GoField, GoStruct, GoType},
+    go::{GoField, GoStruct, GoType, Nullability},
     utils::{replace_acronyms, suffixes},
 };
 
@@ -36,9 +36,21 @@ pub fn schema_object_type(
     type_context: TypeContext,
     additional_structs: &mut Vec<GoStruct>,
 ) -> Result<GoType> {
-    let mut is_nullable = is_null(schema);
+    let mut nullability = if is_null(schema) {
+        Nullability::Nullable
+    } else {
+        Nullability::NonNullable
+    };
 
-    // if it has a title, use that
+    if schema
+        .metadata
+        .as_ref()
+        .and_then(|m| m.default.as_ref())
+        .is_some()
+    {
+        nullability = Nullability::OmitEmpty;
+    }
+
     let ty = if let Some(title) = schema.metadata.as_ref().and_then(|m| m.title.as_ref()) {
         replace_custom_type(title)
     } else if let Some(reference) = &schema.reference {
@@ -56,7 +68,7 @@ pub fn schema_object_type(
         let nullable = nullable_type(subschemas)?;
         if let Some(non_null) = nullable {
             ensure!(subschemas.len() == 2, "multiple subschemas in anyOf");
-            is_nullable = true;
+            nullability = Nullability::Nullable;
             // extract non-null type
             let GoType { name, .. } =
                 schema_object_type(non_null, type_context, additional_structs)?;
@@ -78,7 +90,7 @@ pub fn schema_object_type(
 
     Ok(GoType {
         name: ty,
-        is_nullable,
+        nullability,
     })
 }
 
@@ -197,7 +209,7 @@ pub fn type_from_instance_type(
         // for nullable array item types, we have to use a pointer type, even for basic types,
         // so we can pass null as elements
         // otherwise they would just be omitted from the array
-        replace_custom_type(&if item_type.is_nullable {
+        replace_custom_type(&if item_type.nullability == Nullability::Nullable {
             format!("[]*{}", item_type.name)
         } else {
             format!("[]{}", item_type.name)

--- a/packages/go-gen/src/schema.rs
+++ b/packages/go-gen/src/schema.rs
@@ -210,9 +210,9 @@ pub fn type_from_instance_type(
         // so we can pass null as elements
         // otherwise they would just be omitted from the array
         replace_custom_type(&if item_type.nullability == Nullability::Nullable {
-            format!("[]*{}", item_type.name)
+            format!("Array[*{}]", item_type.name)
         } else {
-            format!("[]{}", item_type.name)
+            format!("Array[{}]", item_type.name)
         })
     } else {
         unreachable!("instance type should be one of the above")

--- a/packages/go-gen/src/schema.rs
+++ b/packages/go-gen/src/schema.rs
@@ -265,6 +265,8 @@ pub fn custom_type_of(ty: &str) -> Option<&str> {
         "Int128" => Some("string"),
         "Binary" => Some("[]byte"),
         "HexBinary" => Some("string"),
+        "ReplyOn" => Some("replyOn"),
+        "VoteOption" => Some("voteOption"),
         "Checksum" => Some("Checksum"),
         "Addr" => Some("string"),
         "Decimal" => Some("string"),

--- a/packages/go-gen/src/schema.rs
+++ b/packages/go-gen/src/schema.rs
@@ -42,6 +42,10 @@ pub fn schema_object_type(
         Nullability::NonNullable
     };
 
+    // Check for a default value.
+    // This is the case if the field was annotated with `#[serde(default)]` or variations of it.
+    // A `null` value is not necessarily allowed in this case,
+    // so we want to omit the field on the Go side.
     if schema
         .metadata
         .as_ref()

--- a/packages/go-gen/tests/cosmwasm_std__AllBalanceResponse.go
+++ b/packages/go-gen/tests/cosmwasm_std__AllBalanceResponse.go
@@ -1,6 +1,6 @@
 // AllBalancesResponse is the expected response to AllBalancesQuery
 type AllBalancesResponse struct {
-	Amount []Coin `json:"amount"` // in wasmvm, there is an alias for `[]Coin`
+	Amount Array[Coin] `json:"amount"`
 }
 
 // Coin is a string representation of the sdk.Coin type (more portable than sdk.Int)

--- a/packages/go-gen/tests/cosmwasm_std__AllDelegationsResponse.go
+++ b/packages/go-gen/tests/cosmwasm_std__AllDelegationsResponse.go
@@ -1,6 +1,6 @@
 // AllDelegationsResponse is the expected response to AllDelegationsQuery
 type AllDelegationsResponse struct {
-	Delegations []Delegation `json:"delegations"` // in wasmvm, there is an alias for `[]Delegation`
+	Delegations Array[Delegation] `json:"delegations"`
 }
 
 // Coin is a string representation of the sdk.Coin type (more portable than sdk.Int)

--- a/packages/go-gen/tests/cosmwasm_std__AllValidatorsResponse.go
+++ b/packages/go-gen/tests/cosmwasm_std__AllValidatorsResponse.go
@@ -1,6 +1,6 @@
 // AllValidatorsResponse is the expected response to AllValidatorsQuery
 type AllValidatorsResponse struct {
-	Validators []Validator `json:"validators"` // in wasmvm, there is an alias for `[]Validator`
+	Validators Array[Validator] `json:"validators"`
 }
 
 type Validator struct {

--- a/packages/go-gen/tests/cosmwasm_std__BankMsg.go
+++ b/packages/go-gen/tests/cosmwasm_std__BankMsg.go
@@ -1,15 +1,15 @@
 // SendMsg contains instructions for a Cosmos-SDK/SendMsg
 // It has a fixed interface here and should be converted into the proper SDK format before dispatching
 type SendMsg struct {
-	Amount    []Coin `json:"amount"`
-	ToAddress string `json:"to_address"`
+	Amount    Array[Coin] `json:"amount"`
+	ToAddress string      `json:"to_address"`
 }
 
 // BurnMsg will burn the given coins from the contract's account.
 // There is no Cosmos SDK message that performs this, but it can be done by calling the bank keeper.
 // Important if a contract controls significant token supply that must be retired.
 type BurnMsg struct {
-	Amount []Coin `json:"amount"`
+	Amount Array[Coin] `json:"amount"`
 }
 
 type BankMsg struct {

--- a/packages/go-gen/tests/cosmwasm_std__DelegationResponse.go
+++ b/packages/go-gen/tests/cosmwasm_std__DelegationResponse.go
@@ -10,9 +10,9 @@ type Coin struct {
 }
 
 type FullDelegation struct {
-	AccumulatedRewards []Coin `json:"accumulated_rewards"` // in wasmvm, there is an alias for `[]Coin`
-	Amount             Coin   `json:"amount"`
-	CanRedelegate      Coin   `json:"can_redelegate"`
-	Delegator          string `json:"delegator"`
-	Validator          string `json:"validator"`
+	AccumulatedRewards Array[Coin] `json:"accumulated_rewards"`
+	Amount             Coin        `json:"amount"`
+	CanRedelegate      Coin        `json:"can_redelegate"`
+	Delegator          string      `json:"delegator"`
+	Validator          string      `json:"validator"`
 }

--- a/packages/go-gen/tests/cosmwasm_std__DelegationRewardsResponse.go
+++ b/packages/go-gen/tests/cosmwasm_std__DelegationRewardsResponse.go
@@ -1,6 +1,6 @@
 // See <https://github.com/cosmos/cosmos-sdk/blob/c74e2887b0b73e81d48c2f33e6b1020090089ee0/proto/cosmos/distribution/v1beta1/query.proto#L169-L178>
 type DelegationRewardsResponse struct {
-	Rewards []DecCoin `json:"rewards"`
+	Rewards Array[DecCoin] `json:"rewards"` // in wasmvm, this has type `[]DecCoin`
 }
 
 // A coin type with decimal amount. Modeled after the Cosmos SDK's [DecCoin](https://github.com/cosmos/cosmos-sdk/blob/c74e2887b0b73e81d48c2f33e6b1020090089ee0/proto/cosmos/base/v1beta1/coin.proto#L32-L41) type

--- a/packages/go-gen/tests/cosmwasm_std__DelegationTotalRewardsResponse.go
+++ b/packages/go-gen/tests/cosmwasm_std__DelegationTotalRewardsResponse.go
@@ -1,7 +1,7 @@
 // See <https://github.com/cosmos/cosmos-sdk/blob/c74e2887b0b73e81d48c2f33e6b1020090089ee0/proto/cosmos/distribution/v1beta1/query.proto#L189-L200>
 type DelegationTotalRewardsResponse struct {
-	Rewards []DelegatorReward `json:"rewards"`
-	Total   []DecCoin         `json:"total"`
+	Rewards Array[DelegatorReward] `json:"rewards"` // in wasmvm, this has type `[]DelegatorReward`
+	Total   Array[DecCoin]         `json:"total"`   // in wasmvm, this has type `[]DecCoin`
 }
 
 // A coin type with decimal amount. Modeled after the Cosmos SDK's [DecCoin](https://github.com/cosmos/cosmos-sdk/blob/c74e2887b0b73e81d48c2f33e6b1020090089ee0/proto/cosmos/base/v1beta1/coin.proto#L32-L41) type
@@ -11,6 +11,6 @@ type DecCoin struct {
 }
 
 type DelegatorReward struct {
-	Reward           []DecCoin `json:"reward"`
-	ValidatorAddress string    `json:"validator_address"`
+	Reward           Array[DecCoin] `json:"reward"` // in wasmvm, this has type `[]DecCoin`
+	ValidatorAddress string         `json:"validator_address"`
 }

--- a/packages/go-gen/tests/cosmwasm_std__DelegatorValidatorsResponse.go
+++ b/packages/go-gen/tests/cosmwasm_std__DelegatorValidatorsResponse.go
@@ -1,4 +1,4 @@
 // See <https://github.com/cosmos/cosmos-sdk/blob/b0acf60e6c39f7ab023841841fc0b751a12c13ff/proto/cosmos/distribution/v1beta1/query.proto#L212-L220>
 type DelegatorValidatorsResponse struct {
-	Validators []string `json:"validators"`
+	Validators Array[string] `json:"validators"` // in wasmvm, this has type `[]string`
 }

--- a/packages/go-gen/tests/cosmwasm_std__DenomMetadataResponse.go
+++ b/packages/go-gen/tests/cosmwasm_std__DenomMetadataResponse.go
@@ -7,8 +7,8 @@ type DenomMetadata struct {
 	// Base represents the base denom (should be the DenomUnit with exponent = 0).
 	Base string `json:"base"`
 	// DenomUnits represents the list of DenomUnits for a given coin
-	DenomUnits  []DenomUnit `json:"denom_units"`
-	Description string      `json:"description"`
+	DenomUnits  Array[DenomUnit] `json:"denom_units"` // in wasmvm, this has type `[]DenomUnit`
+	Description string           `json:"description"`
 	// Display indicates the suggested denom that should be
 	// displayed in clients.
 	Display string `json:"display"`
@@ -35,7 +35,7 @@ type DenomMetadata struct {
 // Replicating the cosmos-sdk bank module DenomUnit type
 type DenomUnit struct {
 	// Aliases is a list of string aliases for the given denom
-	Aliases []string `json:"aliases"`
+	Aliases Array[string] `json:"aliases"` // in wasmvm, this has type `[]string`
 	// Denom represents the string name of the given denom unit (e.g uatom).
 	Denom string `json:"denom"`
 	// Exponent represents power of 10 exponent that one must

--- a/packages/go-gen/tests/cosmwasm_std__DistributionMsg.go
+++ b/packages/go-gen/tests/cosmwasm_std__DistributionMsg.go
@@ -16,7 +16,7 @@ type WithdrawDelegatorRewardMsg struct {
 // `depositor` is automatically filled with the current contract's address
 type FundCommunityPoolMsg struct {
 	// Amount is the list of coins to be send to the community pool
-	Amount []Coin `json:"amount"`
+	Amount Array[Coin] `json:"amount"`
 }
 
 type DistributionMsg struct {

--- a/packages/go-gen/tests/cosmwasm_std__GovMsg.go
+++ b/packages/go-gen/tests/cosmwasm_std__GovMsg.go
@@ -8,8 +8,8 @@ type VoteMsg struct {
 }
 
 type VoteWeightedMsg struct {
-	Options    []WeightedVoteOption `json:"options"`
-	ProposalID uint64               `json:"proposal_id"` // in wasmvm, this is `ProposalId`
+	Options    Array[WeightedVoteOption] `json:"options"`     // in wasmvm, this has type `[]WeightedVoteOption`
+	ProposalID uint64                    `json:"proposal_id"` // in wasmvm, this is `ProposalId`
 }
 
 type GovMsg struct {

--- a/packages/go-gen/tests/cosmwasm_std__GovMsg.go
+++ b/packages/go-gen/tests/cosmwasm_std__GovMsg.go
@@ -1,0 +1,26 @@
+type VoteMsg struct {
+	// Option is the vote option.
+	//
+	// This used to be called "vote", but was changed for consistency with Cosmos SDK.
+	// The old name is still supported for backwards compatibility.
+	Option     voteOption `json:"option"`
+	ProposalID uint64     `json:"proposal_id"` // in wasmvm, this is `ProposalId`
+}
+
+type VoteWeightedMsg struct {
+	Options    []WeightedVoteOption `json:"options"`
+	ProposalID uint64               `json:"proposal_id"` // in wasmvm, this is `ProposalId`
+}
+
+type GovMsg struct {
+	// This maps directly to [MsgVote](https://github.com/cosmos/cosmos-sdk/blob/v0.42.5/proto/cosmos/gov/v1beta1/tx.proto#L46-L56) in the Cosmos SDK with voter set to the contract address.
+	Vote *VoteMsg `json:"vote,omitempty"`
+	/// This maps directly to [MsgVoteWeighted](https://github.com/cosmos/cosmos-sdk/blob/v0.45.8/proto/cosmos/gov/v1beta1/tx.proto#L66-L78) in the Cosmos SDK with voter set to the contract address.
+	VoteWeighted *VoteWeightedMsg `json:"vote_weighted,omitempty"`
+}
+
+type WeightedVoteOption struct {
+	Option voteOption `json:"option"`
+	// Weight is a Decimal string, e.g. "0.25" for 25%
+	Weight string `json:"weight"`
+}

--- a/packages/go-gen/tests/cosmwasm_std__WasmMsg.go
+++ b/packages/go-gen/tests/cosmwasm_std__WasmMsg.go
@@ -10,7 +10,7 @@ type ExecuteMsg struct {
 	// the contract ID and instance ID. The sdk module should maintain a reverse lookup table.
 	ContractAddr string `json:"contract_addr"`
 	// Send is an optional amount of coins this contract sends to the called contract
-	Funds []Coin `json:"funds"`
+	Funds Array[Coin] `json:"funds"`
 	// Msg is assumed to be a json-encoded message, which will be passed directly
 	// as `userMsg` when calling `Handle` on the above-defined contract
 	Msg []byte `json:"msg"`
@@ -24,7 +24,7 @@ type InstantiateMsg struct {
 	// CodeID is the reference to the wasm byte code as used by the Cosmos-SDK
 	CodeID uint64 `json:"code_id"`
 	// Send is an optional amount of coins this contract sends to the called contract
-	Funds []Coin `json:"funds"`
+	Funds Array[Coin] `json:"funds"`
 	// Label is optional metadata to be stored with a contract instance.
 	Label string `json:"label"`
 	// Msg is assumed to be a json-encoded message, which will be passed directly
@@ -40,7 +40,7 @@ type Instantiate2Msg struct {
 	// CodeID is the reference to the wasm byte code as used by the Cosmos-SDK
 	CodeID uint64 `json:"code_id"`
 	// Send is an optional amount of coins this contract sends to the called contract
-	Funds []Coin `json:"funds"`
+	Funds Array[Coin] `json:"funds"`
 	// Label is optional metadata to be stored with a contract instance.
 	Label string `json:"label"`
 	// Msg is assumed to be a json-encoded message, which will be passed directly


### PR DESCRIPTION
- Adds special handling for `ReplyOn` and `VoteOption`, as those have corresponding custom types in wasmvm.
- Generates the new `Array[T]` type added in wasmvm. This is now always used for `Vec<T>`. `Option<Vec<T>>` continues to be generated as `*[]T`.
- Fields with a `#[serde(default)]` annotation now add `omitempty`. This is necessary because serde fails if these are passed as `null`. Only missing entries are accepted and replaced with the default value.