### PR TITLE
Optimize `sqrt`s

### DIFF
--- a/packages/std/src/math/isqrt.rs
+++ b/packages/std/src/math/isqrt.rs
@@ -13,8 +13,10 @@ pub trait Isqrt {
 impl<I> Isqrt for I
 where
     I: Unsigned
+        + Log2
         + ops::Add<I, Output = I>
         + ops::Div<I, Output = I>
+        + ops::Shl<u32, Output = I>
         + ops::Shr<u32, Output = I>
         + cmp::PartialOrd
         + Copy
@@ -23,9 +25,13 @@ where
     /// Algorithm adapted from
     /// [Wikipedia](https://en.wikipedia.org/wiki/Integer_square_root#Example_implementation_in_C).
     fn isqrt(self) -> Self {
-        let mut x0 = self >> 1;
+        let zero = Self::from(0);
+        if self == zero {
+            return zero;
+        }
+        let mut x0 = I::from(1u8) << ((self.log_2() / 2) + 1);
 
-        if x0 > 0.into() {
+        if x0 > zero {
             let mut x1 = (x0 + self / x0) >> 1;
 
             while x1 < x0 {
@@ -51,6 +57,29 @@ impl Unsigned for Uint128 {}
 impl Unsigned for Uint256 {}
 impl Unsigned for Uint512 {}
 impl Unsigned for usize {}
+
+trait Log2 {
+    fn log_2(self) -> u32;
+}
+macro_rules! impl_log2 {
+    ($type:ty) => {
+        impl Log2 for $type {
+            fn log_2(self) -> u32 {
+                self.ilog2()
+            }
+        }
+    };
+}
+impl_log2!(u8);
+impl_log2!(u16);
+impl_log2!(u32);
+impl_log2!(u64);
+impl_log2!(u128);
+impl_log2!(usize);
+impl_log2!(Uint64);
+impl_log2!(Uint128);
+impl_log2!(Uint256);
+impl_log2!(Uint512);
 
 #[cfg(test)]
 mod tests {

--- a/packages/std/src/math/uint128.rs
+++ b/packages/std/src/math/uint128.rs
@@ -96,6 +96,16 @@ impl Uint128 {
         self.0.pow(exp).into()
     }
 
+    /// Returns the base 2 logarithm of the number, rounded down.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if `self` is zero.
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    pub fn ilog2(self) -> u32 {
+        self.0.checked_ilog2().unwrap()
+    }
+
     /// Returns `self * numerator / denominator`.
     ///
     /// Due to the nature of the integer division involved, the result is always floored.

--- a/packages/std/src/math/uint256.rs
+++ b/packages/std/src/math/uint256.rs
@@ -168,6 +168,16 @@ impl Uint256 {
         Self(self.0.pow(exp))
     }
 
+    /// Returns the base 2 logarithm of the number, rounded down.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if `self` is zero.
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    pub fn ilog2(self) -> u32 {
+        self.0.checked_ilog2().unwrap()
+    }
+
     /// Returns `self * numerator / denominator`.
     ///
     /// Due to the nature of the integer division involved, the result is always floored.

--- a/packages/std/src/math/uint512.rs
+++ b/packages/std/src/math/uint512.rs
@@ -193,6 +193,16 @@ impl Uint512 {
         Self(self.0.pow(exp))
     }
 
+    /// Returns the base 2 logarithm of the number, rounded down.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if `self` is zero.
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    pub fn ilog2(self) -> u32 {
+        self.0.checked_ilog2().unwrap()
+    }
+
     pub fn checked_add(self, other: Self) -> Result<Self, OverflowError> {
         self.0
             .checked_add(other.0)

--- a/packages/std/src/math/uint64.rs
+++ b/packages/std/src/math/uint64.rs
@@ -90,6 +90,16 @@ impl Uint64 {
         self.0.pow(exp).into()
     }
 
+    /// Returns the base 2 logarithm of the number, rounded down.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if `self` is zero.
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    pub fn ilog2(self) -> u32 {
+        self.0.checked_ilog2().unwrap()
+    }
+
     /// Returns `self * numerator / denominator`.
     ///
     /// Due to the nature of the integer division involved, the result is always floored.


### PR DESCRIPTION
closes #1897 
- The upper bound for `isqrt` can be lowered using `ilog2`.
- The [max precision](https://github.com/CosmWasm/cosmwasm/blob/a34949b861dfa11ec8016b468922e48e6a6d785d/packages/std/src/math/decimal.rs#L362) for the `Decimal::sqrt` can also be calculated directly using `ilog10`

TODOs:
- [x] use better bound for `isqrt`
- [x] calculate max precision for `Decimal::sqrt` (I added a section to the [HackMD](https://hackmd.io/@webmaster128/SJThlukj_))
- [x] poove that the max precision calculated here actually is the maximum. I ran some tests and didn't find any counter-examples and the resulting function also looks like this is the case, but given all the intermediate rounding it is not obvious and it would be good to have a proof.
- [x] benchmark the number of wasm instructions it takes. Some notes:
  - Rust `std`'s `ilog10` looks very efficient (and crazy), but no idea how good `bnum`'s implementation is
  - even with an efficient log, it might still be faster to try the checked math