### PR TITLE
Add IntoEvent macro which automatically implement Into<Event> to a struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,6 +380,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "corosensei"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -428,7 +434,10 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "2.0.0-rc.1"
 dependencies = [
+ "convert_case",
  "cosmwasm-std",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 

--- a/contracts/burner/Cargo.lock
+++ b/contracts/burner/Cargo.lock
@@ -185,6 +185,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "795bc6e66a8e340f075fcf6227e417a2dc976b92b91f3cdc778bb858778b6747"
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "corosensei"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,6 +218,9 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "2.0.0-rc.1"
 dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 

--- a/contracts/crypto-verify/Cargo.lock
+++ b/contracts/crypto-verify/Cargo.lock
@@ -174,6 +174,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "795bc6e66a8e340f075fcf6227e417a2dc976b92b91f3cdc778bb858778b6747"
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "corosensei"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +207,9 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "2.0.0-rc.1"
 dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 

--- a/contracts/cyberpunk/Cargo.lock
+++ b/contracts/cyberpunk/Cargo.lock
@@ -209,6 +209,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "corosensei"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,6 +242,9 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "2.0.0-rc.1"
 dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 

--- a/contracts/empty/Cargo.lock
+++ b/contracts/empty/Cargo.lock
@@ -174,6 +174,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "795bc6e66a8e340f075fcf6227e417a2dc976b92b91f3cdc778bb858778b6747"
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "corosensei"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +207,9 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "2.0.0-rc.1"
 dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 

--- a/contracts/floaty/Cargo.lock
+++ b/contracts/floaty/Cargo.lock
@@ -174,6 +174,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "795bc6e66a8e340f075fcf6227e417a2dc976b92b91f3cdc778bb858778b6747"
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "corosensei"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +207,9 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "2.0.0-rc.1"
 dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 

--- a/contracts/hackatom/Cargo.lock
+++ b/contracts/hackatom/Cargo.lock
@@ -174,6 +174,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "795bc6e66a8e340f075fcf6227e417a2dc976b92b91f3cdc778bb858778b6747"
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "corosensei"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +207,9 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "2.0.0-rc.1"
 dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 

--- a/contracts/ibc-reflect-send/Cargo.lock
+++ b/contracts/ibc-reflect-send/Cargo.lock
@@ -174,6 +174,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "795bc6e66a8e340f075fcf6227e417a2dc976b92b91f3cdc778bb858778b6747"
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "corosensei"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +207,9 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "2.0.0-rc.1"
 dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 

--- a/contracts/ibc-reflect/Cargo.lock
+++ b/contracts/ibc-reflect/Cargo.lock
@@ -174,6 +174,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "795bc6e66a8e340f075fcf6227e417a2dc976b92b91f3cdc778bb858778b6747"
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "corosensei"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +207,9 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "2.0.0-rc.1"
 dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 

--- a/contracts/queue/Cargo.lock
+++ b/contracts/queue/Cargo.lock
@@ -174,6 +174,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "795bc6e66a8e340f075fcf6227e417a2dc976b92b91f3cdc778bb858778b6747"
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "corosensei"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +207,9 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "2.0.0-rc.1"
 dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 

--- a/contracts/reflect/Cargo.lock
+++ b/contracts/reflect/Cargo.lock
@@ -174,6 +174,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "795bc6e66a8e340f075fcf6227e417a2dc976b92b91f3cdc778bb858778b6747"
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "corosensei"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +207,9 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "2.0.0-rc.1"
 dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 

--- a/contracts/staking/Cargo.lock
+++ b/contracts/staking/Cargo.lock
@@ -174,6 +174,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "795bc6e66a8e340f075fcf6227e417a2dc976b92b91f3cdc778bb858778b6747"
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "corosensei"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +207,9 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "2.0.0-rc.1"
 dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 

--- a/contracts/virus/Cargo.lock
+++ b/contracts/virus/Cargo.lock
@@ -174,6 +174,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "795bc6e66a8e340f075fcf6227e417a2dc976b92b91f3cdc778bb858778b6747"
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "corosensei"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +207,9 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "2.0.0-rc.1"
 dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 

--- a/packages/derive/Cargo.toml
+++ b/packages/derive/Cargo.toml
@@ -16,6 +16,9 @@ default = []
 
 [dependencies]
 syn = { version = "1.0", features = ["full"] }
+quote = "1.0"
+proc-macro2 = "1.0.32"
+convert_case = "0.4.0"
 
 [dev-dependencies]
 # Needed for testing docs

--- a/packages/derive/src/into_event.rs
+++ b/packages/derive/src/into_event.rs
@@ -1,0 +1,110 @@
+extern crate proc_macro;
+
+use convert_case::{Case, Casing};
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::spanned::Spanned;
+use syn::{Attribute, DataStruct, DeriveInput, Error, Field, Ident, Result};
+
+/// scan attrs and get `to_string_fn` attribute
+fn scan_to_string_fn(field: &Field) -> Result<Option<proc_macro2::TokenStream>> {
+    let filtered: Vec<&Attribute> = field
+        .attrs
+        .iter()
+        .filter(|a| a.path.is_ident("to_string_fn"))
+        .collect();
+    if filtered.len() > 1 {
+        return Err(Error::new(
+            field.span(),
+            "[IntoEvent] Only one or zero `to_string_fn` can be applied to one field.",
+        ));
+    };
+    if filtered.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(filtered[0].tokens.clone()))
+    }
+}
+
+/// scan attrs and return if it has any `to_string`
+fn has_use_to_string(field: &Field) -> Result<bool> {
+    let mut filtered = field
+        .attrs
+        .iter()
+        .filter(|a| a.path.is_ident("use_to_string"));
+    if filtered.clone().any(|a| !a.tokens.is_empty()) {
+        return Err(Error::new(
+            field.span(),
+            "[IntoEvent] attribute `use_to_string` has some value. If you intend to specify the cast function to string, use `to_string_fn` instead.",
+        ));
+    }
+    Ok(filtered.next().is_some())
+}
+
+/// generate an ast for `impl Into<cosmwasm::Event>` from a struct
+fn make_init_from_struct(id: Ident, struct_data: DataStruct) -> Result<proc_macro2::TokenStream> {
+    // snake case of struct ident
+    let name = id.to_string().as_str().to_case(Case::Snake);
+
+    // generate the body of `fn into`
+    // generating `Event::new()` part
+    let mut fn_body = quote!(
+        cosmwasm_std::Event::new(#name)
+    );
+
+    // chain `.add_attribute`s to `Event::new()` part
+    for field in struct_data.fields {
+        let field_id = match field.clone().ident {
+            None => {
+                return Err(Error::new(
+                    field.span(),
+                    "[IntoEvent] Unexpected unnamed field.",
+                ))
+            }
+            Some(field_id) => field_id,
+        };
+        let value = match (scan_to_string_fn(&field)?, has_use_to_string(&field)?) {
+            (Some(_), true) => return Err(Error::new(
+                field.span(),
+                "[IntoEvent] Both `use_to_string` and `to_string_fn` are applied to an field. Only one can be applied.",
+            )),
+            (Some(to_string_fn), false) => quote!(#to_string_fn(self.#field_id)),
+            (None, true) => quote!(self.#field_id.to_string()),
+            (None, false) => quote!(self.#field_id),
+        };
+        fn_body.extend(quote!(
+            .add_attribute(stringify!(#field_id), #value)
+        ))
+    }
+
+    // generate the `impl Into<cosmwasm_std::Event>` from generated `fn_body`
+    let gen = quote!(
+        impl Into<cosmwasm_std::Event> for #id {
+            fn into(self) -> cosmwasm_std::Event {
+                #fn_body
+            }
+        }
+    );
+    Ok(gen)
+}
+
+/// derive `IntoEvent` from a derive input. The input needs to be a struct.
+pub fn derive_into_event(input: DeriveInput) -> TokenStream {
+    match input.data {
+        syn::Data::Struct(struct_data) => make_init_from_struct(input.ident, struct_data)
+            .unwrap_or_else(|e| e.to_compile_error())
+            .into(),
+        syn::Data::Enum(enum_data) => Error::new(
+            enum_data.enum_token.span,
+            "[IntoEvent] `derive(IntoEvent)` cannot be applied to Enum.",
+        )
+        .to_compile_error()
+        .into(),
+        syn::Data::Union(union_data) => Error::new(
+            union_data.union_token.span,
+            "[IntoEvent] `derive(IntoEvent)` cannot be applied to Union.",
+        )
+        .to_compile_error()
+        .into(),
+    }
+}

--- a/packages/derive/src/into_event.rs
+++ b/packages/derive/src/into_event.rs
@@ -22,7 +22,7 @@ fn scan_to_string_fn(field: &Field) -> Result<Option<proc_macro2::TokenStream>> 
     if filtered.is_empty() {
         Ok(None)
     } else {
-        Ok(Some(filtered[0].tokens.clone()))
+        Ok(Some(filtered[0].parse_args()?))
     }
 }
 
@@ -35,7 +35,7 @@ fn has_use_to_string(field: &Field) -> Result<bool> {
     if filtered.clone().any(|a| !a.tokens.is_empty()) {
         return Err(Error::new(
             field.span(),
-            "[IntoEvent] attribute `use_to_string` has some value. If you intend to specify the cast function to string, use `to_string_fn` instead.",
+            "[IntoEvent] An attribute `use_to_string` has some value. If you intend to specify the cast function to string, use `to_string_fn` instead.",
         ));
     }
     Ok(filtered.next().is_some())
@@ -88,23 +88,143 @@ fn make_init_from_struct(id: Ident, struct_data: DataStruct) -> Result<proc_macr
     Ok(gen)
 }
 
-/// derive `IntoEvent` from a derive input. The input needs to be a struct.
-pub fn derive_into_event(input: DeriveInput) -> TokenStream {
+fn derive_into_event_impl(input: DeriveInput) -> proc_macro2::TokenStream {
     match input.data {
-        syn::Data::Struct(struct_data) => make_init_from_struct(input.ident, struct_data)
-            .unwrap_or_else(|e| e.to_compile_error())
-            .into(),
+        syn::Data::Struct(struct_data) => {
+            make_init_from_struct(input.ident, struct_data).unwrap_or_else(|e| e.to_compile_error())
+        }
         syn::Data::Enum(enum_data) => Error::new(
             enum_data.enum_token.span,
             "[IntoEvent] `derive(IntoEvent)` cannot be applied to Enum.",
         )
-        .to_compile_error()
-        .into(),
+        .to_compile_error(),
         syn::Data::Union(union_data) => Error::new(
             union_data.union_token.span,
             "[IntoEvent] `derive(IntoEvent)` cannot be applied to Union.",
         )
-        .to_compile_error()
-        .into(),
+        .to_compile_error(),
+    }
+}
+
+/// derive `IntoEvent` from a derive input. The input needs to be a struct.
+pub fn derive_into_event(input: DeriveInput) -> TokenStream {
+    derive_into_event_impl(input).into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proc_macro2::TokenStream;
+    use syn::parse_quote;
+
+    fn expect_compile_error(ts: TokenStream, msg: &str) {
+        assert!(
+            ts.to_string().starts_with("compile_error ! {"),
+            "Code does not raise compile error: `{}`",
+            ts
+        );
+
+        assert!(
+            ts.to_string().contains(msg),
+            "Error does not have expected message \"{}\": `{}`",
+            msg,
+            ts
+        );
+    }
+
+    #[test]
+    fn test_doc_example() {
+        let input: DeriveInput = parse_quote! {
+            struct StructName {
+                field_name_1: field_type_1,
+                #[use_to_string]
+                field_name_2: field_type_2,
+                #[to_string_fn(cast_fn_3)]
+                field_name_3: field_type_3,
+            }
+        };
+        let result_implement = derive_into_event_impl(input);
+        let expected: TokenStream = parse_quote! {
+            impl Into<cosmwasm_std::Event> for StructName {
+                fn into(self) -> cosmwasm_std::Event {
+                    cosmwasm_std::Event::new("struct_name")
+                        .add_attribute(stringify!(field_name_1), self.field_name_1)
+                        .add_attribute(stringify!(field_name_2), self.field_name_2.to_string())
+                        .add_attribute(stringify!(field_name_3), cast_fn_3 (self.field_name_3))
+                }
+            }
+        };
+        assert_eq!(expected.to_string(), result_implement.to_string())
+    }
+
+    #[test]
+    fn test_error_multiple_to_string_functions() {
+        let input: DeriveInput = parse_quote! {
+            struct StructName {
+                #[to_string_fn(cast_fn_1)]
+                #[to_string_fn(cast_fn_1)]
+                field_name_1: field_type_1,
+            }
+        };
+        let result_implement = derive_into_event_impl(input);
+        expect_compile_error(
+            result_implement,
+            "[IntoEvent] Only one or zero `to_string_fn`",
+        );
+    }
+
+    #[test]
+    fn test_error_use_to_string_has_value() {
+        let input: DeriveInput = parse_quote! {
+            struct StructName {
+                #[use_to_string(foo)]
+                field_name_1: field_type_1,
+            }
+        };
+        let result_implement = derive_into_event_impl(input);
+        expect_compile_error(
+            result_implement,
+            "[IntoEvent] An attribute `use_to_string` has some value",
+        );
+    }
+
+    #[test]
+    fn test_error_both_two_attributes_is_used() {
+        let input: DeriveInput = parse_quote! {
+            struct StructName {
+                #[use_to_string]
+                #[to_string_fn(cast_fn_1)]
+                field_name_1: field_type_1,
+            }
+        };
+        let result_implement = derive_into_event_impl(input);
+        expect_compile_error(
+            result_implement,
+            "[IntoEvent] Both `use_to_string` and `to_string_fn`",
+        );
+    }
+
+    #[test]
+    fn test_error_derive_enum() {
+        let input: DeriveInput = parse_quote! {
+            enum Enum {}
+        };
+        let result_implement = derive_into_event_impl(input);
+        expect_compile_error(
+            result_implement,
+            "[IntoEvent] `derive(IntoEvent)` cannot be applied to Enum",
+        );
+    }
+
+    #[test]
+    fn test_error_derive_union() {
+        let input: DeriveInput = parse_quote! {
+            union Union {}
+        };
+        let result_implement = derive_into_event_impl(input);
+        expect_compile_error(
+            result_implement,
+            "[IntoEvent] `derive(IntoEvent)` cannot be applied to Union",
+        );
     }
 }

--- a/packages/derive/src/lib.rs
+++ b/packages/derive/src/lib.rs
@@ -1,6 +1,8 @@
 #[macro_use]
 extern crate syn;
 
+mod into_event;
+
 use proc_macro::TokenStream;
 use std::str::FromStr;
 
@@ -78,4 +80,46 @@ pub fn entry_point(_attr: TokenStream, mut item: TokenStream) -> TokenStream {
     let entry = TokenStream::from_str(&new_code).unwrap();
     item.extend(entry);
     item
+}
+
+/// generate an ast for `impl Into<cosmwasm::Event>` from a struct
+///
+/// Structure:
+///
+/// ```no_test
+/// #[derive(IntoEvent)]
+/// struct StructName {
+///     field_name_1: field_type_1,
+///     // if the value's type does not implement `Into<String>` trait
+///     // and it implements `ToString` trait, programmers can specify
+///     // to use `field_name_1.to_string()` to get string
+///     // by applying `use_to_string`.
+///     #[use_to_string]
+///     field_name_2: field_type_2,
+///     // if the value's type does not implement both `Into<String>` and
+///     // `ToString` traits, programmers need specify a function
+///     // to get string with `casting_fn(field_name_2)` by applying
+///     // `to_string_fn(casting_fn)` attribute.
+///     // this `casting_fn` needs to have the type `field_type -> String`.
+///     #[to_string_fn(cast_fn_3)]
+///     field_name_3: field_type_3,
+/// }
+/// ```
+///
+/// Output AST:
+///
+/// ```no_test
+/// impl Into<cosmwasm::Event> for `StructName` {
+///     fn into(self) -> Event {
+///         Event::new("struct_name")
+///             .add_attribute("field_name_1", self.field_value_1)
+///             .add_attribute("field_name_2", self.field_value_2.to_string())
+///             .add_attribute("field_name_3", casting_fn(self.field_value_3))
+///     }
+/// }
+/// ```
+#[proc_macro_derive(IntoEvent, attributes(to_string_fn, use_to_string))]
+pub fn derive_into_event(input: TokenStream) -> TokenStream {
+    let derive_input = parse_macro_input!(input as syn::DeriveInput);
+    into_event::derive_into_event(derive_input)
 }

--- a/packages/derive/src/lib.rs
+++ b/packages/derive/src/lib.rs
@@ -109,12 +109,12 @@ pub fn entry_point(_attr: TokenStream, mut item: TokenStream) -> TokenStream {
 /// Output AST:
 ///
 /// ```no_test
-/// impl Into<cosmwasm::Event> for `StructName` {
-///     fn into(self) -> Event {
-///         Event::new("struct_name")
-///             .add_attribute("field_name_1", self.field_value_1)
-///             .add_attribute("field_name_2", self.field_value_2.to_string())
-///             .add_attribute("field_name_3", casting_fn(self.field_value_3))
+/// impl Into<cosmwasm_std::Event> for StructName {
+///     fn into(self) -> cosmwasm_std::Event {
+///         cosmwasm_std::Event::new("struct_name")
+///             .add_attribute("field_name_1", self.field_name_1)
+///             .add_attribute("field_name_2", self.field_name_2.to_string())
+///             .add_attribute("field_name_3", cast_fn_3(self.field_name_3))
 ///     }
 /// }
 /// ```

--- a/packages/derive/tests/test.rs
+++ b/packages/derive/tests/test.rs
@@ -1,0 +1,82 @@
+extern crate cosmwasm_derive;
+
+use cosmwasm_derive::IntoEvent;
+use cosmwasm_std::{attr, coins, Addr, Coin, Event};
+
+fn coins_to_string(coins: Vec<Coin>) -> String {
+    format!(
+        "[{}]",
+        coins
+            .iter()
+            .map(|c| c.to_string())
+            .collect::<Vec<String>>()
+            .join(", ")
+    )
+}
+
+#[test]
+fn into_event_basic() {
+    #[derive(IntoEvent)]
+    struct TransferEvent {
+        #[use_to_string]
+        id: u64,
+        from: Addr,
+        receiver: Addr,
+        #[to_string_fn(coins_to_string)]
+        amount: Vec<Coin>,
+    }
+
+    let transfer = TransferEvent {
+        id: 42,
+        from: Addr::unchecked("alice"),
+        receiver: Addr::unchecked("bob"),
+        amount: coins(42, "link"),
+    };
+    let expected = Event::new("transfer_event").add_attributes(vec![
+        attr("id", "42"),
+        attr("from", "alice"),
+        attr("receiver", "bob"),
+        attr("amount", coins_to_string(coins(42, "link"))),
+    ]);
+    let transfer_event: Event = transfer.into();
+    assert_eq!(transfer_event, expected);
+}
+
+#[test]
+fn into_event_with_non_related_attribute() {
+    #[derive(IntoEvent)]
+    struct TransferEvent {
+        #[rustfmt::skip]
+        from: Addr,
+        #[rustfmt::skip]
+        receiver: Addr,
+        #[rustfmt::skip]
+        #[to_string_fn(coins_to_string)]
+        amount: Vec<Coin>,
+    }
+
+    let transfer = TransferEvent {
+        from: Addr::unchecked("alice"),
+        receiver: Addr::unchecked("bob"),
+        amount: coins(42, "link"),
+    };
+    let expected = Event::new("transfer_event").add_attributes(vec![
+        attr("from", "alice"),
+        attr("receiver", "bob"),
+        attr("amount", coins_to_string(coins(42, "link"))),
+    ]);
+    let transfer_event: Event = transfer.into();
+    assert_eq!(transfer_event, expected);
+}
+
+#[test]
+fn into_event_no_fields() {
+    #[derive(IntoEvent)]
+    struct A {}
+
+    let a = A {};
+    let expected = Event::new("a");
+
+    let a_event: Event = a.into();
+    assert_eq!(a_event, expected);
+}

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -134,4 +134,4 @@ pub mod testing;
 
 // Re-exports
 
-pub use cosmwasm_derive::entry_point;
+pub use cosmwasm_derive::{entry_point, IntoEvent};


### PR DESCRIPTION
This PR suggests and implements a derive macro for structs named `IntoEvent` which is for developers of contracts.
With this, `#[derive(IntoEvent)]` implements `Into<Event>` to a decorated struct.
This makes it easier to make a structure representing an event.

An Example usage:

```
#[derive(Clone, IntoEvent)]
struct TransferEvent {
    from: Addr,
    receiver: Addr,
    #[to_string_fn(coins_to_string)]
    amount: Vec<Coin>,
}

let transfer_event = TransferEvent {
    from: Addr::unchecked("alice"),
    receiver: Addr::unchecked("bob"),
    amount: coins(42, "link"),
};

let response = Response::<Empty>::new().add_event(transfer_event);
```

See the document of `derive_into_event` in [packages/derive/src/lib.rs](https://github.com/CosmWasm/cosmwasm/compare/main...loloicci:into-event?expand=1#diff-484ed4ec90b9bea6e333d2819a67f7b7421528d49e411d19fb93f25105e070ab) to learn how to use it.

See tests in [packages/std/src/results/response.rs](https://github.com/CosmWasm/cosmwasm/compare/main...loloicci:into-event?expand=1#diff-976ae3b551b58eb0572b82fe272e28afca3db2b45cc6abdc32ded1db4c8409d4) for more example usages.