### PR TITLE
CI fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ workflows:
 jobs:
   arm64:
     machine:
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2204:2024.01.1
     resource_class: arm.large
     steps:
       - checkout
@@ -843,7 +843,7 @@ jobs:
           command: apt update && apt install -y python3-pip
       - run:
           name: Install dependencies
-          command: pip3 install requests bs4
+          command: pip3 install requests bs4 --break-system-packages
       - run:
           name: Check dead links
           command: devtools/deadlinks.py


### PR DESCRIPTION
CircleCI is [deprecating](https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/50177) the ubuntu image we were using.
Also, the deadlinks job [failed](https://app.circleci.com/pipelines/github/CosmWasm/cosmwasm/6682/workflows/40a65a7e-9149-4c5c-8e5a-c6cac299c011/jobs/99913) today on main. This fixes it.