### PR TITLE
Allow disabling cranelift

### DIFF
--- a/packages/vm/Cargo.toml
+++ b/packages/vm/Cargo.toml
@@ -20,8 +20,9 @@ staking = ["cosmwasm-std/staking"]
 stargate = ["cosmwasm-std/stargate"]
 # Use cranelift backend instead of singlepass. This is required for development on Windows.
 #
-# LEGACY: This doesn't do anything anymore. Cranelift is automatically pulled in on Windows.
-cranelift = []
+# Note: This feature is automatically enabled on Windows, you don't have to toggle it manually anymore.
+# This is just to be able to debug issues with Cranelift on non-Windows platforms.
+cranelift = ["wasmer/cranelift"]
 # For heap profiling. Only used in the "heap_profiling" example.
 dhat-heap = ["dep:dhat"]
 

--- a/packages/vm/Cargo.toml
+++ b/packages/vm/Cargo.toml
@@ -19,7 +19,9 @@ staking = ["cosmwasm-std/staking"]
 # this enables all stargate-related functionality, including the ibc entry points
 stargate = ["cosmwasm-std/stargate"]
 # Use cranelift backend instead of singlepass. This is required for development on Windows.
-cranelift = ["wasmer/cranelift"]
+#
+# LEGACY: This doesn't do anything anymore. Cranelift is automatically pulled in on Windows.
+cranelift = []
 # For heap profiling. Only used in the "heap_profiling" example.
 dhat-heap = ["dep:dhat"]
 
@@ -42,7 +44,7 @@ serde = { workspace = true }
 serde_json = "1.0.40"
 sha2 = "0.10.3"
 thiserror = "1.0.26"
-wasmer = { version = "=4.2.6", default-features = false, features = ["cranelift", "singlepass"] }
+wasmer = { version = "=4.2.6", default-features = false, features = ["singlepass"] }
 wasmer-middlewares = "=4.2.6"
 strum = { version = "0.25.0", default-features = false, features = ["derive"] }
 # For heap profiling. Only used in the "heap_profiling" example. This has to be a non-dev dependency
@@ -58,6 +60,9 @@ tracing = "0.1.32"
 # wasmer-middlewares = { git = "https://github.com/wasmerio/wasmer", rev = "877ce1f7c44fad853c" }
 # wasmer = { path = "../../../wasmer/lib/api", default-features = false, features = ["cranelift", "singlepass"] }
 # wasmer-middlewares = { path = "../../../wasmer/lib/middlewares" }
+
+[target.'cfg(target_family = "windows")'.dependencies]
+wasmer = { version = "=4.2.6", default-features = false, features = ["cranelift"] }
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }

--- a/packages/vm/Cargo.toml
+++ b/packages/vm/Cargo.toml
@@ -18,10 +18,7 @@ iterator = ["cosmwasm-std/iterator"]
 staking = ["cosmwasm-std/staking"]
 # this enables all stargate-related functionality, including the ibc entry points
 stargate = ["cosmwasm-std/stargate"]
-# Use cranelift backend instead of singlepass. This is required for development on Windows.
-#
-# Note: This feature is automatically enabled on Windows, you don't have to toggle it manually anymore.
-# This is just to be able to debug issues with Cranelift on non-Windows platforms.
+# Use cranelift backend instead of singlepass
 cranelift = ["wasmer/cranelift"]
 # For heap profiling. Only used in the "heap_profiling" example.
 dhat-heap = ["dep:dhat"]
@@ -61,9 +58,6 @@ tracing = "0.1.32"
 # wasmer-middlewares = { git = "https://github.com/wasmerio/wasmer", rev = "877ce1f7c44fad853c" }
 # wasmer = { path = "../../../wasmer/lib/api", default-features = false, features = ["cranelift", "singlepass"] }
 # wasmer-middlewares = { path = "../../../wasmer/lib/middlewares" }
-
-[target.'cfg(target_family = "windows")'.dependencies]
-wasmer = { version = "=4.2.6", default-features = false, features = ["cranelift"] }
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }

--- a/packages/vm/src/static_analysis.rs
+++ b/packages/vm/src/static_analysis.rs
@@ -107,10 +107,11 @@ impl ExportInfo for &wasmer::Module {
 mod tests {
     use std::str::FromStr;
 
+    use crate::wasm_backend::make_compiler_config;
     use crate::VmError;
 
     use super::*;
-    use wasmer::{Cranelift, Store};
+    use wasmer::Store;
 
     static CONTRACT: &[u8] = include_bytes!("../testdata/hackatom.wasm");
     static CORRUPTED: &[u8] = include_bytes!("../testdata/corrupted.wasm");
@@ -201,7 +202,7 @@ mod tests {
     #[test]
     fn exported_function_names_works_for_wasmer_with_no_prefix() {
         let wasm = wat::parse_str(r#"(module)"#).unwrap();
-        let compiler = Cranelift::default();
+        let compiler = make_compiler_config();
         let store = Store::new(compiler);
         let module = wasmer::Module::new(&store, wasm).unwrap();
         let exports = module.exported_function_names(None);
@@ -219,7 +220,7 @@ mod tests {
             )"#,
         )
         .unwrap();
-        let compiler = Cranelift::default();
+        let compiler = make_compiler_config();
         let store = Store::new(compiler);
         let module = wasmer::Module::new(&store, wasm).unwrap();
         let exports = module.exported_function_names(None);
@@ -232,7 +233,7 @@ mod tests {
     #[test]
     fn exported_function_names_works_for_wasmer_with_prefix() {
         let wasm = wat::parse_str(r#"(module)"#).unwrap();
-        let compiler = Cranelift::default();
+        let compiler = make_compiler_config();
         let store = Store::new(compiler);
         let module = wasmer::Module::new(&store, wasm).unwrap();
         let exports = module.exported_function_names(Some("b"));
@@ -251,7 +252,7 @@ mod tests {
             )"#,
         )
         .unwrap();
-        let compiler = Cranelift::default();
+        let compiler = make_compiler_config();
         let store = Store::new(compiler);
         let module = wasmer::Module::new(&store, wasm).unwrap();
         let exports = module.exported_function_names(Some("b"));

--- a/packages/vm/src/wasm_backend/engine.rs
+++ b/packages/vm/src/wasm_backend/engine.rs
@@ -28,9 +28,9 @@ fn cost(_operator: &Operator) -> u64 {
 
 /// Creates the appropriate compiler config for the platform
 pub fn make_compiler_config() -> impl CompilerConfig + Into<Engine> {
-    #[cfg(target_family = "windows")]
+    #[cfg(any(feature = "cranelift", target_family = "windows"))]
     return wasmer::Cranelift::new();
-    #[cfg(not(target_family = "windows"))]
+    #[cfg(not(any(feature = "cranelift", target_family = "windows")))]
     wasmer::Singlepass::new()
 }
 

--- a/packages/vm/src/wasm_backend/engine.rs
+++ b/packages/vm/src/wasm_backend/engine.rs
@@ -26,11 +26,11 @@ fn cost(_operator: &Operator) -> u64 {
     150
 }
 
-/// Creates the appropriate compiler config for the platform
+/// Use Cranelift as the compiler backend if the feature is enabled
 pub fn make_compiler_config() -> impl CompilerConfig + Into<Engine> {
-    #[cfg(any(feature = "cranelift", target_family = "windows"))]
+    #[cfg(feature = "cranelift")]
     return wasmer::Cranelift::new();
-    #[cfg(not(any(feature = "cranelift", target_family = "windows")))]
+    #[cfg(not(feature = "cranelift"))]
     wasmer::Singlepass::new()
 }
 

--- a/packages/vm/src/wasm_backend/gatekeeper.rs
+++ b/packages/vm/src/wasm_backend/gatekeeper.rs
@@ -746,8 +746,9 @@ impl FunctionMiddleware for FunctionGatekeeper {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::wasm_backend::make_compiler_config;
     use std::sync::Arc;
-    use wasmer::{CompilerConfig, Cranelift, Module, Store};
+    use wasmer::{CompilerConfig, Module, Store};
 
     #[test]
     fn valid_wasm_instance_sanity() {
@@ -764,7 +765,7 @@ mod tests {
         .unwrap();
 
         let deterministic = Arc::new(Gatekeeper::default());
-        let mut compiler = Cranelift::default();
+        let mut compiler = make_compiler_config();
         compiler.push_middleware(deterministic);
         let store = Store::new(compiler);
         let result = Module::new(&store, wasm);
@@ -785,7 +786,7 @@ mod tests {
         .unwrap();
 
         let deterministic = Arc::new(Gatekeeper::default());
-        let mut compiler = Cranelift::default();
+        let mut compiler = make_compiler_config();
         compiler.push_middleware(deterministic);
         let store = Store::new(compiler);
         let result = Module::new(&store, wasm);
@@ -809,7 +810,7 @@ mod tests {
         .unwrap();
 
         let deterministic = Arc::new(Gatekeeper::default());
-        let mut compiler = Cranelift::default();
+        let mut compiler = make_compiler_config();
         compiler.push_middleware(deterministic);
         let store = Store::new(compiler);
         let result = Module::new(&store, wasm);

--- a/packages/vm/src/wasm_backend/mod.rs
+++ b/packages/vm/src/wasm_backend/mod.rs
@@ -3,5 +3,8 @@ mod engine;
 mod gatekeeper;
 mod limiting_tunables;
 
+#[cfg(test)]
+pub use engine::make_compiler_config;
+
 pub use compile::compile;
 pub use engine::{make_compiling_engine, make_runtime_engine};


### PR DESCRIPTION
Closes #1720

This PR removes the dependence on wasmer's cranelift backend by only enabling it on the Windows family of platforms and otherwise using the Singlepass compiler as usual.

After this patch on a Linux machine:

```
~/work/cosmwasm$ cargo tree | grep cranelift
warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
package:   /home/aumetra/work/cosmwasm/packages/vm/Cargo.toml
workspace: /home/aumetra/work/cosmwasm/Cargo.toml
~/work/cosmwasm$
```

But when enabling all targets for `cargo tree`:

```
~/work/cosmwasm$ cargo tree --all-targets | grep cranelift
warning: the --all-targets flag has been changed to --target=all
warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
package:   /home/aumetra/work/cosmwasm/packages/vm/Cargo.toml
workspace: /home/aumetra/work/cosmwasm/Cargo.toml
    │   ├── wasmer-compiler-cranelift v4.2.6
    │   │   ├── cranelift-codegen v0.91.1
    │   │   │   ├── cranelift-bforest v0.91.1
    │   │   │   │   └── cranelift-entity v0.91.1
    │   │   │   ├── cranelift-codegen-shared v0.91.1
    │   │   │   ├── cranelift-egraph v0.91.1
    │   │   │   │   ├── cranelift-entity v0.91.1
    │   │   │   ├── cranelift-entity v0.91.1
    │   │   │   ├── cranelift-codegen-meta v0.91.1
    │   │   │   │   └── cranelift-codegen-shared v0.91.1
    │   │   │   └── cranelift-isle v0.91.1
    │   │   ├── cranelift-entity v0.91.1
    │   │   ├── cranelift-frontend v0.91.1
    │   │   │   ├── cranelift-codegen v0.91.1 (*)
~/work/cosmwasm$
```