### PR TITLE
Metrics for the pinned cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 - cosmwasm-vm: Add `secp256r1_verify` and `secp256r1_recover_pubkey` imports for
   ECDSA signature verification over secp256r1. ([#1983], [#2057])
+- cosmwasm-vm: Add metrics for the pinned memory cache ([#2059])
 
 [#1983]: https://github.com/CosmWasm/cosmwasm/pull/1983
 [#2057]: https://github.com/CosmWasm/cosmwasm/pull/2057
@@ -22,6 +23,7 @@ and this project adheres to
 
 [#2044]: https://github.com/CosmWasm/cosmwasm/pull/2044
 [#2051]: https://github.com/CosmWasm/cosmwasm/pull/2051
+[#2059]: https://github.com/CosmWasm/cosmwasm/pull/2059
 
 ## [2.0.0] - 2024-03-12
 

--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -1438,7 +1438,7 @@ mod tests {
         cache.pin(&checksum).unwrap();
 
         let heavy_metrics = cache.heavy_metrics();
-        assert_eq!(heavy_metrics.hits_per_pinned_contract, vec![(checksum, 0)]);
+        assert_eq!(heavy_metrics.hits_per_pinned_contract, [(checksum, 0)]);
 
         let backend = mock_backend(&[]);
         let _ = cache
@@ -1446,7 +1446,7 @@ mod tests {
             .unwrap();
 
         let heavy_metrics = cache.heavy_metrics();
-        assert_eq!(heavy_metrics.hits_per_pinned_contract, vec![(checksum, 1)]);
+        assert_eq!(heavy_metrics.hits_per_pinned_contract, [(checksum, 1)]);
     }
 
     #[test]

--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -1431,6 +1431,25 @@ mod tests {
     }
 
     #[test]
+    fn heavy_metrics_works() {
+        let cache = unsafe { Cache::new(make_testing_options()).unwrap() };
+        let checksum = cache.save_wasm(CONTRACT).unwrap();
+
+        cache.pin(&checksum).unwrap();
+
+        let heavy_metrics = cache.heavy_metrics();
+        assert_eq!(heavy_metrics.hits_per_pinned_contract, vec![(checksum, 0)]);
+
+        let backend = mock_backend(&[]);
+        let _ = cache
+            .get_instance(&checksum, backend, TESTING_OPTIONS)
+            .unwrap();
+
+        let heavy_metrics = cache.heavy_metrics();
+        assert_eq!(heavy_metrics.hits_per_pinned_contract, vec![(checksum, 1)]);
+    }
+
+    #[test]
     fn pin_unpin_works() {
         let cache = unsafe { Cache::new(make_testing_options()).unwrap() };
         let checksum = cache.save_wasm(CONTRACT).unwrap();

--- a/packages/vm/src/lib.rs
+++ b/packages/vm/src/lib.rs
@@ -23,7 +23,9 @@ mod wasm_backend;
 pub use crate::backend::{
     Backend, BackendApi, BackendError, BackendResult, GasInfo, Querier, Storage,
 };
-pub use crate::cache::{AnalysisReport, Cache, CacheOptions, Metrics, Stats};
+pub use crate::cache::{
+    AnalysisReport, Cache, CacheOptions, Metrics, PerModuleMetrics, PinnedMetrics, Stats,
+};
 pub use crate::calls::{
     call_execute, call_execute_raw, call_instantiate, call_instantiate_raw, call_migrate,
     call_migrate_raw, call_query, call_query_raw, call_reply, call_reply_raw, call_sudo,

--- a/packages/vm/src/modules/pinned_memory_cache.rs
+++ b/packages/vm/src/modules/pinned_memory_cache.rs
@@ -6,7 +6,6 @@ use crate::VmResult;
 
 /// Struct storing some additional metadata, which is only of interest for the pinned cache,
 /// alongside the cached module.
-// TODO: Maybe implement a `Deref` for this? But would it even worth it considering how little it is actually used?
 pub struct InstrumentedModule {
     /// Number of loads from memory this module received
     pub hits: u32,


### PR DESCRIPTION
Relates to #2034 

This PR adds the `Cache::heavy_metrics` call and some instrumentation wrappers inside the `PinnedMemoryCache` to provide the number of hits per cached module.  
These hits are stored alongside the actual cached module inside the hash map.

When calling the `heavy_metrics` function, it simply iterates over the hash map and builds a vector containing a number of tuples.