### PR TITLE
Correctly construct `Region` to uphold deallocation safety invariant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ and this project adheres to
 [#2051]: https://github.com/CosmWasm/cosmwasm/pull/2051
 [#2059]: https://github.com/CosmWasm/cosmwasm/pull/2059
 
+### Fixed
+
+- cosmwasm-std: Correctly deallocate vectors that were turned into a `Region`
+  via `release_buffer` ([#2062])
+
+[#2062]: https://github.com/CosmWasm/cosmwasm/pull/2062
+
 ## [2.0.0] - 2024-03-12
 
 ### Fixed

--- a/packages/std/src/imports.rs
+++ b/packages/std/src/imports.rs
@@ -348,7 +348,7 @@ impl Api for ExternalApi {
     }
 
     fn addr_humanize(&self, canonical: &CanonicalAddr) -> StdResult<Addr> {
-        let send = build_region(&canonical);
+        let send = build_region(canonical.as_slice());
         let send_ptr = &*send as *const Region as u32;
         let human = alloc(HUMAN_ADDRESS_BUFFER_LENGTH);
 

--- a/packages/std/src/memory.rs
+++ b/packages/std/src/memory.rs
@@ -79,7 +79,6 @@ pub unsafe fn consume_region(ptr: *mut Region) -> Vec<u8> {
 ///
 /// This is important to uphold the safety invariant of the `dealloc` method, which requires us to pass the same Layout
 /// into it as was used to allocate a memory region.
-///
 /// And since `size` is one of the parameters, it is important to pass in the exact same capacity.
 ///
 /// See: <https://doc.rust-lang.org/stable/alloc/alloc/trait.GlobalAlloc.html#safety-2>

--- a/packages/std/src/memory.rs
+++ b/packages/std/src/memory.rs
@@ -33,7 +33,7 @@ pub fn alloc(size: usize) -> *mut Region {
 /// Similar to alloc, but instead of creating a new vector it consumes an existing one and returns
 /// a pointer to the Region (preventing the memory from being freed until explicitly called later).
 ///
-/// The resulting Region has capacity = length, the buffer capacity is shrunk down to its length.
+/// The resulting Region spans the entire region allocated by the vector, preserving the length and capacity components.
 pub fn release_buffer(buffer: Vec<u8>) -> *mut Region {
     let region = build_region(&buffer);
     mem::forget(buffer);


### PR DESCRIPTION
Closes #2061

To cite from the comments of the patch:

> Shrinking the buffer down to the length is important to uphold a safety invariant by the `dealloc` method.
> Passing in a differing size into the `dealloc` layout is considered undefined behaviour.
>
> See: <https://doc.rust-lang.org/stable/alloc/alloc/trait.GlobalAlloc.html#safety-2>
