### PR TITLE
Update proc macros to syn v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,7 +441,8 @@ name = "cosmwasm-derive"
 version = "2.0.0"
 dependencies = [
  "cosmwasm-std",
- "syn 1.0.109",
+ "quote",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -465,7 +466,7 @@ version = "2.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1661,9 +1662,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
@@ -1690,9 +1691,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.32"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,7 +464,6 @@ dependencies = [
 name = "cosmwasm-schema-derive"
 version = "2.0.0"
 dependencies = [
- "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.28",
@@ -1187,12 +1186,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -2166,7 +2159,7 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,6 +464,8 @@ dependencies = [
 name = "cosmwasm-schema-derive"
 version = "2.0.0"
 dependencies = [
+ "heck 0.5.0",
+ "manyhow",
  "proc-macro2",
  "quote",
  "syn 2.0.28",
@@ -1188,6 +1190,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1375,6 +1383,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "manyhow"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bc2a348104913df6d14170bedef54faf224a0970ec7b1f8750748ab94fcd52"
+dependencies = [
+ "manyhow-macros",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.28",
+]
+
+[[package]]
+name = "manyhow-macros"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "532aa12d5846b38a524b3acd99fb74dc8a5f193b33e65dac142ef92bd60f9416"
+dependencies = [
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -1658,6 +1689,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "version_check",
+]
+
+[[package]]
+name = "proc-macro-utils"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f59e109e2f795a5070e69578c4dc101068139f74616778025ae1011d4cd41a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "smallvec",
 ]
 
 [[package]]
@@ -2159,7 +2201,7 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,7 +465,6 @@ name = "cosmwasm-schema-derive"
 version = "2.0.0"
 dependencies = [
  "heck 0.5.0",
- "manyhow",
  "proc-macro2",
  "quote",
  "syn 2.0.28",
@@ -1386,29 +1385,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "manyhow"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bc2a348104913df6d14170bedef54faf224a0970ec7b1f8750748ab94fcd52"
-dependencies = [
- "manyhow-macros",
- "proc-macro2",
- "quote",
- "syn 2.0.28",
-]
-
-[[package]]
-name = "manyhow-macros"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532aa12d5846b38a524b3acd99fb74dc8a5f193b33e65dac142ef92bd60f9416"
-dependencies = [
- "proc-macro-utils",
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1689,17 +1665,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "version_check",
-]
-
-[[package]]
-name = "proc-macro-utils"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f59e109e2f795a5070e69578c4dc101068139f74616778025ae1011d4cd41a8"
-dependencies = [
- "proc-macro2",
- "quote",
- "smallvec",
 ]
 
 [[package]]

--- a/contracts/burner/Cargo.lock
+++ b/contracts/burner/Cargo.lock
@@ -239,6 +239,8 @@ dependencies = [
 name = "cosmwasm-schema-derive"
 version = "2.0.0"
 dependencies = [
+ "heck 0.5.0",
+ "manyhow",
  "proc-macro2",
  "quote",
  "syn 2.0.37",
@@ -820,6 +822,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,6 +941,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "manyhow"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bc2a348104913df6d14170bedef54faf224a0970ec7b1f8750748ab94fcd52"
+dependencies = [
+ "manyhow-macros",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+]
+
+[[package]]
+name = "manyhow-macros"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "532aa12d5846b38a524b3acd99fb74dc8a5f193b33e65dac142ef92bd60f9416"
+dependencies = [
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -1095,6 +1126,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "version_check",
+]
+
+[[package]]
+name = "proc-macro-utils"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f59e109e2f795a5070e69578c4dc101068139f74616778025ae1011d4cd41a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "smallvec",
 ]
 
 [[package]]
@@ -1492,7 +1534,7 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",

--- a/contracts/burner/Cargo.lock
+++ b/contracts/burner/Cargo.lock
@@ -239,7 +239,6 @@ dependencies = [
 name = "cosmwasm-schema-derive"
 version = "2.0.0"
 dependencies = [
- "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.37",
@@ -819,12 +818,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex"
@@ -1499,7 +1492,7 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",

--- a/contracts/burner/Cargo.lock
+++ b/contracts/burner/Cargo.lock
@@ -220,7 +220,8 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "2.0.0"
 dependencies = [
- "syn 1.0.109",
+ "quote",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -240,7 +241,7 @@ version = "2.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1098,9 +1099,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.67"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
@@ -1127,9 +1128,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]

--- a/contracts/burner/Cargo.lock
+++ b/contracts/burner/Cargo.lock
@@ -240,7 +240,6 @@ name = "cosmwasm-schema-derive"
 version = "2.0.0"
 dependencies = [
  "heck 0.5.0",
- "manyhow",
  "proc-macro2",
  "quote",
  "syn 2.0.37",
@@ -944,29 +943,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "manyhow"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bc2a348104913df6d14170bedef54faf224a0970ec7b1f8750748ab94fcd52"
-dependencies = [
- "manyhow-macros",
- "proc-macro2",
- "quote",
- "syn 2.0.37",
-]
-
-[[package]]
-name = "manyhow-macros"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532aa12d5846b38a524b3acd99fb74dc8a5f193b33e65dac142ef92bd60f9416"
-dependencies = [
- "proc-macro-utils",
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1126,17 +1102,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "version_check",
-]
-
-[[package]]
-name = "proc-macro-utils"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f59e109e2f795a5070e69578c4dc101068139f74616778025ae1011d4cd41a8"
-dependencies = [
- "proc-macro2",
- "quote",
- "smallvec",
 ]
 
 [[package]]

--- a/contracts/crypto-verify/Cargo.lock
+++ b/contracts/crypto-verify/Cargo.lock
@@ -229,7 +229,6 @@ name = "cosmwasm-schema-derive"
 version = "2.0.0"
 dependencies = [
  "heck 0.5.0",
- "manyhow",
  "proc-macro2",
  "quote",
  "syn 2.0.37",
@@ -961,29 +960,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "manyhow"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bc2a348104913df6d14170bedef54faf224a0970ec7b1f8750748ab94fcd52"
-dependencies = [
- "manyhow-macros",
- "proc-macro2",
- "quote",
- "syn 2.0.37",
-]
-
-[[package]]
-name = "manyhow-macros"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532aa12d5846b38a524b3acd99fb74dc8a5f193b33e65dac142ef92bd60f9416"
-dependencies = [
- "proc-macro-utils",
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1143,17 +1119,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "version_check",
-]
-
-[[package]]
-name = "proc-macro-utils"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f59e109e2f795a5070e69578c4dc101068139f74616778025ae1011d4cd41a8"
-dependencies = [
- "proc-macro2",
- "quote",
- "smallvec",
 ]
 
 [[package]]

--- a/contracts/crypto-verify/Cargo.lock
+++ b/contracts/crypto-verify/Cargo.lock
@@ -228,7 +228,6 @@ dependencies = [
 name = "cosmwasm-schema-derive"
 version = "2.0.0"
 dependencies = [
- "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.37",
@@ -824,12 +823,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex"
@@ -1542,7 +1535,7 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",

--- a/contracts/crypto-verify/Cargo.lock
+++ b/contracts/crypto-verify/Cargo.lock
@@ -228,6 +228,8 @@ dependencies = [
 name = "cosmwasm-schema-derive"
 version = "2.0.0"
 dependencies = [
+ "heck 0.5.0",
+ "manyhow",
  "proc-macro2",
  "quote",
  "syn 2.0.37",
@@ -825,6 +827,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -950,6 +958,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "manyhow"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bc2a348104913df6d14170bedef54faf224a0970ec7b1f8750748ab94fcd52"
+dependencies = [
+ "manyhow-macros",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+]
+
+[[package]]
+name = "manyhow-macros"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "532aa12d5846b38a524b3acd99fb74dc8a5f193b33e65dac142ef92bd60f9416"
+dependencies = [
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -1112,6 +1143,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "version_check",
+]
+
+[[package]]
+name = "proc-macro-utils"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f59e109e2f795a5070e69578c4dc101068139f74616778025ae1011d4cd41a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "smallvec",
 ]
 
 [[package]]
@@ -1535,7 +1577,7 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",

--- a/contracts/crypto-verify/Cargo.lock
+++ b/contracts/crypto-verify/Cargo.lock
@@ -209,7 +209,8 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "2.0.0"
 dependencies = [
- "syn 1.0.109",
+ "quote",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -229,7 +230,7 @@ version = "2.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1115,9 +1116,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.67"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
@@ -1144,9 +1145,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]

--- a/contracts/cyberpunk/Cargo.lock
+++ b/contracts/cyberpunk/Cargo.lock
@@ -244,7 +244,8 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "2.0.0"
 dependencies = [
- "syn 1.0.109",
+ "quote",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -264,7 +265,7 @@ version = "2.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1196,9 +1197,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.67"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
@@ -1225,9 +1226,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]

--- a/contracts/cyberpunk/Cargo.lock
+++ b/contracts/cyberpunk/Cargo.lock
@@ -263,7 +263,6 @@ dependencies = [
 name = "cosmwasm-schema-derive"
 version = "2.0.0"
 dependencies = [
- "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.37",
@@ -885,12 +884,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1623,7 +1616,7 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",

--- a/contracts/cyberpunk/Cargo.lock
+++ b/contracts/cyberpunk/Cargo.lock
@@ -264,7 +264,6 @@ name = "cosmwasm-schema-derive"
 version = "2.0.0"
 dependencies = [
  "heck 0.5.0",
- "manyhow",
  "proc-macro2",
  "quote",
  "syn 2.0.37",
@@ -1042,29 +1041,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "manyhow"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bc2a348104913df6d14170bedef54faf224a0970ec7b1f8750748ab94fcd52"
-dependencies = [
- "manyhow-macros",
- "proc-macro2",
- "quote",
- "syn 2.0.37",
-]
-
-[[package]]
-name = "manyhow-macros"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532aa12d5846b38a524b3acd99fb74dc8a5f193b33e65dac142ef92bd60f9416"
-dependencies = [
- "proc-macro-utils",
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1224,17 +1200,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "version_check",
-]
-
-[[package]]
-name = "proc-macro-utils"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f59e109e2f795a5070e69578c4dc101068139f74616778025ae1011d4cd41a8"
-dependencies = [
- "proc-macro2",
- "quote",
- "smallvec",
 ]
 
 [[package]]

--- a/contracts/cyberpunk/Cargo.lock
+++ b/contracts/cyberpunk/Cargo.lock
@@ -263,6 +263,8 @@ dependencies = [
 name = "cosmwasm-schema-derive"
 version = "2.0.0"
 dependencies = [
+ "heck 0.5.0",
+ "manyhow",
  "proc-macro2",
  "quote",
  "syn 2.0.37",
@@ -886,6 +888,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1031,6 +1039,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "manyhow"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bc2a348104913df6d14170bedef54faf224a0970ec7b1f8750748ab94fcd52"
+dependencies = [
+ "manyhow-macros",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+]
+
+[[package]]
+name = "manyhow-macros"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "532aa12d5846b38a524b3acd99fb74dc8a5f193b33e65dac142ef92bd60f9416"
+dependencies = [
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -1193,6 +1224,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "version_check",
+]
+
+[[package]]
+name = "proc-macro-utils"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f59e109e2f795a5070e69578c4dc101068139f74616778025ae1011d4cd41a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "smallvec",
 ]
 
 [[package]]
@@ -1616,7 +1658,7 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",

--- a/contracts/empty/Cargo.lock
+++ b/contracts/empty/Cargo.lock
@@ -228,6 +228,8 @@ dependencies = [
 name = "cosmwasm-schema-derive"
 version = "2.0.0"
 dependencies = [
+ "heck 0.5.0",
+ "manyhow",
  "proc-macro2",
  "quote",
  "syn 2.0.37",
@@ -819,6 +821,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -932,6 +940,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "manyhow"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bc2a348104913df6d14170bedef54faf224a0970ec7b1f8750748ab94fcd52"
+dependencies = [
+ "manyhow-macros",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+]
+
+[[package]]
+name = "manyhow-macros"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "532aa12d5846b38a524b3acd99fb74dc8a5f193b33e65dac142ef92bd60f9416"
+dependencies = [
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -1094,6 +1125,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "version_check",
+]
+
+[[package]]
+name = "proc-macro-utils"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f59e109e2f795a5070e69578c4dc101068139f74616778025ae1011d4cd41a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "smallvec",
 ]
 
 [[package]]
@@ -1491,7 +1533,7 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",

--- a/contracts/empty/Cargo.lock
+++ b/contracts/empty/Cargo.lock
@@ -228,7 +228,6 @@ dependencies = [
 name = "cosmwasm-schema-derive"
 version = "2.0.0"
 dependencies = [
- "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.37",
@@ -818,12 +817,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex"
@@ -1498,7 +1491,7 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",

--- a/contracts/empty/Cargo.lock
+++ b/contracts/empty/Cargo.lock
@@ -209,7 +209,8 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "2.0.0"
 dependencies = [
- "syn 1.0.109",
+ "quote",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -229,7 +230,7 @@ version = "2.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1097,9 +1098,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.67"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
@@ -1126,9 +1127,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]

--- a/contracts/empty/Cargo.lock
+++ b/contracts/empty/Cargo.lock
@@ -229,7 +229,6 @@ name = "cosmwasm-schema-derive"
 version = "2.0.0"
 dependencies = [
  "heck 0.5.0",
- "manyhow",
  "proc-macro2",
  "quote",
  "syn 2.0.37",
@@ -943,29 +942,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "manyhow"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bc2a348104913df6d14170bedef54faf224a0970ec7b1f8750748ab94fcd52"
-dependencies = [
- "manyhow-macros",
- "proc-macro2",
- "quote",
- "syn 2.0.37",
-]
-
-[[package]]
-name = "manyhow-macros"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532aa12d5846b38a524b3acd99fb74dc8a5f193b33e65dac142ef92bd60f9416"
-dependencies = [
- "proc-macro-utils",
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1125,17 +1101,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "version_check",
-]
-
-[[package]]
-name = "proc-macro-utils"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f59e109e2f795a5070e69578c4dc101068139f74616778025ae1011d4cd41a8"
-dependencies = [
- "proc-macro2",
- "quote",
- "smallvec",
 ]
 
 [[package]]

--- a/contracts/floaty/Cargo.lock
+++ b/contracts/floaty/Cargo.lock
@@ -209,7 +209,8 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "2.0.0"
 dependencies = [
- "syn 1.0.109",
+ "quote",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -229,7 +230,7 @@ version = "2.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -1105,9 +1106,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
@@ -1134,9 +1135,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]

--- a/contracts/floaty/Cargo.lock
+++ b/contracts/floaty/Cargo.lock
@@ -228,6 +228,8 @@ dependencies = [
 name = "cosmwasm-schema-derive"
 version = "2.0.0"
 dependencies = [
+ "heck 0.5.0",
+ "manyhow",
  "proc-macro2",
  "quote",
  "syn 2.0.32",
@@ -821,6 +823,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -934,6 +942,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "manyhow"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bc2a348104913df6d14170bedef54faf224a0970ec7b1f8750748ab94fcd52"
+dependencies = [
+ "manyhow-macros",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.32",
+]
+
+[[package]]
+name = "manyhow-macros"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "532aa12d5846b38a524b3acd99fb74dc8a5f193b33e65dac142ef92bd60f9416"
+dependencies = [
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -1102,6 +1133,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "version_check",
+]
+
+[[package]]
+name = "proc-macro-utils"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f59e109e2f795a5070e69578c4dc101068139f74616778025ae1011d4cd41a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "smallvec",
 ]
 
 [[package]]
@@ -1509,7 +1551,7 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",

--- a/contracts/floaty/Cargo.lock
+++ b/contracts/floaty/Cargo.lock
@@ -228,7 +228,6 @@ dependencies = [
 name = "cosmwasm-schema-derive"
 version = "2.0.0"
 dependencies = [
- "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.32",
@@ -820,12 +819,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex"
@@ -1516,7 +1509,7 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",

--- a/contracts/floaty/Cargo.lock
+++ b/contracts/floaty/Cargo.lock
@@ -229,7 +229,6 @@ name = "cosmwasm-schema-derive"
 version = "2.0.0"
 dependencies = [
  "heck 0.5.0",
- "manyhow",
  "proc-macro2",
  "quote",
  "syn 2.0.32",
@@ -945,29 +944,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "manyhow"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bc2a348104913df6d14170bedef54faf224a0970ec7b1f8750748ab94fcd52"
-dependencies = [
- "manyhow-macros",
- "proc-macro2",
- "quote",
- "syn 2.0.32",
-]
-
-[[package]]
-name = "manyhow-macros"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532aa12d5846b38a524b3acd99fb74dc8a5f193b33e65dac142ef92bd60f9416"
-dependencies = [
- "proc-macro-utils",
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1133,17 +1109,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "version_check",
-]
-
-[[package]]
-name = "proc-macro-utils"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f59e109e2f795a5070e69578c4dc101068139f74616778025ae1011d4cd41a8"
-dependencies = [
- "proc-macro2",
- "quote",
- "smallvec",
 ]
 
 [[package]]

--- a/contracts/hackatom/Cargo.lock
+++ b/contracts/hackatom/Cargo.lock
@@ -228,7 +228,6 @@ dependencies = [
 name = "cosmwasm-schema-derive"
 version = "2.0.0"
 dependencies = [
- "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.37",
@@ -821,12 +820,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex"
@@ -1501,7 +1494,7 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",

--- a/contracts/hackatom/Cargo.lock
+++ b/contracts/hackatom/Cargo.lock
@@ -229,7 +229,6 @@ name = "cosmwasm-schema-derive"
 version = "2.0.0"
 dependencies = [
  "heck 0.5.0",
- "manyhow",
  "proc-macro2",
  "quote",
  "syn 2.0.37",
@@ -946,29 +945,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "manyhow"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bc2a348104913df6d14170bedef54faf224a0970ec7b1f8750748ab94fcd52"
-dependencies = [
- "manyhow-macros",
- "proc-macro2",
- "quote",
- "syn 2.0.37",
-]
-
-[[package]]
-name = "manyhow-macros"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532aa12d5846b38a524b3acd99fb74dc8a5f193b33e65dac142ef92bd60f9416"
-dependencies = [
- "proc-macro-utils",
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1128,17 +1104,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "version_check",
-]
-
-[[package]]
-name = "proc-macro-utils"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f59e109e2f795a5070e69578c4dc101068139f74616778025ae1011d4cd41a8"
-dependencies = [
- "proc-macro2",
- "quote",
- "smallvec",
 ]
 
 [[package]]

--- a/contracts/hackatom/Cargo.lock
+++ b/contracts/hackatom/Cargo.lock
@@ -228,6 +228,8 @@ dependencies = [
 name = "cosmwasm-schema-derive"
 version = "2.0.0"
 dependencies = [
+ "heck 0.5.0",
+ "manyhow",
  "proc-macro2",
  "quote",
  "syn 2.0.37",
@@ -822,6 +824,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -935,6 +943,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "manyhow"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bc2a348104913df6d14170bedef54faf224a0970ec7b1f8750748ab94fcd52"
+dependencies = [
+ "manyhow-macros",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+]
+
+[[package]]
+name = "manyhow-macros"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "532aa12d5846b38a524b3acd99fb74dc8a5f193b33e65dac142ef92bd60f9416"
+dependencies = [
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -1097,6 +1128,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "version_check",
+]
+
+[[package]]
+name = "proc-macro-utils"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f59e109e2f795a5070e69578c4dc101068139f74616778025ae1011d4cd41a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "smallvec",
 ]
 
 [[package]]
@@ -1494,7 +1536,7 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",

--- a/contracts/hackatom/Cargo.lock
+++ b/contracts/hackatom/Cargo.lock
@@ -209,7 +209,8 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "2.0.0"
 dependencies = [
- "syn 1.0.109",
+ "quote",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -229,7 +230,7 @@ version = "2.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1100,9 +1101,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.67"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
@@ -1129,9 +1130,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]

--- a/contracts/ibc-reflect-send/Cargo.lock
+++ b/contracts/ibc-reflect-send/Cargo.lock
@@ -228,7 +228,6 @@ dependencies = [
 name = "cosmwasm-schema-derive"
 version = "2.0.0"
 dependencies = [
- "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.37",
@@ -808,12 +807,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex"
@@ -1499,7 +1492,7 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",

--- a/contracts/ibc-reflect-send/Cargo.lock
+++ b/contracts/ibc-reflect-send/Cargo.lock
@@ -229,7 +229,6 @@ name = "cosmwasm-schema-derive"
 version = "2.0.0"
 dependencies = [
  "heck 0.5.0",
- "manyhow",
  "proc-macro2",
  "quote",
  "syn 2.0.37",
@@ -944,29 +943,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "manyhow"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bc2a348104913df6d14170bedef54faf224a0970ec7b1f8750748ab94fcd52"
-dependencies = [
- "manyhow-macros",
- "proc-macro2",
- "quote",
- "syn 2.0.37",
-]
-
-[[package]]
-name = "manyhow-macros"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532aa12d5846b38a524b3acd99fb74dc8a5f193b33e65dac142ef92bd60f9416"
-dependencies = [
- "proc-macro-utils",
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1126,17 +1102,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "version_check",
-]
-
-[[package]]
-name = "proc-macro-utils"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f59e109e2f795a5070e69578c4dc101068139f74616778025ae1011d4cd41a8"
-dependencies = [
- "proc-macro2",
- "quote",
- "smallvec",
 ]
 
 [[package]]

--- a/contracts/ibc-reflect-send/Cargo.lock
+++ b/contracts/ibc-reflect-send/Cargo.lock
@@ -209,7 +209,8 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "2.0.0"
 dependencies = [
- "syn 1.0.109",
+ "quote",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -229,7 +230,7 @@ version = "2.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1098,9 +1099,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.67"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
@@ -1127,9 +1128,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]

--- a/contracts/ibc-reflect-send/Cargo.lock
+++ b/contracts/ibc-reflect-send/Cargo.lock
@@ -228,6 +228,8 @@ dependencies = [
 name = "cosmwasm-schema-derive"
 version = "2.0.0"
 dependencies = [
+ "heck 0.5.0",
+ "manyhow",
  "proc-macro2",
  "quote",
  "syn 2.0.37",
@@ -809,6 +811,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,6 +941,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "manyhow"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bc2a348104913df6d14170bedef54faf224a0970ec7b1f8750748ab94fcd52"
+dependencies = [
+ "manyhow-macros",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+]
+
+[[package]]
+name = "manyhow-macros"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "532aa12d5846b38a524b3acd99fb74dc8a5f193b33e65dac142ef92bd60f9416"
+dependencies = [
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -1095,6 +1126,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "version_check",
+]
+
+[[package]]
+name = "proc-macro-utils"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f59e109e2f795a5070e69578c4dc101068139f74616778025ae1011d4cd41a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "smallvec",
 ]
 
 [[package]]
@@ -1492,7 +1534,7 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",

--- a/contracts/ibc-reflect/Cargo.lock
+++ b/contracts/ibc-reflect/Cargo.lock
@@ -228,7 +228,6 @@ dependencies = [
 name = "cosmwasm-schema-derive"
 version = "2.0.0"
 dependencies = [
- "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.37",
@@ -808,12 +807,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex"
@@ -1499,7 +1492,7 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",

--- a/contracts/ibc-reflect/Cargo.lock
+++ b/contracts/ibc-reflect/Cargo.lock
@@ -229,7 +229,6 @@ name = "cosmwasm-schema-derive"
 version = "2.0.0"
 dependencies = [
  "heck 0.5.0",
- "manyhow",
  "proc-macro2",
  "quote",
  "syn 2.0.37",
@@ -944,29 +943,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "manyhow"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bc2a348104913df6d14170bedef54faf224a0970ec7b1f8750748ab94fcd52"
-dependencies = [
- "manyhow-macros",
- "proc-macro2",
- "quote",
- "syn 2.0.37",
-]
-
-[[package]]
-name = "manyhow-macros"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532aa12d5846b38a524b3acd99fb74dc8a5f193b33e65dac142ef92bd60f9416"
-dependencies = [
- "proc-macro-utils",
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1126,17 +1102,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "version_check",
-]
-
-[[package]]
-name = "proc-macro-utils"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f59e109e2f795a5070e69578c4dc101068139f74616778025ae1011d4cd41a8"
-dependencies = [
- "proc-macro2",
- "quote",
- "smallvec",
 ]
 
 [[package]]

--- a/contracts/ibc-reflect/Cargo.lock
+++ b/contracts/ibc-reflect/Cargo.lock
@@ -209,7 +209,8 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "2.0.0"
 dependencies = [
- "syn 1.0.109",
+ "quote",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -229,7 +230,7 @@ version = "2.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1098,9 +1099,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.67"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
@@ -1127,9 +1128,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]

--- a/contracts/ibc-reflect/Cargo.lock
+++ b/contracts/ibc-reflect/Cargo.lock
@@ -228,6 +228,8 @@ dependencies = [
 name = "cosmwasm-schema-derive"
 version = "2.0.0"
 dependencies = [
+ "heck 0.5.0",
+ "manyhow",
  "proc-macro2",
  "quote",
  "syn 2.0.37",
@@ -809,6 +811,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,6 +941,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "manyhow"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bc2a348104913df6d14170bedef54faf224a0970ec7b1f8750748ab94fcd52"
+dependencies = [
+ "manyhow-macros",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+]
+
+[[package]]
+name = "manyhow-macros"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "532aa12d5846b38a524b3acd99fb74dc8a5f193b33e65dac142ef92bd60f9416"
+dependencies = [
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -1095,6 +1126,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "version_check",
+]
+
+[[package]]
+name = "proc-macro-utils"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f59e109e2f795a5070e69578c4dc101068139f74616778025ae1011d4cd41a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "smallvec",
 ]
 
 [[package]]
@@ -1492,7 +1534,7 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",

--- a/contracts/queue/Cargo.lock
+++ b/contracts/queue/Cargo.lock
@@ -228,7 +228,6 @@ dependencies = [
 name = "cosmwasm-schema-derive"
 version = "2.0.0"
 dependencies = [
- "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.37",
@@ -808,12 +807,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex"
@@ -1499,7 +1492,7 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",

--- a/contracts/queue/Cargo.lock
+++ b/contracts/queue/Cargo.lock
@@ -229,7 +229,6 @@ name = "cosmwasm-schema-derive"
 version = "2.0.0"
 dependencies = [
  "heck 0.5.0",
- "manyhow",
  "proc-macro2",
  "quote",
  "syn 2.0.37",
@@ -933,29 +932,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "manyhow"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bc2a348104913df6d14170bedef54faf224a0970ec7b1f8750748ab94fcd52"
-dependencies = [
- "manyhow-macros",
- "proc-macro2",
- "quote",
- "syn 2.0.37",
-]
-
-[[package]]
-name = "manyhow-macros"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532aa12d5846b38a524b3acd99fb74dc8a5f193b33e65dac142ef92bd60f9416"
-dependencies = [
- "proc-macro-utils",
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1115,17 +1091,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "version_check",
-]
-
-[[package]]
-name = "proc-macro-utils"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f59e109e2f795a5070e69578c4dc101068139f74616778025ae1011d4cd41a8"
-dependencies = [
- "proc-macro2",
- "quote",
- "smallvec",
 ]
 
 [[package]]

--- a/contracts/queue/Cargo.lock
+++ b/contracts/queue/Cargo.lock
@@ -209,7 +209,8 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "2.0.0"
 dependencies = [
- "syn 1.0.109",
+ "quote",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -229,7 +230,7 @@ version = "2.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1087,9 +1088,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.67"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
@@ -1127,9 +1128,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]

--- a/contracts/queue/Cargo.lock
+++ b/contracts/queue/Cargo.lock
@@ -228,6 +228,8 @@ dependencies = [
 name = "cosmwasm-schema-derive"
 version = "2.0.0"
 dependencies = [
+ "heck 0.5.0",
+ "manyhow",
  "proc-macro2",
  "quote",
  "syn 2.0.37",
@@ -809,6 +811,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -922,6 +930,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "manyhow"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bc2a348104913df6d14170bedef54faf224a0970ec7b1f8750748ab94fcd52"
+dependencies = [
+ "manyhow-macros",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+]
+
+[[package]]
+name = "manyhow-macros"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "532aa12d5846b38a524b3acd99fb74dc8a5f193b33e65dac142ef92bd60f9416"
+dependencies = [
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -1084,6 +1115,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "version_check",
+]
+
+[[package]]
+name = "proc-macro-utils"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f59e109e2f795a5070e69578c4dc101068139f74616778025ae1011d4cd41a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "smallvec",
 ]
 
 [[package]]
@@ -1492,7 +1534,7 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",

--- a/contracts/reflect/Cargo.lock
+++ b/contracts/reflect/Cargo.lock
@@ -229,7 +229,6 @@ name = "cosmwasm-schema-derive"
 version = "2.0.0"
 dependencies = [
  "heck 0.5.0",
- "manyhow",
  "proc-macro2",
  "quote",
  "syn 2.0.37",
@@ -933,29 +932,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "manyhow"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bc2a348104913df6d14170bedef54faf224a0970ec7b1f8750748ab94fcd52"
-dependencies = [
- "manyhow-macros",
- "proc-macro2",
- "quote",
- "syn 2.0.37",
-]
-
-[[package]]
-name = "manyhow-macros"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532aa12d5846b38a524b3acd99fb74dc8a5f193b33e65dac142ef92bd60f9416"
-dependencies = [
- "proc-macro-utils",
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1115,17 +1091,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "version_check",
-]
-
-[[package]]
-name = "proc-macro-utils"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f59e109e2f795a5070e69578c4dc101068139f74616778025ae1011d4cd41a8"
-dependencies = [
- "proc-macro2",
- "quote",
- "smallvec",
 ]
 
 [[package]]

--- a/contracts/reflect/Cargo.lock
+++ b/contracts/reflect/Cargo.lock
@@ -228,6 +228,8 @@ dependencies = [
 name = "cosmwasm-schema-derive"
 version = "2.0.0"
 dependencies = [
+ "heck 0.5.0",
+ "manyhow",
  "proc-macro2",
  "quote",
  "syn 2.0.37",
@@ -809,6 +811,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -922,6 +930,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "manyhow"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bc2a348104913df6d14170bedef54faf224a0970ec7b1f8750748ab94fcd52"
+dependencies = [
+ "manyhow-macros",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+]
+
+[[package]]
+name = "manyhow-macros"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "532aa12d5846b38a524b3acd99fb74dc8a5f193b33e65dac142ef92bd60f9416"
+dependencies = [
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -1084,6 +1115,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "version_check",
+]
+
+[[package]]
+name = "proc-macro-utils"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f59e109e2f795a5070e69578c4dc101068139f74616778025ae1011d4cd41a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "smallvec",
 ]
 
 [[package]]
@@ -1493,7 +1535,7 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",

--- a/contracts/reflect/Cargo.lock
+++ b/contracts/reflect/Cargo.lock
@@ -209,7 +209,8 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "2.0.0"
 dependencies = [
- "syn 1.0.109",
+ "quote",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -229,7 +230,7 @@ version = "2.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1087,9 +1088,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.67"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
@@ -1116,9 +1117,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]

--- a/contracts/reflect/Cargo.lock
+++ b/contracts/reflect/Cargo.lock
@@ -228,7 +228,6 @@ dependencies = [
 name = "cosmwasm-schema-derive"
 version = "2.0.0"
 dependencies = [
- "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.37",
@@ -808,12 +807,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex"
@@ -1500,7 +1493,7 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",

--- a/contracts/staking/Cargo.lock
+++ b/contracts/staking/Cargo.lock
@@ -228,7 +228,6 @@ dependencies = [
 name = "cosmwasm-schema-derive"
 version = "2.0.0"
 dependencies = [
- "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.37",
@@ -814,12 +813,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex"
@@ -1527,7 +1520,7 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",

--- a/contracts/staking/Cargo.lock
+++ b/contracts/staking/Cargo.lock
@@ -228,6 +228,8 @@ dependencies = [
 name = "cosmwasm-schema-derive"
 version = "2.0.0"
 dependencies = [
+ "heck 0.5.0",
+ "manyhow",
  "proc-macro2",
  "quote",
  "syn 2.0.37",
@@ -815,6 +817,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -928,6 +936,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "manyhow"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bc2a348104913df6d14170bedef54faf224a0970ec7b1f8750748ab94fcd52"
+dependencies = [
+ "manyhow-macros",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+]
+
+[[package]]
+name = "manyhow-macros"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "532aa12d5846b38a524b3acd99fb74dc8a5f193b33e65dac142ef92bd60f9416"
+dependencies = [
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -1090,6 +1121,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "version_check",
+]
+
+[[package]]
+name = "proc-macro-utils"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f59e109e2f795a5070e69578c4dc101068139f74616778025ae1011d4cd41a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "smallvec",
 ]
 
 [[package]]
@@ -1520,7 +1562,7 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",

--- a/contracts/staking/Cargo.lock
+++ b/contracts/staking/Cargo.lock
@@ -229,7 +229,6 @@ name = "cosmwasm-schema-derive"
 version = "2.0.0"
 dependencies = [
  "heck 0.5.0",
- "manyhow",
  "proc-macro2",
  "quote",
  "syn 2.0.37",
@@ -939,29 +938,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "manyhow"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bc2a348104913df6d14170bedef54faf224a0970ec7b1f8750748ab94fcd52"
-dependencies = [
- "manyhow-macros",
- "proc-macro2",
- "quote",
- "syn 2.0.37",
-]
-
-[[package]]
-name = "manyhow-macros"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532aa12d5846b38a524b3acd99fb74dc8a5f193b33e65dac142ef92bd60f9416"
-dependencies = [
- "proc-macro-utils",
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1121,17 +1097,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "version_check",
-]
-
-[[package]]
-name = "proc-macro-utils"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f59e109e2f795a5070e69578c4dc101068139f74616778025ae1011d4cd41a8"
-dependencies = [
- "proc-macro2",
- "quote",
- "smallvec",
 ]
 
 [[package]]

--- a/contracts/staking/Cargo.lock
+++ b/contracts/staking/Cargo.lock
@@ -209,7 +209,8 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "2.0.0"
 dependencies = [
- "syn 1.0.109",
+ "quote",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -229,7 +230,7 @@ version = "2.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1093,9 +1094,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.67"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
@@ -1122,9 +1123,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]

--- a/contracts/virus/Cargo.lock
+++ b/contracts/virus/Cargo.lock
@@ -229,7 +229,6 @@ name = "cosmwasm-schema-derive"
 version = "2.0.0"
 dependencies = [
  "heck 0.5.0",
- "manyhow",
  "proc-macro2",
  "quote",
  "syn 2.0.37",
@@ -933,29 +932,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "manyhow"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bc2a348104913df6d14170bedef54faf224a0970ec7b1f8750748ab94fcd52"
-dependencies = [
- "manyhow-macros",
- "proc-macro2",
- "quote",
- "syn 2.0.37",
-]
-
-[[package]]
-name = "manyhow-macros"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532aa12d5846b38a524b3acd99fb74dc8a5f193b33e65dac142ef92bd60f9416"
-dependencies = [
- "proc-macro-utils",
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1115,17 +1091,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "version_check",
-]
-
-[[package]]
-name = "proc-macro-utils"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f59e109e2f795a5070e69578c4dc101068139f74616778025ae1011d4cd41a8"
-dependencies = [
- "proc-macro2",
- "quote",
- "smallvec",
 ]
 
 [[package]]

--- a/contracts/virus/Cargo.lock
+++ b/contracts/virus/Cargo.lock
@@ -228,6 +228,8 @@ dependencies = [
 name = "cosmwasm-schema-derive"
 version = "2.0.0"
 dependencies = [
+ "heck 0.5.0",
+ "manyhow",
  "proc-macro2",
  "quote",
  "syn 2.0.37",
@@ -809,6 +811,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -922,6 +930,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "manyhow"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bc2a348104913df6d14170bedef54faf224a0970ec7b1f8750748ab94fcd52"
+dependencies = [
+ "manyhow-macros",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+]
+
+[[package]]
+name = "manyhow-macros"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "532aa12d5846b38a524b3acd99fb74dc8a5f193b33e65dac142ef92bd60f9416"
+dependencies = [
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -1084,6 +1115,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "version_check",
+]
+
+[[package]]
+name = "proc-macro-utils"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f59e109e2f795a5070e69578c4dc101068139f74616778025ae1011d4cd41a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "smallvec",
 ]
 
 [[package]]
@@ -1481,7 +1523,7 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",

--- a/contracts/virus/Cargo.lock
+++ b/contracts/virus/Cargo.lock
@@ -228,7 +228,6 @@ dependencies = [
 name = "cosmwasm-schema-derive"
 version = "2.0.0"
 dependencies = [
- "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.37",
@@ -808,12 +807,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex"
@@ -1488,7 +1481,7 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",

--- a/contracts/virus/Cargo.lock
+++ b/contracts/virus/Cargo.lock
@@ -209,7 +209,8 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "2.0.0"
 dependencies = [
- "syn 1.0.109",
+ "quote",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -229,7 +230,7 @@ version = "2.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1087,9 +1088,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.67"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
@@ -1116,9 +1117,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]

--- a/packages/derive/Cargo.toml
+++ b/packages/derive/Cargo.toml
@@ -15,7 +15,8 @@ proc-macro = true
 default = []
 
 [dependencies]
-syn = { version = "1.0", features = ["full"] }
+quote = "1.0.35"
+syn = { version = "2", features = ["full"] }
 
 [dev-dependencies]
 # Needed for testing docs

--- a/packages/derive/src/lib.rs
+++ b/packages/derive/src/lib.rs
@@ -73,6 +73,6 @@ pub fn entry_point(_attr: TokenStream, mut item: TokenStream) -> TokenStream {
         }
     };
 
-    item.extend::<TokenStream>(new_code.into());
+    item.extend(TokenStream::from(new_code));
     item
 }

--- a/packages/schema-derive/Cargo.toml
+++ b/packages/schema-derive/Cargo.toml
@@ -9,7 +9,6 @@ license = "Apache-2.0"
 
 [dependencies]
 heck = "0.5.0"
-manyhow = "0.11.1"
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "2", features = ["extra-traits", "full", "printing"] }

--- a/packages/schema-derive/Cargo.toml
+++ b/packages/schema-derive/Cargo.toml
@@ -8,9 +8,11 @@ repository = "https://github.com/CosmWasm/cosmwasm/tree/main/packages/schema"
 license = "Apache-2.0"
 
 [dependencies]
+heck = "0.5.0"
+manyhow = "0.11.1"
 proc-macro2 = "1"
 quote = "1"
-syn = { version = "1", features = ["full", "printing", "extra-traits"] }
+syn = { version = "2", features = ["extra-traits", "full", "printing"] }
 
 [lib]
 proc-macro = true

--- a/packages/schema-derive/Cargo.toml
+++ b/packages/schema-derive/Cargo.toml
@@ -8,7 +8,6 @@ repository = "https://github.com/CosmWasm/cosmwasm/tree/main/packages/schema"
 license = "Apache-2.0"
 
 [dependencies]
-heck = "0.5.0"
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "2", features = ["extra-traits", "full", "printing"] }

--- a/packages/schema-derive/src/cw_serde.rs
+++ b/packages/schema-derive/src/cw_serde.rs
@@ -1,42 +1,38 @@
-use syn::{parse_quote, DeriveInput};
+use manyhow::bail;
+use quote::{quote, ToTokens};
+use syn::DeriveInput;
 
-pub fn cw_serde_impl(input: DeriveInput) -> DeriveInput {
+pub fn cw_serde_impl(input: DeriveInput) -> syn::Result<DeriveInput> {
+    let mut stream = quote! {
+        #[derive(
+            ::cosmwasm_schema::serde::Serialize,
+            ::cosmwasm_schema::serde::Deserialize,
+            ::std::clone::Clone,
+            ::std::fmt::Debug,
+            ::std::cmp::PartialEq,
+            ::cosmwasm_schema::schemars::JsonSchema
+        )]
+        #[allow(clippy::derive_partial_eq_without_eq)] // Allow users of `#[cw_serde]` to not implement Eq without clippy complaining
+        #[serde(deny_unknown_fields, crate = "::cosmwasm_schema::serde")]
+        #[schemars(crate = "::cosmwasm_schema::schemars")]
+    };
+
     match input.data {
-        syn::Data::Struct(_) => parse_quote! {
-            #[derive(
-                ::cosmwasm_schema::serde::Serialize,
-                ::cosmwasm_schema::serde::Deserialize,
-                ::std::clone::Clone,
-                ::std::fmt::Debug,
-                ::std::cmp::PartialEq,
-                ::cosmwasm_schema::schemars::JsonSchema
-            )]
-            #[allow(clippy::derive_partial_eq_without_eq)] // Allow users of `#[cw_serde]` to not implement Eq without clippy complaining
-            #[serde(deny_unknown_fields, crate = "::cosmwasm_schema::serde")]
-            #[schemars(crate = "::cosmwasm_schema::schemars")]
-            #input
-        },
-        syn::Data::Enum(_) => parse_quote! {
-            #[derive(
-                ::cosmwasm_schema::serde::Serialize,
-                ::cosmwasm_schema::serde::Deserialize,
-                ::std::clone::Clone,
-                ::std::fmt::Debug,
-                ::std::cmp::PartialEq,
-                ::cosmwasm_schema::schemars::JsonSchema
-            )]
-            #[allow(clippy::derive_partial_eq_without_eq)] // Allow users of `#[cw_serde]` to not implement Eq without clippy complaining
-            #[serde(deny_unknown_fields, rename_all = "snake_case", crate = "::cosmwasm_schema::serde")]
-            #[schemars(crate = "::cosmwasm_schema::schemars")]
-            #input
-        },
-        syn::Data::Union(_) => panic!("unions are not supported"),
+        syn::Data::Struct(..) => (),
+        syn::Data::Enum(..) => {
+            stream.extend(quote! { #[serde(rename_all = "snake_case")] });
+        }
+        syn::Data::Union(..) => bail!(input, "unions are not supported"),
     }
+
+    stream.extend(input.to_token_stream());
+    syn::parse2(stream)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use syn::parse_quote;
 
     #[test]
     fn structs() {
@@ -45,7 +41,8 @@ mod tests {
                 pub verifier: String,
                 pub beneficiary: String,
             }
-        });
+        })
+        .unwrap();
 
         let expected = parse_quote! {
             #[derive(
@@ -72,7 +69,8 @@ mod tests {
     fn empty_struct() {
         let expanded = cw_serde_impl(parse_quote! {
             pub struct InstantiateMsg {}
-        });
+        })
+        .unwrap();
 
         let expected = parse_quote! {
             #[derive(
@@ -101,7 +99,8 @@ mod tests {
                     amount: Vec<Coin>,
                 },
             }
-        });
+        })
+        .unwrap();
 
         let expected = parse_quote! {
             #[derive(
@@ -113,8 +112,9 @@ mod tests {
                 ::cosmwasm_schema::schemars::JsonSchema
             )]
             #[allow(clippy::derive_partial_eq_without_eq)]
-            #[serde(deny_unknown_fields, rename_all = "snake_case", crate = "::cosmwasm_schema::serde")]
+            #[serde(deny_unknown_fields, crate = "::cosmwasm_schema::serde")]
             #[schemars(crate = "::cosmwasm_schema::schemars")]
+            #[serde(rename_all = "snake_case")]
             pub enum SudoMsg {
                 StealFunds {
                     recipient: String,
@@ -134,6 +134,7 @@ mod tests {
                 x: u32,
                 y: u32,
             }
-        });
+        })
+        .unwrap();
     }
 }

--- a/packages/schema-derive/src/cw_serde.rs
+++ b/packages/schema-derive/src/cw_serde.rs
@@ -1,4 +1,4 @@
-use manyhow::bail;
+use crate::error::bail;
 use quote::{quote, ToTokens};
 use syn::DeriveInput;
 

--- a/packages/schema-derive/src/error.rs
+++ b/packages/schema-derive/src/error.rs
@@ -23,7 +23,7 @@ macro_rules! fallible_macro {
             #[ $( $attribute_decl )* ]
         )*
         pub fn $macro_name ( $( $params )* ) -> $inner_return {
-            let result = move || -> syn::Result<_> {
+            let result = move || -> ::syn::Result<_> {
                 $( $fn_body )*
             };
 

--- a/packages/schema-derive/src/error.rs
+++ b/packages/schema-derive/src/error.rs
@@ -1,0 +1,40 @@
+macro_rules! bail {
+    ($span_src:expr, $msg:literal) => {{
+        return Err($crate::error::error_message!($span_src, $msg));
+    }};
+}
+
+macro_rules! error_message {
+    ($span_src:expr, $msg:literal) => {{
+        ::syn::Error::new(::syn::spanned::Spanned::span(&{ $span_src }), $msg)
+    }};
+}
+
+macro_rules! fallible_macro {
+    (
+        $(
+            #[ $( $attribute_decl:tt )* ]
+        )*
+        pub fn $macro_name:ident ( $( $params:tt )* ) -> syn::Result<$inner_return:path> {
+            $( $fn_body:tt )*
+        }
+    ) => {
+        $(
+            #[ $( $attribute_decl )* ]
+        )*
+        pub fn $macro_name ( $( $params )* ) -> $inner_return {
+            let result = move || -> syn::Result<_> {
+                $( $fn_body )*
+            };
+
+            match result() {
+                Ok(val) => val,
+                Err(err) => err.into_compile_error().into(),
+            }
+        }
+    }
+}
+
+pub(crate) use bail;
+pub(crate) use error_message;
+pub(crate) use fallible_macro;

--- a/packages/schema-derive/src/generate_api.rs
+++ b/packages/schema-derive/src/generate_api.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use manyhow::bail;
+use crate::error::bail;
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{

--- a/packages/schema-derive/src/generate_api.rs
+++ b/packages/schema-derive/src/generate_api.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 
+use manyhow::bail;
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{
@@ -80,19 +81,17 @@ enum Value {
 }
 
 impl Value {
-    fn unwrap_type(self) -> syn::Path {
-        if let Self::Type(p) = self {
-            p
-        } else {
-            panic!("expected a type");
+    fn get_type(self) -> syn::Result<syn::Path> {
+        match self {
+            Self::Type(p) => Ok(p),
+            Self::Str(other) => bail!(other, "expected a type"),
         }
     }
 
-    fn unwrap_str(self) -> syn::LitStr {
-        if let Self::Str(s) = self {
-            s
-        } else {
-            panic!("expected a string literal");
+    fn get_str(self) -> syn::Result<syn::LitStr> {
+        match self {
+            Self::Str(p) => Ok(p),
+            Self::Type(other) => bail!(other, "expected a string literal"),
         }
     }
 }
@@ -134,11 +133,11 @@ pub struct Options {
 
 impl Parse for Options {
     fn parse(input: ParseStream) -> syn::parse::Result<Self> {
-        let pairs = input.parse_terminated::<Pair, Token![,]>(Pair::parse)?;
+        let pairs = input.parse_terminated(Pair::parse, Token![,])?;
         let mut map: BTreeMap<_, _> = pairs.into_iter().map(|p| p.0).collect();
 
         let name = if let Some(name_override) = map.remove(&parse_quote!(name)) {
-            let name_override = name_override.unwrap_str();
+            let name_override = name_override.get_str()?;
             quote! {
                 #name_override
             }
@@ -149,7 +148,7 @@ impl Parse for Options {
         };
 
         let version = if let Some(version_override) = map.remove(&parse_quote!(version)) {
-            let version_override = version_override.unwrap_str();
+            let version_override = version_override.get_str()?;
             quote! {
                 #version_override
             }
@@ -161,7 +160,7 @@ impl Parse for Options {
 
         let instantiate = match map.remove(&parse_quote!(instantiate)) {
             Some(ty) => {
-                let ty = ty.unwrap_type();
+                let ty = ty.get_type()?;
                 quote! {Some(::cosmwasm_schema::schema_for!(#ty))}
             }
             None => quote! { None },
@@ -169,7 +168,7 @@ impl Parse for Options {
 
         let execute = match map.remove(&parse_quote!(execute)) {
             Some(ty) => {
-                let ty = ty.unwrap_type();
+                let ty = ty.get_type()?;
                 quote! {Some(::cosmwasm_schema::schema_for!(#ty))}
             }
             None => quote! { None },
@@ -177,7 +176,7 @@ impl Parse for Options {
 
         let (query, responses) = match map.remove(&parse_quote!(query)) {
             Some(ty) => {
-                let ty = ty.unwrap_type();
+                let ty = ty.get_type()?;
                 (
                     quote! {Some(::cosmwasm_schema::schema_for!(#ty))},
                     quote! { Some(<#ty as ::cosmwasm_schema::QueryResponses>::response_schemas().unwrap()) },
@@ -188,7 +187,7 @@ impl Parse for Options {
 
         let migrate = match map.remove(&parse_quote!(migrate)) {
             Some(ty) => {
-                let ty = ty.unwrap_type();
+                let ty = ty.get_type()?;
                 quote! {Some(::cosmwasm_schema::schema_for!(#ty))}
             }
             None => quote! { None },
@@ -196,14 +195,14 @@ impl Parse for Options {
 
         let sudo = match map.remove(&parse_quote!(sudo)) {
             Some(ty) => {
-                let ty = ty.unwrap_type();
+                let ty = ty.get_type()?;
                 quote! {Some(::cosmwasm_schema::schema_for!(#ty))}
             }
             None => quote! { None },
         };
 
         if let Some((invalid_option, _)) = map.into_iter().next() {
-            panic!("unknown generate_api option: {invalid_option}");
+            bail!(invalid_option, "unknown generate_api option");
         }
 
         Ok(Self {
@@ -312,7 +311,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "unknown generate_api option: asd")]
+    #[should_panic(expected = "unknown generate_api option")]
     fn invalid_option() {
         let _options: Options = parse_quote! {
             instantiate: InstantiateMsg,

--- a/packages/schema-derive/src/lib.rs
+++ b/packages/schema-derive/src/lib.rs
@@ -1,23 +1,24 @@
 mod cw_serde;
+mod error;
 mod generate_api;
 mod query_responses;
 
-use manyhow::manyhow;
+use self::error::fallible_macro;
 use quote::ToTokens;
 use syn::parse_macro_input;
 
-#[manyhow]
-#[proc_macro_derive(QueryResponses, attributes(returns, query_responses))]
-pub fn query_responses_derive(
-    input: proc_macro::TokenStream,
-) -> syn::Result<proc_macro::TokenStream> {
-    let input = syn::parse(input)?;
-    let expanded = query_responses::query_responses_derive_impl(input)?;
+fallible_macro! {
+    #[proc_macro_derive(QueryResponses, attributes(returns, query_responses))]
+    pub fn query_responses_derive(
+        input: proc_macro::TokenStream,
+    ) -> syn::Result<proc_macro::TokenStream> {
+        let input = syn::parse(input)?;
+        let expanded = query_responses::query_responses_derive_impl(input)?;
 
-    Ok(expanded.into_token_stream().into())
+        Ok(expanded.into_token_stream().into())
+    }
 }
 
-#[manyhow]
 #[proc_macro]
 pub fn write_api(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse_macro_input!(input as generate_api::Options);
@@ -26,7 +27,6 @@ pub fn write_api(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     proc_macro::TokenStream::from(expanded)
 }
 
-#[manyhow]
 #[proc_macro]
 pub fn generate_api(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse_macro_input!(input as generate_api::Options);
@@ -35,13 +35,14 @@ pub fn generate_api(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     proc_macro::TokenStream::from(expanded)
 }
 
-#[manyhow]
-#[proc_macro_attribute]
-pub fn cw_serde(
-    _attr: proc_macro::TokenStream,
-    input: proc_macro::TokenStream,
-) -> syn::Result<proc_macro::TokenStream> {
-    let input = syn::parse(input)?;
-    let expanded = cw_serde::cw_serde_impl(input)?;
-    Ok(expanded.into_token_stream().into())
+fallible_macro! {
+    #[proc_macro_attribute]
+    pub fn cw_serde(
+        _attr: proc_macro::TokenStream,
+        input: proc_macro::TokenStream,
+    ) -> syn::Result<proc_macro::TokenStream> {
+        let input = syn::parse(input)?;
+        let expanded = cw_serde::cw_serde_impl(input)?;
+        Ok(expanded.into_token_stream().into())
+    }
 }

--- a/packages/schema-derive/src/lib.rs
+++ b/packages/schema-derive/src/lib.rs
@@ -2,44 +2,46 @@ mod cw_serde;
 mod generate_api;
 mod query_responses;
 
+use manyhow::manyhow;
 use quote::ToTokens;
-use syn::{parse_macro_input, DeriveInput, ItemEnum};
+use syn::parse_macro_input;
 
+#[manyhow]
 #[proc_macro_derive(QueryResponses, attributes(returns, query_responses))]
-pub fn query_responses_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let input = parse_macro_input!(input as ItemEnum);
+pub fn query_responses_derive(
+    input: proc_macro::TokenStream,
+) -> syn::Result<proc_macro::TokenStream> {
+    let input = syn::parse(input)?;
+    let expanded = query_responses::query_responses_derive_impl(input)?;
 
-    let expanded = query_responses::query_responses_derive_impl(input).into_token_stream();
-
-    proc_macro::TokenStream::from(expanded)
+    Ok(expanded.into_token_stream().into())
 }
 
+#[manyhow]
 #[proc_macro]
 pub fn write_api(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse_macro_input!(input as generate_api::Options);
-
     let expanded = generate_api::write_api_impl(input).into_token_stream();
 
     proc_macro::TokenStream::from(expanded)
 }
 
+#[manyhow]
 #[proc_macro]
 pub fn generate_api(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse_macro_input!(input as generate_api::Options);
-
     let expanded = generate_api::generate_api_impl(&input).into_token_stream();
 
     proc_macro::TokenStream::from(expanded)
 }
 
+#[manyhow]
 #[proc_macro_attribute]
 pub fn cw_serde(
     _attr: proc_macro::TokenStream,
     input: proc_macro::TokenStream,
-) -> proc_macro::TokenStream {
-    let input = parse_macro_input!(input as DeriveInput);
-
-    let expanded = cw_serde::cw_serde_impl(input).into_token_stream();
-
-    proc_macro::TokenStream::from(expanded)
+) -> syn::Result<proc_macro::TokenStream> {
+    let input = syn::parse(input)?;
+    let expanded = cw_serde::cw_serde_impl(input)?;
+    Ok(expanded.into_token_stream().into())
 }

--- a/packages/schema-derive/src/query_responses.rs
+++ b/packages/schema-derive/src/query_responses.rs
@@ -1,7 +1,6 @@
 mod context;
 
 use crate::error::{bail, error_message};
-use heck::ToSnakeCase;
 use syn::{
     parse_quote, Expr, ExprTuple, Generics, ItemEnum, ItemImpl, Type, TypeParamBound, Variant,
 };
@@ -93,7 +92,7 @@ fn impl_generics(ctx: &Context, generics: &Generics, bounds: &[TypeParamBound]) 
 
 /// Extract the query -> response mapping out of an enum variant.
 fn parse_query(v: Variant) -> syn::Result<(String, Expr)> {
-    let query = v.ident.to_string().to_snake_case();
+    let query = to_snake_case(&v.ident.to_string());
     let response_ty: Type = v
         .attrs
         .iter()
@@ -129,6 +128,18 @@ fn parse_tuple((q, r): (String, Expr)) -> ExprTuple {
     parse_quote! {
         (#q.to_string(), #r)
     }
+}
+
+fn to_snake_case(input: &str) -> String {
+    // this was stolen from serde for consistent behavior
+    let mut snake = String::new();
+    for (i, ch) in input.char_indices() {
+        if i > 0 && ch.is_uppercase() {
+            snake.push('_');
+        }
+        snake.push(ch.to_ascii_lowercase());
+    }
+    snake
 }
 
 #[cfg(test)]

--- a/packages/schema-derive/src/query_responses.rs
+++ b/packages/schema-derive/src/query_responses.rs
@@ -1,7 +1,7 @@
 mod context;
 
+use crate::error::{bail, error_message};
 use heck::ToSnakeCase;
-use manyhow::{bail, error_message};
 use syn::{
     parse_quote, Expr, ExprTuple, Generics, ItemEnum, ItemImpl, Type, TypeParamBound, Variant,
 };
@@ -98,7 +98,7 @@ fn parse_query(v: Variant) -> syn::Result<(String, Expr)> {
         .attrs
         .iter()
         .find(|a| a.path().is_ident("returns"))
-        .ok_or_else(|| error_message!(v, "missing return type for query"))?
+        .ok_or_else(|| error_message!(&v, "missing return type for query"))?
         .parse_args()
         .map_err(|e| error_message!(e.span(), "return must be a type"))?;
 

--- a/packages/schema-derive/src/query_responses.rs
+++ b/packages/schema-derive/src/query_responses.rs
@@ -348,6 +348,12 @@ mod tests {
     }
 
     #[test]
+    fn to_snake_case_works() {
+        assert_eq!(to_snake_case("SnakeCase"), "snake_case");
+        assert_eq!(to_snake_case("Wasm123AndCo"), "wasm123_and_co");
+    }
+
+    #[test]
     fn nested_works() {
         let input: ItemEnum = parse_quote! {
             #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema, QueryResponses)]

--- a/packages/schema-derive/src/query_responses.rs
+++ b/packages/schema-derive/src/query_responses.rs
@@ -279,9 +279,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(
-        expected = "missing return type for query"
-    )]
+    #[should_panic(expected = "missing return type for query")]
     fn missing_return() {
         let input: ItemEnum = parse_quote! {
             #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema, QueryResponses)]

--- a/packages/schema-derive/src/query_responses/context.rs
+++ b/packages/schema-derive/src/query_responses/context.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use manyhow::bail;
+use crate::error::bail;
 use syn::{Ident, ItemEnum};
 
 const ATTR_PATH: &str = "query_responses";

--- a/packages/schema-derive/src/query_responses/context.rs
+++ b/packages/schema-derive/src/query_responses/context.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 
-use syn::{Ident, ItemEnum, Meta, NestedMeta};
+use manyhow::bail;
+use syn::{Ident, ItemEnum};
 
 const ATTR_PATH: &str = "query_responses";
 
@@ -13,51 +14,42 @@ pub struct Context {
     pub no_bounds_for: HashSet<Ident>,
 }
 
-pub fn get_context(input: &ItemEnum) -> Context {
-    let params = input
-        .attrs
-        .iter()
-        .filter(|attr| matches!(attr.path.get_ident(), Some(id) if *id == ATTR_PATH))
-        .flat_map(|attr| {
-            if let Meta::List(l) = attr.parse_meta().unwrap() {
-                l.nested
-            } else {
-                panic!("{ATTR_PATH} attribute must contain a meta list");
-            }
-        })
-        .map(|nested_meta| {
-            if let NestedMeta::Meta(m) = nested_meta {
-                m
-            } else {
-                panic!("no literals allowed in QueryResponses params")
-            }
-        });
-
+pub fn get_context(input: &ItemEnum) -> syn::Result<Context> {
     let mut ctx = Context {
         is_nested: false,
         no_bounds_for: HashSet::new(),
     };
 
-    for param in params {
-        match param.path().get_ident().unwrap().to_string().as_str() {
-            "no_bounds_for" => {
-                if let Meta::List(l) = param {
-                    for item in l.nested {
-                        match item {
-                            NestedMeta::Meta(Meta::Path(p)) => {
-                                ctx.no_bounds_for.insert(p.get_ident().unwrap().clone());
-                            }
-                            _ => panic!("`no_bounds_for` only accepts a list of type params"),
-                        }
-                    }
-                } else {
-                    panic!("expected a list for `no_bounds_for`")
-                }
-            }
-            "nested" => ctx.is_nested = true,
-            path => panic!("unrecognized QueryResponses param: {path}"),
+    for attr in &input.attrs {
+        if !attr.path().is_ident(ATTR_PATH) {
+            continue;
         }
+
+        let meta_list = attr.meta.require_list()?;
+        meta_list.parse_nested_meta(|param| {
+            if param.path.is_ident("no_bounds_for") {
+                let meta_list: syn::MetaList = param.input.parse()?;
+                meta_list.parse_nested_meta(|item| {
+                    let syn::Meta::Path(p) = item.input.parse()? else {
+                        bail!(
+                            item.input.span(),
+                            "`no_bounds_for` only accepts a list of type params"
+                        );
+                    };
+
+                    ctx.no_bounds_for.insert(p.get_ident().unwrap().clone());
+
+                    Ok(())
+                })?;
+            } else if param.path.is_ident("nested") {
+                ctx.is_nested = true;
+            } else {
+                bail!(param.path, "unrecognized QueryResponses param");
+            }
+
+            Ok(())
+        })?;
     }
 
-    ctx
+    Ok(ctx)
 }


### PR DESCRIPTION
This PR updates all the proc-macro crates to syn v2 and improves the error messages while I was already at it!  
Previously error handling was handled with simple `panic!`s which makes for rather ugly error messages since they don't include spans.

This update uses the `manyhow` crate to bring `anyhow`-like error handling into the proc-macros and produce pretty error messages that point to the exact source of the issue.

Before:

![image](https://github.com/CosmWasm/cosmwasm/assets/50245791/9d833463-6082-4fdc-ba52-857dbc23f26a)

After:

![image](https://github.com/CosmWasm/cosmwasm/assets/50245791/21d0ed7d-0028-41dc-9b8d-c33635c6a19d)
