### PR TITLE
Bump clippy to 1.77.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ workflows:
           matrix:
             parameters:
               # Run with MSRV and some modern stable Rust
-              rust-version: ["1.73.0", "1.76.0"]
+              rust-version: ["1.73.0", "1.77.0"]
       - benchmarking:
           requires:
             - package_vm

--- a/packages/std/src/testing/assertions.rs
+++ b/packages/std/src/testing/assertions.rs
@@ -158,6 +158,7 @@ mod tests {
     )]
     fn assert_approx_with_custom_panic_msg() {
         let adjective = "extra";
+        #[allow(dead_code)]
         #[derive(Debug)]
         struct Foo(u32);
         assert_approx_eq!(

--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -522,6 +522,7 @@ fn save_wasm_to_disk(dir: impl Into<PathBuf>, wasm: &[u8]) -> VmResult<Checksum>
     let mut file = OpenOptions::new()
         .write(true)
         .create(true)
+        .truncate(true)
         .open(filepath)
         .map_err(|e| VmError::cache_err(format!("Error opening Wasm file for writing: {e}")))?;
     file.write_all(wasm)

--- a/packages/vm/src/conversion.rs
+++ b/packages/vm/src/conversion.rs
@@ -41,7 +41,8 @@ mod tests {
         assert_eq!(to_u32(2147483647usize).unwrap(), 2147483647);
         assert_eq!(to_u32(2147483648usize).unwrap(), 2147483648);
         assert_eq!(to_u32(4294967295usize).unwrap(), 4294967295);
-
+        // Gate required for Rust 1.77.0 in Linux, possibly a Rust/clippy regression bug
+        #[cfg(target_pointer_width = "64")]
         match to_u32(4294967296usize) {
             Err(VmError::ConversionErr {
                 from_type,
@@ -130,6 +131,8 @@ mod tests {
         assert_eq!(ref_to_u32(&2147483647usize).unwrap(), 2147483647);
         assert_eq!(ref_to_u32(&2147483648usize).unwrap(), 2147483648);
         assert_eq!(ref_to_u32(&4294967295usize).unwrap(), 4294967295);
+        // Gate required for Rust 1.77.0 in Linux, possibly a Rust/clippy regression bug
+        #[cfg(target_pointer_width = "64")]
         match ref_to_u32(&4294967296usize).unwrap_err() {
             VmError::ConversionErr {
                 from_type,


### PR DESCRIPTION
Here we have a few clippy changes required by latest stable. For those we can get CI testing right away.