### PR TITLE
Make crate used in `entry_point` configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,12 @@ and this project adheres to
 - cosmwasm-vm: Add `secp256r1_verify` and `secp256r1_recover_pubkey` imports for
   ECDSA signature verification over secp256r1. ([#1983], [#2057], [#2058])
 - cosmwasm-vm: Add metrics for the pinned memory cache ([#2059])
+- cosmwasm-derive: The crate used in the expansion can now be renamed ([#2068])
 
 [#1983]: https://github.com/CosmWasm/cosmwasm/pull/1983
 [#2057]: https://github.com/CosmWasm/cosmwasm/pull/2057
 [#2058]: https://github.com/CosmWasm/cosmwasm/pull/2058
+[#2068]: https://github.com/CosmWasm/cosmwasm/pull/2068
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,6 +441,7 @@ name = "cosmwasm-derive"
 version = "2.0.0"
 dependencies = [
  "cosmwasm-std",
+ "proc-macro2",
  "quote",
  "syn 2.0.28",
 ]

--- a/contracts/burner/Cargo.lock
+++ b/contracts/burner/Cargo.lock
@@ -220,6 +220,7 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "2.0.0"
 dependencies = [
+ "proc-macro2",
  "quote",
  "syn 2.0.37",
 ]

--- a/contracts/crypto-verify/Cargo.lock
+++ b/contracts/crypto-verify/Cargo.lock
@@ -209,6 +209,7 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "2.0.0"
 dependencies = [
+ "proc-macro2",
  "quote",
  "syn 2.0.37",
 ]

--- a/contracts/cyberpunk/Cargo.lock
+++ b/contracts/cyberpunk/Cargo.lock
@@ -244,6 +244,7 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "2.0.0"
 dependencies = [
+ "proc-macro2",
  "quote",
  "syn 2.0.37",
 ]

--- a/contracts/empty/Cargo.lock
+++ b/contracts/empty/Cargo.lock
@@ -209,6 +209,7 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "2.0.0"
 dependencies = [
+ "proc-macro2",
  "quote",
  "syn 2.0.37",
 ]

--- a/contracts/floaty/Cargo.lock
+++ b/contracts/floaty/Cargo.lock
@@ -209,6 +209,7 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "2.0.0"
 dependencies = [
+ "proc-macro2",
  "quote",
  "syn 2.0.32",
 ]

--- a/contracts/hackatom/Cargo.lock
+++ b/contracts/hackatom/Cargo.lock
@@ -209,6 +209,7 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "2.0.0"
 dependencies = [
+ "proc-macro2",
  "quote",
  "syn 2.0.37",
 ]

--- a/contracts/ibc-reflect-send/Cargo.lock
+++ b/contracts/ibc-reflect-send/Cargo.lock
@@ -209,6 +209,7 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "2.0.0"
 dependencies = [
+ "proc-macro2",
  "quote",
  "syn 2.0.37",
 ]

--- a/contracts/ibc-reflect/Cargo.lock
+++ b/contracts/ibc-reflect/Cargo.lock
@@ -209,6 +209,7 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "2.0.0"
 dependencies = [
+ "proc-macro2",
  "quote",
  "syn 2.0.37",
 ]

--- a/contracts/queue/Cargo.lock
+++ b/contracts/queue/Cargo.lock
@@ -209,6 +209,7 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "2.0.0"
 dependencies = [
+ "proc-macro2",
  "quote",
  "syn 2.0.37",
 ]

--- a/contracts/reflect/Cargo.lock
+++ b/contracts/reflect/Cargo.lock
@@ -209,6 +209,7 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "2.0.0"
 dependencies = [
+ "proc-macro2",
  "quote",
  "syn 2.0.37",
 ]

--- a/contracts/staking/Cargo.lock
+++ b/contracts/staking/Cargo.lock
@@ -209,6 +209,7 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "2.0.0"
 dependencies = [
+ "proc-macro2",
  "quote",
  "syn 2.0.37",
 ]

--- a/contracts/virus/Cargo.lock
+++ b/contracts/virus/Cargo.lock
@@ -209,6 +209,7 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "2.0.0"
 dependencies = [
+ "proc-macro2",
  "quote",
  "syn 2.0.37",
 ]

--- a/packages/derive/Cargo.toml
+++ b/packages/derive/Cargo.toml
@@ -15,6 +15,7 @@ proc-macro = true
 default = []
 
 [dependencies]
+proc-macro2 = "1.0.79"
 quote = "1.0.35"
 syn = { version = "2", features = ["full"] }
 

--- a/packages/derive/src/lib.rs
+++ b/packages/derive/src/lib.rs
@@ -22,10 +22,6 @@ impl Default for Options {
 impl Parse for Options {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let mut ret = Self::default();
-        if input.is_empty() {
-            return Ok(ret);
-        }
-
         let attrs = Punctuated::<syn::MetaNameValue, Token![,]>::parse_terminated(input)?;
 
         for kv in attrs {

--- a/packages/derive/src/lib.rs
+++ b/packages/derive/src/lib.rs
@@ -1,6 +1,45 @@
 use proc_macro::TokenStream;
-use quote::{format_ident, quote};
-use syn::parse_macro_input;
+use quote::{format_ident, quote, ToTokens};
+use syn::{
+    parse::{Parse, ParseStream},
+    parse_macro_input, parse_quote,
+    punctuated::Punctuated,
+    Token,
+};
+
+struct Options {
+    crate_path: syn::Path,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            crate_path: parse_quote!(::cosmwasm_std),
+        }
+    }
+}
+
+impl Parse for Options {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let mut ret = Self::default();
+        if input.is_empty() {
+            return Ok(ret);
+        }
+
+        let attrs = Punctuated::<syn::MetaNameValue, Token![,]>::parse_terminated(input)?;
+
+        for kv in attrs {
+            if kv.path.is_ident("crate") {
+                let path_as_string: syn::LitStr = syn::parse2(kv.value.to_token_stream())?;
+                ret.crate_path = path_as_string.parse()?
+            } else {
+                return Err(syn::Error::new_spanned(kv, "Unknown attribute"));
+            }
+        }
+
+        Ok(ret)
+    }
+}
 
 /// This attribute macro generates the boilerplate required to call into the
 /// contract-specific logic from the entry-points to the Wasm module.
@@ -50,9 +89,10 @@ use syn::parse_macro_input;
 /// where `InstantiateMsg`, `ExecuteMsg`, and `QueryMsg` are contract defined
 /// types that implement `DeserializeOwned + JsonSchema`.
 #[proc_macro_attribute]
-pub fn entry_point(_attr: TokenStream, mut item: TokenStream) -> TokenStream {
+pub fn entry_point(attr: TokenStream, mut item: TokenStream) -> TokenStream {
     let cloned = item.clone();
     let function = parse_macro_input!(cloned as syn::ItemFn);
+    let Options { crate_path } = parse_macro_input!(attr as Options);
 
     // The first argument is `deps`, the rest is region pointers
     let args = function.sig.inputs.len() - 1;
@@ -68,7 +108,7 @@ pub fn entry_point(_attr: TokenStream, mut item: TokenStream) -> TokenStream {
         mod #wasm_export { // new module to avoid conflict of function name
             #[no_mangle]
             extern "C" fn #fn_name(#( #decl_args : u32 ),*) -> u32 {
-                cosmwasm_std::#do_call(&super::#fn_name, #( #call_args ),*)
+                #crate_path::#do_call(&super::#fn_name, #( #call_args ),*)
             }
         }
     };


### PR DESCRIPTION
Replaces #1539

This PR makes the crate used in the expansion of the `entry_point` macro configurable.  
But with actual error handling and a nice syntax.

Rename example:

```rust
#[entry_point(crate = "::my_crate::cw_std_reexport")]
```

It also rejects other attributes and syntaxes:

```rust
#[entry_point(other = "attribute")] // This is rejected
#[entry_point(::my_crate::cw_std_reexport)] // This is also rejected
```

TODO:

- [x] Tests