### PR TITLE
Add Webauthn example using the secp256r1 API

### DIFF
--- a/contracts/crypto-verify/Cargo.lock
+++ b/contracts/crypto-verify/Cargo.lock
@@ -68,6 +68,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
+name = "base64"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+
+[[package]]
 name = "base64ct"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,7 +244,7 @@ dependencies = [
 name = "cosmwasm-std"
 version = "2.0.0"
 dependencies = [
- "base64",
+ "base64 0.21.2",
  "bech32",
  "bnum",
  "cosmwasm-crypto",
@@ -457,11 +463,13 @@ dependencies = [
 name = "crypto-verify"
 version = "0.0.0"
 dependencies = [
+ "base64 0.22.0",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-vm",
  "hex",
  "hex-literal",
+ "p256",
  "rlp",
  "schemars",
  "serde",

--- a/contracts/crypto-verify/Cargo.toml
+++ b/contracts/crypto-verify/Cargo.toml
@@ -29,9 +29,11 @@ default = []
 cranelift = ["cosmwasm-vm/cranelift"]
 
 [dependencies]
+base64 = "0.22.0"
 cosmwasm-schema = { path = "../../packages/schema" }
 cosmwasm-std = { path = "../../packages/std", features = ["cosmwasm_2_1", "iterator"] }
 hex = "0.4"
+p256 = { version = "0.13.2", default-features = false, features = ["alloc", "ecdsa"] }
 rlp = "0.5"
 schemars = "0.8.12"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/crypto-verify/schema/crypto-verify.json
+++ b/contracts/crypto-verify/schema/crypto-verify.json
@@ -350,7 +350,7 @@
                 "type": "string"
               },
               "r": {
-                "description": "r component of signature",
+                "description": "r component of signature\n\nThe representation of this component is a big-endian encoded 256bit integer",
                 "allOf": [
                   {
                     "$ref": "#/definitions/Binary"
@@ -358,7 +358,7 @@
                 ]
               },
               "s": {
-                "description": "s component of signature",
+                "description": "s component of signature\n\nThe representation of this component is a big-endian encoded 256bit integer",
                 "allOf": [
                   {
                     "$ref": "#/definitions/Binary"
@@ -366,7 +366,7 @@
                 ]
               },
               "x": {
-                "description": "X coordinate of public key point",
+                "description": "X coordinate of public key point\n\nUntagged big-endian serialized byte sequence representing the X coordinate on the secp256r1 elliptic curve",
                 "allOf": [
                   {
                     "$ref": "#/definitions/Binary"
@@ -374,7 +374,7 @@
                 ]
               },
               "y": {
-                "description": "Y coordinate of public key point",
+                "description": "Y coordinate of public key point\n\nUntagged big-endian serialized byte sequence representing the Y coordinate on the secp256r1 elliptic curve",
                 "allOf": [
                   {
                     "$ref": "#/definitions/Binary"

--- a/contracts/crypto-verify/schema/crypto-verify.json
+++ b/contracts/crypto-verify/schema/crypto-verify.json
@@ -309,6 +309,83 @@
           }
         },
         "additionalProperties": false
+      },
+      {
+        "description": "Webauthn component verification",
+        "type": "object",
+        "required": [
+          "verify_webauthn"
+        ],
+        "properties": {
+          "verify_webauthn": {
+            "type": "object",
+            "required": [
+              "authenticator_data",
+              "challenge",
+              "client_data_json",
+              "r",
+              "s",
+              "x",
+              "y"
+            ],
+            "properties": {
+              "authenticator_data": {
+                "description": "Authenticator data",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Binary"
+                  }
+                ]
+              },
+              "challenge": {
+                "description": "Challenge value",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Binary"
+                  }
+                ]
+              },
+              "client_data_json": {
+                "description": "Client data (JSON encoded)",
+                "type": "string"
+              },
+              "r": {
+                "description": "r component of signature",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Binary"
+                  }
+                ]
+              },
+              "s": {
+                "description": "s component of signature",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Binary"
+                  }
+                ]
+              },
+              "x": {
+                "description": "X coordinate of public key point",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Binary"
+                  }
+                ]
+              },
+              "y": {
+                "description": "Y coordinate of public key point",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Binary"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
       }
     ],
     "definitions": {
@@ -413,6 +490,20 @@
       "additionalProperties": false
     },
     "verify_tendermint_signature": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "VerifyResponse",
+      "type": "object",
+      "required": [
+        "verifies"
+      ],
+      "properties": {
+        "verifies": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "verify_webauthn": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "VerifyResponse",
       "type": "object",

--- a/contracts/crypto-verify/schema/raw/query.json
+++ b/contracts/crypto-verify/schema/raw/query.json
@@ -298,6 +298,83 @@
         }
       },
       "additionalProperties": false
+    },
+    {
+      "description": "Webauthn component verification",
+      "type": "object",
+      "required": [
+        "verify_webauthn"
+      ],
+      "properties": {
+        "verify_webauthn": {
+          "type": "object",
+          "required": [
+            "authenticator_data",
+            "challenge",
+            "client_data_json",
+            "r",
+            "s",
+            "x",
+            "y"
+          ],
+          "properties": {
+            "authenticator_data": {
+              "description": "Authenticator data",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Binary"
+                }
+              ]
+            },
+            "challenge": {
+              "description": "Challenge value",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Binary"
+                }
+              ]
+            },
+            "client_data_json": {
+              "description": "Client data (JSON encoded)",
+              "type": "string"
+            },
+            "r": {
+              "description": "r component of signature",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Binary"
+                }
+              ]
+            },
+            "s": {
+              "description": "s component of signature",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Binary"
+                }
+              ]
+            },
+            "x": {
+              "description": "X coordinate of public key point",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Binary"
+                }
+              ]
+            },
+            "y": {
+              "description": "Y coordinate of public key point",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Binary"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
     }
   ],
   "definitions": {

--- a/contracts/crypto-verify/schema/raw/query.json
+++ b/contracts/crypto-verify/schema/raw/query.json
@@ -339,7 +339,7 @@
               "type": "string"
             },
             "r": {
-              "description": "r component of signature",
+              "description": "r component of signature\n\nThe representation of this component is a big-endian encoded 256bit integer",
               "allOf": [
                 {
                   "$ref": "#/definitions/Binary"
@@ -347,7 +347,7 @@
               ]
             },
             "s": {
-              "description": "s component of signature",
+              "description": "s component of signature\n\nThe representation of this component is a big-endian encoded 256bit integer",
               "allOf": [
                 {
                   "$ref": "#/definitions/Binary"
@@ -355,7 +355,7 @@
               ]
             },
             "x": {
-              "description": "X coordinate of public key point",
+              "description": "X coordinate of public key point\n\nUntagged big-endian serialized byte sequence representing the X coordinate on the secp256r1 elliptic curve",
               "allOf": [
                 {
                   "$ref": "#/definitions/Binary"
@@ -363,7 +363,7 @@
               ]
             },
             "y": {
-              "description": "Y coordinate of public key point",
+              "description": "Y coordinate of public key point\n\nUntagged big-endian serialized byte sequence representing the Y coordinate on the secp256r1 elliptic curve",
               "allOf": [
                 {
                   "$ref": "#/definitions/Binary"

--- a/contracts/crypto-verify/schema/raw/response_to_verify_webauthn.json
+++ b/contracts/crypto-verify/schema/raw/response_to_verify_webauthn.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "VerifyResponse",
+  "type": "object",
+  "required": [
+    "verifies"
+  ],
+  "properties": {
+    "verifies": {
+      "type": "boolean"
+    }
+  },
+  "additionalProperties": false
+}

--- a/contracts/crypto-verify/src/lib.rs
+++ b/contracts/crypto-verify/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod contract;
 mod ethereum;
 pub mod msg;
+mod webauthn;

--- a/contracts/crypto-verify/src/msg.rs
+++ b/contracts/crypto-verify/src/msg.rs
@@ -92,12 +92,20 @@ pub enum QueryMsg {
         /// Challenge value
         challenge: Binary,
         /// X coordinate of public key point
+        ///
+        /// Untagged big-endian serialized byte sequence representing the X coordinate on the secp256r1 elliptic curve
         x: Binary,
         /// Y coordinate of public key point
+        ///
+        /// Untagged big-endian serialized byte sequence representing the Y coordinate on the secp256r1 elliptic curve
         y: Binary,
         /// r component of signature
+        ///
+        /// The representation of this component is a big-endian encoded 256bit integer
         r: Binary,
         /// s component of signature
+        ///
+        /// The representation of this component is a big-endian encoded 256bit integer
         s: Binary,
     },
 }

--- a/contracts/crypto-verify/src/msg.rs
+++ b/contracts/crypto-verify/src/msg.rs
@@ -82,6 +82,24 @@ pub enum QueryMsg {
     /// No pagination - this is a short list.
     #[returns(ListVerificationsResponse)]
     ListVerificationSchemes {},
+    /// Webauthn component verification
+    #[returns(VerifyResponse)]
+    VerifyWebauthn {
+        /// Authenticator data
+        authenticator_data: Binary,
+        /// Client data (JSON encoded)
+        client_data_json: String,
+        /// Challenge value
+        challenge: Binary,
+        /// X coordinate of public key point
+        x: Binary,
+        /// Y coordinate of public key point
+        y: Binary,
+        /// r component of signature
+        r: Binary,
+        /// s component of signature
+        s: Binary,
+    },
 }
 
 #[cw_serde]

--- a/contracts/crypto-verify/src/webauthn.rs
+++ b/contracts/crypto-verify/src/webauthn.rs
@@ -2,7 +2,7 @@
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use cosmwasm_std::{Api, StdResult};
-use p256::{ecdsa::Signature, AffinePoint, EncodedPoint, PublicKey};
+use p256::{ecdsa::Signature, elliptic_curve::sec1::FromEncodedPoint, EncodedPoint, PublicKey};
 use sha2::{digest::generic_array::GenericArray, Digest, Sha256};
 
 #[allow(clippy::too_many_arguments)]
@@ -26,8 +26,7 @@ pub fn verify(
     //
     // In production this should have proper error handling
     let point = EncodedPoint::from_affine_coordinates(x.into(), y.into(), false);
-    let affine = AffinePoint::try_from(point).unwrap();
-    let public_key = PublicKey::from_affine(affine).unwrap();
+    let public_key = PublicKey::from_encoded_point(&point).unwrap();
     let signature = Signature::from_scalars(
         GenericArray::clone_from_slice(r),
         GenericArray::clone_from_slice(s),

--- a/contracts/crypto-verify/src/webauthn.rs
+++ b/contracts/crypto-verify/src/webauthn.rs
@@ -25,7 +25,7 @@ pub fn verify(
     // - the signature could actually exist like this for a secp256r1 ECDSA key
     //
     // In production this should have proper error handling
-    let point = EncodedPoint::from_affine_coordinates(x.into(), y.into(), true);
+    let point = EncodedPoint::from_affine_coordinates(x.into(), y.into(), false);
     let affine = AffinePoint::try_from(point).unwrap();
     let public_key = PublicKey::from_affine(affine).unwrap();
     let signature = Signature::from_scalars(

--- a/contracts/crypto-verify/src/webauthn.rs
+++ b/contracts/crypto-verify/src/webauthn.rs
@@ -1,0 +1,61 @@
+//! Adapted from <https://github.com/daimo-eth/p256-verifier/blob/master/test/WebAuthn.t.sol>
+
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use cosmwasm_std::{Api, StdResult};
+use p256::{ecdsa::Signature, AffinePoint, EncodedPoint, PublicKey};
+use sha2::{digest::generic_array::GenericArray, Digest, Sha256};
+
+#[allow(clippy::too_many_arguments)]
+pub fn verify(
+    api: &dyn Api,
+    authenticator_data: &[u8],
+    client_data_json: &str,
+    challenge: &[u8],
+    x: &[u8],
+    y: &[u8],
+    r: &[u8],
+    s: &[u8],
+) -> StdResult<bool> {
+    // We are making a lot of assumptions here about the coordinates, such as:
+    //
+    // - the length of the encoded bytes being correct
+    // - the point being an element of the curve
+    // - the conversion from the encoded coorinate to an affine point succeeding
+    // - the affine point actually being a valid public key
+    // - the signature could actually exist like this for a secp256r1 ECDSA key
+    //
+    // In production this should have proper error handling
+    let point = EncodedPoint::from_affine_coordinates(x.into(), y.into(), true);
+    let affine = AffinePoint::try_from(point).unwrap();
+    let public_key = PublicKey::from_affine(affine).unwrap();
+    let signature = Signature::from_scalars(
+        GenericArray::clone_from_slice(r),
+        GenericArray::clone_from_slice(s),
+    )
+    .unwrap();
+
+    // This is missing some checks of some bit flags
+    if authenticator_data.len() < 37 {
+        return Ok(false);
+    }
+
+    // Is this an assertion?
+    if !client_data_json.contains("webauthn.get") {
+        return Ok(false);
+    }
+
+    // Does the challenge belong to the client data?
+    let b64_challenge = URL_SAFE_NO_PAD.encode(challenge);
+    if !client_data_json.contains(b64_challenge.as_str()) {
+        return Ok(false);
+    }
+
+    // Verify :D
+    let mut hasher = Sha256::new();
+    hasher.update(authenticator_data);
+    hasher.update(Sha256::digest(client_data_json));
+    let hash = hasher.finalize();
+
+    api.secp256r1_verify(&hash, &signature.to_bytes(), &public_key.to_sec1_bytes())
+        .map_err(Into::into)
+}

--- a/packages/vm/src/testing/instance.rs
+++ b/packages/vm/src/testing/instance.rs
@@ -17,7 +17,7 @@ use super::storage::MockStorage;
 /// This gas limit is used in integration tests and should be high enough to allow a reasonable
 /// number of contract executions and queries on one instance. For this reason it is significatly
 /// higher than the limit for a single execution that we have in the production setup.
-const DEFAULT_GAS_LIMIT: u64 = 500_000_000; // ~0.5ms
+const DEFAULT_GAS_LIMIT: u64 = 700_000_000; // ~0.7ms
 const DEFAULT_MEMORY_LIMIT: Option<Size> = Some(Size::mebi(16));
 
 pub fn mock_instance(

--- a/packages/vm/src/testing/instance.rs
+++ b/packages/vm/src/testing/instance.rs
@@ -17,7 +17,7 @@ use super::storage::MockStorage;
 /// This gas limit is used in integration tests and should be high enough to allow a reasonable
 /// number of contract executions and queries on one instance. For this reason it is significatly
 /// higher than the limit for a single execution that we have in the production setup.
-const DEFAULT_GAS_LIMIT: u64 = 700_000_000; // ~0.7ms
+const DEFAULT_GAS_LIMIT: u64 = 500_000_000; // ~0.5ms
 const DEFAULT_MEMORY_LIMIT: Option<Size> = Some(Size::mebi(16));
 
 pub fn mock_instance(


### PR DESCRIPTION
Note: I haven't really found any good official test vectors when searching for them. So I checked other implementations verifying Webauthn attestations on chain, and I found [this Solidity contract](https://github.com/daimo-eth/p256-verifier) and used its test vectors.

They seem to check out, I guess.