### PR TITLE
fix: avoid div with zero in assert_approx_eq

### DIFF
--- a/packages/core/src/testing/assertions.rs
+++ b/packages/core/src/testing/assertions.rs
@@ -56,12 +56,16 @@ pub fn assert_approx_eq_impl<U: Into<Uint128>>(
 ) {
     let left = left.into();
     let right = right.into();
+
+    if left == right {
+        // If both values are equal, we don't need to check the relative difference.
+        // We check this first to avoid division by zero below.
+        return;
+    }
+
     let max_rel_diff = Decimal::from_str(max_rel_diff).unwrap();
 
     let largest = core::cmp::max(left, right);
-    if largest.is_zero() {
-        return;
-    }
     let rel_diff = Decimal::from_ratio(left.abs_diff(right), largest);
 
     if rel_diff > max_rel_diff {

--- a/packages/core/src/testing/assertions.rs
+++ b/packages/core/src/testing/assertions.rs
@@ -131,6 +131,11 @@ mod tests {
             10_000_000_000_000_000_000_000_000_000_000_000_000_u128,
             "0.10"
         );
+        assert_approx_eq!(0_u32, 0_u32, "0.12");
+        assert_approx_eq!(1_u64, 0_u64, "1");
+        assert_approx_eq!(0_u64, 1_u64, "1");
+        assert_approx_eq!(5_u64, 0_u64, "1");
+        assert_approx_eq!(0_u64, 5_u64, "1");
     }
 
     #[test]

--- a/packages/core/src/testing/assertions.rs
+++ b/packages/core/src/testing/assertions.rs
@@ -59,6 +59,9 @@ pub fn assert_approx_eq_impl<U: Into<Uint128>>(
     let max_rel_diff = Decimal::from_str(max_rel_diff).unwrap();
 
     let largest = core::cmp::max(left, right);
+    if largest.is_zero() {
+        return;
+    }
     let rel_diff = Decimal::from_ratio(left.abs_diff(right), largest);
 
     if rel_diff > max_rel_diff {


### PR DESCRIPTION
Currently, when both values are zero `assert_approx_eq` fails due to division by zero rather than succeeding because the values are the same. This fixes that.