### PR TITLE
Rename math functions to strict_add/strict_sub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,10 @@ and this project adheres to
   `Uint512::add` ([#2092])
 - cosmwasm-std: Add `{CosmosMsg,SubMsg,Response}::change_custom` to change the
   custom message type ([#2099])
-- cosmwasm-std: Add `Uint{64,128,256,512}::panicking_add` and `::panicking_sub`
-  which are like the `Add`/`Sub` implementations but `const`. ([#2098])
+- cosmwasm-std: Add `Uint{64,128,256,512}::strict_add` and `::strict_sub` which
+  are like the `Add`/`Sub` implementations but `const`. ([#2098], [#2107])
 - cosmwasm-std: Let `Timestamp::plus_nanos`/`::minus_nanos` use
-  `Uint64::panicking_add`/`::panicking_sub` and document overflows. ([#2098])
+  `Uint64::strict_add`/`::strict_sub` and document overflows. ([#2098], [#2107])
 
 [#1983]: https://github.com/CosmWasm/cosmwasm/pull/1983
 [#2057]: https://github.com/CosmWasm/cosmwasm/pull/2057
@@ -36,6 +36,7 @@ and this project adheres to
 [#2092]: https://github.com/CosmWasm/cosmwasm/pull/2092
 [#2098]: https://github.com/CosmWasm/cosmwasm/pull/2098
 [#2099]: https://github.com/CosmWasm/cosmwasm/pull/2099
+[#2107]: https://github.com/CosmWasm/cosmwasm/pull/2107
 
 ### Changed
 

--- a/packages/core/src/math/uint128.rs
+++ b/packages/core/src/math/uint128.rs
@@ -263,22 +263,22 @@ impl Uint128 {
         Self(self.0.saturating_pow(exp))
     }
 
-    /// This is the same as [`Uint128::add`] but const.
+    /// Strict integer addition. Computes `self + rhs`, panicking if overflow occurred.
     ///
-    /// Panics on overflow.
+    /// This is the same as [`Uint128::add`] but const.
     #[must_use = "this returns the result of the operation, without modifying the original"]
-    pub const fn panicking_add(self, other: Self) -> Self {
-        match self.0.checked_add(other.u128()) {
+    pub const fn strict_add(self, rhs: Self) -> Self {
+        match self.0.checked_add(rhs.u128()) {
             None => panic!("attempt to add with overflow"),
             Some(sum) => Self(sum),
         }
     }
 
-    /// This is the same as [`Uint128::sub`] but const.
+    /// Strict integer subtraction. Computes `self - rhs`, panicking if overflow occurred.
     ///
-    /// Panics on overflow.
+    /// This is the same as [`Uint128::sub`] but const.
     #[must_use = "this returns the result of the operation, without modifying the original"]
-    pub const fn panicking_sub(self, other: Self) -> Self {
+    pub const fn strict_sub(self, other: Self) -> Self {
         match self.0.checked_sub(other.u128()) {
             None => panic!("attempt to subtract with overflow"),
             Some(diff) => Self(diff),
@@ -394,7 +394,7 @@ impl Add<Uint128> for Uint128 {
     type Output = Self;
 
     fn add(self, rhs: Self) -> Self {
-        self.panicking_add(rhs)
+        self.strict_add(rhs)
     }
 }
 forward_ref_binop!(impl Add, add for Uint128, Uint128);
@@ -403,7 +403,7 @@ impl Sub<Uint128> for Uint128 {
     type Output = Self;
 
     fn sub(self, rhs: Self) -> Self {
-        self.panicking_sub(rhs)
+        self.strict_sub(rhs)
     }
 }
 forward_ref_binop!(impl Sub, sub for Uint128, Uint128);
@@ -1191,18 +1191,34 @@ mod tests {
     }
 
     #[test]
-    fn uint128_panicking_sub_works() {
+    fn uint128_strict_add_works() {
         let a = Uint128::new(5);
         let b = Uint128::new(3);
-        assert_eq!(a.panicking_sub(b), Uint128::new(2));
+        assert_eq!(a.strict_add(b), Uint128::new(8));
+        assert_eq!(b.strict_add(a), Uint128::new(8));
+    }
+
+    #[test]
+    #[should_panic(expected = "attempt to add with overflow")]
+    fn uint128_strict_add_panics_on_overflow() {
+        let a = Uint128::MAX;
+        let b = Uint128::ONE;
+        let _ = a.strict_add(b);
+    }
+
+    #[test]
+    fn uint128_strict_sub_works() {
+        let a = Uint128::new(5);
+        let b = Uint128::new(3);
+        assert_eq!(a.strict_sub(b), Uint128::new(2));
     }
 
     #[test]
     #[should_panic(expected = "attempt to subtract with overflow")]
-    fn uint128_panicking_sub_panics_on_overflow() {
+    fn uint128_strict_sub_panics_on_overflow() {
         let a = Uint128::ZERO;
         let b = Uint128::ONE;
-        let _diff = a.panicking_sub(b);
+        let _ = a.strict_sub(b);
     }
 
     #[test]

--- a/packages/core/src/math/uint256.rs
+++ b/packages/core/src/math/uint256.rs
@@ -335,22 +335,22 @@ impl Uint256 {
         Self(self.0.saturating_pow(exp))
     }
 
-    /// This is the same as [`Uint256::add`] but const.
+    /// Strict integer addition. Computes `self + rhs`, panicking if overflow occurred.
     ///
-    /// Panics on overflow.
+    /// This is the same as [`Uint256::add`] but const.
     #[must_use = "this returns the result of the operation, without modifying the original"]
-    pub const fn panicking_add(self, other: Self) -> Self {
-        match self.0.checked_add(other.0) {
+    pub const fn strict_add(self, rhs: Self) -> Self {
+        match self.0.checked_add(rhs.0) {
             None => panic!("attempt to add with overflow"),
             Some(sum) => Self(sum),
         }
     }
 
-    /// This is the same as [`Uint256::sub`] but const.
+    /// Strict integer subtraction. Computes `self - rhs`, panicking if overflow occurred.
     ///
-    /// Panics on overflow.
+    /// This is the same as [`Uint256::sub`] but const.
     #[must_use = "this returns the result of the operation, without modifying the original"]
-    pub const fn panicking_sub(self, other: Self) -> Self {
+    pub const fn strict_sub(self, other: Self) -> Self {
         match self.0.checked_sub(other.0) {
             None => panic!("attempt to subtract with overflow"),
             Some(diff) => Self(diff),
@@ -464,7 +464,7 @@ impl Add<Uint256> for Uint256 {
     type Output = Self;
 
     fn add(self, rhs: Self) -> Self {
-        self.panicking_add(rhs)
+        self.strict_add(rhs)
     }
 }
 forward_ref_binop!(impl Add, add for Uint256, Uint256);
@@ -473,7 +473,7 @@ impl Sub<Uint256> for Uint256 {
     type Output = Self;
 
     fn sub(self, rhs: Self) -> Self {
-        self.panicking_sub(rhs)
+        self.strict_sub(rhs)
     }
 }
 forward_ref_binop!(impl Sub, sub for Uint256, Uint256);
@@ -1740,18 +1740,34 @@ mod tests {
     }
 
     #[test]
-    fn uint256_panicking_sub_works() {
+    fn uint256_strict_add_works() {
         let a = Uint256::from(5u32);
         let b = Uint256::from(3u32);
-        assert_eq!(a.panicking_sub(b), Uint256::from(2u32));
+        assert_eq!(a.strict_add(b), Uint256::from(8u32));
+        assert_eq!(b.strict_add(a), Uint256::from(8u32));
+    }
+
+    #[test]
+    #[should_panic(expected = "attempt to add with overflow")]
+    fn uint256_strict_add_panics_on_overflow() {
+        let a = Uint256::MAX;
+        let b = Uint256::ONE;
+        let _ = a.strict_add(b);
+    }
+
+    #[test]
+    fn uint256_strict_sub_works() {
+        let a = Uint256::from(5u32);
+        let b = Uint256::from(3u32);
+        assert_eq!(a.strict_sub(b), Uint256::from(2u32));
     }
 
     #[test]
     #[should_panic(expected = "attempt to subtract with overflow")]
-    fn uint256_panicking_sub_panics_on_overflow() {
+    fn uint256_strict_sub_panics_on_overflow() {
         let a = Uint256::ZERO;
         let b = Uint256::ONE;
-        let _diff = a.panicking_sub(b);
+        let _ = a.strict_sub(b);
     }
 
     #[test]

--- a/packages/core/src/math/uint512.rs
+++ b/packages/core/src/math/uint512.rs
@@ -298,22 +298,22 @@ impl Uint512 {
         Self(self.0.saturating_pow(exp))
     }
 
-    /// This is the same as [`Uint512::add`] but const.
+    /// Strict integer addition. Computes `self + rhs`, panicking if overflow occurred.
     ///
-    /// Panics on overflow.
+    /// This is the same as [`Uint512::add`] but const.
     #[must_use = "this returns the result of the operation, without modifying the original"]
-    pub const fn panicking_add(self, other: Self) -> Self {
-        match self.0.checked_add(other.0) {
+    pub const fn strict_add(self, rhs: Self) -> Self {
+        match self.0.checked_add(rhs.0) {
             None => panic!("attempt to add with overflow"),
             Some(sum) => Self(sum),
         }
     }
 
-    /// This is the same as [`Uint512::sub`] but const.
+    /// Strict integer subtraction. Computes `self - rhs`, panicking if overflow occurred.
     ///
-    /// Panics on overflow.
+    /// This is the same as [`Uint512::sub`] but const.
     #[must_use = "this returns the result of the operation, without modifying the original"]
-    pub const fn panicking_sub(self, other: Self) -> Self {
+    pub const fn strict_sub(self, other: Self) -> Self {
         match self.0.checked_sub(other.0) {
             None => panic!("attempt to subtract with overflow"),
             Some(diff) => Self(diff),
@@ -443,7 +443,7 @@ impl Add<Uint512> for Uint512 {
     type Output = Self;
 
     fn add(self, rhs: Self) -> Self {
-        self.panicking_add(rhs)
+        self.strict_add(rhs)
     }
 }
 forward_ref_binop!(impl Add, add for Uint512, Uint512);
@@ -452,7 +452,7 @@ impl Sub<Uint512> for Uint512 {
     type Output = Self;
 
     fn sub(self, rhs: Self) -> Self {
-        self.panicking_sub(rhs)
+        self.strict_sub(rhs)
     }
 }
 forward_ref_binop!(impl Sub, sub for Uint512, Uint512);
@@ -1389,18 +1389,34 @@ mod tests {
     }
 
     #[test]
-    fn uint512_panicking_sub_works() {
+    fn uint512_strict_add_works() {
         let a = Uint512::from(5u32);
         let b = Uint512::from(3u32);
-        assert_eq!(a.panicking_sub(b), Uint512::from(2u32));
+        assert_eq!(a.strict_add(b), Uint512::from(8u32));
+        assert_eq!(b.strict_add(a), Uint512::from(8u32));
+    }
+
+    #[test]
+    #[should_panic(expected = "attempt to add with overflow")]
+    fn uint512_strict_add_panics_on_overflow() {
+        let a = Uint512::MAX;
+        let b = Uint512::ONE;
+        let _ = a.strict_add(b);
+    }
+
+    #[test]
+    fn uint512_strict_sub_works() {
+        let a = Uint512::from(5u32);
+        let b = Uint512::from(3u32);
+        assert_eq!(a.strict_sub(b), Uint512::from(2u32));
     }
 
     #[test]
     #[should_panic(expected = "attempt to subtract with overflow")]
-    fn uint512_panicking_sub_panics_on_overflow() {
+    fn uint512_strict_sub_panics_on_overflow() {
         let a = Uint512::ZERO;
         let b = Uint512::ONE;
-        let _diff = a.panicking_sub(b);
+        let _ = a.strict_sub(b);
     }
 
     #[test]

--- a/packages/core/src/math/uint64.rs
+++ b/packages/core/src/math/uint64.rs
@@ -257,22 +257,22 @@ impl Uint64 {
         Self(self.0.saturating_pow(exp))
     }
 
-    /// This is the same as [`Uint64::add`] but const.
+    /// Strict integer addition. Computes `self + rhs`, panicking if overflow occurred.
     ///
-    /// Panics on overflow.
+    /// This is the same as [`Uint64::add`] but const.
     #[must_use = "this returns the result of the operation, without modifying the original"]
-    pub const fn panicking_add(self, other: Self) -> Self {
-        match self.0.checked_add(other.u64()) {
+    pub const fn strict_add(self, rhs: Self) -> Self {
+        match self.0.checked_add(rhs.u64()) {
             None => panic!("attempt to add with overflow"),
             Some(sum) => Self(sum),
         }
     }
 
-    /// This is the same as [`Uint64::sub`] but const.
+    /// Strict integer subtraction. Computes `self - rhs`, panicking if overflow occurred.
     ///
-    /// Panics on overflow.
+    /// This is the same as [`Uint64::sub`] but const.
     #[must_use = "this returns the result of the operation, without modifying the original"]
-    pub const fn panicking_sub(self, other: Self) -> Self {
+    pub const fn strict_sub(self, other: Self) -> Self {
         match self.0.checked_sub(other.u64()) {
             None => panic!("attempt to subtract with overflow"),
             Some(diff) => Self(diff),
@@ -367,7 +367,7 @@ impl Add<Uint64> for Uint64 {
     type Output = Self;
 
     fn add(self, rhs: Self) -> Self {
-        self.panicking_add(rhs)
+        self.strict_add(rhs)
     }
 }
 forward_ref_binop!(impl Add, add for Uint64, Uint64);
@@ -376,7 +376,7 @@ impl Sub<Uint64> for Uint64 {
     type Output = Self;
 
     fn sub(self, rhs: Self) -> Self {
-        self.panicking_sub(rhs)
+        self.strict_sub(rhs)
     }
 }
 forward_ref_binop!(impl Sub, sub for Uint64, Uint64);
@@ -1105,18 +1105,34 @@ mod tests {
     }
 
     #[test]
-    fn uint64_panicking_sub_works() {
+    fn uint64_strict_add_works() {
         let a = Uint64::new(5);
         let b = Uint64::new(3);
-        assert_eq!(a.panicking_sub(b), Uint64::new(2));
+        assert_eq!(a.strict_add(b), Uint64::new(8));
+        assert_eq!(b.strict_add(a), Uint64::new(8));
+    }
+
+    #[test]
+    #[should_panic(expected = "attempt to add with overflow")]
+    fn uint64_strict_add_panics_on_overflow() {
+        let a = Uint64::MAX;
+        let b = Uint64::ONE;
+        let _ = a.strict_add(b);
+    }
+
+    #[test]
+    fn uint64_strict_sub_works() {
+        let a = Uint64::new(5);
+        let b = Uint64::new(3);
+        assert_eq!(a.strict_sub(b), Uint64::new(2));
     }
 
     #[test]
     #[should_panic(expected = "attempt to subtract with overflow")]
-    fn uint64_panicking_sub_panics_on_overflow() {
+    fn uint64_strict_sub_panics_on_overflow() {
         let a = Uint64::ZERO;
         let b = Uint64::ONE;
-        let _diff = a.panicking_sub(b);
+        let _ = a.strict_sub(b);
     }
 
     #[test]

--- a/packages/std/src/timestamp.rs
+++ b/packages/std/src/timestamp.rs
@@ -84,7 +84,7 @@ impl Timestamp {
     #[must_use = "this returns the result of the operation, without modifying the original"]
     // no #[inline] here as this could be shared with all the callers
     pub const fn plus_nanos(&self, addition: u64) -> Timestamp {
-        let nanos = self.0.panicking_add(Uint64::new(addition));
+        let nanos = self.0.strict_add(Uint64::new(addition));
         Timestamp(nanos)
     }
 
@@ -135,7 +135,7 @@ impl Timestamp {
     #[must_use = "this returns the result of the operation, without modifying the original"]
     // no #[inline] here as this could be shared with all the callers
     pub const fn minus_nanos(&self, subtrahend: u64) -> Timestamp {
-        Timestamp(self.0.panicking_sub(Uint64::new(subtrahend)))
+        Timestamp(self.0.strict_sub(Uint64::new(subtrahend)))
     }
 
     /// Returns nanoseconds since epoch


### PR DESCRIPTION
Turns out the Rust standard library add the functions from #2098 under a different name. See https://github.com/rust-lang/rust/issues/118260. Since this was not yet release, we can use those names too.