### PR TITLE
Optimize `isqrt`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to
 - cosmwasm-schema-derive: Improve emitted error messages ([#2063])
 - cosmwasm-schema: `#[cw_serde]` now doesn't add `#[serde(deny_unknown_fields)]`
   to the expanded code anymore ([#2080])
+- cosmwasm-std: Improve performance of `Uint{64,128,256,512}::isqrt` ([#2108])
 
 [#2044]: https://github.com/CosmWasm/cosmwasm/pull/2044
 [#2051]: https://github.com/CosmWasm/cosmwasm/pull/2051
@@ -54,6 +55,7 @@ and this project adheres to
 [#2063]: https://github.com/CosmWasm/cosmwasm/pull/2063
 [#2070]: https://github.com/CosmWasm/cosmwasm/pull/2070
 [#2080]: https://github.com/CosmWasm/cosmwasm/pull/2080
+[#2108]: https://github.com/CosmWasm/cosmwasm/pull/2108
 
 ## [2.0.1] - 2024-04-03
 

--- a/packages/core/src/math/isqrt.rs
+++ b/packages/core/src/math/isqrt.rs
@@ -13,25 +13,24 @@ pub trait Isqrt {
 impl<I> Isqrt for I
 where
     I: Unsigned
-        + Log2
         + ops::Add<I, Output = I>
         + ops::Div<I, Output = I>
         + ops::Shl<u32, Output = I>
         + ops::Shr<u32, Output = I>
         + cmp::PartialOrd
-        + Copy
-        + From<u8>,
+        + Copy,
 {
     /// Algorithm adapted from
     /// [Wikipedia](https://en.wikipedia.org/wiki/Integer_square_root#Example_implementation_in_C).
     fn isqrt(self) -> Self {
-        let zero = Self::from(0);
-        if self == zero {
-            return zero;
+        // sqrt(0) = 0, sqrt(1) = 1
+        if self <= Self::ONE {
+            return self;
         }
-        let mut x0 = Self::from(1u8) << ((self.log_2() / 2) + 1);
 
-        if x0 > zero {
+        let mut x0 = Self::ONE << ((self.log_2() / 2) + 1);
+
+        if x0 > Self::ZERO {
             let mut x1 = (x0 + self / x0) >> 1;
 
             while x1 < x0 {
@@ -46,40 +45,35 @@ where
 }
 
 /// Marker trait for types that represent unsigned integers.
-pub trait Unsigned {}
-impl Unsigned for u8 {}
-impl Unsigned for u16 {}
-impl Unsigned for u32 {}
-impl Unsigned for u64 {}
-impl Unsigned for u128 {}
-impl Unsigned for Uint64 {}
-impl Unsigned for Uint128 {}
-impl Unsigned for Uint256 {}
-impl Unsigned for Uint512 {}
-impl Unsigned for usize {}
+pub trait Unsigned {
+    const ZERO: Self;
+    const ONE: Self;
 
-trait Log2 {
     fn log_2(self) -> u32;
 }
-macro_rules! impl_log2 {
-    ($type:ty) => {
-        impl Log2 for $type {
+
+macro_rules! impl_unsigned {
+    ($type:ty, $zero:expr, $one:expr) => {
+        impl Unsigned for $type {
+            const ZERO: Self = $zero;
+            const ONE: Self = $one;
+
             fn log_2(self) -> u32 {
                 self.ilog2()
             }
         }
     };
 }
-impl_log2!(u8);
-impl_log2!(u16);
-impl_log2!(u32);
-impl_log2!(u64);
-impl_log2!(u128);
-impl_log2!(usize);
-impl_log2!(Uint64);
-impl_log2!(Uint128);
-impl_log2!(Uint256);
-impl_log2!(Uint512);
+impl_unsigned!(u8, 0, 1);
+impl_unsigned!(u16, 0, 1);
+impl_unsigned!(u32, 0, 1);
+impl_unsigned!(u64, 0, 1);
+impl_unsigned!(u128, 0, 1);
+impl_unsigned!(usize, 0, 1);
+impl_unsigned!(Uint64, Self::zero(), Self::one());
+impl_unsigned!(Uint128, Self::zero(), Self::one());
+impl_unsigned!(Uint256, Self::zero(), Self::one());
+impl_unsigned!(Uint512, Self::zero(), Self::one());
 
 #[cfg(test)]
 mod tests {

--- a/packages/core/src/math/isqrt.rs
+++ b/packages/core/src/math/isqrt.rs
@@ -13,8 +13,10 @@ pub trait Isqrt {
 impl<I> Isqrt for I
 where
     I: Unsigned
+        + Log2
         + ops::Add<I, Output = I>
         + ops::Div<I, Output = I>
+        + ops::Shl<u32, Output = I>
         + ops::Shr<u32, Output = I>
         + cmp::PartialOrd
         + Copy
@@ -23,9 +25,13 @@ where
     /// Algorithm adapted from
     /// [Wikipedia](https://en.wikipedia.org/wiki/Integer_square_root#Example_implementation_in_C).
     fn isqrt(self) -> Self {
-        let mut x0 = self >> 1;
+        let zero = Self::from(0);
+        if self == zero {
+            return zero;
+        }
+        let mut x0 = Self::from(1u8) << ((self.log_2() / 2) + 1);
 
-        if x0 > 0.into() {
+        if x0 > zero {
             let mut x1 = (x0 + self / x0) >> 1;
 
             while x1 < x0 {
@@ -51,6 +57,29 @@ impl Unsigned for Uint128 {}
 impl Unsigned for Uint256 {}
 impl Unsigned for Uint512 {}
 impl Unsigned for usize {}
+
+trait Log2 {
+    fn log_2(self) -> u32;
+}
+macro_rules! impl_log2 {
+    ($type:ty) => {
+        impl Log2 for $type {
+            fn log_2(self) -> u32 {
+                self.ilog2()
+            }
+        }
+    };
+}
+impl_log2!(u8);
+impl_log2!(u16);
+impl_log2!(u32);
+impl_log2!(u64);
+impl_log2!(u128);
+impl_log2!(usize);
+impl_log2!(Uint64);
+impl_log2!(Uint128);
+impl_log2!(Uint256);
+impl_log2!(Uint512);
 
 #[cfg(test)]
 mod tests {

--- a/packages/core/src/math/uint128.rs
+++ b/packages/core/src/math/uint128.rs
@@ -96,6 +96,16 @@ impl Uint128 {
         self.0.pow(exp).into()
     }
 
+    /// Returns the base 2 logarithm of the number, rounded down.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if `self` is zero.
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    pub fn ilog2(self) -> u32 {
+        self.0.checked_ilog2().unwrap()
+    }
+
     /// Returns `self * numerator / denominator`.
     ///
     /// Due to the nature of the integer division involved, the result is always floored.

--- a/packages/core/src/math/uint256.rs
+++ b/packages/core/src/math/uint256.rs
@@ -168,6 +168,16 @@ impl Uint256 {
         Self(self.0.pow(exp))
     }
 
+    /// Returns the base 2 logarithm of the number, rounded down.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if `self` is zero.
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    pub fn ilog2(self) -> u32 {
+        self.0.checked_ilog2().unwrap()
+    }
+
     /// Returns `self * numerator / denominator`.
     ///
     /// Due to the nature of the integer division involved, the result is always floored.

--- a/packages/core/src/math/uint512.rs
+++ b/packages/core/src/math/uint512.rs
@@ -193,6 +193,16 @@ impl Uint512 {
         Self(self.0.pow(exp))
     }
 
+    /// Returns the base 2 logarithm of the number, rounded down.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if `self` is zero.
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    pub fn ilog2(self) -> u32 {
+        self.0.checked_ilog2().unwrap()
+    }
+
     pub fn checked_add(self, other: Self) -> Result<Self, OverflowError> {
         self.0
             .checked_add(other.0)

--- a/packages/core/src/math/uint64.rs
+++ b/packages/core/src/math/uint64.rs
@@ -90,6 +90,16 @@ impl Uint64 {
         self.0.pow(exp).into()
     }
 
+    /// Returns the base 2 logarithm of the number, rounded down.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if `self` is zero.
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    pub fn ilog2(self) -> u32 {
+        self.0.checked_ilog2().unwrap()
+    }
+
     /// Returns `self * numerator / denominator`.
     ///
     /// Due to the nature of the integer division involved, the result is always floored.


### PR DESCRIPTION
taken out of #2029
somewhat related to #1897 

Benchmarked the gas costs and they look *much* better for big numbers, while only having a small regression for small numbers:

| Uint64::isqrt | 1.0     | MAX     | MAX / 2 |
| ------------- | ------- | ------- | ------- |
| old           | 4026600 | 4446000 | 4440900 |
| new           | 4045800 | 4182450 | 4207950 |
| rel.diff.     | +0.5%   | -5.9%   | -5.2%   |

| Uint128::isqrt | 1.0     | MAX      | MAX / 2  |
| -------------- | ------- | -------- | -------- |
| old            | 4065600 | 24899400 | 24076200 |
| new            | 4156200 | 4937850  | 6977250  |
| rel.diff.      | +2.2%   | -80.2%   | -71%     |

| Uint256::isqrt | 1.0     | MAX       | MAX / 2   |
| -------------- | ------- | --------- | --------- |
| old            | 4145700 | 114904200 | 114196500 |
| new            | 4333500 | 7516500   | 14925450  |
| rel.diff.      | +4.5%   | -93.5%    | -86.9%    |

| Uint512::isqrt | 1.0     | MAX       | MAX / 2   |
| -------------- | ------- | --------- | --------- |
| old            | 4208550 | 567245850 | 565513200 |
| new            | 4555800 | 15074250  | 37877400  |
| rel.diff.      | +8.2%   | -97.3%    | -93.3%    |

If we want to avoid the increase in the lower numbers really badly, we could try to figure out the points until which the old version is better and manually check if the number is below that threshold, but that's likely to change with different compiler versions, bnum updates, etc.