### PR TITLE
Exclude `#[state_version]` doc-test

### DIFF
--- a/packages/derive/src/lib.rs
+++ b/packages/derive/src/lib.rs
@@ -98,7 +98,7 @@ impl Parse for Options {
 ///
 /// The VM will use this as a hint whether it needs to run the migrate function of your contract or not.
 ///
-/// ```
+/// ```no_run
 /// # use cosmwasm_std::{
 /// #     DepsMut, entry_point, Env,
 /// #     Response, StdResult,


### PR DESCRIPTION
Not sure if this is specific to M1 ARM, but for me it causes this error:
```
---- packages/derive/src/lib.rs - entry_point (line 101) stdout ----
LLVM ERROR: Global variable '_ZN8rust_out4main46_doctest_main_packages_derive_src_lib_rs_101_018__CW_STATE_VERSION17hc5f83b3b1105f862E' has an invalid section specifier 'cw_state_version': mach-o section specifier requires a segment and section separated by a comma.
Couldn't compile the test.
```
Since we only expect it to work correctly on wasm anyways, I just disabled it.