### PR TITLE
BLS12-381 Additions from review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ and this project adheres to
 - cosmwasm-vm: Read the state version from Wasm modules and return them as part
   of `AnalyzeReport` ([#2129])
 - cosmwasm-vm: Add `bls12_381_aggregate_g1`, `bls12_381_aggregate_g2`,
-  `bls12_381_aggregate_pairing_equality`, `bls12_381_hash_to_g1`, and
+  `bls12_381_pairing_equality`, `bls12_381_hash_to_g1`, and
   `bls12_381_hash_to_g1` to enable BLS12-381 curve operations, such as verifying
   pairing equalities ([#2106])
 

--- a/contracts/crypto-verify/src/bls12_381.rs
+++ b/contracts/crypto-verify/src/bls12_381.rs
@@ -9,6 +9,6 @@ pub fn verify(
     dst: &[u8],
 ) -> StdResult<bool> {
     let s = api.bls12_381_hash_to_g2(HashFunction::Sha256, msg, dst)?;
-    api.bls12_381_aggregate_pairing_equality(p, q, r, &s)
+    api.bls12_381_pairing_equality(p, q, r, &s)
         .map_err(Into::into)
 }

--- a/packages/core/src/errors/mod.rs
+++ b/packages/core/src/errors/mod.rs
@@ -13,6 +13,4 @@ pub use core_error::{
 };
 pub use recover_pubkey_error::RecoverPubkeyError;
 pub use system_error::SystemError;
-pub use verification_error::{
-    AggregationError, AggregationPairingEqualityError, VerificationError,
-};
+pub use verification_error::{AggregationError, PairingEqualityError, VerificationError};

--- a/packages/core/src/errors/recover_pubkey_error.rs
+++ b/packages/core/src/errors/recover_pubkey_error.rs
@@ -66,7 +66,7 @@ impl From<CryptoError> for RecoverPubkeyError {
             CryptoError::GenericErr { .. } => RecoverPubkeyError::unknown_err(original.code()),
             CryptoError::InvalidRecoveryParam { .. } => RecoverPubkeyError::InvalidRecoveryParam,
             CryptoError::Aggregation { .. }
-            | CryptoError::AggregationPairingEquality { .. }
+            | CryptoError::PairingEquality { .. }
             | CryptoError::BatchErr { .. }
             | CryptoError::InvalidPubkeyFormat { .. }
             | CryptoError::InvalidPoint { .. }

--- a/packages/core/src/errors/verification_error.rs
+++ b/packages/core/src/errors/verification_error.rs
@@ -17,7 +17,7 @@ pub enum AggregationError {
 
 #[derive(Display, Debug, PartialEq)]
 #[cfg_attr(feature = "std", derive(thiserror::Error))]
-pub enum AggregationPairingEqualityError {
+pub enum PairingEqualityError {
     #[display("List of G1 points is empty")]
     EmptyG1,
     #[display("List of G2 points is empty")]
@@ -35,10 +35,6 @@ pub enum AggregationPairingEqualityError {
 pub enum VerificationError {
     #[display("Aggregation error: {source}")]
     Aggregation { source: AggregationError },
-    #[display("Aggregation pairing equality error: {source}")]
-    AggregationPairingEquality {
-        source: AggregationPairingEqualityError,
-    },
     #[display("Batch error")]
     BatchErr,
     #[display("Generic error")]
@@ -55,6 +51,8 @@ pub enum VerificationError {
     InvalidPoint,
     #[display("Unknown hash function")]
     UnknownHashFunction,
+    #[display("Aggregation pairing equality error: {source}")]
+    PairingEquality { source: PairingEqualityError },
     #[display("Unknown error: {error_code}")]
     UnknownErr { error_code: u32, backtrace: BT },
 }
@@ -75,8 +73,8 @@ impl PartialEq<VerificationError> for VerificationError {
             VerificationError::Aggregation { source: lhs_source } => {
                 matches!(rhs, VerificationError::Aggregation { source: rhs_source } if rhs_source == lhs_source)
             }
-            VerificationError::AggregationPairingEquality { source: lhs_source } => {
-                matches!(rhs, VerificationError::AggregationPairingEquality { source: rhs_source } if rhs_source == lhs_source)
+            VerificationError::PairingEquality { source: lhs_source } => {
+                matches!(rhs, VerificationError::PairingEquality { source: rhs_source } if rhs_source == lhs_source)
             }
             VerificationError::BatchErr => matches!(rhs, VerificationError::BatchErr),
             VerificationError::GenericErr => matches!(rhs, VerificationError::GenericErr),
@@ -127,35 +125,35 @@ impl From<CryptoError> for VerificationError {
             } => VerificationError::Aggregation {
                 source: AggregationError::NotMultiple,
             },
-            CryptoError::AggregationPairingEquality {
-                source: cosmwasm_crypto::AggregationPairingEqualityError::EmptyG1,
+            CryptoError::PairingEquality {
+                source: cosmwasm_crypto::PairingEqualityError::EmptyG1,
                 ..
-            } => VerificationError::AggregationPairingEquality {
-                source: AggregationPairingEqualityError::EmptyG1,
+            } => VerificationError::PairingEquality {
+                source: PairingEqualityError::EmptyG1,
             },
-            CryptoError::AggregationPairingEquality {
-                source: cosmwasm_crypto::AggregationPairingEqualityError::EmptyG2,
+            CryptoError::PairingEquality {
+                source: cosmwasm_crypto::PairingEqualityError::EmptyG2,
                 ..
-            } => VerificationError::AggregationPairingEquality {
-                source: AggregationPairingEqualityError::EmptyG2,
+            } => VerificationError::PairingEquality {
+                source: PairingEqualityError::EmptyG2,
             },
-            CryptoError::AggregationPairingEquality {
-                source: cosmwasm_crypto::AggregationPairingEqualityError::NotMultipleG1 { .. },
+            CryptoError::PairingEquality {
+                source: cosmwasm_crypto::PairingEqualityError::NotMultipleG1 { .. },
                 ..
-            } => VerificationError::AggregationPairingEquality {
-                source: AggregationPairingEqualityError::NotMultipleG1,
+            } => VerificationError::PairingEquality {
+                source: PairingEqualityError::NotMultipleG1,
             },
-            CryptoError::AggregationPairingEquality {
-                source: cosmwasm_crypto::AggregationPairingEqualityError::NotMultipleG2 { .. },
+            CryptoError::PairingEquality {
+                source: cosmwasm_crypto::PairingEqualityError::NotMultipleG2 { .. },
                 ..
-            } => VerificationError::AggregationPairingEquality {
-                source: AggregationPairingEqualityError::NotMultipleG2,
+            } => VerificationError::PairingEquality {
+                source: PairingEqualityError::NotMultipleG2,
             },
-            CryptoError::AggregationPairingEquality {
-                source: cosmwasm_crypto::AggregationPairingEqualityError::UnequalPointAmount { .. },
+            CryptoError::PairingEquality {
+                source: cosmwasm_crypto::PairingEqualityError::UnequalPointAmount { .. },
                 ..
-            } => VerificationError::AggregationPairingEquality {
-                source: AggregationPairingEqualityError::UnequalPointAmount,
+            } => VerificationError::PairingEquality {
+                source: PairingEqualityError::UnequalPointAmount,
             },
             CryptoError::InvalidHashFormat { .. } => VerificationError::InvalidHashFormat,
             CryptoError::InvalidPubkeyFormat { .. } => VerificationError::InvalidPubkeyFormat,

--- a/packages/core/src/lib.rs
+++ b/packages/core/src/lib.rs
@@ -28,11 +28,11 @@ pub use crate::addresses::{instantiate2_address, Addr, CanonicalAddr, Instantiat
 pub use crate::binary::Binary;
 pub use crate::encoding::{from_base64, from_hex, to_base64, to_hex};
 pub use crate::errors::{
-    AggregationError, AggregationPairingEqualityError, CheckedFromRatioError,
-    CheckedMultiplyFractionError, CheckedMultiplyRatioError, CoinFromStrError, CoinsError,
-    ConversionOverflowError, CoreError, CoreResult, DivideByZeroError, DivisionError,
-    OverflowError, OverflowOperation, RecoverPubkeyError, RoundDownOverflowError,
-    RoundUpOverflowError, SystemError, VerificationError,
+    AggregationError, CheckedFromRatioError, CheckedMultiplyFractionError,
+    CheckedMultiplyRatioError, CoinFromStrError, CoinsError, ConversionOverflowError, CoreError,
+    CoreResult, DivideByZeroError, DivisionError, OverflowError, OverflowOperation,
+    PairingEqualityError, RecoverPubkeyError, RoundDownOverflowError, RoundUpOverflowError,
+    SystemError, VerificationError,
 };
 pub use crate::hex_binary::HexBinary;
 pub use crate::math::{

--- a/packages/crypto/benches/main.rs
+++ b/packages/crypto/benches/main.rs
@@ -16,10 +16,10 @@ use k256::ecdsa::SigningKey; // type alias
 use sha2::Sha256;
 
 use cosmwasm_crypto::{
-    bls12_381_aggregate_g1, bls12_381_aggregate_g2, bls12_381_aggregate_pairing_equality,
-    bls12_381_g1_generator, bls12_381_hash_to_g1, bls12_381_hash_to_g2, ed25519_batch_verify,
-    ed25519_verify, secp256k1_recover_pubkey, secp256k1_verify, secp256r1_recover_pubkey,
-    secp256r1_verify, HashFunction, BLS12_381_G1_POINT_LEN, BLS12_381_G2_POINT_LEN,
+    bls12_381_aggregate_g1, bls12_381_aggregate_g2, bls12_381_g1_generator, bls12_381_hash_to_g1,
+    bls12_381_hash_to_g2, bls12_381_pairing_equality, ed25519_batch_verify, ed25519_verify,
+    secp256k1_recover_pubkey, secp256k1_verify, secp256r1_recover_pubkey, secp256r1_verify,
+    HashFunction, BLS12_381_G1_POINT_LEN, BLS12_381_G2_POINT_LEN,
 };
 use std::cmp::min;
 
@@ -187,22 +187,19 @@ where
                 .serialize_compressed(&mut serialized_signature[..])
                 .unwrap();
 
-            group.bench_function(
-                format!("bls12_381_aggregate_pairing_equality_{num_points}"),
-                |b| {
-                    b.iter(|| {
-                        let is_valid = black_box(bls12_381_aggregate_pairing_equality(
-                            &serialized_pubkeys,
-                            &serialized_messages,
-                            &bls12_381_g1_generator(),
-                            &serialized_signature,
-                        ))
-                        .unwrap();
+            group.bench_function(format!("bls12_381_pairing_equality_{num_points}"), |b| {
+                b.iter(|| {
+                    let is_valid = black_box(bls12_381_pairing_equality(
+                        &serialized_pubkeys,
+                        &serialized_messages,
+                        &bls12_381_g1_generator(),
+                        &serialized_signature,
+                    ))
+                    .unwrap();
 
-                        assert!(is_valid);
-                    });
-                },
-            );
+                    assert!(is_valid);
+                });
+            });
         }
     }
 
@@ -231,7 +228,7 @@ where
         let message = bls12_381_hash_to_g2(HashFunction::Sha256, &BLS_MESSAGE, BLS_DST);
 
         b.iter(|| {
-            let is_equal = bls12_381_aggregate_pairing_equality(
+            let is_equal = bls12_381_pairing_equality(
                 black_box(&BLS_PUBKEY),
                 &message,
                 &generator,

--- a/packages/crypto/src/bls12_318/mod.rs
+++ b/packages/crypto/src/bls12_318/mod.rs
@@ -7,7 +7,7 @@ mod points;
 pub use aggregate::{bls12_381_aggregate_g1, bls12_381_aggregate_g2};
 pub use constants::{bls12_381_g1_generator, bls12_381_g2_generator};
 pub use hash::{bls12_381_hash_to_g1, bls12_381_hash_to_g2, HashFunction};
-pub use pairing::bls12_381_aggregate_pairing_equality;
+pub use pairing::bls12_381_pairing_equality;
 pub use points::{bls12_381_g1_is_identity, bls12_381_g2_is_identity};
 
 pub const BLS12_381_G1_POINT_LEN: usize = 48;

--- a/packages/crypto/src/errors.rs
+++ b/packages/crypto/src/errors.rs
@@ -20,7 +20,7 @@ pub enum Aggregation {
 
 #[derive(Debug, Display)]
 #[cfg_attr(feature = "std", derive(thiserror::Error))]
-pub enum AggregationPairingEquality {
+pub enum PairingEquality {
     #[display("List of G1 points is empty")]
     EmptyG1,
     #[display("List of G2 points is empty")]
@@ -47,11 +47,6 @@ pub enum InvalidPoint {
 pub enum CryptoError {
     #[display("Point aggregation error: {source}")]
     Aggregation { source: Aggregation, backtrace: BT },
-    #[display("Aggregation pairing equality error: {source}")]
-    AggregationPairingEquality {
-        source: AggregationPairingEquality,
-        backtrace: BT,
-    },
     #[display("Batch verify error: {msg}")]
     BatchErr { msg: String, backtrace: BT },
     #[display("Crypto error: {msg}")]
@@ -66,6 +61,11 @@ pub enum CryptoError {
     InvalidRecoveryParam { backtrace: BT },
     #[display("Invalid point: {source}")]
     InvalidPoint { source: InvalidPoint, backtrace: BT },
+    #[display("Pairing equality error: {source}")]
+    PairingEquality {
+        source: PairingEquality,
+        backtrace: BT,
+    },
     #[display("Unknown hash function")]
     UnknownHashFunction { backtrace: BT },
 }
@@ -127,24 +127,24 @@ impl CryptoError {
             CryptoError::InvalidPoint { .. } => 8,
             CryptoError::UnknownHashFunction { .. } => 9,
             CryptoError::GenericErr { .. } => 10,
-            CryptoError::AggregationPairingEquality {
-                source: AggregationPairingEquality::NotMultipleG1 { .. },
+            CryptoError::PairingEquality {
+                source: PairingEquality::NotMultipleG1 { .. },
                 ..
             } => 11,
-            CryptoError::AggregationPairingEquality {
-                source: AggregationPairingEquality::NotMultipleG2 { .. },
+            CryptoError::PairingEquality {
+                source: PairingEquality::NotMultipleG2 { .. },
                 ..
             } => 12,
-            CryptoError::AggregationPairingEquality {
-                source: AggregationPairingEquality::UnequalPointAmount { .. },
+            CryptoError::PairingEquality {
+                source: PairingEquality::UnequalPointAmount { .. },
                 ..
             } => 13,
-            CryptoError::AggregationPairingEquality {
-                source: AggregationPairingEquality::EmptyG1 { .. },
+            CryptoError::PairingEquality {
+                source: PairingEquality::EmptyG1 { .. },
                 ..
             } => 14,
-            CryptoError::AggregationPairingEquality {
-                source: AggregationPairingEquality::EmptyG2 { .. },
+            CryptoError::PairingEquality {
+                source: PairingEquality::EmptyG2 { .. },
                 ..
             } => 15,
             CryptoError::Aggregation {
@@ -169,10 +169,10 @@ impl From<Aggregation> for CryptoError {
     }
 }
 
-impl From<AggregationPairingEquality> for CryptoError {
+impl From<PairingEquality> for CryptoError {
     #[track_caller]
-    fn from(value: AggregationPairingEquality) -> Self {
-        Self::AggregationPairingEquality {
+    fn from(value: PairingEquality) -> Self {
+        Self::PairingEquality {
             source: value,
             backtrace: BT::capture(),
         }

--- a/packages/crypto/src/lib.rs
+++ b/packages/crypto/src/lib.rs
@@ -23,9 +23,9 @@ mod secp256r1;
 #[cfg(feature = "std")]
 #[doc(hidden)]
 pub use crate::bls12_318::{
-    bls12_381_aggregate_g1, bls12_381_aggregate_g2, bls12_381_aggregate_pairing_equality,
-    bls12_381_g1_generator, bls12_381_g1_is_identity, bls12_381_g2_generator,
-    bls12_381_g2_is_identity, bls12_381_hash_to_g1, bls12_381_hash_to_g2, HashFunction,
+    bls12_381_aggregate_g1, bls12_381_aggregate_g2, bls12_381_g1_generator,
+    bls12_381_g1_is_identity, bls12_381_g2_generator, bls12_381_g2_is_identity,
+    bls12_381_hash_to_g1, bls12_381_hash_to_g2, bls12_381_pairing_equality, HashFunction,
     BLS12_381_G1_POINT_LEN, BLS12_381_G2_POINT_LEN,
 };
 #[doc(hidden)]
@@ -36,8 +36,8 @@ pub use crate::ed25519::EDDSA_PUBKEY_LEN;
 pub use crate::ed25519::{ed25519_batch_verify, ed25519_verify};
 #[doc(hidden)]
 pub use crate::errors::{
-    Aggregation as AggregationError, AggregationPairingEquality as AggregationPairingEqualityError,
-    CryptoError, CryptoResult,
+    Aggregation as AggregationError, CryptoError, CryptoResult,
+    PairingEquality as PairingEqualityError,
 };
 #[doc(hidden)]
 pub use crate::secp256k1::{secp256k1_recover_pubkey, secp256k1_verify};

--- a/packages/crypto/tests/bls12_381.rs
+++ b/packages/crypto/tests/bls12_381.rs
@@ -6,9 +6,9 @@ use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use base64::engine::general_purpose::STANDARD;
 use base64_serde::base64_serde_type;
 use cosmwasm_crypto::{
-    bls12_381_aggregate_g1, bls12_381_aggregate_g2, bls12_381_aggregate_pairing_equality,
-    bls12_381_g1_generator, bls12_381_g1_is_identity, bls12_381_g2_is_identity,
-    bls12_381_hash_to_g2, HashFunction, BLS12_381_G2_POINT_LEN,
+    bls12_381_aggregate_g1, bls12_381_aggregate_g2, bls12_381_g1_generator,
+    bls12_381_g1_is_identity, bls12_381_g2_is_identity, bls12_381_hash_to_g2,
+    bls12_381_pairing_equality, HashFunction, BLS12_381_G2_POINT_LEN,
 };
 
 const PROOF_OF_POSSESSION_DST: &[u8] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_";
@@ -258,7 +258,7 @@ fn bls12_381_verify_works() {
                 return Ok(false);
             }
 
-            let bool_result = bls12_381_aggregate_pairing_equality(
+            let bool_result = bls12_381_pairing_equality(
                 &pubkey,
                 &message_point,
                 &bls12_381_g1_generator(),
@@ -334,7 +334,7 @@ fn bls12_381_aggregate_verify_works() {
                 return Ok(false);
             }
 
-            let bool_result = bls12_381_aggregate_pairing_equality(
+            let bool_result = bls12_381_pairing_equality(
                 &pubkeys,
                 &messages,
                 &bls12_381_g1_generator(),
@@ -409,7 +409,7 @@ fn bls12_381_fast_aggregate_verify_works() {
                 return Ok(false);
             }
 
-            let bool_result = bls12_381_aggregate_pairing_equality(
+            let bool_result = bls12_381_pairing_equality(
                 &pubkey,
                 &message_point,
                 &bls12_381_g1_generator(),

--- a/packages/std/src/imports.rs
+++ b/packages/std/src/imports.rs
@@ -17,8 +17,8 @@ use crate::{
     memory::get_optional_region_address,
 };
 use crate::{
-    AggregationError, AggregationPairingEqualityError, RecoverPubkeyError, StdError, StdResult,
-    SystemError, VerificationError,
+    AggregationError, PairingEqualityError, RecoverPubkeyError, StdError, StdResult, SystemError,
+    VerificationError,
 };
 
 /// An upper bound for typical canonical address lengths (e.g. 20 in Cosmos SDK/Ethereum or 32 in Nano/Substrate)
@@ -58,12 +58,7 @@ extern "C" {
     fn bls12_381_aggregate_g2(g2s_ptr: u32, out_ptr: u32) -> u32;
 
     #[cfg(feature = "cosmwasm_2_1")]
-    fn bls12_381_aggregate_pairing_equality(
-        ps_ptr: u32,
-        qs_ptr: u32,
-        r_ptr: u32,
-        s_ptr: u32,
-    ) -> u32;
+    fn bls12_381_pairing_equality(ps_ptr: u32, qs_ptr: u32, r_ptr: u32, s_ptr: u32) -> u32;
 
     #[cfg(feature = "cosmwasm_2_1")]
     fn bls12_381_hash_to_g1(hash_function: u32, msg_ptr: u32, dst_ptr: u32, out_ptr: u32) -> u32;
@@ -439,7 +434,7 @@ impl Api for ExternalApi {
     }
 
     #[cfg(feature = "cosmwasm_2_1")]
-    fn bls12_381_aggregate_pairing_equality(
+    fn bls12_381_pairing_equality(
         &self,
         ps: &[u8],
         qs: &[u8],
@@ -456,27 +451,26 @@ impl Api for ExternalApi {
         let send_r_ptr = &*send_r as *const Region as u32;
         let send_s_ptr = &*send_s as *const Region as u32;
 
-        let result = unsafe {
-            bls12_381_aggregate_pairing_equality(send_ps_ptr, send_qs_ptr, send_r_ptr, send_s_ptr)
-        };
+        let result =
+            unsafe { bls12_381_pairing_equality(send_ps_ptr, send_qs_ptr, send_r_ptr, send_s_ptr) };
         match result {
             0 => Ok(true),
             1 => Ok(false),
             8 => Err(VerificationError::InvalidPoint),
-            11 => Err(VerificationError::AggregationPairingEquality {
-                source: AggregationPairingEqualityError::NotMultipleG1,
+            11 => Err(VerificationError::PairingEquality {
+                source: PairingEqualityError::NotMultipleG1,
             }),
-            12 => Err(VerificationError::AggregationPairingEquality {
-                source: AggregationPairingEqualityError::NotMultipleG2,
+            12 => Err(VerificationError::PairingEquality {
+                source: PairingEqualityError::NotMultipleG2,
             }),
-            13 => Err(VerificationError::AggregationPairingEquality {
-                source: AggregationPairingEqualityError::UnequalPointAmount,
+            13 => Err(VerificationError::PairingEquality {
+                source: PairingEqualityError::UnequalPointAmount,
             }),
-            14 => Err(VerificationError::AggregationPairingEquality {
-                source: AggregationPairingEqualityError::EmptyG1,
+            14 => Err(VerificationError::PairingEquality {
+                source: PairingEqualityError::EmptyG1,
             }),
-            15 => Err(VerificationError::AggregationPairingEquality {
-                source: AggregationPairingEqualityError::EmptyG2,
+            15 => Err(VerificationError::PairingEquality {
+                source: PairingEqualityError::EmptyG2,
             }),
             error_code => Err(VerificationError::unknown_err(error_code)),
         }

--- a/packages/std/src/imports.rs
+++ b/packages/std/src/imports.rs
@@ -9,17 +9,14 @@ use crate::sections::decode_sections2;
 use crate::sections::encode_sections;
 use crate::serde::from_json;
 use crate::traits::{Api, Querier, QuerierResult, Storage};
-#[cfg(feature = "cosmwasm_2_1")]
-use crate::HashFunction;
 #[cfg(feature = "iterator")]
 use crate::{
     iterator::{Order, Record},
     memory::get_optional_region_address,
 };
-use crate::{
-    AggregationError, PairingEqualityError, RecoverPubkeyError, StdError, StdResult, SystemError,
-    VerificationError,
-};
+#[cfg(feature = "cosmwasm_2_1")]
+use crate::{AggregationError, HashFunction, PairingEqualityError};
+use crate::{RecoverPubkeyError, StdError, StdResult, SystemError, VerificationError};
 
 /// An upper bound for typical canonical address lengths (e.g. 20 in Cosmos SDK/Ethereum or 32 in Nano/Substrate)
 const CANONICAL_ADDRESS_BUFFER_LENGTH: usize = 64;

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -109,14 +109,14 @@ pub mod testing;
 pub use cosmwasm_core::CoreError as StdError;
 pub use cosmwasm_core::CoreResult as StdResult;
 pub use cosmwasm_core::{
-    from_base64, from_hex, instantiate2_address, to_base64, to_hex, Addr, AggregationError,
-    AggregationPairingEqualityError, Binary, CanonicalAddr, CheckedFromRatioError,
-    CheckedMultiplyFractionError, CheckedMultiplyRatioError, CoinFromStrError, CoinsError,
-    ConversionOverflowError, Decimal, Decimal256, Decimal256RangeExceeded, DecimalRangeExceeded,
-    DivideByZeroError, DivisionError, Fraction, HexBinary, Instantiate2AddressError, Int128,
-    Int256, Int512, Int64, Isqrt, OverflowError, OverflowOperation, RecoverPubkeyError,
-    SignedDecimal, SignedDecimal256, SignedDecimal256RangeExceeded, SignedDecimalRangeExceeded,
-    SystemError, Timestamp, Uint128, Uint256, Uint512, Uint64, VerificationError,
+    from_base64, from_hex, instantiate2_address, to_base64, to_hex, Addr, AggregationError, Binary,
+    CanonicalAddr, CheckedFromRatioError, CheckedMultiplyFractionError, CheckedMultiplyRatioError,
+    CoinFromStrError, CoinsError, ConversionOverflowError, Decimal, Decimal256,
+    Decimal256RangeExceeded, DecimalRangeExceeded, DivideByZeroError, DivisionError, Fraction,
+    HexBinary, Instantiate2AddressError, Int128, Int256, Int512, Int64, Isqrt, OverflowError,
+    OverflowOperation, PairingEqualityError, RecoverPubkeyError, SignedDecimal, SignedDecimal256,
+    SignedDecimal256RangeExceeded, SignedDecimalRangeExceeded, SystemError, Timestamp, Uint128,
+    Uint256, Uint512, Uint64, VerificationError,
 };
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/packages/std/src/testing/mock.rs
+++ b/packages/std/src/testing/mock.rs
@@ -160,14 +160,14 @@ impl Api for MockApi {
         cosmwasm_crypto::bls12_381_aggregate_g2(g2s).map_err(Into::into)
     }
 
-    fn bls12_381_aggregate_pairing_equality(
+    fn bls12_381_pairing_equality(
         &self,
         ps: &[u8],
         qs: &[u8],
         r: &[u8],
         s: &[u8],
     ) -> Result<bool, VerificationError> {
-        cosmwasm_crypto::bls12_381_aggregate_pairing_equality(ps, qs, r, s).map_err(Into::into)
+        cosmwasm_crypto::bls12_381_pairing_equality(ps, qs, r, s).map_err(Into::into)
     }
 
     fn bls12_381_hash_to_g1(
@@ -1357,7 +1357,7 @@ mod tests {
     }
 
     #[test]
-    fn bls12_381_aggregate_pairing_equality_works() {
+    fn bls12_381_pairing_equality_works() {
         let api = MockApi::default();
 
         let dst = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_";
@@ -1377,7 +1377,7 @@ mod tests {
         let s = hex!("9104e74b9dfd3ad502f25d6a5ef57db0ed7d9a0e00f3500586d8ce44231212542fcfaf87840539b398bf07626705cf1105d246ca1062c6c2e1a53029a0f790ed5e3cb1f52f8234dc5144c45fc847c0cd37a92d68e7c5ba7c648a8a339f171244");
 
         let is_valid = api
-            .bls12_381_aggregate_pairing_equality(&ps, &qs, &g1_generator, &s)
+            .bls12_381_pairing_equality(&ps, &qs, &g1_generator, &s)
             .unwrap();
         assert!(is_valid);
     }
@@ -1439,12 +1439,7 @@ mod tests {
 
         let g1_generator = cosmwasm_crypto::bls12_381_g1_generator();
         let is_valid = api
-            .bls12_381_aggregate_pairing_equality(
-                &g1_generator,
-                &signature,
-                &PK_LEO_MAINNET,
-                &msg_point,
-            )
+            .bls12_381_pairing_equality(&g1_generator, &signature, &PK_LEO_MAINNET, &msg_point)
             .unwrap();
 
         assert!(is_valid);

--- a/packages/std/src/traits.rs
+++ b/packages/std/src/traits.rs
@@ -198,7 +198,7 @@ pub trait Api {
     }
 
     #[allow(unused_variables)]
-    fn bls12_381_aggregate_pairing_equality(
+    fn bls12_381_pairing_equality(
         &self,
         ps: &[u8],
         qs: &[u8],

--- a/packages/std/src/traits.rs
+++ b/packages/std/src/traits.rs
@@ -197,6 +197,32 @@ pub trait Api {
         unimplemented!()
     }
 
+    /// Checks the following pairing equality:
+    ///
+    /// e(p_1, q_1) × e(p_2, q_2) × … × e(p_n, q_n) = e(s, q)
+    ///
+    /// The argument `ps` contain the points p_1, ..., p_n ∈ G1 as a concatenation of 48 byte elements.
+    /// The argument `qs` contain the points q_1, ..., q_n ∈ G2 as a concatenation of 96 byte elements.
+    ///
+    /// ## Examples
+    ///
+    /// A simple signature check with one pairing on the left hand side (e(p, q) = e(s, q)):
+    ///
+    /// ```
+    /// # use cosmwasm_std::{Api, HashFunction, StdResult};
+    /// pub fn verify(
+    ///     api: &dyn Api,
+    ///     g1_generator: &[u8],
+    ///     signature: &[u8],
+    ///     pubkey: &[u8],
+    ///     msg: &[u8],
+    ///     dst: &[u8],
+    /// ) -> StdResult<bool> {
+    ///     let msg_hashed = api.bls12_381_hash_to_g2(HashFunction::Sha256, msg, dst)?;
+    ///     api.bls12_381_pairing_equality(g1_generator, signature, pubkey, &msg_hashed)
+    ///         .map_err(Into::into)
+    /// }
+    /// ```
     #[allow(unused_variables)]
     fn bls12_381_pairing_equality(
         &self,

--- a/packages/vm/src/compatibility.rs
+++ b/packages/vm/src/compatibility.rs
@@ -22,7 +22,7 @@ const SUPPORTED_IMPORTS: &[&str] = &[
     "env.addr_humanize",
     "env.bls12_381_aggregate_g1",
     "env.bls12_381_aggregate_g2",
-    "env.bls12_381_aggregate_pairing_equality",
+    "env.bls12_381_pairing_equality",
     "env.bls12_381_hash_to_g1",
     "env.bls12_381_hash_to_g2",
     "env.secp256k1_verify",

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -15,8 +15,8 @@ use crate::environment::Environment;
 use crate::errors::{CommunicationError, VmError, VmResult};
 use crate::imports::{
     do_abort, do_addr_canonicalize, do_addr_humanize, do_addr_validate, do_bls12_381_aggregate_g1,
-    do_bls12_381_aggregate_g2, do_bls12_381_aggregate_pairing_equality, do_bls12_381_hash_to_g1,
-    do_bls12_381_hash_to_g2, do_db_read, do_db_remove, do_db_write, do_debug,
+    do_bls12_381_aggregate_g2, do_bls12_381_hash_to_g1, do_bls12_381_hash_to_g2,
+    do_bls12_381_pairing_equality, do_db_read, do_db_remove, do_db_write, do_debug,
     do_ed25519_batch_verify, do_ed25519_verify, do_query_chain, do_secp256k1_recover_pubkey,
     do_secp256k1_verify, do_secp256r1_recover_pubkey, do_secp256r1_verify,
 };
@@ -164,8 +164,8 @@ where
         // Returns a single u32 which signifies the validity of the pairing equality.
         // Returns 0 if the pairing equality exists, 1 if it doesnt, and any other code may be interpreted as a `CryptoError`.
         env_imports.insert(
-            "bls12_381_aggregate_pairing_equality",
-            Function::new_typed_with_env(&mut store, &fe, do_bls12_381_aggregate_pairing_equality),
+            "bls12_381_pairing_equality",
+            Function::new_typed_with_env(&mut store, &fe, do_bls12_381_pairing_equality),
         );
 
         // Three parameters, "hash_function" and "msg" and "dst", are passed down which are both arbitrary octet strings.


### PR DESCRIPTION
Three commits with some improvements (I think). The main change is the removal of the "aggregate" prefix because we only have and only need one pairing equality