### PR TITLE
Revamp region system

### DIFF
--- a/packages/std/src/exports.rs
+++ b/packages/std/src/exports.rs
@@ -458,9 +458,9 @@ where
     C: CustomMsg,
     E: ToString,
 {
-    let env: Vec<u8> = unsafe { Region::from_heap_ptr(env_ptr).into_inner() };
-    let info: Vec<u8> = unsafe { Region::from_heap_ptr(info_ptr).into_inner() };
-    let msg: Vec<u8> = unsafe { Region::from_heap_ptr(msg_ptr).into_inner() };
+    let env: Vec<u8> = unsafe { Region::from_heap_ptr(env_ptr).into_vec() };
+    let info: Vec<u8> = unsafe { Region::from_heap_ptr(info_ptr).into_vec() };
+    let msg: Vec<u8> = unsafe { Region::from_heap_ptr(msg_ptr).into_vec() };
 
     let env: Env = try_into_contract_result!(from_json(env));
     let info: MessageInfo = try_into_contract_result!(from_json(info));
@@ -482,9 +482,9 @@ where
     C: CustomMsg,
     E: ToString,
 {
-    let env: Vec<u8> = unsafe { Region::from_heap_ptr(env_ptr).into_inner() };
-    let info: Vec<u8> = unsafe { Region::from_heap_ptr(info_ptr).into_inner() };
-    let msg: Vec<u8> = unsafe { Region::from_heap_ptr(msg_ptr).into_inner() };
+    let env: Vec<u8> = unsafe { Region::from_heap_ptr(env_ptr).into_vec() };
+    let info: Vec<u8> = unsafe { Region::from_heap_ptr(info_ptr).into_vec() };
+    let msg: Vec<u8> = unsafe { Region::from_heap_ptr(msg_ptr).into_vec() };
 
     let env: Env = try_into_contract_result!(from_json(env));
     let info: MessageInfo = try_into_contract_result!(from_json(info));
@@ -505,8 +505,8 @@ where
     C: CustomMsg,
     E: ToString,
 {
-    let env: Vec<u8> = unsafe { Region::from_heap_ptr(env_ptr).into_inner() };
-    let msg: Vec<u8> = unsafe { Region::from_heap_ptr(msg_ptr).into_inner() };
+    let env: Vec<u8> = unsafe { Region::from_heap_ptr(env_ptr).into_vec() };
+    let msg: Vec<u8> = unsafe { Region::from_heap_ptr(msg_ptr).into_vec() };
 
     let env: Env = try_into_contract_result!(from_json(env));
     let msg: M = try_into_contract_result!(from_json(msg));
@@ -526,8 +526,8 @@ where
     C: CustomMsg,
     E: ToString,
 {
-    let env: Vec<u8> = unsafe { Region::from_heap_ptr(env_ptr).into_inner() };
-    let msg: Vec<u8> = unsafe { Region::from_heap_ptr(msg_ptr).into_inner() };
+    let env: Vec<u8> = unsafe { Region::from_heap_ptr(env_ptr).into_vec() };
+    let msg: Vec<u8> = unsafe { Region::from_heap_ptr(msg_ptr).into_vec() };
 
     let env: Env = try_into_contract_result!(from_json(env));
     let msg: M = try_into_contract_result!(from_json(msg));
@@ -546,8 +546,8 @@ where
     C: CustomMsg,
     E: ToString,
 {
-    let env: Vec<u8> = unsafe { Region::from_heap_ptr(env_ptr).into_inner() };
-    let msg: Vec<u8> = unsafe { Region::from_heap_ptr(msg_ptr).into_inner() };
+    let env: Vec<u8> = unsafe { Region::from_heap_ptr(env_ptr).into_vec() };
+    let msg: Vec<u8> = unsafe { Region::from_heap_ptr(msg_ptr).into_vec() };
 
     let env: Env = try_into_contract_result!(from_json(env));
     let msg: Reply = try_into_contract_result!(from_json(msg));
@@ -566,8 +566,8 @@ where
     M: DeserializeOwned,
     E: ToString,
 {
-    let env: Vec<u8> = unsafe { Region::from_heap_ptr(env_ptr).into_inner() };
-    let msg: Vec<u8> = unsafe { Region::from_heap_ptr(msg_ptr).into_inner() };
+    let env: Vec<u8> = unsafe { Region::from_heap_ptr(env_ptr).into_vec() };
+    let msg: Vec<u8> = unsafe { Region::from_heap_ptr(msg_ptr).into_vec() };
 
     let env: Env = try_into_contract_result!(from_json(env));
     let msg: M = try_into_contract_result!(from_json(msg));
@@ -585,8 +585,8 @@ where
     Q: CustomQuery,
     E: ToString,
 {
-    let env: Vec<u8> = unsafe { Region::from_heap_ptr(env_ptr).into_inner() };
-    let msg: Vec<u8> = unsafe { Region::from_heap_ptr(msg_ptr).into_inner() };
+    let env: Vec<u8> = unsafe { Region::from_heap_ptr(env_ptr).into_vec() };
+    let msg: Vec<u8> = unsafe { Region::from_heap_ptr(msg_ptr).into_vec() };
 
     let env: Env = try_into_contract_result!(from_json(env));
     let msg: IbcChannelOpenMsg = try_into_contract_result!(from_json(msg));
@@ -606,8 +606,8 @@ where
     C: CustomMsg,
     E: ToString,
 {
-    let env: Vec<u8> = unsafe { Region::from_heap_ptr(env_ptr).into_inner() };
-    let msg: Vec<u8> = unsafe { Region::from_heap_ptr(msg_ptr).into_inner() };
+    let env: Vec<u8> = unsafe { Region::from_heap_ptr(env_ptr).into_vec() };
+    let msg: Vec<u8> = unsafe { Region::from_heap_ptr(msg_ptr).into_vec() };
 
     let env: Env = try_into_contract_result!(from_json(env));
     let msg: IbcChannelConnectMsg = try_into_contract_result!(from_json(msg));
@@ -627,8 +627,8 @@ where
     C: CustomMsg,
     E: ToString,
 {
-    let env: Vec<u8> = unsafe { Region::from_heap_ptr(env_ptr).into_inner() };
-    let msg: Vec<u8> = unsafe { Region::from_heap_ptr(msg_ptr).into_inner() };
+    let env: Vec<u8> = unsafe { Region::from_heap_ptr(env_ptr).into_vec() };
+    let msg: Vec<u8> = unsafe { Region::from_heap_ptr(msg_ptr).into_vec() };
 
     let env: Env = try_into_contract_result!(from_json(env));
     let msg: IbcChannelCloseMsg = try_into_contract_result!(from_json(msg));
@@ -648,8 +648,8 @@ where
     C: CustomMsg,
     E: ToString,
 {
-    let env: Vec<u8> = unsafe { Region::from_heap_ptr(env_ptr).into_inner() };
-    let msg: Vec<u8> = unsafe { Region::from_heap_ptr(msg_ptr).into_inner() };
+    let env: Vec<u8> = unsafe { Region::from_heap_ptr(env_ptr).into_vec() };
+    let msg: Vec<u8> = unsafe { Region::from_heap_ptr(msg_ptr).into_vec() };
 
     let env: Env = try_into_contract_result!(from_json(env));
     let msg: IbcPacketReceiveMsg = try_into_contract_result!(from_json(msg));
@@ -669,8 +669,8 @@ where
     C: CustomMsg,
     E: ToString,
 {
-    let env: Vec<u8> = unsafe { Region::from_heap_ptr(env_ptr).into_inner() };
-    let msg: Vec<u8> = unsafe { Region::from_heap_ptr(msg_ptr).into_inner() };
+    let env: Vec<u8> = unsafe { Region::from_heap_ptr(env_ptr).into_vec() };
+    let msg: Vec<u8> = unsafe { Region::from_heap_ptr(msg_ptr).into_vec() };
 
     let env: Env = try_into_contract_result!(from_json(env));
     let msg: IbcPacketAckMsg = try_into_contract_result!(from_json(msg));
@@ -690,8 +690,8 @@ where
     C: CustomMsg,
     E: ToString,
 {
-    let env: Vec<u8> = unsafe { Region::from_heap_ptr(env_ptr).into_inner() };
-    let msg: Vec<u8> = unsafe { Region::from_heap_ptr(msg_ptr).into_inner() };
+    let env: Vec<u8> = unsafe { Region::from_heap_ptr(env_ptr).into_vec() };
+    let msg: Vec<u8> = unsafe { Region::from_heap_ptr(msg_ptr).into_vec() };
 
     let env: Env = try_into_contract_result!(from_json(env));
     let msg: IbcPacketTimeoutMsg = try_into_contract_result!(from_json(msg));

--- a/packages/std/src/exports.rs
+++ b/packages/std/src/exports.rs
@@ -128,7 +128,7 @@ where
         msg_ptr as *mut Region<Owned>,
     );
     let v = to_json_vec(&res).unwrap();
-    Region::from_data(v).to_heap_ptr() as u32
+    Region::from_vec(v).to_heap_ptr() as u32
 }
 
 /// do_execute should be wrapped in an external "C" export, containing a contract-specific function as arg
@@ -158,7 +158,7 @@ where
         msg_ptr as *mut Region<Owned>,
     );
     let v = to_json_vec(&res).unwrap();
-    Region::from_data(v).to_heap_ptr() as u32
+    Region::from_vec(v).to_heap_ptr() as u32
 }
 
 /// do_migrate should be wrapped in an external "C" export, containing a contract-specific function as arg
@@ -186,7 +186,7 @@ where
         msg_ptr as *mut Region<Owned>,
     );
     let v = to_json_vec(&res).unwrap();
-    Region::from_data(v).to_heap_ptr() as u32
+    Region::from_vec(v).to_heap_ptr() as u32
 }
 
 /// do_sudo should be wrapped in an external "C" export, containing a contract-specific function as arg
@@ -214,7 +214,7 @@ where
         msg_ptr as *mut Region<Owned>,
     );
     let v = to_json_vec(&res).unwrap();
-    Region::from_data(v).to_heap_ptr() as u32
+    Region::from_vec(v).to_heap_ptr() as u32
 }
 
 /// do_reply should be wrapped in an external "C" export, containing a contract-specific function as arg
@@ -241,7 +241,7 @@ where
         msg_ptr as *mut Region<Owned>,
     );
     let v = to_json_vec(&res).unwrap();
-    Region::from_data(v).to_heap_ptr() as u32
+    Region::from_vec(v).to_heap_ptr() as u32
 }
 
 /// do_query should be wrapped in an external "C" export, containing a contract-specific function as arg
@@ -267,7 +267,7 @@ where
         msg_ptr as *mut Region<Owned>,
     );
     let v = to_json_vec(&res).unwrap();
-    Region::from_data(v).to_heap_ptr() as u32
+    Region::from_vec(v).to_heap_ptr() as u32
 }
 
 /// do_ibc_channel_open is designed for use with #[entry_point] to make a "C" extern
@@ -294,7 +294,7 @@ where
         msg_ptr as *mut Region<Owned>,
     );
     let v = to_json_vec(&res).unwrap();
-    Region::from_data(v).to_heap_ptr() as u32
+    Region::from_vec(v).to_heap_ptr() as u32
 }
 
 /// do_ibc_channel_connect is designed for use with #[entry_point] to make a "C" extern
@@ -323,7 +323,7 @@ where
         msg_ptr as *mut Region<Owned>,
     );
     let v = to_json_vec(&res).unwrap();
-    Region::from_data(v).to_heap_ptr() as u32
+    Region::from_vec(v).to_heap_ptr() as u32
 }
 
 /// do_ibc_channel_close is designed for use with #[entry_point] to make a "C" extern
@@ -352,7 +352,7 @@ where
         msg_ptr as *mut Region<Owned>,
     );
     let v = to_json_vec(&res).unwrap();
-    Region::from_data(v).to_heap_ptr() as u32
+    Region::from_vec(v).to_heap_ptr() as u32
 }
 
 /// do_ibc_packet_receive is designed for use with #[entry_point] to make a "C" extern
@@ -382,7 +382,7 @@ where
         msg_ptr as *mut Region<Owned>,
     );
     let v = to_json_vec(&res).unwrap();
-    Region::from_data(v).to_heap_ptr() as u32
+    Region::from_vec(v).to_heap_ptr() as u32
 }
 
 /// do_ibc_packet_ack is designed for use with #[entry_point] to make a "C" extern
@@ -412,7 +412,7 @@ where
         msg_ptr as *mut Region<Owned>,
     );
     let v = to_json_vec(&res).unwrap();
-    Region::from_data(v).to_heap_ptr() as u32
+    Region::from_vec(v).to_heap_ptr() as u32
 }
 
 /// do_ibc_packet_timeout is designed for use with #[entry_point] to make a "C" extern
@@ -443,7 +443,7 @@ where
         msg_ptr as *mut Region<Owned>,
     );
     let v = to_json_vec(&res).unwrap();
-    Region::from_data(v).to_heap_ptr() as u32
+    Region::from_vec(v).to_heap_ptr() as u32
 }
 
 fn _do_instantiate<Q, M, C, E>(

--- a/packages/std/src/imports.rs
+++ b/packages/std/src/imports.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 use cosmwasm_core::{Addr, CanonicalAddr};
 
 use crate::import_helpers::{from_high_half, from_low_half};
-use crate::memory::{alloc, build_region, consume_region, Region};
+use crate::memory::{Owned, Region};
 use crate::results::SystemResult;
 #[cfg(feature = "iterator")]
 use crate::sections::decode_sections2;
@@ -106,8 +106,8 @@ impl ExternalStorage {
 
 impl Storage for ExternalStorage {
     fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
-        let key = build_region(key);
-        let key_ptr = &*key as *const Region as u32;
+        let key = Region::from_data(key);
+        let key_ptr = key.as_ptr() as u32;
 
         let read = unsafe { db_read(key_ptr) };
         if read == 0 {
@@ -115,9 +115,10 @@ impl Storage for ExternalStorage {
             return None;
         }
 
-        let value_ptr = read as *mut Region;
-        let data = unsafe { consume_region(value_ptr) };
-        Some(data)
+        let value_ptr = read as *mut Region<Owned>;
+        let data = unsafe { Region::from_heap_ptr(value_ptr) };
+
+        Some(data.into_inner())
     }
 
     fn set(&mut self, key: &[u8], value: &[u8]) {
@@ -125,18 +126,19 @@ impl Storage for ExternalStorage {
             panic!("TL;DR: Value must not be empty in Storage::set but in most cases you can use Storage::remove instead. Long story: Getting empty values from storage is not well supported at the moment. Some of our internal interfaces cannot differentiate between a non-existent key and an empty value. Right now, you cannot rely on the behaviour of empty values. To protect you from trouble later on, we stop here. Sorry for the inconvenience! We highly welcome you to contribute to CosmWasm, making this more solid one way or the other.");
         }
 
-        // keep the boxes in scope, so we free it at the end (don't cast to pointers same line as build_region)
-        let key = build_region(key);
-        let key_ptr = &*key as *const Region as u32;
-        let mut value = build_region(value);
-        let value_ptr = &mut *value as *mut Region as u32;
+        let key = Region::from_data(key);
+        let key_ptr = key.as_ptr() as u32;
+
+        let value = Region::from_data(value);
+        let value_ptr = value.as_ptr() as u32;
+
         unsafe { db_write(key_ptr, value_ptr) };
     }
 
     fn remove(&mut self, key: &[u8]) {
-        // keep the boxes in scope, so we free it at the end (don't cast to pointers same line as build_region)
-        let key = build_region(key);
-        let key_ptr = &*key as *const Region as u32;
+        let key = Region::from_data(key);
+        let key_ptr = key.as_ptr() as u32;
+
         unsafe { db_remove(key_ptr) };
     }
 
@@ -187,8 +189,8 @@ impl Storage for ExternalStorage {
 fn create_iter(start: Option<&[u8]>, end: Option<&[u8]>, order: Order) -> u32 {
     // There is lots of gotchas on turning options into regions for FFI, thus this design
     // See: https://github.com/CosmWasm/cosmwasm/pull/509
-    let start_region = start.map(build_region);
-    let end_region = end.map(build_region);
+    let start_region = start.map(Region::from_data);
+    let end_region = end.map(Region::from_data);
     let start_region_addr = get_optional_region_address(&start_region.as_ref());
     let end_region_addr = get_optional_region_address(&end_region.as_ref());
     unsafe { db_scan(start_region_addr, end_region_addr, order as i32) }
@@ -235,9 +237,10 @@ impl Iterator for ExternalPartialIterator {
             return None;
         }
 
-        let data_region = next_result as *mut Region;
-        let data = unsafe { consume_region(data_region) };
-        Some(data)
+        let data_region = next_result as *mut Region<Owned>;
+        let data = unsafe { Region::from_heap_ptr(data_region) };
+
+        Some(data.into_inner())
     }
 }
 
@@ -263,9 +266,11 @@ impl Iterator for ExternalIterator {
 
     fn next(&mut self) -> Option<Self::Item> {
         let next_result = unsafe { db_next(self.iterator_id) };
-        let kv_region_ptr = next_result as *mut Region;
-        let kv = unsafe { consume_region(kv_region_ptr) };
-        let (key, value) = decode_sections2(kv);
+        let kv_region_ptr = next_result as *mut Region<Owned>;
+        let kv = unsafe { Region::from_heap_ptr(kv_region_ptr) };
+
+        let (key, value) = decode_sections2(kv.into_inner());
+
         if key.len() == 0 {
             None
         } else {
@@ -283,8 +288,9 @@ fn skip_iter(iter_id: u32, count: usize) {
             // early return
             return;
         }
+
         // just deallocate the region
-        unsafe { consume_region(region as *mut Region) };
+        unsafe { Region::from_heap_ptr(region as *mut Region<Owned>) };
     }
 }
 
@@ -307,12 +313,13 @@ impl Api for ExternalApi {
             // Stop here to allow handling the error in the contract.
             return Err(StdError::generic_err("input too long for addr_validate"));
         }
-        let source = build_region(input_bytes);
-        let source_ptr = &*source as *const Region as u32;
+        let source = Region::from_data(input_bytes);
+        let source_ptr = source.as_ptr() as u32;
 
         let result = unsafe { addr_validate(source_ptr) };
         if result != 0 {
-            let error = unsafe { consume_string_region_written_by_vm(result as *mut Region) };
+            let error =
+                unsafe { consume_string_region_written_by_vm(result as *mut Region<Owned>) };
             return Err(StdError::generic_err(format!(
                 "addr_validate errored: {}",
                 error
@@ -332,38 +339,41 @@ impl Api for ExternalApi {
                 "input too long for addr_canonicalize",
             ));
         }
-        let send = build_region(input_bytes);
-        let send_ptr = &*send as *const Region as u32;
-        let canon = alloc(CANONICAL_ADDRESS_BUFFER_LENGTH);
+        let send = Region::from_data(input_bytes);
+        let send_ptr = send.as_ptr() as u32;
+        let canon = Region::with_capacity(CANONICAL_ADDRESS_BUFFER_LENGTH);
 
-        let result = unsafe { addr_canonicalize(send_ptr, canon as u32) };
+        let result = unsafe { addr_canonicalize(send_ptr, canon.as_ptr() as u32) };
         if result != 0 {
-            let error = unsafe { consume_string_region_written_by_vm(result as *mut Region) };
+            let error =
+                unsafe { consume_string_region_written_by_vm(result as *mut Region<Owned>) };
             return Err(StdError::generic_err(format!(
                 "addr_canonicalize errored: {}",
                 error
             )));
         }
 
-        let out = unsafe { consume_region(canon) };
-        Ok(CanonicalAddr::from(out))
+        Ok(CanonicalAddr::from(canon.into_inner()))
     }
 
     fn addr_humanize(&self, canonical: &CanonicalAddr) -> StdResult<Addr> {
-        let send = build_region(canonical.as_slice());
-        let send_ptr = &*send as *const Region as u32;
-        let human = alloc(HUMAN_ADDRESS_BUFFER_LENGTH);
+        let send = Region::from_data(canonical.as_slice());
+        let send_ptr = send.as_ptr() as u32;
+        let human = Region::with_capacity(HUMAN_ADDRESS_BUFFER_LENGTH);
 
-        let result = unsafe { addr_humanize(send_ptr, human as u32) };
+        let result = unsafe { addr_humanize(send_ptr, human.as_ptr() as u32) };
         if result != 0 {
-            let error = unsafe { consume_string_region_written_by_vm(result as *mut Region) };
+            let error =
+                unsafe { consume_string_region_written_by_vm(result as *mut Region<Owned>) };
             return Err(StdError::generic_err(format!(
                 "addr_humanize errored: {}",
                 error
             )));
         }
 
-        let address = unsafe { consume_string_region_written_by_vm(human) };
+        // TODO: Optimize this heap allocation away?
+        // I mean technically we save a bunch of heap allocation now anyway, but we can optimize this, too!
+        let address = unsafe { consume_string_region_written_by_vm(human.to_heap_ptr()) };
         Ok(Addr::unchecked(address))
     }
 
@@ -373,12 +383,12 @@ impl Api for ExternalApi {
         signature: &[u8],
         public_key: &[u8],
     ) -> Result<bool, VerificationError> {
-        let hash_send = build_region(message_hash);
-        let hash_send_ptr = &*hash_send as *const Region as u32;
-        let sig_send = build_region(signature);
-        let sig_send_ptr = &*sig_send as *const Region as u32;
-        let pubkey_send = build_region(public_key);
-        let pubkey_send_ptr = &*pubkey_send as *const Region as u32;
+        let hash_send = Region::from_data(message_hash);
+        let hash_send_ptr = hash_send.as_ptr() as u32;
+        let sig_send = Region::from_data(signature);
+        let sig_send_ptr = sig_send.as_ptr() as u32;
+        let pubkey_send = Region::from_data(public_key);
+        let pubkey_send_ptr = pubkey_send.as_ptr() as u32;
 
         let result = unsafe { secp256k1_verify(hash_send_ptr, sig_send_ptr, pubkey_send_ptr) };
         match result {
@@ -399,10 +409,10 @@ impl Api for ExternalApi {
         signature: &[u8],
         recover_param: u8,
     ) -> Result<Vec<u8>, RecoverPubkeyError> {
-        let hash_send = build_region(message_hash);
-        let hash_send_ptr = &*hash_send as *const Region as u32;
-        let sig_send = build_region(signature);
-        let sig_send_ptr = &*sig_send as *const Region as u32;
+        let hash_send = Region::from_data(message_hash);
+        let hash_send_ptr = hash_send.as_ptr() as u32;
+        let sig_send = Region::from_data(signature);
+        let sig_send_ptr = sig_send.as_ptr() as u32;
 
         let result =
             unsafe { secp256k1_recover_pubkey(hash_send_ptr, sig_send_ptr, recover_param.into()) };
@@ -410,7 +420,8 @@ impl Api for ExternalApi {
         let pubkey_ptr = from_low_half(result);
         match error_code {
             0 => {
-                let pubkey = unsafe { consume_region(pubkey_ptr as *mut Region) };
+                let pubkey =
+                    unsafe { Region::from_heap_ptr(pubkey_ptr as *mut Region<Owned>).into_inner() };
                 Ok(pubkey)
             }
             2 => panic!("MessageTooLong must not happen. This is a bug in the VM."),
@@ -428,12 +439,12 @@ impl Api for ExternalApi {
         signature: &[u8],
         public_key: &[u8],
     ) -> Result<bool, VerificationError> {
-        let hash_send = build_region(message_hash);
-        let hash_send_ptr = &*hash_send as *const Region as u32;
-        let sig_send = build_region(signature);
-        let sig_send_ptr = &*sig_send as *const Region as u32;
-        let pubkey_send = build_region(public_key);
-        let pubkey_send_ptr = &*pubkey_send as *const Region as u32;
+        let hash_send = Region::from_data(message_hash);
+        let hash_send_ptr = hash_send.as_ptr() as u32;
+        let sig_send = Region::from_data(signature);
+        let sig_send_ptr = sig_send.as_ptr() as u32;
+        let pubkey_send = Region::from_data(public_key);
+        let pubkey_send_ptr = pubkey_send.as_ptr() as u32;
 
         let result = unsafe { secp256r1_verify(hash_send_ptr, sig_send_ptr, pubkey_send_ptr) };
         match result {
@@ -455,10 +466,10 @@ impl Api for ExternalApi {
         signature: &[u8],
         recover_param: u8,
     ) -> Result<Vec<u8>, RecoverPubkeyError> {
-        let hash_send = build_region(message_hash);
-        let hash_send_ptr = &*hash_send as *const Region as u32;
-        let sig_send = build_region(signature);
-        let sig_send_ptr = &*sig_send as *const Region as u32;
+        let hash_send = Region::from_data(message_hash);
+        let hash_send_ptr = hash_send.as_ptr() as u32;
+        let sig_send = Region::from_data(signature);
+        let sig_send_ptr = sig_send.as_ptr() as u32;
 
         let result =
             unsafe { secp256r1_recover_pubkey(hash_send_ptr, sig_send_ptr, recover_param.into()) };
@@ -466,7 +477,8 @@ impl Api for ExternalApi {
         let pubkey_ptr = from_low_half(result);
         match error_code {
             0 => {
-                let pubkey = unsafe { consume_region(pubkey_ptr as *mut Region) };
+                let pubkey =
+                    unsafe { Region::from_heap_ptr(pubkey_ptr as *mut Region<Owned>).into_inner() };
                 Ok(pubkey)
             }
             2 => panic!("MessageTooLong must not happen. This is a bug in the VM."),
@@ -483,12 +495,12 @@ impl Api for ExternalApi {
         signature: &[u8],
         public_key: &[u8],
     ) -> Result<bool, VerificationError> {
-        let msg_send = build_region(message);
-        let msg_send_ptr = &*msg_send as *const Region as u32;
-        let sig_send = build_region(signature);
-        let sig_send_ptr = &*sig_send as *const Region as u32;
-        let pubkey_send = build_region(public_key);
-        let pubkey_send_ptr = &*pubkey_send as *const Region as u32;
+        let msg_send = Region::from_data(message);
+        let msg_send_ptr = msg_send.as_ptr() as u32;
+        let sig_send = Region::from_data(signature);
+        let sig_send_ptr = sig_send.as_ptr() as u32;
+        let pubkey_send = Region::from_data(public_key);
+        let pubkey_send_ptr = pubkey_send.as_ptr() as u32;
 
         let result = unsafe { ed25519_verify(msg_send_ptr, sig_send_ptr, pubkey_send_ptr) };
         match result {
@@ -510,16 +522,16 @@ impl Api for ExternalApi {
         public_keys: &[&[u8]],
     ) -> Result<bool, VerificationError> {
         let msgs_encoded = encode_sections(messages);
-        let msgs_send = build_region(&msgs_encoded);
-        let msgs_send_ptr = &*msgs_send as *const Region as u32;
+        let msgs_send = Region::from_data(msgs_encoded);
+        let msgs_send_ptr = msgs_send.as_ptr() as u32;
 
         let sigs_encoded = encode_sections(signatures);
-        let sig_sends = build_region(&sigs_encoded);
-        let sigs_send_ptr = &*sig_sends as *const Region as u32;
+        let sig_sends = Region::from_data(sigs_encoded);
+        let sigs_send_ptr = sig_sends.as_ptr() as u32;
 
         let pubkeys_encoded = encode_sections(public_keys);
-        let pubkeys_send = build_region(&pubkeys_encoded);
-        let pubkeys_send_ptr = &*pubkeys_send as *const Region as u32;
+        let pubkeys_send = Region::from_data(pubkeys_encoded);
+        let pubkeys_send_ptr = pubkeys_send.as_ptr() as u32;
 
         let result =
             unsafe { ed25519_batch_verify(msgs_send_ptr, sigs_send_ptr, pubkeys_send_ptr) };
@@ -536,17 +548,17 @@ impl Api for ExternalApi {
     }
 
     fn debug(&self, message: &str) {
-        // keep the boxes in scope, so we free it at the end (don't cast to pointers same line as build_region)
-        let region = build_region(message.as_bytes());
-        let region_ptr = region.as_ref() as *const Region as u32;
+        // keep the boxes in scope, so we free it at the end (don't cast to pointers same line as Region::from_data)
+        let region = Region::from_data(message.as_bytes());
+        let region_ptr = region.as_ptr() as u32;
         unsafe { debug(region_ptr) };
     }
 }
 
 /// Takes a pointer to a Region and reads the data into a String.
 /// This is for trusted string sources only.
-unsafe fn consume_string_region_written_by_vm(from: *mut Region) -> String {
-    let data = consume_region(from);
+unsafe fn consume_string_region_written_by_vm(from: *mut Region<Owned>) -> String {
+    let data = Region::from_heap_ptr(from).into_inner();
     // We trust the VM/chain to return correct UTF-8, so let's save some gas
     String::from_utf8_unchecked(data)
 }
@@ -562,11 +574,12 @@ impl ExternalQuerier {
 
 impl Querier for ExternalQuerier {
     fn raw_query(&self, bin_request: &[u8]) -> QuerierResult {
-        let req = build_region(bin_request);
-        let request_ptr = &*req as *const Region as u32;
+        let req = Region::from_data(bin_request);
+        let request_ptr = req.as_ptr() as u32;
 
         let response_ptr = unsafe { query_chain(request_ptr) };
-        let response = unsafe { consume_region(response_ptr as *mut Region) };
+        let response =
+            unsafe { Region::from_heap_ptr(response_ptr as *mut Region<Owned>).into_inner() };
 
         from_json(&response).unwrap_or_else(|parsing_err| {
             SystemResult::Err(SystemError::InvalidResponse {
@@ -579,8 +592,7 @@ impl Querier for ExternalQuerier {
 
 #[cfg(feature = "abort")]
 pub fn handle_panic(message: &str) {
-    // keep the boxes in scope, so we free it at the end (don't cast to pointers same line as build_region)
-    let region = build_region(message.as_bytes());
-    let region_ptr = region.as_ref() as *const Region as u32;
+    let region = Region::from_data(message.as_bytes());
+    let region_ptr = region.as_ptr() as u32;
     unsafe { abort(region_ptr) };
 }

--- a/packages/std/src/imports.rs
+++ b/packages/std/src/imports.rs
@@ -371,9 +371,7 @@ impl Api for ExternalApi {
             )));
         }
 
-        // TODO: Optimize this heap allocation away?
-        // I mean technically we save a bunch of heap allocation now anyway, but we can optimize this, too!
-        let address = unsafe { consume_string_region_written_by_vm(human.to_heap_ptr()) };
+        let address = unsafe { String::from_utf8_unchecked(human.into_vec()) };
         Ok(Addr::unchecked(address))
     }
 

--- a/packages/std/src/imports.rs
+++ b/packages/std/src/imports.rs
@@ -106,7 +106,7 @@ impl ExternalStorage {
 
 impl Storage for ExternalStorage {
     fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
-        let key = Region::from_data(key);
+        let key = Region::from_slice(key);
         let key_ptr = key.as_ptr() as u32;
 
         let read = unsafe { db_read(key_ptr) };
@@ -126,17 +126,17 @@ impl Storage for ExternalStorage {
             panic!("TL;DR: Value must not be empty in Storage::set but in most cases you can use Storage::remove instead. Long story: Getting empty values from storage is not well supported at the moment. Some of our internal interfaces cannot differentiate between a non-existent key and an empty value. Right now, you cannot rely on the behaviour of empty values. To protect you from trouble later on, we stop here. Sorry for the inconvenience! We highly welcome you to contribute to CosmWasm, making this more solid one way or the other.");
         }
 
-        let key = Region::from_data(key);
+        let key = Region::from_slice(key);
         let key_ptr = key.as_ptr() as u32;
 
-        let value = Region::from_data(value);
+        let value = Region::from_slice(value);
         let value_ptr = value.as_ptr() as u32;
 
         unsafe { db_write(key_ptr, value_ptr) };
     }
 
     fn remove(&mut self, key: &[u8]) {
-        let key = Region::from_data(key);
+        let key = Region::from_slice(key);
         let key_ptr = key.as_ptr() as u32;
 
         unsafe { db_remove(key_ptr) };
@@ -189,8 +189,8 @@ impl Storage for ExternalStorage {
 fn create_iter(start: Option<&[u8]>, end: Option<&[u8]>, order: Order) -> u32 {
     // There is lots of gotchas on turning options into regions for FFI, thus this design
     // See: https://github.com/CosmWasm/cosmwasm/pull/509
-    let start_region = start.map(Region::from_data);
-    let end_region = end.map(Region::from_data);
+    let start_region = start.map(Region::from_slice);
+    let end_region = end.map(Region::from_slice);
     let start_region_addr = get_optional_region_address(&start_region.as_ref());
     let end_region_addr = get_optional_region_address(&end_region.as_ref());
     unsafe { db_scan(start_region_addr, end_region_addr, order as i32) }
@@ -313,7 +313,7 @@ impl Api for ExternalApi {
             // Stop here to allow handling the error in the contract.
             return Err(StdError::generic_err("input too long for addr_validate"));
         }
-        let source = Region::from_data(input_bytes);
+        let source = Region::from_slice(input_bytes);
         let source_ptr = source.as_ptr() as u32;
 
         let result = unsafe { addr_validate(source_ptr) };
@@ -339,7 +339,7 @@ impl Api for ExternalApi {
                 "input too long for addr_canonicalize",
             ));
         }
-        let send = Region::from_data(input_bytes);
+        let send = Region::from_slice(input_bytes);
         let send_ptr = send.as_ptr() as u32;
         let canon = Region::with_capacity(CANONICAL_ADDRESS_BUFFER_LENGTH);
 
@@ -357,7 +357,7 @@ impl Api for ExternalApi {
     }
 
     fn addr_humanize(&self, canonical: &CanonicalAddr) -> StdResult<Addr> {
-        let send = Region::from_data(canonical.as_slice());
+        let send = Region::from_slice(canonical.as_slice());
         let send_ptr = send.as_ptr() as u32;
         let human = Region::with_capacity(HUMAN_ADDRESS_BUFFER_LENGTH);
 
@@ -383,11 +383,11 @@ impl Api for ExternalApi {
         signature: &[u8],
         public_key: &[u8],
     ) -> Result<bool, VerificationError> {
-        let hash_send = Region::from_data(message_hash);
+        let hash_send = Region::from_slice(message_hash);
         let hash_send_ptr = hash_send.as_ptr() as u32;
-        let sig_send = Region::from_data(signature);
+        let sig_send = Region::from_slice(signature);
         let sig_send_ptr = sig_send.as_ptr() as u32;
-        let pubkey_send = Region::from_data(public_key);
+        let pubkey_send = Region::from_slice(public_key);
         let pubkey_send_ptr = pubkey_send.as_ptr() as u32;
 
         let result = unsafe { secp256k1_verify(hash_send_ptr, sig_send_ptr, pubkey_send_ptr) };
@@ -409,9 +409,9 @@ impl Api for ExternalApi {
         signature: &[u8],
         recover_param: u8,
     ) -> Result<Vec<u8>, RecoverPubkeyError> {
-        let hash_send = Region::from_data(message_hash);
+        let hash_send = Region::from_slice(message_hash);
         let hash_send_ptr = hash_send.as_ptr() as u32;
-        let sig_send = Region::from_data(signature);
+        let sig_send = Region::from_slice(signature);
         let sig_send_ptr = sig_send.as_ptr() as u32;
 
         let result =
@@ -439,11 +439,11 @@ impl Api for ExternalApi {
         signature: &[u8],
         public_key: &[u8],
     ) -> Result<bool, VerificationError> {
-        let hash_send = Region::from_data(message_hash);
+        let hash_send = Region::from_slice(message_hash);
         let hash_send_ptr = hash_send.as_ptr() as u32;
-        let sig_send = Region::from_data(signature);
+        let sig_send = Region::from_slice(signature);
         let sig_send_ptr = sig_send.as_ptr() as u32;
-        let pubkey_send = Region::from_data(public_key);
+        let pubkey_send = Region::from_slice(public_key);
         let pubkey_send_ptr = pubkey_send.as_ptr() as u32;
 
         let result = unsafe { secp256r1_verify(hash_send_ptr, sig_send_ptr, pubkey_send_ptr) };
@@ -466,9 +466,9 @@ impl Api for ExternalApi {
         signature: &[u8],
         recover_param: u8,
     ) -> Result<Vec<u8>, RecoverPubkeyError> {
-        let hash_send = Region::from_data(message_hash);
+        let hash_send = Region::from_slice(message_hash);
         let hash_send_ptr = hash_send.as_ptr() as u32;
-        let sig_send = Region::from_data(signature);
+        let sig_send = Region::from_slice(signature);
         let sig_send_ptr = sig_send.as_ptr() as u32;
 
         let result =
@@ -495,11 +495,11 @@ impl Api for ExternalApi {
         signature: &[u8],
         public_key: &[u8],
     ) -> Result<bool, VerificationError> {
-        let msg_send = Region::from_data(message);
+        let msg_send = Region::from_slice(message);
         let msg_send_ptr = msg_send.as_ptr() as u32;
-        let sig_send = Region::from_data(signature);
+        let sig_send = Region::from_slice(signature);
         let sig_send_ptr = sig_send.as_ptr() as u32;
-        let pubkey_send = Region::from_data(public_key);
+        let pubkey_send = Region::from_slice(public_key);
         let pubkey_send_ptr = pubkey_send.as_ptr() as u32;
 
         let result = unsafe { ed25519_verify(msg_send_ptr, sig_send_ptr, pubkey_send_ptr) };
@@ -522,15 +522,15 @@ impl Api for ExternalApi {
         public_keys: &[&[u8]],
     ) -> Result<bool, VerificationError> {
         let msgs_encoded = encode_sections(messages);
-        let msgs_send = Region::from_data(msgs_encoded);
+        let msgs_send = Region::from_vec(msgs_encoded);
         let msgs_send_ptr = msgs_send.as_ptr() as u32;
 
         let sigs_encoded = encode_sections(signatures);
-        let sig_sends = Region::from_data(sigs_encoded);
+        let sig_sends = Region::from_vec(sigs_encoded);
         let sigs_send_ptr = sig_sends.as_ptr() as u32;
 
         let pubkeys_encoded = encode_sections(public_keys);
-        let pubkeys_send = Region::from_data(pubkeys_encoded);
+        let pubkeys_send = Region::from_vec(pubkeys_encoded);
         let pubkeys_send_ptr = pubkeys_send.as_ptr() as u32;
 
         let result =
@@ -548,8 +548,8 @@ impl Api for ExternalApi {
     }
 
     fn debug(&self, message: &str) {
-        // keep the boxes in scope, so we free it at the end (don't cast to pointers same line as Region::from_data)
-        let region = Region::from_data(message.as_bytes());
+        // keep the boxes in scope, so we free it at the end (don't cast to pointers same line as Region::from_slice)
+        let region = Region::from_slice(message.as_bytes());
         let region_ptr = region.as_ptr() as u32;
         unsafe { debug(region_ptr) };
     }
@@ -574,7 +574,7 @@ impl ExternalQuerier {
 
 impl Querier for ExternalQuerier {
     fn raw_query(&self, bin_request: &[u8]) -> QuerierResult {
-        let req = Region::from_data(bin_request);
+        let req = Region::from_slice(bin_request);
         let request_ptr = req.as_ptr() as u32;
 
         let response_ptr = unsafe { query_chain(request_ptr) };
@@ -592,7 +592,7 @@ impl Querier for ExternalQuerier {
 
 #[cfg(feature = "abort")]
 pub fn handle_panic(message: &str) {
-    let region = Region::from_data(message.as_bytes());
+    let region = Region::from_slice(message.as_bytes());
     let region_ptr = region.as_ptr() as u32;
     unsafe { abort(region_ptr) };
 }

--- a/packages/std/src/memory.rs
+++ b/packages/std/src/memory.rs
@@ -1,15 +1,18 @@
 use alloc::vec::Vec;
 use core::{any::TypeId, marker::PhantomData, mem, ops::Deref, slice};
 
+/// This trait is used to indicate whether a region is borrowed or owned
 pub trait Ownership: 'static {}
 
 impl Ownership for Borrowed {}
 
 impl Ownership for Owned {}
 
-pub struct Owned;
-
+/// This type is used to indicate that the region is borrowed and must not be deallocated
 pub struct Borrowed;
+
+/// This type is used to indicate that the region is owned by the region and must be deallocated
+pub struct Owned;
 
 /// Describes some data allocated in Wasm's linear memory.
 /// A pointer to an instance of this can be returned over FFI boundaries.
@@ -67,6 +70,7 @@ impl Region<Owned> {
         region
     }
 
+    /// Transform the region into a vector
     pub fn into_vec(self) -> Vec<u8> {
         let vector = unsafe {
             Vec::from_raw_parts(

--- a/packages/std/src/memory.rs
+++ b/packages/std/src/memory.rs
@@ -22,7 +22,7 @@ pub struct Borrowed;
 ///
 /// This struct is crate internal since the cosmwasm-vm defines the same type independently.
 #[repr(C)]
-pub struct Region<T: Ownership> {
+pub struct Region<O: Ownership> {
     /// The beginning of the region expressed as bytes from the beginning of the linear memory
     pub offset: u32,
     /// The number of bytes available in this region
@@ -30,7 +30,7 @@ pub struct Region<T: Ownership> {
     /// The number of bytes used in this region
     pub length: u32,
 
-    _marker: PhantomData<T>,
+    _marker: PhantomData<O>,
 }
 
 impl Region<Borrowed> {
@@ -81,9 +81,9 @@ impl Region<Owned> {
     }
 }
 
-impl<T> Region<T>
+impl<O> Region<O>
 where
-    T: Ownership,
+    O: Ownership,
 {
     unsafe fn from_parts(ptr: *const u8, capacity: usize, length: usize) -> Self {
         // Well, this technically violates pointer provenance rules.
@@ -119,9 +119,9 @@ where
     }
 }
 
-impl<T> Deref for Region<T>
+impl<O> Deref for Region<O>
 where
-    T: Ownership,
+    O: Ownership,
 {
     type Target = [u8];
 
@@ -130,13 +130,13 @@ where
     }
 }
 
-impl<T> Drop for Region<T>
+impl<O> Drop for Region<O>
 where
-    T: Ownership,
+    O: Ownership,
 {
     fn drop(&mut self) {
         // Since we can't specialize the drop impl we need to perform a runtime check
-        if TypeId::of::<T>() == TypeId::of::<Owned>() {
+        if TypeId::of::<O>() == TypeId::of::<Owned>() {
             let region_start = self.offset as *mut u8;
 
             // This case is explicitely disallowed by Vec

--- a/packages/std/src/memory.rs
+++ b/packages/std/src/memory.rs
@@ -1,17 +1,11 @@
 use alloc::vec::Vec;
 use core::{any::TypeId, marker::PhantomData, mem, ops::Deref, slice};
 
-mod sealed {
-    pub trait Sealed: 'static {}
+pub trait Ownership: 'static {}
 
-    impl Sealed for super::Owned {}
+impl Ownership for Borrowed {}
 
-    impl Sealed for super::Borrowed {}
-}
-
-pub trait Ownership: sealed::Sealed + 'static {}
-
-impl<T> Ownership for T where T: sealed::Sealed {}
+impl Ownership for Owned {}
 
 pub struct Owned;
 

--- a/packages/std/src/memory.rs
+++ b/packages/std/src/memory.rs
@@ -162,10 +162,5 @@ where
 /// or zero if not present
 #[cfg(feature = "iterator")]
 pub fn get_optional_region_address<O: Ownership>(region: &Option<&Region<O>>) -> u32 {
-    /// Returns the address of the Region as an offset in linear memory
-    fn get_region_address<O: Ownership>(region: &Region<O>) -> u32 {
-        region.as_ptr() as u32
-    }
-
-    region.map(get_region_address).unwrap_or(0)
+    region.map(|r| r.as_ptr() as u32).unwrap_or(0)
 }

--- a/packages/std/src/memory.rs
+++ b/packages/std/src/memory.rs
@@ -66,9 +66,9 @@ pub trait Ownership: sealed::Sealed + 'static {}
 
 impl<T> Ownership for T where T: sealed::Sealed {}
 
-pub struct Owned {}
+pub struct Owned;
 
-pub struct Borrowed {}
+pub struct Borrowed;
 
 /// Describes some data allocated in Wasm's linear memory.
 /// A pointer to an instance of this can be returned over FFI boundaries.

--- a/packages/std/src/memory.rs
+++ b/packages/std/src/memory.rs
@@ -108,7 +108,7 @@ impl Region<Owned> {
         region
     }
 
-    pub fn into_inner(self) -> Vec<u8> {
+    pub fn into_vec(self) -> Vec<u8> {
         let vector = unsafe {
             Vec::from_raw_parts(
                 self.offset as *mut u8,

--- a/packages/std/src/memory.rs
+++ b/packages/std/src/memory.rs
@@ -33,6 +33,11 @@ pub struct Region<O: Ownership> {
     _marker: PhantomData<O>,
 }
 
+const _: () = {
+    assert!(mem::size_of::<Region<Borrowed>>() == 12);
+    assert!(mem::size_of::<Region<Owned>>() == 12);
+};
+
 impl Region<Borrowed> {
     pub fn from_slice(slice: &[u8]) -> Self {
         unsafe { Self::from_parts(slice.as_ptr(), slice.len(), slice.len()) }

--- a/packages/vm/src/memory.rs
+++ b/packages/vm/src/memory.rs
@@ -8,10 +8,6 @@ use crate::errors::{
     VmResult,
 };
 
-const _: () = {
-    assert!(std::mem::size_of::<Region>() == 12);
-};
-
 /****** read/write to wasm memory buffer ****/
 
 /// Describes some data allocated in Wasm's linear memory.

--- a/packages/vm/src/memory.rs
+++ b/packages/vm/src/memory.rs
@@ -8,6 +8,10 @@ use crate::errors::{
     VmResult,
 };
 
+const _: () = {
+    assert!(std::mem::size_of::<Region>() == 12);
+};
+
 /****** read/write to wasm memory buffer ****/
 
 /// Describes some data allocated in Wasm's linear memory.


### PR DESCRIPTION
This is a full internal rewrite of the region system, making use of the fact that the stack is part of the linear memory in WASM and can be read by the host.  

Meaning a decrease in allocations when calling host functions from the guest module, and the entire system is now a little more robust and has a nicer API.

---

So far I tested it locally with the `crypto-verify` contract which is a pretty complex one, but the CI will run all the contracts, so we'll see how it holds up.