### PR TITLE
Add workspace check on merge commit

### DIFF
--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -1,4 +1,4 @@
-name: Contract Development
+name: Contract
 
 # Pushes to long living branches and all PRs
 on:

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -1,0 +1,25 @@
+name: Workspace
+
+# Check workspace build on merge commit of all PRs.
+# Branches are checked better by CircleCI.
+on:
+  pull_request:
+
+env:
+  RUST_BACKTRACE: 1
+
+jobs:
+  check-workspace:
+    name: Check workspace
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.73.0
+          targets: wasm32-unknown-unknown
+          components: clippy, rustfmt
+      - name: Check workspace
+        run: ./devtools/check_workspace.sh

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -23,3 +23,17 @@ jobs:
           components: clippy, rustfmt
       - name: Check workspace
         run: ./devtools/check_workspace.sh
+
+  test-workspace:
+    name: Test workspace
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.73.0
+          components: rustfmt
+      - name: Test workspace
+        run: ./devtools/test_workspace.sh


### PR DESCRIPTION
This inspired by the CI failure in #4035 caused by a successful branch build but an incompatible merge commit between the PR branch and the destination branch (usually main).

The merge commit checks have been an open request in CircleCI for a long time. I don't know if this has been solved in the meantime or not.
- https://discuss.circleci.com/t/ability-to-checkout-merge-commits-not-just-branch-commits-maybe-even-make-it-the-default/28777
- https://ideas.circleci.com/cloud-feature-requests/p/show-test-results-for-prospective-merge-of-a-github-pr