### PR TITLE
Add message_info and deprecate mock_info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ and this project adheres to
 - cosmwasm-vm: Update wasmer to 4.3.1 ([#2147], [#2153])
 - cosmwasm-vm: Rebalance gas costs for cryptographic functions and wasm
   instructions. ([#2152])
+- cosmwasm-std: Add message_info and deprecate mock_info ([#2160])
 
 [#2044]: https://github.com/CosmWasm/cosmwasm/pull/2044
 [#2051]: https://github.com/CosmWasm/cosmwasm/pull/2051
@@ -92,6 +93,7 @@ and this project adheres to
 [#2147]: https://github.com/CosmWasm/cosmwasm/pull/2147
 [#2152]: https://github.com/CosmWasm/cosmwasm/pull/2152
 [#2153]: https://github.com/CosmWasm/cosmwasm/pull/2153
+[#2160]: https://github.com/CosmWasm/cosmwasm/pull/2160
 
 ## [2.0.1] - 2024-04-03
 

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -4,7 +4,7 @@ This guide explains what is needed to upgrade contracts when migrating over
 major releases of `cosmwasm`. Note that you can also view the
 [complete CHANGELOG](./CHANGELOG.md) to understand the differences.
 
-## 1.5.x -> 2.0.0
+## 1.5.x -> 2.0.x
 
 - Update `cosmwasm-*` dependencies in Cargo.toml (skip the ones you don't use):
 
@@ -261,6 +261,10 @@ major releases of `cosmwasm`. Note that you can also view the
   the `reply` entry point. This functionality is an optional addition introduced
   in 2.0. To keep the CosmWasm 1.x behaviour, just set payload to
   `Binary::default()`.
+
+- In test code, replace calls to `mock_info` with `message_info`. This takes a
+  `&Addr` as the first argument which you get by using owned `Addr` in the test
+  bodies.
 
 ## 1.4.x -> 1.5.0
 

--- a/contracts/burner/src/contract.rs
+++ b/contracts/burner/src/contract.rs
@@ -83,7 +83,7 @@ fn cleanup(storage: &mut dyn Storage, mut limit: usize) -> usize {
 mod tests {
     use super::*;
     use cosmwasm_std::testing::{
-        mock_dependencies, mock_dependencies_with_balance, mock_env, mock_info,
+        message_info, mock_dependencies, mock_dependencies_with_balance, mock_env,
     };
     use cosmwasm_std::{coins, Attribute, StdError, Storage, SubMsg};
 
@@ -102,8 +102,10 @@ mod tests {
     fn instantiate_fails() {
         let mut deps = mock_dependencies();
 
+        let creator = deps.api.addr_make("creator");
+
         let msg = InstantiateMsg {};
-        let info = mock_info("creator", &coins(1000, "earth"));
+        let info = message_info(&creator, &coins(1000, "earth"));
         // we can just call .unwrap() to assert this was a success
         let res = instantiate(deps.as_mut(), mock_env(), info, msg);
         match res.unwrap_err() {
@@ -164,6 +166,8 @@ mod tests {
     fn execute_cleans_up_data() {
         let mut deps = mock_dependencies_with_balance(&coins(123456, "gold"));
 
+        let anon = deps.api.addr_make("anon");
+
         // store some sample data
         deps.storage.set(b"foo", b"bar");
         deps.storage.set(b"key2", b"data2");
@@ -179,7 +183,7 @@ mod tests {
         let res = execute(
             deps.as_mut(),
             mock_env(),
-            mock_info("anon", &[]),
+            message_info(&anon, &[]),
             ExecuteMsg::Cleanup { limit: Some(2) },
         )
         .unwrap();
@@ -192,7 +196,7 @@ mod tests {
         let res = execute(
             deps.as_mut(),
             mock_env(),
-            mock_info("anon", &[]),
+            message_info(&anon, &[]),
             ExecuteMsg::Cleanup { limit: Some(2) },
         )
         .unwrap();

--- a/contracts/crypto-verify/src/contract.rs
+++ b/contracts/crypto-verify/src/contract.rs
@@ -324,7 +324,7 @@ pub fn query_verify_bls12_pairing_g2(
 mod tests {
     use super::*;
     use cosmwasm_std::testing::{
-        mock_dependencies, mock_env, mock_info, MockApi, MockQuerier, MockStorage,
+        message_info, mock_dependencies, mock_env, MockApi, MockQuerier, MockStorage,
     };
     use cosmwasm_std::{from_json, OwnedDeps, RecoverPubkeyError, VerificationError};
     use hex_literal::hex;
@@ -354,8 +354,9 @@ mod tests {
 
     fn setup() -> OwnedDeps<MockStorage, MockApi, MockQuerier> {
         let mut deps = mock_dependencies();
+        let creator = deps.api.addr_make(CREATOR);
         let msg = InstantiateMsg {};
-        let info = mock_info(CREATOR, &[]);
+        let info = message_info(&creator, &[]);
         let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
         assert_eq!(0, res.messages.len());
         deps

--- a/contracts/cyberpunk/src/contract.rs
+++ b/contracts/cyberpunk/src/contract.rs
@@ -227,14 +227,15 @@ fn query_denom(deps: Deps, denom: String) -> StdResult<DenomMetadata> {
 mod tests {
     use super::*;
     use cosmwasm_std::testing::{
-        mock_dependencies, mock_env, mock_info, MockApi, MockQuerier, MockStorage,
+        message_info, mock_dependencies, mock_env, MockApi, MockQuerier, MockStorage,
     };
     use cosmwasm_std::{from_json, DenomMetadata, DenomUnit, OwnedDeps};
 
     fn setup() -> OwnedDeps<MockStorage, MockApi, MockQuerier> {
         let mut deps = mock_dependencies();
+        let creator = deps.api.addr_make("creator");
         let msg = Empty {};
-        let info = mock_info("creator", &[]);
+        let info = message_info(&creator, &[]);
         let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
         assert_eq!(0, res.messages.len());
         deps
@@ -248,9 +249,10 @@ mod tests {
     #[test]
     fn debug_works() {
         let mut deps = setup();
+        let caller = deps.api.addr_make("caller");
 
         let msg = ExecuteMsg::Debug {};
-        execute(deps.as_mut(), mock_env(), mock_info("caller", &[]), msg).unwrap();
+        execute(deps.as_mut(), mock_env(), message_info(&caller, &[]), msg).unwrap();
     }
 
     #[test]

--- a/contracts/ibc-reflect-send/src/contract.rs
+++ b/contracts/ibc-reflect-send/src/contract.rs
@@ -202,19 +202,20 @@ fn query_admin(deps: Deps) -> StdResult<AdminResponse> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
+    use cosmwasm_std::testing::{message_info, mock_dependencies, mock_env};
 
     const CREATOR: &str = "creator";
 
     #[test]
     fn instantiate_works() {
         let mut deps = mock_dependencies();
+        let creator = deps.api.addr_make(CREATOR);
         let msg = InstantiateMsg {};
-        let info = mock_info(CREATOR, &[]);
+        let info = message_info(&creator, &[]);
         let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
         assert_eq!(0, res.messages.len());
 
         let admin = query_admin(deps.as_ref()).unwrap();
-        assert_eq!(CREATOR, admin.admin.as_str());
+        assert_eq!(admin.admin.as_str(), creator.as_str());
     }
 }

--- a/contracts/ibc-reflect-send/src/ibc.rs
+++ b/contracts/ibc-reflect-send/src/ibc.rs
@@ -230,9 +230,9 @@ mod tests {
     use crate::msg::{AccountResponse, ExecuteMsg, InstantiateMsg, QueryMsg};
 
     use cosmwasm_std::testing::{
-        mock_dependencies, mock_env, mock_ibc_channel_connect_ack, mock_ibc_channel_open_init,
-        mock_ibc_channel_open_try, mock_ibc_packet_ack, mock_info, MockApi, MockQuerier,
-        MockStorage,
+        message_info, mock_dependencies, mock_env, mock_ibc_channel_connect_ack,
+        mock_ibc_channel_open_init, mock_ibc_channel_open_try, mock_ibc_packet_ack, MockApi,
+        MockQuerier, MockStorage,
     };
     use cosmwasm_std::{coin, coins, BankMsg, CosmosMsg, IbcAcknowledgement, OwnedDeps};
 
@@ -240,8 +240,9 @@ mod tests {
 
     fn setup() -> OwnedDeps<MockStorage, MockApi, MockQuerier> {
         let mut deps = mock_dependencies();
+        let creator = deps.api.addr_make(CREATOR);
         let msg = InstantiateMsg {};
-        let info = mock_info(CREATOR, &[]);
+        let info = message_info(&creator, &[]);
         let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
         assert_eq!(0, res.messages.len());
         deps
@@ -337,6 +338,7 @@ mod tests {
 
         // init contract
         let mut deps = setup();
+        let creator = deps.api.addr_make(CREATOR);
         // channel handshake
         connect(deps.as_mut(), channel_id);
         // get feedback from WhoAmI packet
@@ -352,7 +354,7 @@ mod tests {
             channel_id: channel_id.into(),
             msgs: msgs_to_dispatch,
         };
-        let info = mock_info(CREATOR, &[]);
+        let info = message_info(&creator, &[]);
         let mut res = execute(deps.as_mut(), mock_env(), info, handle_msg).unwrap();
         assert_eq!(1, res.messages.len());
         let msg = match res.messages.swap_remove(0).msg {
@@ -380,6 +382,7 @@ mod tests {
 
         // init contract
         let mut deps = setup();
+        let creator = deps.api.addr_make(CREATOR);
         // channel handshake
         connect(deps.as_mut(), reflect_channel_id);
         // get feedback from WhoAmI packet
@@ -390,7 +393,7 @@ mod tests {
             reflect_channel_id: "random-channel".into(),
             transfer_channel_id: transfer_channel_id.into(),
         };
-        let info = mock_info(CREATOR, &coins(12344, "utrgd"));
+        let info = message_info(&creator, &coins(12344, "utrgd"));
         execute(deps.as_mut(), mock_env(), info, msg).unwrap_err();
 
         // let's try with no sent funds in the message
@@ -398,7 +401,7 @@ mod tests {
             reflect_channel_id: reflect_channel_id.into(),
             transfer_channel_id: transfer_channel_id.into(),
         };
-        let info = mock_info(CREATOR, &[]);
+        let info = message_info(&creator, &[]);
         execute(deps.as_mut(), mock_env(), info, msg).unwrap_err();
 
         // 3rd times the charm
@@ -406,7 +409,7 @@ mod tests {
             reflect_channel_id: reflect_channel_id.into(),
             transfer_channel_id: transfer_channel_id.into(),
         };
-        let info = mock_info(CREATOR, &coins(12344, "utrgd"));
+        let info = message_info(&creator, &coins(12344, "utrgd"));
         let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
         assert_eq!(1, res.messages.len());
         match &res.messages[0].msg {

--- a/contracts/ibc-reflect/src/contract.rs
+++ b/contracts/ibc-reflect/src/contract.rs
@@ -347,9 +347,10 @@ pub fn ibc_packet_timeout(
 mod tests {
     use super::*;
     use cosmwasm_std::testing::{
-        mock_dependencies, mock_env, mock_ibc_channel_close_init, mock_ibc_channel_connect_ack,
-        mock_ibc_channel_open_init, mock_ibc_channel_open_try, mock_ibc_packet_recv, mock_info,
-        mock_wasmd_attr, MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR,
+        message_info, mock_dependencies, mock_env, mock_ibc_channel_close_init,
+        mock_ibc_channel_connect_ack, mock_ibc_channel_open_init, mock_ibc_channel_open_try,
+        mock_ibc_packet_recv, mock_wasmd_attr, MockApi, MockQuerier, MockStorage,
+        MOCK_CONTRACT_ADDR,
     };
     use cosmwasm_std::{attr, coin, coins, from_json, BankMsg, OwnedDeps, WasmMsg};
 
@@ -361,12 +362,13 @@ mod tests {
 
     fn setup() -> OwnedDeps<MockStorage, MockApi, MockQuerier> {
         let mut deps = mock_dependencies();
+        let creator = deps.api.addr_make(CREATOR);
         let msg = InstantiateMsg {
             reflect_code_id: REFLECT_ID,
         };
-        let info = mock_info(CREATOR, &[]);
+        let info = message_info(&creator, &[]);
         let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
-        assert_eq!(0, res.messages.len());
+        assert_eq!(res.messages.len(), 0);
         deps
     }
 
@@ -420,11 +422,12 @@ mod tests {
     #[test]
     fn instantiate_works() {
         let mut deps = mock_dependencies();
+        let creator = deps.api.addr_make(CREATOR);
 
         let msg = InstantiateMsg {
             reflect_code_id: 17,
         };
-        let info = mock_info("creator", &[]);
+        let info = message_info(&creator, &[]);
         let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
         assert_eq!(0, res.messages.len())
     }

--- a/contracts/queue/src/contract.rs
+++ b/contracts/queue/src/contract.rs
@@ -179,14 +179,15 @@ fn query_open_iterators(deps: Deps, count: u32) -> Empty {
 mod tests {
     use super::*;
     use cosmwasm_std::testing::{
-        mock_dependencies_with_balance, mock_env, mock_info, MockApi, MockQuerier, MockStorage,
+        message_info, mock_dependencies_with_balance, mock_env, MockApi, MockQuerier, MockStorage,
     };
     use cosmwasm_std::{coins, from_json, OwnedDeps};
 
     /// Instantiates a contract with no elements
     fn create_contract() -> (OwnedDeps<MockStorage, MockApi, MockQuerier>, MessageInfo) {
         let mut deps = mock_dependencies_with_balance(&coins(1000, "earth"));
-        let info = mock_info("creator", &coins(1000, "earth"));
+        let creator = deps.api.addr_make("creator");
+        let info = message_info(&creator, &coins(1000, "earth"));
         let res = instantiate(deps.as_mut(), mock_env(), info.clone(), InstantiateMsg {}).unwrap();
         assert_eq!(0, res.messages.len());
         (deps, info)

--- a/contracts/staking/src/contract.rs
+++ b/contracts/staking/src/contract.rs
@@ -407,7 +407,7 @@ pub fn query_investment(deps: Deps) -> StdResult<InvestmentResponse> {
 mod tests {
     use super::*;
     use cosmwasm_std::testing::{
-        mock_dependencies, mock_env, mock_info, MockQuerier, StakingQuerier, MOCK_CONTRACT_ADDR,
+        message_info, mock_dependencies, mock_env, MockQuerier, StakingQuerier, MOCK_CONTRACT_ADDR,
     };
     use cosmwasm_std::{coins, Addr, Coin, CosmosMsg, Decimal, FullDelegation, Validator};
     use std::str::FromStr;
@@ -457,22 +457,23 @@ mod tests {
         }
     }
 
-    fn get_balance(deps: Deps, addr: &str) -> Uint128 {
-        query_balance(deps, addr).unwrap().balance
+    fn get_balance(deps: Deps, addr: &Addr) -> Uint128 {
+        query_balance(deps, addr.as_str()).unwrap().balance
     }
 
-    fn get_claims(deps: Deps, addr: &str) -> Uint128 {
-        query_claims(deps, addr).unwrap().claims
+    fn get_claims(deps: Deps, addr: &Addr) -> Uint128 {
+        query_claims(deps, addr.as_str()).unwrap().claims
     }
 
     #[test]
     fn initialization_with_missing_validator() {
         let mut deps = mock_dependencies();
+        let creator = deps.api.addr_make("creator");
+
         deps.querier
             .staking
             .update("ustake", &[sample_validator("john")], &[]);
 
-        let creator = deps.api.addr_make("creator").to_string();
         let msg = InstantiateMsg {
             name: "Cool Derivative".to_string(),
             symbol: "DRV".to_string(),
@@ -481,7 +482,7 @@ mod tests {
             exit_tax: Decimal::percent(2),
             min_withdrawal: Uint128::new(50),
         };
-        let info = mock_info(&creator, &[]);
+        let info = message_info(&creator, &[]);
 
         // make sure we can instantiate with this
         let res = instantiate(deps.as_mut(), mock_env(), info, msg);
@@ -496,6 +497,8 @@ mod tests {
     #[test]
     fn proper_initialization() {
         let mut deps = mock_dependencies();
+        let creator = deps.api.addr_make("creator");
+
         deps.querier.staking.update(
             "ustake",
             &[
@@ -506,7 +509,6 @@ mod tests {
             &[],
         );
 
-        let creator = deps.api.addr_make("creator").to_string();
         let msg = InstantiateMsg {
             name: "Cool Derivative".to_string(),
             symbol: "DRV".to_string(),
@@ -515,7 +517,7 @@ mod tests {
             exit_tax: Decimal::percent(2),
             min_withdrawal: Uint128::new(50),
         };
-        let info = mock_info(&creator, &[]);
+        let info = message_info(&creator, &[]);
 
         // make sure we can instantiate with this
         let res = instantiate(deps.as_mut(), mock_env(), info, msg.clone()).unwrap();
@@ -534,7 +536,7 @@ mod tests {
 
         // investment info correct
         let invest = query_investment(deps.as_ref()).unwrap();
-        assert_eq!(&invest.owner, &creator);
+        assert_eq!(&invest.owner, creator.as_str());
         assert_eq!(&invest.validator, &msg.validator);
         assert_eq!(invest.exit_tax, msg.exit_tax);
         assert_eq!(invest.min_withdrawal, msg.min_withdrawal);
@@ -549,18 +551,19 @@ mod tests {
         let mut deps = mock_dependencies();
         set_validator(&mut deps.querier);
 
-        let creator = deps.api.addr_make("creator").to_string();
+        let creator = deps.api.addr_make("creator");
+        let bob = deps.api.addr_make("bob");
+
         let instantiate_msg = default_init(2, 50);
-        let info = mock_info(&creator, &[]);
+        let info = message_info(&creator, &[]);
 
         // make sure we can instantiate with this
         let res = instantiate(deps.as_mut(), mock_env(), info, instantiate_msg).unwrap();
         assert_eq!(0, res.messages.len());
 
         // let's bond some tokens now
-        let bob = deps.api.addr_make("bob").to_string();
         let bond_msg = ExecuteMsg::Bond {};
-        let info = mock_info(&bob, &[coin(10, "random"), coin(1000, "ustake")]);
+        let info = message_info(&bob, &[coin(10, "random"), coin(1000, "ustake")]);
 
         // try to bond and make sure we trigger delegation
         let res = execute(deps.as_mut(), mock_env(), info, bond_msg).unwrap();
@@ -589,18 +592,21 @@ mod tests {
         let mut deps = mock_dependencies();
         set_validator(&mut deps.querier);
 
-        let creator = deps.api.addr_make("creator").to_string();
+        let creator = deps.api.addr_make("creator");
+        let bob = deps.api.addr_make("bob");
+        let alice = deps.api.addr_make("alice");
+        let contract = deps.api.addr_make(MOCK_CONTRACT_ADDR);
+
         let instantiate_msg = default_init(2, 50);
-        let info = mock_info(creator.as_str(), &[]);
+        let info = message_info(&creator, &[]);
 
         // make sure we can instantiate with this
         let res = instantiate(deps.as_mut(), mock_env(), info, instantiate_msg).unwrap();
         assert_eq!(0, res.messages.len());
 
         // let's bond some tokens now
-        let bob = deps.api.addr_make("bob").to_string();
         let bond_msg = ExecuteMsg::Bond {};
-        let info = mock_info(bob.as_str(), &[coin(10, "random"), coin(1000, "ustake")]);
+        let info = message_info(&bob, &[coin(10, "random"), coin(1000, "ustake")]);
         let res = execute(deps.as_mut(), mock_env(), info, bond_msg).unwrap();
         assert_eq!(1, res.messages.len());
 
@@ -609,11 +615,13 @@ mod tests {
 
         // fake a reinvestment (this must be sent by the contract itself)
         let rebond_msg = ExecuteMsg::_BondAllTokens {};
-        let info = mock_info(MOCK_CONTRACT_ADDR, &[]);
+        let info = message_info(&contract, &[]);
         deps.querier
             .bank
-            .update_balance(MOCK_CONTRACT_ADDR, coins(500, "ustake"));
-        let _ = execute(deps.as_mut(), mock_env(), info, rebond_msg).unwrap();
+            .update_balance(&contract, coins(500, "ustake"));
+        let mut env = mock_env();
+        env.contract.address = contract.clone();
+        let _ = execute(deps.as_mut(), env, info, rebond_msg).unwrap();
 
         // update the querier with new bond
         set_delegation(&mut deps.querier, 1500, "ustake");
@@ -626,9 +634,8 @@ mod tests {
         assert_eq!(invest.nominal_value, ratio);
 
         // we bond some other tokens and get a different issuance price (maintaining the ratio)
-        let alice = deps.api.addr_make("alice").to_string();
         let bond_msg = ExecuteMsg::Bond {};
-        let info = mock_info(alice.as_str(), &[coin(3000, "ustake")]);
+        let info = message_info(&alice, &[coin(3000, "ustake")]);
         let res = execute(deps.as_mut(), mock_env(), info, bond_msg).unwrap();
         assert_eq!(1, res.messages.len());
 
@@ -636,10 +643,7 @@ mod tests {
         set_delegation(&mut deps.querier, 3000, "ustake");
 
         // alice should have gotten 2000 DRV for the 3000 stake, keeping the ratio at 1.5
-        assert_eq!(
-            get_balance(deps.as_ref(), alice.as_str()),
-            Uint128::new(2000)
-        );
+        assert_eq!(get_balance(deps.as_ref(), &alice), Uint128::new(2000));
 
         let invest = query_investment(deps.as_ref()).unwrap();
         assert_eq!(invest.token_supply, Uint128::new(3000));
@@ -652,18 +656,19 @@ mod tests {
         let mut deps = mock_dependencies();
         set_validator(&mut deps.querier);
 
-        let creator = deps.api.addr_make("creator").to_string();
+        let creator = deps.api.addr_make("creator");
+        let bob = deps.api.addr_make("bob");
+
         let instantiate_msg = default_init(2, 50);
-        let info = mock_info(creator.as_str(), &[]);
+        let info = message_info(&creator, &[]);
 
         // make sure we can instantiate with this
         let res = instantiate(deps.as_mut(), mock_env(), info, instantiate_msg).unwrap();
         assert_eq!(0, res.messages.len());
 
         // let's bond some tokens now
-        let bob = deps.api.addr_make("bob").to_string();
         let bond_msg = ExecuteMsg::Bond {};
-        let info = mock_info(bob.as_str(), &[coin(500, "photon")]);
+        let info = message_info(&bob, &[coin(500, "photon")]);
 
         // try to bond and make sure we trigger delegation
         let res = execute(deps.as_mut(), mock_env(), info, bond_msg);
@@ -680,18 +685,20 @@ mod tests {
         let mut deps = mock_dependencies();
         set_validator(&mut deps.querier);
 
-        let creator = deps.api.addr_make("creator").to_string();
+        let creator = deps.api.addr_make("creator");
+        let bob = deps.api.addr_make("bob");
+        let contract = deps.api.addr_make(MOCK_CONTRACT_ADDR);
+
         let instantiate_msg = default_init(10, 50);
-        let info = mock_info(creator.as_str(), &[]);
+        let info = message_info(&creator, &[]);
 
         // make sure we can instantiate with this
         let res = instantiate(deps.as_mut(), mock_env(), info, instantiate_msg).unwrap();
         assert_eq!(0, res.messages.len());
 
         // let's bond some tokens now
-        let bob = deps.api.addr_make("bob").to_string();
         let bond_msg = ExecuteMsg::Bond {};
-        let info = mock_info(bob.as_str(), &[coin(10, "random"), coin(1000, "ustake")]);
+        let info = message_info(&bob, &[coin(10, "random"), coin(1000, "ustake")]);
         let res = execute(deps.as_mut(), mock_env(), info, bond_msg).unwrap();
         assert_eq!(1, res.messages.len());
 
@@ -701,21 +708,23 @@ mod tests {
         // fake a reinvestment (this must be sent by the contract itself)
         // after this, we see 1000 issues and 1500 bonded (and a price of 1.5)
         let rebond_msg = ExecuteMsg::_BondAllTokens {};
-        let info = mock_info(MOCK_CONTRACT_ADDR, &[]);
+        let info = message_info(&contract, &[]);
         deps.querier
             .bank
-            .update_balance(MOCK_CONTRACT_ADDR, coins(500, "ustake"));
-        let _ = execute(deps.as_mut(), mock_env(), info, rebond_msg).unwrap();
+            .update_balance(&contract, coins(500, "ustake"));
+        let mut env = mock_env();
+        env.contract.address = contract.clone();
+        let _ = execute(deps.as_mut(), env, info, rebond_msg).unwrap();
 
         // update the querier with new bond, lower balance
         set_delegation(&mut deps.querier, 1500, "ustake");
-        deps.querier.bank.update_balance(MOCK_CONTRACT_ADDR, vec![]);
+        deps.querier.bank.update_balance(&contract, vec![]);
 
         // creator now tries to unbond these tokens - this must fail
         let unbond_msg = ExecuteMsg::Unbond {
             amount: Uint128::new(600),
         };
-        let info = mock_info(creator.as_str(), &[]);
+        let info = message_info(&creator, &[]);
         let res = execute(deps.as_mut(), mock_env(), info, unbond_msg);
         match res.unwrap_err() {
             StakingError::Std {
@@ -733,7 +742,7 @@ mod tests {
         let owner_cut = Uint128::new(60);
         let bobs_claim = Uint128::new(810);
         let bobs_balance = Uint128::new(400);
-        let info = mock_info(bob.as_str(), &[]);
+        let info = message_info(&bob, &[]);
         let res = execute(deps.as_mut(), mock_env(), info, unbond_msg).unwrap();
         assert_eq!(1, res.messages.len());
         let delegate = &res.messages[0].msg;
@@ -749,10 +758,10 @@ mod tests {
         set_delegation(&mut deps.querier, 690, "ustake");
 
         // check balances
-        assert_eq!(get_balance(deps.as_ref(), bob.as_str()), bobs_balance);
-        assert_eq!(get_balance(deps.as_ref(), creator.as_str()), owner_cut);
+        assert_eq!(get_balance(deps.as_ref(), &bob), bobs_balance);
+        assert_eq!(get_balance(deps.as_ref(), &creator), owner_cut);
         // proper claims
-        assert_eq!(get_claims(deps.as_ref(), bob.as_str()), bobs_claim);
+        assert_eq!(get_claims(deps.as_ref(), &bob), bobs_claim);
 
         // supplies updated, ratio the same (1.5)
         let ratio = Decimal::from_str("1.5").unwrap();

--- a/contracts/virus/src/contract.rs
+++ b/contracts/virus/src/contract.rs
@@ -96,16 +96,17 @@ pub fn execute_spread(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
+    use cosmwasm_std::testing::{message_info, mock_dependencies, mock_env};
 
     const CREATOR: &str = "creator";
 
     #[test]
     fn instantiate_works() {
         let mut deps = mock_dependencies();
+        let creator = deps.api.addr_make(CREATOR);
         let msg = InstantiateMsg {};
-        let info = mock_info(CREATOR, &[]);
+        let info = message_info(&creator, &[]);
         let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
-        assert_eq!(0, res.messages.len());
+        assert_eq!(res.messages.len(), 0);
     }
 }

--- a/packages/std/src/coin.rs
+++ b/packages/std/src/coin.rs
@@ -63,14 +63,14 @@ impl fmt::Display for Coin {
 ///
 /// ```
 /// # use cosmwasm_std::{coins, BankMsg, CosmosMsg, Response, SubMsg};
-/// # use cosmwasm_std::testing::{mock_env, mock_info};
+/// # use cosmwasm_std::testing::mock_env;
 /// # let env = mock_env();
-/// # let info = mock_info("sender", &[]);
+/// # let recipient = "blub".to_string();
 /// let tip = coins(123, "ucosm");
 ///
 /// let mut response: Response = Default::default();
 /// response.messages = vec![SubMsg::new(BankMsg::Send {
-///   to_address: info.sender.into(),
+///   to_address: recipient,
 ///   amount: tip,
 /// })];
 /// ```
@@ -86,7 +86,7 @@ pub fn coins(amount: u128, denom: impl Into<String>) -> Vec<Coin> {
 /// # use cosmwasm_std::{coin, BankMsg, CosmosMsg, Response, SubMsg};
 /// # use cosmwasm_std::testing::{mock_env, mock_info};
 /// # let env = mock_env();
-/// # let info = mock_info("sender", &[]);
+/// # let recipient = "blub".to_string();
 /// let tip = vec![
 ///     coin(123, "ucosm"),
 ///     coin(24, "ustake"),
@@ -94,7 +94,7 @@ pub fn coins(amount: u128, denom: impl Into<String>) -> Vec<Coin> {
 ///
 /// let mut response: Response = Default::default();
 /// response.messages = vec![SubMsg::new(BankMsg::Send {
-///     to_address: info.sender.into(),
+///     to_address: recipient,
 ///     amount: tip,
 /// })];
 /// ```

--- a/packages/std/src/testing/message_info.rs
+++ b/packages/std/src/testing/message_info.rs
@@ -1,0 +1,83 @@
+use crate::{Addr, Coin, MessageInfo};
+
+/// A constructor function for [`MessageInfo`].
+///
+/// This is optimized for writing testing contract. It
+/// lives in `cosmwasm_std::testing` because constructing MessageInfo
+/// objects is not something that you usually need in contract code.
+///
+/// ## Examples
+///
+/// ```
+/// # use cosmwasm_std::{DepsMut, Env, Response, MessageInfo, StdResult};
+/// # struct InstantiateMsg {
+/// #     pub verifier: String,
+/// #     pub beneficiary: String,
+/// # }
+/// # pub fn instantiate(
+/// #     _deps: DepsMut,
+/// #     _env: Env,
+/// #     _info: MessageInfo,
+/// #     _msg: InstantiateMsg,
+/// # ) -> StdResult<Response> {
+/// #     Ok(Response::new().add_attribute("action", "instantiate"))
+/// # }
+/// use cosmwasm_std::coins;
+/// use cosmwasm_std::testing::{message_info, mock_dependencies, mock_env};
+///
+/// let mut deps = mock_dependencies();
+///
+/// // Create some Addr instances for testing
+/// let creator = deps.api.addr_make("creator");
+/// let verifier = deps.api.addr_make("verifies");
+/// let beneficiary = deps.api.addr_make("benefits");
+///
+/// let msg = InstantiateMsg {
+///     verifier: verifier.to_string(),
+///     beneficiary: beneficiary.to_string(),
+/// };
+/// let info = message_info(&creator, &coins(1000, "earth"));
+/// let response = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
+/// assert_eq!(response.messages.len(), 0);
+/// ```
+pub fn message_info(sender: &Addr, funds: &[Coin]) -> MessageInfo {
+    MessageInfo {
+        sender: sender.clone(),
+        funds: funds.to_vec(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cosmwasm_core::Uint128;
+
+    use crate::coins;
+
+    use super::*;
+
+    #[test]
+    fn message_info_works() {
+        let addr = Addr::unchecked("cosmwasm1...");
+
+        let info = message_info(&addr, &[]);
+        assert_eq!(
+            info,
+            MessageInfo {
+                sender: addr.clone(),
+                funds: vec![],
+            }
+        );
+
+        let info = message_info(&addr, &coins(123, "foo"));
+        assert_eq!(
+            info,
+            MessageInfo {
+                sender: addr.clone(),
+                funds: vec![Coin {
+                    amount: Uint128::new(123),
+                    denom: "foo".to_string(),
+                }],
+            }
+        );
+    }
+}

--- a/packages/std/src/testing/message_info.rs
+++ b/packages/std/src/testing/message_info.rs
@@ -2,8 +2,8 @@ use crate::{Addr, Coin, MessageInfo};
 
 /// A constructor function for [`MessageInfo`].
 ///
-/// This is optimized for writing testing contract. It
-/// lives in `cosmwasm_std::testing` because constructing MessageInfo
+/// This is designed for writing contract tests.
+/// It lives in `cosmwasm_std::testing` because constructing MessageInfo
 /// objects is not something that you usually need in contract code.
 ///
 /// ## Examples

--- a/packages/std/src/testing/mock.rs
+++ b/packages/std/src/testing/mock.rs
@@ -358,6 +358,7 @@ pub fn mock_env() -> Env {
 
 /// Just set sender and funds for the message.
 /// This is intended for use in test code only.
+#[deprecated(note = "This is inconvenient and unsafe. Use message_info instead.")]
 pub fn mock_info(sender: &str, funds: &[Coin]) -> MessageInfo {
     MessageInfo {
         sender: Addr::unchecked(sender),
@@ -1199,6 +1200,7 @@ mod tests {
 
     #[test]
     fn mock_info_works() {
+        #[allow(deprecated)]
         let info = mock_info("my name", &coins(100, "atom"));
         assert_eq!(
             info,

--- a/packages/std/src/testing/mod.rs
+++ b/packages/std/src/testing/mod.rs
@@ -3,10 +3,12 @@
 // Exposed for testing only
 // Both unit tests and integration tests are compiled to native code, so everything in here does not need to compile to Wasm.
 
+mod message_info;
 mod mock;
 
 pub use cosmwasm_core::testing::*;
 
+pub use message_info::message_info;
 #[cfg(feature = "cosmwasm_1_3")]
 pub use mock::DistributionQuerier;
 #[cfg(feature = "staking")]

--- a/packages/std/src/testing/mod.rs
+++ b/packages/std/src/testing/mod.rs
@@ -9,13 +9,15 @@ mod mock;
 pub use cosmwasm_core::testing::*;
 
 pub use message_info::message_info;
+#[allow(deprecated)]
+pub use mock::mock_info;
 #[cfg(feature = "cosmwasm_1_3")]
 pub use mock::DistributionQuerier;
 #[cfg(feature = "staking")]
 pub use mock::StakingQuerier;
 pub use mock::{
     mock_dependencies, mock_dependencies_with_balance, mock_dependencies_with_balances, mock_env,
-    mock_info, mock_wasmd_attr, BankQuerier, MockApi, MockQuerier, MockQuerierCustomHandlerResult,
+    mock_wasmd_attr, BankQuerier, MockApi, MockQuerier, MockQuerierCustomHandlerResult,
     MockStorage, MOCK_CONTRACT_ADDR,
 };
 #[cfg(feature = "stargate")]


### PR DESCRIPTION
3 reasons for this:
1. The function is a constructor that does not mock anything
2. We have owned `Addr` instances and don't want to call `.as_str()` all the time
3. `mock_info` is unsafe as it internally uses `Addr::unchecked`

TODO:

- [x] Implementation
- [x] CHANGELOG entry
- [x] MIGRATING entry for CosmWasm 1 -> 2