### PR TITLE
Rename `state_version` to `migrate_version`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,8 @@ and this project adheres to
   `Uint64::strict_add`/`::strict_sub` and document overflows. ([#2098], [#2107])
 - cosmwasm-std: Add `QuerierWrapper::query_grpc` helper for gRPC queries.
   ([#2120])
-- cosmwasm-derive: Add `state_version` attribute for `migrate` entrypoints
-  ([#2124])
+- cosmwasm-derive: Add `migrate_version` attribute for `migrate` entrypoints
+  ([#2124], [#2166])
 - cosmwasm-vm: Read the migrate version from Wasm modules and return them as
   part of `AnalyzeReport` ([#2129], [#2166])
 - cosmwasm-vm: Add `bls12_381_aggregate_g1`, `bls12_381_aggregate_g2`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,8 @@ and this project adheres to
   ([#2120])
 - cosmwasm-derive: Add `state_version` attribute for `migrate` entrypoints
   ([#2124])
-- cosmwasm-vm: Read the state version from Wasm modules and return them as part
-  of `AnalyzeReport` ([#2129])
+- cosmwasm-vm: Read the migrate version from Wasm modules and return them as
+  part of `AnalyzeReport` ([#2129], [#2166])
 - cosmwasm-vm: Add `bls12_381_aggregate_g1`, `bls12_381_aggregate_g2`,
   `bls12_381_pairing_equality`, `bls12_381_hash_to_g1`, and
   `bls12_381_hash_to_g2` to enable BLS12-381 curve operations, such as verifying
@@ -60,6 +60,7 @@ and this project adheres to
 [#2120]: https://github.com/CosmWasm/cosmwasm/pull/2120
 [#2124]: https://github.com/CosmWasm/cosmwasm/pull/2124
 [#2129]: https://github.com/CosmWasm/cosmwasm/pull/2129
+[#2166]: https://github.com/CosmWasm/cosmwasm/pull/2166
 
 ### Changed
 

--- a/packages/derive/src/lib.rs
+++ b/packages/derive/src/lib.rs
@@ -153,7 +153,7 @@ fn expand_attributes(func: &mut ItemFn) -> syn::Result<TokenStream> {
             #[doc(hidden)]
             #[cfg(target_arch = "wasm32")]
             #[link_section = "cw_migrate_version"]
-            /// This is an internal constant exported as a custom section denoting the contract state version.
+            /// This is an internal constant exported as a custom section denoting the contract migrate version.
             /// The format and even the existence of this value is an implementation detail, DO NOT RELY ON THIS!
             static __CW_MIGRATE_VERSION: &str = #version;
         };
@@ -265,7 +265,7 @@ mod test {
             #[doc(hidden)]
             #[cfg(target_arch = "wasm32")]
             #[link_section = "cw_migrate_version"]
-            /// This is an internal constant exported as a custom section denoting the contract state version.
+            /// This is an internal constant exported as a custom section denoting the contract migrate version.
             /// The format and even the existence of this value is an implementation detail, DO NOT RELY ON THIS!
             static __CW_MIGRATE_VERSION: &str = "2";
 

--- a/packages/derive/src/lib.rs
+++ b/packages/derive/src/lib.rs
@@ -106,7 +106,7 @@ impl Parse for Options {
 /// #
 /// # type MigrateMsg = ();
 /// #[entry_point]
-/// #[state_version(2)]
+/// #[migrate_version(2)]
 /// pub fn migrate(deps: DepsMut, env: Env, msg: MigrateMsg) -> StdResult<Response> {
 ///     todo!();
 /// }
@@ -123,7 +123,7 @@ fn expand_attributes(func: &mut ItemFn) -> syn::Result<TokenStream> {
     let attributes = std::mem::take(&mut func.attrs);
     let mut stream = TokenStream::new();
     for attribute in attributes {
-        if !attribute.path().is_ident("state_version") {
+        if !attribute.path().is_ident("migrate_version") {
             func.attrs.push(attribute);
             continue;
         }
@@ -152,10 +152,10 @@ fn expand_attributes(func: &mut ItemFn) -> syn::Result<TokenStream> {
             #[allow(unused)]
             #[doc(hidden)]
             #[cfg(target_arch = "wasm32")]
-            #[link_section = "cw_state_version"]
+            #[link_section = "cw_migrate_version"]
             /// This is an internal constant exported as a custom section denoting the contract state version.
             /// The format and even the existence of this value is an implementation detail, DO NOT RELY ON THIS!
-            static __CW_STATE_VERSION: &str = #version;
+            static __CW_MIGRATE_VERSION: &str = #version;
         };
     }
 
@@ -202,7 +202,7 @@ mod test {
     #[test]
     fn contract_state_zero_not_allowed() {
         let code = quote! {
-            #[state_version(0)]
+            #[migrate_version(0)]
             fn migrate() -> Response {
                 // Logic here
             }
@@ -217,9 +217,9 @@ mod test {
     }
 
     #[test]
-    fn contract_state_version_on_non_migrate() {
+    fn contract_migrate_version_on_non_migrate() {
         let code = quote! {
-            #[state_version(42)]
+            #[migrate_version(42)]
             fn anything_else() -> Response {
                 // Logic here
             }
@@ -234,9 +234,9 @@ mod test {
     }
 
     #[test]
-    fn contract_state_version_in_u64() {
+    fn contract_migrate_version_in_u64() {
         let code = quote! {
-            #[state_version(0xDEAD_BEEF_FFFF_DEAD_2BAD)]
+            #[migrate_version(0xDEAD_BEEF_FFFF_DEAD_2BAD)]
             fn migrate(deps: DepsMut, env: Env, msg: MigrateMsg) -> Response {
                 // Logic here
             }
@@ -251,9 +251,9 @@ mod test {
     }
 
     #[test]
-    fn contract_state_version_expansion() {
+    fn contract_migrate_version_expansion() {
         let code = quote! {
-            #[state_version(2)]
+            #[migrate_version(2)]
             fn migrate(deps: DepsMut, env: Env, msg: MigrateMsg) -> Response {
                 // Logic here
             }
@@ -264,10 +264,10 @@ mod test {
             #[allow(unused)]
             #[doc(hidden)]
             #[cfg(target_arch = "wasm32")]
-            #[link_section = "cw_state_version"]
+            #[link_section = "cw_migrate_version"]
             /// This is an internal constant exported as a custom section denoting the contract state version.
             /// The format and even the existence of this value is an implementation detail, DO NOT RELY ON THIS!
-            static __CW_STATE_VERSION: &str = "2";
+            static __CW_MIGRATE_VERSION: &str = "2";
 
             fn migrate(deps: DepsMut, env: Env, msg: MigrateMsg) -> Response {
                 // Logic here

--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -133,7 +133,7 @@ pub struct AnalysisReport {
     pub entrypoints: BTreeSet<Entrypoint>,
     /// The set of capabilities the contract requires.
     pub required_capabilities: BTreeSet<String>,
-    /// The contract state version exported set by the contract developer
+    /// The contract migrate version exported set by the contract developer
     pub contract_migrate_version: Option<u64>,
 }
 

--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -134,7 +134,7 @@ pub struct AnalysisReport {
     /// The set of capabilities the contract requires.
     pub required_capabilities: BTreeSet<String>,
     /// The contract state version exported set by the contract developer
-    pub contract_state_version: Option<u64>,
+    pub contract_migrate_version: Option<u64>,
 }
 
 impl<A, S, Q> Cache<A, S, Q>
@@ -323,7 +323,7 @@ where
             required_capabilities: required_capabilities_from_module(&module)
                 .into_iter()
                 .collect(),
-            contract_state_version: module.contract_state_version,
+            contract_migrate_version: module.contract_migrate_version,
         })
     }
 
@@ -1416,7 +1416,7 @@ mod tests {
                     E::Query
                 ]),
                 required_capabilities: BTreeSet::new(),
-                contract_state_version: None,
+                contract_migrate_version: None,
             }
         );
 
@@ -1434,7 +1434,7 @@ mod tests {
                     "iterator".to_string(),
                     "stargate".to_string()
                 ]),
-                contract_state_version: None,
+                contract_migrate_version: None,
             }
         );
 
@@ -1446,13 +1446,13 @@ mod tests {
                 has_ibc_entry_points: false,
                 entrypoints: BTreeSet::new(),
                 required_capabilities: BTreeSet::from(["iterator".to_string()]),
-                contract_state_version: None,
+                contract_migrate_version: None,
             }
         );
 
         let mut wasm_with_version = EMPTY_CONTRACT.to_vec();
         let custom_section = wasm_encoder::CustomSection {
-            name: Cow::Borrowed("cw_state_version"),
+            name: Cow::Borrowed("cw_migrate_version"),
             data: Cow::Borrowed(b"21"),
         };
         custom_section.append_to_component(&mut wasm_with_version);
@@ -1465,7 +1465,7 @@ mod tests {
                 has_ibc_entry_points: false,
                 entrypoints: BTreeSet::new(),
                 required_capabilities: BTreeSet::from(["iterator".to_string()]),
-                contract_state_version: Some(21),
+                contract_migrate_version: Some(21),
             }
         );
     }

--- a/packages/vm/src/parsed_wasm.rs
+++ b/packages/vm/src/parsed_wasm.rs
@@ -66,7 +66,7 @@ pub struct ParsedWasm<'a> {
     pub total_func_params: usize,
     /// Collections of functions that are potentially pending validation
     pub func_validator: FunctionValidator<'a>,
-    /// Contract state version as defined in a custom section
+    /// Contract migrate version as defined in a custom section
     pub contract_migrate_version: Option<u64>,
 }
 

--- a/packages/vm/src/parsed_wasm.rs
+++ b/packages/vm/src/parsed_wasm.rs
@@ -67,7 +67,7 @@ pub struct ParsedWasm<'a> {
     /// Collections of functions that are potentially pending validation
     pub func_validator: FunctionValidator<'a>,
     /// Contract state version as defined in a custom section
-    pub contract_state_version: Option<u64>,
+    pub contract_migrate_version: Option<u64>,
 }
 
 impl<'a> ParsedWasm<'a> {
@@ -110,7 +110,7 @@ impl<'a> ParsedWasm<'a> {
             max_func_results: 0,
             total_func_params: 0,
             func_validator: FunctionValidator::Pending(OpaqueDebug::default()),
-            contract_state_version: None,
+            contract_migrate_version: None,
         };
 
         for p in Parser::new(0).parse_all(wasm) {
@@ -182,12 +182,12 @@ impl<'a> ParsedWasm<'a> {
                 Payload::ExportSection(e) => {
                     this.exports = e.into_iter().collect::<Result<Vec<_>, _>>()?;
                 }
-                Payload::CustomSection(reader) if reader.name() == "cw_state_version" => {
+                Payload::CustomSection(reader) if reader.name() == "cw_migrate_version" => {
                     // This is supposed to be valid UTF-8
                     let raw_version = str::from_utf8(reader.data())
                         .map_err(|err| VmError::static_validation_err(err.to_string()))?;
 
-                    this.contract_state_version = Some(
+                    this.contract_migrate_version = Some(
                         raw_version
                             .parse::<u64>()
                             .map_err(|err| VmError::static_validation_err(err.to_string()))?,
@@ -234,18 +234,19 @@ mod test {
     use super::ParsedWasm;
 
     #[test]
-    fn read_state_version() {
+    fn read_migrate_version() {
         let wasm_data =
-            wat::parse_str(r#"( module ( @custom "cw_state_version" "42" ) )"#).unwrap();
+            wat::parse_str(r#"( module ( @custom "cw_migrate_version" "42" ) )"#).unwrap();
         let parsed = ParsedWasm::parse(&wasm_data).unwrap();
 
-        assert_eq!(parsed.contract_state_version, Some(42));
+        assert_eq!(parsed.contract_migrate_version, Some(42));
     }
 
     #[test]
-    fn read_state_version_fails() {
+    fn read_migrate_version_fails() {
         let wasm_data =
-            wat::parse_str(r#"( module ( @custom "cw_state_version" "not a number" ) )"#).unwrap();
+            wat::parse_str(r#"( module ( @custom "cw_migrate_version" "not a number" ) )"#)
+                .unwrap();
         assert!(ParsedWasm::parse(&wasm_data).is_err());
     }
 }


### PR DESCRIPTION
closes #2164 