### PR TITLE
Implement TransferMsgBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ and this project adheres to
   `ibc_source_callback` and `ibc_destination_callback`, as well as the
   `IbcCallbackRequest` type. ([#2025])
 - cosmwasm-vm: Add support for the two new IBC Callbacks entrypoints. ([#2025])
+- cosmwasm-std: Add `TransferMsgBuilder` to more easily create an
+  `IbcMsg::Transfer` with different kinds of memo values, including IBC
+  Callbacks memo values. ([#2167])
 
 [#1983]: https://github.com/CosmWasm/cosmwasm/pull/1983
 [#2025]: https://github.com/CosmWasm/cosmwasm/pull/2025
@@ -64,6 +67,7 @@ and this project adheres to
 [#2124]: https://github.com/CosmWasm/cosmwasm/pull/2124
 [#2129]: https://github.com/CosmWasm/cosmwasm/pull/2129
 [#2166]: https://github.com/CosmWasm/cosmwasm/pull/2166
+[#2167]: https://github.com/CosmWasm/cosmwasm/pull/2167
 
 ### Changed
 

--- a/packages/std/src/ibc.rs
+++ b/packages/std/src/ibc.rs
@@ -13,7 +13,10 @@ use crate::StdResult;
 use crate::{to_json_binary, Binary};
 
 mod callbacks;
+mod transfer_msg_builder;
+
 pub use callbacks::*;
+pub use transfer_msg_builder::*;
 
 /// These are messages in the IBC lifecycle. Only usable by IBC-enabled contracts
 /// (contracts that directly speak the IBC protocol via 6 entry points)

--- a/packages/std/src/ibc/callbacks.rs
+++ b/packages/std/src/ibc/callbacks.rs
@@ -61,9 +61,9 @@ use crate::{Addr, IbcAcknowledgement, IbcPacket, Uint64};
 pub struct IbcCallbackRequest {
     // using private fields to force use of the constructors
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) src_callback: Option<IbcSrcCallback>,
+    src_callback: Option<IbcSrcCallback>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) dest_callback: Option<IbcDstCallback>,
+    dest_callback: Option<IbcDstCallback>,
 }
 
 impl IbcCallbackRequest {

--- a/packages/std/src/ibc/callbacks.rs
+++ b/packages/std/src/ibc/callbacks.rs
@@ -39,9 +39,9 @@ use crate::{Addr, IbcAcknowledgement, IbcPacket, Uint64};
 pub struct IbcCallbackRequest {
     // using private fields to force use of the constructors
     #[serde(skip_serializing_if = "Option::is_none")]
-    src_callback: Option<IbcSrcCallback>,
+    pub(crate) src_callback: Option<IbcSrcCallback>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    dest_callback: Option<IbcDstCallback>,
+    pub(crate) dest_callback: Option<IbcDstCallback>,
 }
 
 impl IbcCallbackRequest {

--- a/packages/std/src/ibc/callbacks.rs
+++ b/packages/std/src/ibc/callbacks.rs
@@ -15,12 +15,34 @@ use crate::{Addr, IbcAcknowledgement, IbcPacket, Uint64};
 ///
 /// # Example
 ///
+/// Using [`TransferMsgBuilder`](crate::TransferMsgBuilder):
+/// ```rust
+/// use cosmwasm_std::{
+///     to_json_string, Coin, IbcCallbackRequest, TransferMsgBuilder, IbcSrcCallback, IbcTimeout, Response,
+///     Timestamp,
+/// };
+/// # use cosmwasm_std::testing::mock_env;
+/// # let env = mock_env();
+///
+/// let _transfer = TransferMsgBuilder::new(
+///     "channel-0".to_string(),
+///     "cosmos1example".to_string(),
+///     Coin::new(10u32, "ucoin"),
+///     Timestamp::from_seconds(12345),
+/// )
+/// .with_src_callback(IbcSrcCallback {
+///     address: env.contract.address,
+///     gas_limit: None,
+/// })
+/// .build();
+/// ```
+///
+/// Manual serialization:
 /// ```rust
 /// use cosmwasm_std::{
 ///     to_json_string, Coin, IbcCallbackRequest, IbcMsg, IbcSrcCallback, IbcTimeout, Response,
 ///     Timestamp,
 /// };
-///
 /// # use cosmwasm_std::testing::mock_env;
 /// # let env = mock_env();
 ///

--- a/packages/std/src/ibc/callbacks.rs
+++ b/packages/std/src/ibc/callbacks.rs
@@ -24,7 +24,7 @@ use crate::{Addr, IbcAcknowledgement, IbcPacket, Uint64};
 /// # use cosmwasm_std::testing::mock_env;
 /// # let env = mock_env();
 ///
-/// let _transfer = TransferMsgBuilder::new(
+/// let _msg = TransferMsgBuilder::new(
 ///     "channel-0".to_string(),
 ///     "cosmos1example".to_string(),
 ///     Coin::new(10u32, "ucoin"),

--- a/packages/std/src/ibc/transfer_msg_builder.rs
+++ b/packages/std/src/ibc/transfer_msg_builder.rs
@@ -1,0 +1,263 @@
+use std::marker::PhantomData;
+
+use crate::{
+    to_json_string, Coin, IbcCallbackRequest, IbcDstCallback, IbcMsg, IbcSrcCallback, IbcTimeout,
+};
+
+// these are the different states the TransferMsgBuilder can be in
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct EmptyMemo;
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct WithMemo;
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct WithSrcCallback;
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct WithDstCallback;
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct WithCallbacks;
+
+// TODO: use trait for MemoData and get rid of state?
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum MemoData {
+    Empty,
+    Text(String),
+    IbcCallbacks(IbcCallbackRequest),
+}
+
+impl From<MemoData> for Option<String> {
+    fn from(memo: MemoData) -> Option<String> {
+        match memo {
+            MemoData::Empty => None,
+            MemoData::Text(text) => Some(text),
+            MemoData::IbcCallbacks(callbacks) => Some(to_json_string(&callbacks).unwrap()),
+        }
+    }
+}
+
+impl<T> TransferMsgBuilder<T> {
+    pub fn build(self) -> IbcMsg {
+        IbcMsg::Transfer {
+            channel_id: self.channel_id,
+            to_address: self.to_address,
+            amount: self.amount,
+            timeout: self.timeout,
+            memo: self.memo.into(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TransferMsgBuilder<State> {
+    channel_id: String,
+    to_address: String,
+    amount: Coin,
+    timeout: IbcTimeout,
+    memo: MemoData,
+    _state: PhantomData<State>,
+}
+
+impl TransferMsgBuilder<EmptyMemo> {
+    pub fn new(
+        channel_id: impl Into<String>,
+        to_address: impl Into<String>,
+        amount: Coin,
+        timeout: impl Into<IbcTimeout>,
+    ) -> Self {
+        Self {
+            channel_id: channel_id.into(),
+            to_address: to_address.into(),
+            amount,
+            timeout: timeout.into(),
+            memo: MemoData::Empty,
+            _state: PhantomData,
+        }
+    }
+
+    pub fn with_memo(self, memo: impl Into<String>) -> TransferMsgBuilder<WithMemo> {
+        TransferMsgBuilder {
+            channel_id: self.channel_id,
+            to_address: self.to_address,
+            amount: self.amount,
+            timeout: self.timeout,
+            memo: MemoData::Text(memo.into()),
+            _state: PhantomData,
+        }
+    }
+
+    pub fn with_src_callback(
+        self,
+        src_callback: IbcSrcCallback,
+    ) -> TransferMsgBuilder<WithSrcCallback> {
+        TransferMsgBuilder {
+            channel_id: self.channel_id,
+            to_address: self.to_address,
+            amount: self.amount,
+            timeout: self.timeout,
+            memo: MemoData::IbcCallbacks(IbcCallbackRequest::source(src_callback)),
+            _state: PhantomData,
+        }
+    }
+
+    pub fn with_dst_callback(
+        self,
+        dst_callback: IbcDstCallback,
+    ) -> TransferMsgBuilder<WithDstCallback> {
+        TransferMsgBuilder {
+            channel_id: self.channel_id,
+            to_address: self.to_address,
+            amount: self.amount,
+            timeout: self.timeout,
+            memo: MemoData::IbcCallbacks(IbcCallbackRequest::destination(dst_callback)),
+            _state: PhantomData,
+        }
+    }
+}
+
+impl TransferMsgBuilder<WithSrcCallback> {
+    pub fn with_dst_callback(
+        self,
+        dst_callback: IbcDstCallback,
+    ) -> TransferMsgBuilder<WithCallbacks> {
+        TransferMsgBuilder {
+            channel_id: self.channel_id,
+            to_address: self.to_address,
+            amount: self.amount,
+            timeout: self.timeout,
+            memo: match self.memo {
+                MemoData::IbcCallbacks(IbcCallbackRequest {
+                    src_callback: Some(src_callback),
+                    ..
+                }) => MemoData::IbcCallbacks(IbcCallbackRequest::both(src_callback, dst_callback)),
+                _ => unreachable!(), // we know this never happens because of the WithSrcCallback state
+            },
+            _state: PhantomData,
+        }
+    }
+}
+
+impl TransferMsgBuilder<WithDstCallback> {
+    pub fn with_src_callback(
+        self,
+        src_callback: IbcSrcCallback,
+    ) -> TransferMsgBuilder<WithCallbacks> {
+        TransferMsgBuilder {
+            channel_id: self.channel_id,
+            to_address: self.to_address,
+            amount: self.amount,
+            timeout: self.timeout,
+            memo: match self.memo {
+                MemoData::IbcCallbacks(IbcCallbackRequest {
+                    dest_callback: Some(dst_callback),
+                    ..
+                }) => MemoData::IbcCallbacks(IbcCallbackRequest::both(src_callback, dst_callback)),
+                _ => unreachable!(), // we know this never happens because of the WithDstCallback state
+            },
+            _state: PhantomData,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{coin, Addr, Timestamp, Uint64};
+
+    use super::*;
+
+    #[test]
+    fn test_transfer_msg_builder() {
+        let src_callback = IbcSrcCallback {
+            address: Addr::unchecked("src"),
+            gas_limit: Some(Uint64::new(12345)),
+        };
+        let dst_callback = IbcDstCallback {
+            address: "dst".to_string(),
+            gas_limit: None,
+        };
+
+        let empty_memo_builder = TransferMsgBuilder::new(
+            "channel-0",
+            "cosmos1example",
+            coin(10, "ucoin"),
+            Timestamp::from_seconds(12345),
+        );
+
+        let empty = empty_memo_builder.clone().build();
+        let with_memo = empty_memo_builder.clone().with_memo("memo").build();
+
+        let with_src_callback_builder = empty_memo_builder
+            .clone()
+            .with_src_callback(src_callback.clone());
+        let with_src_callback = with_src_callback_builder.clone().build();
+        let with_dst_callback_builder = empty_memo_builder
+            .clone()
+            .with_dst_callback(dst_callback.clone());
+        let with_dst_callback = with_dst_callback_builder.clone().build();
+
+        let with_both_callbacks1 = with_src_callback_builder
+            .with_dst_callback(dst_callback.clone())
+            .build();
+
+        let with_both_callbacks2 = with_dst_callback_builder
+            .with_src_callback(src_callback.clone())
+            .build();
+
+        // assert all the different messages
+        assert_eq!(
+            empty,
+            IbcMsg::Transfer {
+                channel_id: "channel-0".to_string(),
+                to_address: "cosmos1example".to_string(),
+                amount: coin(10, "ucoin"),
+                timeout: Timestamp::from_seconds(12345).into(),
+                memo: None,
+            }
+        );
+        assert_eq!(
+            with_memo,
+            IbcMsg::Transfer {
+                channel_id: "channel-0".to_string(),
+                to_address: "cosmos1example".to_string(),
+                amount: coin(10, "ucoin"),
+                timeout: Timestamp::from_seconds(12345).into(),
+                memo: Some("memo".to_string()),
+            }
+        );
+        assert_eq!(
+            with_src_callback,
+            IbcMsg::Transfer {
+                channel_id: "channel-0".to_string(),
+                to_address: "cosmos1example".to_string(),
+                amount: coin(10, "ucoin"),
+                timeout: Timestamp::from_seconds(12345).into(),
+                memo: Some(
+                    to_json_string(&IbcCallbackRequest::source(src_callback.clone())).unwrap()
+                ),
+            }
+        );
+        assert_eq!(
+            with_dst_callback,
+            IbcMsg::Transfer {
+                channel_id: "channel-0".to_string(),
+                to_address: "cosmos1example".to_string(),
+                amount: coin(10, "ucoin"),
+                timeout: Timestamp::from_seconds(12345).into(),
+                memo: Some(
+                    to_json_string(&IbcCallbackRequest::destination(dst_callback.clone())).unwrap()
+                ),
+            }
+        );
+        assert_eq!(
+            with_both_callbacks1,
+            IbcMsg::Transfer {
+                channel_id: "channel-0".to_string(),
+                to_address: "cosmos1example".to_string(),
+                amount: coin(10, "ucoin"),
+                timeout: Timestamp::from_seconds(12345).into(),
+                memo: Some(
+                    to_json_string(&IbcCallbackRequest::both(src_callback, dst_callback)).unwrap()
+                ),
+            }
+        );
+        assert_eq!(with_both_callbacks1, with_both_callbacks2);
+    }
+}

--- a/packages/std/src/ibc/transfer_msg_builder.rs
+++ b/packages/std/src/ibc/transfer_msg_builder.rs
@@ -76,6 +76,7 @@ pub struct TransferMsgBuilder<MemoData> {
 }
 
 impl TransferMsgBuilder<EmptyMemo> {
+    /// Creates a new transfer message with the given parameters and no memo.
     pub fn new(
         channel_id: impl Into<String>,
         to_address: impl Into<String>,
@@ -91,6 +92,7 @@ impl TransferMsgBuilder<EmptyMemo> {
         }
     }
 
+    /// Adds a memo text to the transfer message.
     pub fn with_memo(self, memo: impl Into<String>) -> TransferMsgBuilder<WithMemo> {
         TransferMsgBuilder {
             channel_id: self.channel_id,
@@ -101,6 +103,10 @@ impl TransferMsgBuilder<EmptyMemo> {
         }
     }
 
+    /// Adds an IBC source callback entry to the memo field.
+    /// Use this if you want to receive IBC callbacks on the source chain.
+    ///
+    /// For more info check out [`crate::IbcSourceCallbackMsg`].
     pub fn with_src_callback(
         self,
         src_callback: IbcSrcCallback,
@@ -114,6 +120,10 @@ impl TransferMsgBuilder<EmptyMemo> {
         }
     }
 
+    /// Adds an IBC destination callback entry to the memo field.
+    /// Use this if you want to receive IBC callbacks on the destination chain.
+    ///
+    /// For more info check out [`crate::IbcDestinationCallbackMsg`].
     pub fn with_dst_callback(
         self,
         dst_callback: IbcDstCallback,
@@ -129,6 +139,10 @@ impl TransferMsgBuilder<EmptyMemo> {
 }
 
 impl TransferMsgBuilder<WithSrcCallback> {
+    /// Adds an IBC destination callback entry to the memo field.
+    /// Use this if you want to receive IBC callbacks on the destination chain.
+    ///
+    /// For more info check out [`crate::IbcDestinationCallbackMsg`].
     pub fn with_dst_callback(
         self,
         dst_callback: IbcDstCallback,
@@ -147,6 +161,10 @@ impl TransferMsgBuilder<WithSrcCallback> {
 }
 
 impl TransferMsgBuilder<WithDstCallback> {
+    /// Adds an IBC source callback entry to the memo field.
+    /// Use this if you want to receive IBC callbacks on the source chain.
+    ///
+    /// For more info check out [`crate::IbcSourceCallbackMsg`].
     pub fn with_src_callback(
         self,
         src_callback: IbcSrcCallback,

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -45,6 +45,7 @@ pub use crate::ibc::{
     IbcDestinationCallbackMsg, IbcDstCallback, IbcEndpoint, IbcMsg, IbcOrder, IbcPacket,
     IbcPacketAckMsg, IbcPacketReceiveMsg, IbcPacketTimeoutMsg, IbcReceiveResponse,
     IbcSourceCallbackMsg, IbcSrcCallback, IbcTimeout, IbcTimeoutBlock, IbcTimeoutCallbackMsg,
+    TransferMsgBuilder,
 };
 #[cfg(feature = "iterator")]
 pub use crate::iterator::{Order, Record};


### PR DESCRIPTION
closes #2122 
This is a follow-up to one of @srdtrk's [comments](https://github.com/CosmWasm/cosmwasm/pull/2025#discussion_r1570530639) in the IBC Callbacks PR.

It implements a builder for the `IbcMsg::Transfer` that handles the serialization of the memo field and provides type safety. We can also add more functions and memo states later if we need to support additional custom memo field formats.