### PR TITLE
Update Rust version of clippy CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ workflows:
           matrix:
             parameters:
               # Run with MSRV and some modern stable Rust
-              rust-version: ["1.74.0", "1.77.0"]
+              rust-version: ["1.74.0", "1.78.0"]
       - benchmarking:
           requires:
             - package_vm


### PR DESCRIPTION
closes #2168

I didn't see any issues on my machine.