### PR TITLE
make order (de)serialize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to
   Callbacks memo values. ([#2167])
 - cosmwasm-std: Add `IbcMsg::WriteAcknowledgement` for async IBC
   acknowledgements ([#2130])
+- cosmwasm-std: Add derive attributes for `Order` ([#2174])
 
 [#1983]: https://github.com/CosmWasm/cosmwasm/pull/1983
 [#2025]: https://github.com/CosmWasm/cosmwasm/pull/2025
@@ -74,6 +75,7 @@ and this project adheres to
 [#2130]: https://github.com/CosmWasm/cosmwasm/pull/2130
 [#2166]: https://github.com/CosmWasm/cosmwasm/pull/2166
 [#2167]: https://github.com/CosmWasm/cosmwasm/pull/2167
+[#2174]: https://github.com/CosmWasm/cosmwasm/pull/2174
 
 ### Changed
 

--- a/packages/std/src/iterator.rs
+++ b/packages/std/src/iterator.rs
@@ -1,4 +1,6 @@
 use crate::StdError;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
 /// A record of a key-value storage that is created through an iterator API.
 /// The first element (key) is always raw binary data. The second element
@@ -6,7 +8,8 @@ use crate::StdError;
 /// allows contracts to reuse the type when deserializing database records.
 pub type Record<V = Vec<u8>> = (Vec<u8>, V);
 
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
 // We assign these to integers to provide a stable API for passing over FFI (to wasm and Go)
 pub enum Order {
     Ascending = 1,


### PR DESCRIPTION
This PR adds the appropriate derive attributes
so that the `Order` type can be sent in messages