### PR TITLE
Make `IbcAckCallbackMsg` and `IbcTimeoutCallbackMsg` fields public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- cosmwasm-std: Make fields of `IbcAckCallbackMsg` and `IbcTimeoutCallbackMsg`
+  public. ([#2191])
+
+[#2191]: https://github.com/CosmWasm/cosmwasm/pull/2191
+
 ## [2.1.0] - 2024-07-11
 
 ### Fixed

--- a/packages/std/src/ibc/callbacks.rs
+++ b/packages/std/src/ibc/callbacks.rs
@@ -136,9 +136,9 @@ pub enum IbcSourceCallbackMsg {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[non_exhaustive]
 pub struct IbcAckCallbackMsg {
-    acknowledgement: IbcAcknowledgement,
-    original_packet: IbcPacket,
-    relayer: Addr,
+    pub acknowledgement: IbcAcknowledgement,
+    pub original_packet: IbcPacket,
+    pub relayer: Addr,
 }
 
 impl IbcAckCallbackMsg {
@@ -158,8 +158,8 @@ impl IbcAckCallbackMsg {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[non_exhaustive]
 pub struct IbcTimeoutCallbackMsg {
-    packet: IbcPacket,
-    relayer: Addr,
+    pub packet: IbcPacket,
+    pub relayer: Addr,
 }
 
 impl IbcTimeoutCallbackMsg {


### PR DESCRIPTION
These should be public, otherwise you cannot read them in the contract.