### PR TITLE
Migrate to Prettier 3.3.3 and reformat

### DIFF
--- a/contracts/ibc-callbacks/README.md
+++ b/contracts/ibc-callbacks/README.md
@@ -1,8 +1,8 @@
 # IBC Callbacks Contract
 
-This is a simple contract to demonstrate [IBC Callbacks]. It sends an ICS-20
-transfer message to a remote chain and writes to storage which callbacks were
-called. This can then be queried using the `CallbackStats` query.
+This is a simple contract to demonstrate [IBC Callbacks]. It sends an ICS-20 transfer
+message to a remote chain and writes to storage which callbacks were called. This
+can then be queried using the `CallbackStats` query.
 
 [ibc callbacks]:
   https://github.com/cosmos/ibc-go/blob/main/docs/architecture/adr-008-app-caller-cbs.md

--- a/devtools/format_md.sh
+++ b/devtools/format_md.sh
@@ -11,4 +11,4 @@ while getopts c option; do
   esac
 done
 
-npx prettier@2.7.1 --$op "./**/*.md"
+npx prettier@3.3.3 --$op "./**/*.md"

--- a/devtools/format_yml.sh
+++ b/devtools/format_yml.sh
@@ -11,4 +11,4 @@ while getopts c option; do
   esac
 done
 
-npx prettier@2.7.1 --$op "./**/*.yml"
+npx prettier@3.3.3 --$op "./**/*.yml"

--- a/docs/PINNING.md
+++ b/docs/PINNING.md
@@ -75,4 +75,5 @@ every block.
   https://github.com/CosmWasm/wasmd/blob/v0.50.0/x/wasm/keeper/keeper.go#L1011-L1028
 
 [^1]: https://github.com/CosmWasm/wasmd/pull/1799
+
 [^2]: https://github.com/CosmWasm/cosmwasm/issues/2034


### PR DESCRIPTION
I have a hard time trying to understand where the change in `contracts/ibc-callbacks/README.md` is coming from but whatever, prettier is always right