### PR TITLE
Enable `cosmwasm_2_2` for `ibc-reflect`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -579,10 +579,8 @@ jobs:
       - restore_cache:
           keys:
             - cargocache-v2-contract_crypto_verify-rust:1.74-{{ checksum "Cargo.lock" }}
-      # TODO: Enable this once 2.1 has been released to crates.io
       - check_contract:
           min_version: "2.1"
-          skip_cosmwasm_check: true
       - save_cache:
           paths:
             - /usr/local/cargo/registry
@@ -665,10 +663,8 @@ jobs:
       - restore_cache:
           keys:
             - cargocache-v2-contract_ibc_callbacks-rust:1.74-{{ checksum "Cargo.lock" }}
-      # TODO: Enable this once 2.1 has been released to crates.io
       - check_contract:
           min_version: "2.1"
-          skip_cosmwasm_check: true
       - save_cache:
           paths:
             - /usr/local/cargo/registry
@@ -695,9 +691,9 @@ jobs:
       - restore_cache:
           keys:
             - cargocache-v2-contract_ibc_reflect-rust:1.74-{{ checksum "Cargo.lock" }}
-      # TODO: Enable this once 2.1 has been released to crates.io
+      # TODO: enable again once 2.2 is released
       - check_contract:
-          min_version: "2.1"
+          min_version: "2.2"
           skip_cosmwasm_check: true
       - save_cache:
           paths:
@@ -809,8 +805,10 @@ jobs:
       - restore_cache:
           keys:
             - cargocache-v2-contract_reflect-rust:1.74-{{ checksum "Cargo.lock" }}
+      # TODO: enable again once 2.2 is released
       - check_contract:
-          min_version: "2.0"
+          min_version: "2.2"
+          skip_cosmwasm_check: true
       - save_cache:
           paths:
             - /usr/local/cargo/registry

--- a/contracts/reflect/Cargo.toml
+++ b/contracts/reflect/Cargo.toml
@@ -31,7 +31,7 @@ cranelift = ["cosmwasm-vm/cranelift"]
 
 [dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }
-cosmwasm-std = { path = "../../packages/std", default-features = false, features = ["std", "staking", "stargate", "cosmwasm_2_0"] }
+cosmwasm-std = { path = "../../packages/std", default-features = false, features = ["std", "staking", "stargate", "cosmwasm_2_2"] }
 schemars = "0.8.12"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = "1.0.26"

--- a/contracts/reflect/schema/raw/execute.json
+++ b/contracts/reflect/schema/raw/execute.json
@@ -476,6 +476,47 @@
         }
       ]
     },
+    "IbcAcknowledgement": {
+      "type": "object",
+      "required": [
+        "data"
+      ],
+      "properties": {
+        "data": {
+          "$ref": "#/definitions/Binary"
+        }
+      },
+      "additionalProperties": false
+    },
+    "IbcFee": {
+      "type": "object",
+      "required": [
+        "ack_fee",
+        "receive_fee",
+        "timeout_fee"
+      ],
+      "properties": {
+        "ack_fee": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Coin"
+          }
+        },
+        "receive_fee": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Coin"
+          }
+        },
+        "timeout_fee": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Coin"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
     "IbcMsg": {
       "description": "These are messages in the IBC lifecycle. Only usable by IBC-enabled contracts (contracts that directly speak the IBC protocol via 6 entry points)",
       "oneOf": [
@@ -568,6 +609,45 @@
           "additionalProperties": false
         },
         {
+          "description": "Acknowledges a packet that this contract received over IBC. This allows acknowledging a packet that was not acknowledged yet in the `ibc_packet_receive` call.",
+          "type": "object",
+          "required": [
+            "write_acknowledgement"
+          ],
+          "properties": {
+            "write_acknowledgement": {
+              "type": "object",
+              "required": [
+                "ack",
+                "channel_id",
+                "packet_sequence"
+              ],
+              "properties": {
+                "ack": {
+                  "description": "The acknowledgement to send back",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/IbcAcknowledgement"
+                    }
+                  ]
+                },
+                "channel_id": {
+                  "description": "Existing channel where the packet was received",
+                  "type": "string"
+                },
+                "packet_sequence": {
+                  "description": "Sequence number of the packet that was received",
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
           "description": "This will close an existing channel that is owned by this contract. Port is auto-assigned to the contract's IBC port",
           "type": "object",
           "required": [
@@ -582,6 +662,93 @@
               "properties": {
                 "channel_id": {
                   "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Incentivizes the next IBC packet sent after this message with a fee. Note that this does not necessarily have to be a packet sent by this contract. The fees are taken from the contract's balance immediately and locked until the packet is handled.\n\n# Example\n\nMost commonly, you will attach this message to a response right before sending a packet using [`IbcMsg::SendPacket`] or [`IbcMsg::Transfer`].\n\n```rust # use cosmwasm_std::{IbcMsg, IbcEndpoint, IbcFee, IbcTimeout, Coin, coins, CosmosMsg, Response, Timestamp};\n\nlet incentivize = IbcMsg::PayPacketFee { port_id: \"transfer\".to_string(), channel_id: \"source-channel\".to_string(), fee: IbcFee { receive_fee: coins(100, \"token\"), ack_fee: coins(201, \"token\"), timeout_fee: coins(200, \"token\"), }, relayers: vec![], }; let transfer = IbcMsg::Transfer { channel_id: \"source-channel\".to_string(), to_address: \"receiver\".to_string(), amount: Coin::new(100u32, \"token\"), timeout: IbcTimeout::with_timestamp(Timestamp::from_nanos(0)), memo: None, };\n\n# #[cfg(feature = \"stargate\")] let _: Response = Response::new() .add_message(CosmosMsg::Ibc(incentivize)) .add_message(CosmosMsg::Ibc(transfer)); ```",
+          "type": "object",
+          "required": [
+            "pay_packet_fee"
+          ],
+          "properties": {
+            "pay_packet_fee": {
+              "type": "object",
+              "required": [
+                "channel_id",
+                "fee",
+                "port_id",
+                "relayers"
+              ],
+              "properties": {
+                "channel_id": {
+                  "description": "The channel id on the chain where the packet is sent from (this chain).",
+                  "type": "string"
+                },
+                "fee": {
+                  "$ref": "#/definitions/IbcFee"
+                },
+                "port_id": {
+                  "description": "The port id on the chain where the packet is sent from (this chain).",
+                  "type": "string"
+                },
+                "relayers": {
+                  "description": "Allowlist of relayer addresses that can receive the fee. An empty list means that any relayer can receive the fee.\n\nThis is currently not implemented and *must* be empty.",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Incentivizes the existing IBC packet with the given port, channel and sequence with a fee. Note that this does not necessarily have to be a packet sent by this contract. The fees are taken from the contract's balance immediately and locked until the packet is handled. They are added to the existing fees on the packet.",
+          "type": "object",
+          "required": [
+            "pay_packet_fee_async"
+          ],
+          "properties": {
+            "pay_packet_fee_async": {
+              "type": "object",
+              "required": [
+                "channel_id",
+                "fee",
+                "port_id",
+                "relayers",
+                "sequence"
+              ],
+              "properties": {
+                "channel_id": {
+                  "description": "The channel id on the chain where the packet is sent from (this chain).",
+                  "type": "string"
+                },
+                "fee": {
+                  "$ref": "#/definitions/IbcFee"
+                },
+                "port_id": {
+                  "description": "The port id on the chain where the packet is sent from (this chain).",
+                  "type": "string"
+                },
+                "relayers": {
+                  "description": "Allowlist of relayer addresses that can receive the fee. An empty list means that any relayer can receive the fee.\n\nThis is currently not implemented and *must* be empty.",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "sequence": {
+                  "description": "The sequence number of the packet that should be incentivized.",
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
                 }
               },
               "additionalProperties": false

--- a/contracts/reflect/schema/raw/query.json
+++ b/contracts/reflect/schema/raw/query.json
@@ -422,6 +422,34 @@
             }
           },
           "additionalProperties": false
+        },
+        {
+          "description": "Queries whether the given channel supports IBC fees. If port_id is omitted, it will default to the contract's own channel. (To save a PortId{} call)\n\nReturns a `FeeEnabledChannelResponse`.",
+          "type": "object",
+          "required": [
+            "fee_enabled_channel"
+          ],
+          "properties": {
+            "fee_enabled_channel": {
+              "type": "object",
+              "required": [
+                "channel_id"
+              ],
+              "properties": {
+                "channel_id": {
+                  "type": "string"
+                },
+                "port_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
         }
       ]
     },

--- a/contracts/reflect/schema/reflect.json
+++ b/contracts/reflect/schema/reflect.json
@@ -486,6 +486,47 @@
           }
         ]
       },
+      "IbcAcknowledgement": {
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "$ref": "#/definitions/Binary"
+          }
+        },
+        "additionalProperties": false
+      },
+      "IbcFee": {
+        "type": "object",
+        "required": [
+          "ack_fee",
+          "receive_fee",
+          "timeout_fee"
+        ],
+        "properties": {
+          "ack_fee": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Coin"
+            }
+          },
+          "receive_fee": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Coin"
+            }
+          },
+          "timeout_fee": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Coin"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
       "IbcMsg": {
         "description": "These are messages in the IBC lifecycle. Only usable by IBC-enabled contracts (contracts that directly speak the IBC protocol via 6 entry points)",
         "oneOf": [
@@ -578,6 +619,45 @@
             "additionalProperties": false
           },
           {
+            "description": "Acknowledges a packet that this contract received over IBC. This allows acknowledging a packet that was not acknowledged yet in the `ibc_packet_receive` call.",
+            "type": "object",
+            "required": [
+              "write_acknowledgement"
+            ],
+            "properties": {
+              "write_acknowledgement": {
+                "type": "object",
+                "required": [
+                  "ack",
+                  "channel_id",
+                  "packet_sequence"
+                ],
+                "properties": {
+                  "ack": {
+                    "description": "The acknowledgement to send back",
+                    "allOf": [
+                      {
+                        "$ref": "#/definitions/IbcAcknowledgement"
+                      }
+                    ]
+                  },
+                  "channel_id": {
+                    "description": "Existing channel where the packet was received",
+                    "type": "string"
+                  },
+                  "packet_sequence": {
+                    "description": "Sequence number of the packet that was received",
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
             "description": "This will close an existing channel that is owned by this contract. Port is auto-assigned to the contract's IBC port",
             "type": "object",
             "required": [
@@ -592,6 +672,93 @@
                 "properties": {
                   "channel_id": {
                     "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Incentivizes the next IBC packet sent after this message with a fee. Note that this does not necessarily have to be a packet sent by this contract. The fees are taken from the contract's balance immediately and locked until the packet is handled.\n\n# Example\n\nMost commonly, you will attach this message to a response right before sending a packet using [`IbcMsg::SendPacket`] or [`IbcMsg::Transfer`].\n\n```rust # use cosmwasm_std::{IbcMsg, IbcEndpoint, IbcFee, IbcTimeout, Coin, coins, CosmosMsg, Response, Timestamp};\n\nlet incentivize = IbcMsg::PayPacketFee { port_id: \"transfer\".to_string(), channel_id: \"source-channel\".to_string(), fee: IbcFee { receive_fee: coins(100, \"token\"), ack_fee: coins(201, \"token\"), timeout_fee: coins(200, \"token\"), }, relayers: vec![], }; let transfer = IbcMsg::Transfer { channel_id: \"source-channel\".to_string(), to_address: \"receiver\".to_string(), amount: Coin::new(100u32, \"token\"), timeout: IbcTimeout::with_timestamp(Timestamp::from_nanos(0)), memo: None, };\n\n# #[cfg(feature = \"stargate\")] let _: Response = Response::new() .add_message(CosmosMsg::Ibc(incentivize)) .add_message(CosmosMsg::Ibc(transfer)); ```",
+            "type": "object",
+            "required": [
+              "pay_packet_fee"
+            ],
+            "properties": {
+              "pay_packet_fee": {
+                "type": "object",
+                "required": [
+                  "channel_id",
+                  "fee",
+                  "port_id",
+                  "relayers"
+                ],
+                "properties": {
+                  "channel_id": {
+                    "description": "The channel id on the chain where the packet is sent from (this chain).",
+                    "type": "string"
+                  },
+                  "fee": {
+                    "$ref": "#/definitions/IbcFee"
+                  },
+                  "port_id": {
+                    "description": "The port id on the chain where the packet is sent from (this chain).",
+                    "type": "string"
+                  },
+                  "relayers": {
+                    "description": "Allowlist of relayer addresses that can receive the fee. An empty list means that any relayer can receive the fee.\n\nThis is currently not implemented and *must* be empty.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Incentivizes the existing IBC packet with the given port, channel and sequence with a fee. Note that this does not necessarily have to be a packet sent by this contract. The fees are taken from the contract's balance immediately and locked until the packet is handled. They are added to the existing fees on the packet.",
+            "type": "object",
+            "required": [
+              "pay_packet_fee_async"
+            ],
+            "properties": {
+              "pay_packet_fee_async": {
+                "type": "object",
+                "required": [
+                  "channel_id",
+                  "fee",
+                  "port_id",
+                  "relayers",
+                  "sequence"
+                ],
+                "properties": {
+                  "channel_id": {
+                    "description": "The channel id on the chain where the packet is sent from (this chain).",
+                    "type": "string"
+                  },
+                  "fee": {
+                    "$ref": "#/definitions/IbcFee"
+                  },
+                  "port_id": {
+                    "description": "The port id on the chain where the packet is sent from (this chain).",
+                    "type": "string"
+                  },
+                  "relayers": {
+                    "description": "Allowlist of relayer addresses that can receive the fee. An empty list means that any relayer can receive the fee.\n\nThis is currently not implemented and *must* be empty.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "sequence": {
+                    "description": "The sequence number of the packet that should be incentivized.",
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
                   }
                 },
                 "additionalProperties": false
@@ -1496,6 +1663,34 @@
             ],
             "properties": {
               "channel": {
+                "type": "object",
+                "required": [
+                  "channel_id"
+                ],
+                "properties": {
+                  "channel_id": {
+                    "type": "string"
+                  },
+                  "port_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Queries whether the given channel supports IBC fees. If port_id is omitted, it will default to the contract's own channel. (To save a PortId{} call)\n\nReturns a `FeeEnabledChannelResponse`.",
+            "type": "object",
+            "required": [
+              "fee_enabled_channel"
+            ],
+            "properties": {
+              "fee_enabled_channel": {
                 "type": "object",
                 "required": [
                   "channel_id"


### PR DESCRIPTION
Needed for my IBC fee tests in wasmd

While I was at it, I also enabled the other cosmwasm-check CI jobs for contracts that were disabled before the 2.1 release.