### PR TITLE
Add derives for utoipa schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -653,6 +653,7 @@ dependencies = [
  "sha2",
  "static_assertions",
  "thiserror",
+ "utoipa",
 ]
 
 [[package]]
@@ -2978,6 +2979,30 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "utoipa"
+version = "4.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5afb1a60e207dca502682537fefcfd9921e71d0b83e9576060f09abc6efab23"
+dependencies = [
+ "indexmap 2.2.6",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bf0e16c02bc4bf5322ab65f10ab1149bdbcaa782cba66dc7057370a3f8190be"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
 
 [[package]]
 name = "uuid"

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -51,6 +51,7 @@ cosmwasm_2_1 = ["cosmwasm_2_0"]
 # This enables functionality that is only available on 2.2 chains.
 # It adds `IbcMsg::PayPacketFee` and `IbcMsg::PayPacketFeeAsync`.
 cosmwasm_2_2 = ["cosmwasm_2_1"]
+utoipa = ["dep:utoipa"]
 
 [dependencies]
 base64 = "0.22.0"
@@ -66,6 +67,7 @@ serde-json-wasm = { version = "1.0.1", default-features = false, features = ["st
 static_assertions = "1.1.0"
 thiserror = "1.0.26"
 rmp-serde = "1.1"
+utoipa = { version = "4.2.3", optional = true}
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 bech32 = "0.11.0"

--- a/packages/std/src/addresses.rs
+++ b/packages/std/src/addresses.rs
@@ -29,6 +29,7 @@ use crate::{HexBinary, __internal::forward_ref_partial_eq};
 #[derive(
     Serialize, Deserialize, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, schemars::JsonSchema,
 )]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct Addr(String);
 
 forward_ref_partial_eq!(Addr, Addr);
@@ -129,6 +130,7 @@ impl<'a> From<&'a Addr> for Cow<'a, Addr> {
 /// So the type should be treated as a marker to express the intended data type, not as
 /// a validity guarantee of any sort.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash, schemars::JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct CanonicalAddr(Binary);
 
 /// Implement `CanonicalAddr == Binary`

--- a/packages/std/src/binary.rs
+++ b/packages/std/src/binary.rs
@@ -15,6 +15,7 @@ use crate::{
 /// This is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>.
 /// See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.
 #[derive(Clone, Default, PartialEq, Eq, Hash, PartialOrd, Ord, schemars::JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema), schema(value_type = String))]
 pub struct Binary(#[schemars(with = "String")] Vec<u8>);
 
 impl Binary {

--- a/packages/std/src/checksum.rs
+++ b/packages/std/src/checksum.rs
@@ -14,6 +14,7 @@ use crate::{StdError, StdResult};
 /// This is often referred to as "code ID" in go-cosmwasm, even if code ID
 /// usually refers to an auto-incrementing number.
 #[derive(JsonSchema, Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema), schema(value_type = String))]
 pub struct Checksum(#[schemars(with = "String")] [u8; 32]);
 
 impl Checksum {

--- a/packages/std/src/coin.rs
+++ b/packages/std/src/coin.rs
@@ -7,6 +7,7 @@ use crate::CoinFromStrError;
 use crate::Uint128;
 
 #[derive(Serialize, Deserialize, Clone, Default, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct Coin {
     pub denom: String,
     pub amount: Uint128,

--- a/packages/std/src/errors/system_error.rs
+++ b/packages/std/src/errors/system_error.rs
@@ -15,6 +15,7 @@ use crate::Binary;
 #[derive(
     Serialize, Deserialize, Clone, Debug, PartialEq, Eq, schemars::JsonSchema, thiserror::Error,
 )]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum SystemError {

--- a/packages/std/src/hex_binary.rs
+++ b/packages/std/src/hex_binary.rs
@@ -15,6 +15,7 @@ use crate::{
 /// This is similar to `cosmwasm_std::Binary` but uses hex.
 /// See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.
 #[derive(Clone, Default, PartialEq, Eq, Hash, PartialOrd, Ord, schemars::JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema), schema(value_type = String))]
 pub struct HexBinary(#[schemars(with = "String")] Vec<u8>);
 
 impl HexBinary {

--- a/packages/std/src/ibc.rs
+++ b/packages/std/src/ibc.rs
@@ -22,6 +22,7 @@ pub use transfer_msg_builder::*;
 /// (contracts that directly speak the IBC protocol via 6 entry points)
 #[non_exhaustive]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum IbcMsg {
     /// Sends bank tokens owned by the contract to the given address on another chain.
@@ -145,6 +146,7 @@ pub enum IbcMsg {
 }
 
 #[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct IbcFee {
     // the packet receive fee
     pub receive_fee: Vec<Coin>,
@@ -155,6 +157,7 @@ pub struct IbcFee {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct IbcEndpoint {
     pub port_id: String,
     pub channel_id: String,
@@ -164,6 +167,7 @@ pub struct IbcEndpoint {
 /// the timestamp or the block height. Using this rather complex enum instead of
 /// two timeout fields we ensure that at least one timeout is set.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 pub struct IbcTimeout {
     // use private fields to enforce the use of constructors, which ensure that at least one is set
@@ -219,6 +223,7 @@ impl From<IbcTimeoutBlock> for IbcTimeout {
 /// IbcChannel defines all information on a channel.
 /// This is generally used in the hand-shake process, but can be queried directly.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[non_exhaustive]
 pub struct IbcChannel {
     pub endpoint: IbcEndpoint,
@@ -254,6 +259,7 @@ impl IbcChannel {
 /// Values come from https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/ibc/core/channel/v1/channel.proto#L69-L80
 /// Naming comes from the protobuf files and go translations.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub enum IbcOrder {
     #[serde(rename = "ORDER_UNORDERED")]
     Unordered,
@@ -266,6 +272,7 @@ pub enum IbcOrder {
 /// freezing clients.
 /// Ordering is (revision_number, timeout_height)
 #[derive(Serialize, Deserialize, Copy, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct IbcTimeoutBlock {
     /// the version that the client is currently on
     /// (e.g. after resetting the chain this could increment 1 as height drops to 0)
@@ -297,6 +304,7 @@ impl Ord for IbcTimeoutBlock {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[non_exhaustive]
 pub struct IbcPacket {
     /// The raw data sent from the other side in the packet
@@ -330,6 +338,7 @@ impl IbcPacket {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[non_exhaustive]
 pub struct IbcAcknowledgement {
     pub data: Binary,
@@ -351,6 +360,7 @@ impl IbcAcknowledgement {
 
 /// The message that is passed into `ibc_channel_open`
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum IbcChannelOpenMsg {
     /// The ChanOpenInit step from https://github.com/cosmos/ibc/tree/master/spec/core/ics-004-channel-and-packet-semantics#channel-lifecycle-management
@@ -407,6 +417,7 @@ impl From<IbcChannelOpenMsg> for IbcChannel {
 pub type IbcChannelOpenResponse = Option<Ibc3ChannelOpenResponse>;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct Ibc3ChannelOpenResponse {
     /// We can set the channel version to a different one than we were called with
     pub version: String,
@@ -414,6 +425,7 @@ pub struct Ibc3ChannelOpenResponse {
 
 /// The message that is passed into `ibc_channel_connect`
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum IbcChannelConnectMsg {
     /// The ChanOpenAck step from https://github.com/cosmos/ibc/tree/master/spec/core/ics-004-channel-and-packet-semantics#channel-lifecycle-management
@@ -466,6 +478,7 @@ impl From<IbcChannelConnectMsg> for IbcChannel {
 
 /// The message that is passed into `ibc_channel_close`
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum IbcChannelCloseMsg {
     /// The ChanCloseInit step from https://github.com/cosmos/ibc/tree/master/spec/core/ics-004-channel-and-packet-semantics#channel-lifecycle-management
@@ -502,6 +515,7 @@ impl From<IbcChannelCloseMsg> for IbcChannel {
 
 /// The message that is passed into `ibc_packet_receive`
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[non_exhaustive]
 pub struct IbcPacketReceiveMsg {
     pub packet: IbcPacket,
@@ -516,6 +530,7 @@ impl IbcPacketReceiveMsg {
 
 /// The message that is passed into `ibc_packet_ack`
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[non_exhaustive]
 pub struct IbcPacketAckMsg {
     pub acknowledgement: IbcAcknowledgement,
@@ -539,6 +554,7 @@ impl IbcPacketAckMsg {
 
 /// The message that is passed into `ibc_packet_timeout`
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[non_exhaustive]
 pub struct IbcPacketTimeoutMsg {
     pub packet: IbcPacket,
@@ -559,6 +575,7 @@ impl IbcPacketTimeoutMsg {
 /// or that cannot redispatch messages (like the handshake callbacks)
 /// will use other Response types
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[non_exhaustive]
 pub struct IbcBasicResponse<T = Empty> {
     /// Optional list of messages to pass. These will be executed in order.
@@ -701,6 +718,7 @@ impl<T> IbcBasicResponse<T> {
 /// the calling chain. (Returning ContractResult::Err will abort processing of this packet
 /// and not inform the calling chain).
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[non_exhaustive]
 pub struct IbcReceiveResponse<T = Empty> {
     /// The bytes we return to the contract that sent the packet.

--- a/packages/std/src/ibc/callbacks.rs
+++ b/packages/std/src/ibc/callbacks.rs
@@ -58,6 +58,7 @@ use crate::{Addr, IbcAcknowledgement, IbcPacket, Uint64};
 /// };
 /// ```
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct IbcCallbackRequest {
     // using private fields to force use of the constructors
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -93,6 +94,7 @@ impl IbcCallbackRequest {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct IbcSrcCallback {
     /// The source chain address that should receive the callback.
     /// For CosmWasm contracts, this *must* be `env.contract.address`.
@@ -104,6 +106,7 @@ pub struct IbcSrcCallback {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct IbcDstCallback {
     /// The destination chain address that should receive the callback.
     pub address: String,
@@ -127,6 +130,7 @@ pub struct IbcDstCallback {
 ///   For `IbcMsg::Transfer`, this is the `memo` field and it needs to be json-encoded.
 /// - The receiver of the callback must also be the sender of the message.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum IbcSourceCallbackMsg {
     Acknowledgement(IbcAckCallbackMsg),
@@ -134,6 +138,7 @@ pub enum IbcSourceCallbackMsg {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[non_exhaustive]
 pub struct IbcAckCallbackMsg {
     pub acknowledgement: IbcAcknowledgement,
@@ -156,6 +161,7 @@ impl IbcAckCallbackMsg {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[non_exhaustive]
 pub struct IbcTimeoutCallbackMsg {
     pub packet: IbcPacket,
@@ -188,6 +194,7 @@ impl IbcTimeoutCallbackMsg {
 /// - You have to add serialized [`IbcCallbackRequest`] to a specific field of the message.
 ///   For `IbcMsg::Transfer`, this is the `memo` field and it needs to be json-encoded.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct IbcDestinationCallbackMsg {
     pub packet: IbcPacket,
     pub ack: IbcAcknowledgement,

--- a/packages/std/src/iterator.rs
+++ b/packages/std/src/iterator.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 pub type Record<V = Vec<u8>> = (Vec<u8>, V);
 
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 // We assign these to integers to provide a stable API for passing over FFI (to wasm and Go)
 pub enum Order {

--- a/packages/std/src/math/decimal.rs
+++ b/packages/std/src/math/decimal.rs
@@ -20,6 +20,7 @@ use super::{Uint128, Uint256};
 ///
 /// The greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)
 #[derive(Copy, Clone, Default, PartialEq, Eq, PartialOrd, Ord, schemars::JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema), schema(value_type = String))]
 pub struct Decimal(#[schemars(with = "String")] Uint128);
 
 forward_ref_partial_eq!(Decimal, Decimal);

--- a/packages/std/src/math/decimal256.rs
+++ b/packages/std/src/math/decimal256.rs
@@ -24,6 +24,7 @@ use super::Uint256;
 /// 115792089237316195423570985008687907853269984665640564039457.584007913129639935
 /// (which is (2^256 - 1) / 10^18)
 #[derive(Copy, Clone, Default, PartialEq, Eq, PartialOrd, Ord, schemars::JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema), schema(value_type = String))]
 pub struct Decimal256(#[schemars(with = "String")] Uint256);
 
 forward_ref_partial_eq!(Decimal256, Decimal256);

--- a/packages/std/src/math/int128.rs
+++ b/packages/std/src/math/int128.rs
@@ -31,6 +31,7 @@ use super::num_consts::NumConsts;
 /// assert_eq!(a.i128(), 258);
 /// ```
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, PartialOrd, Ord, schemars::JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema), schema(value_type = String))]
 pub struct Int128(#[schemars(with = "String")] pub(crate) i128);
 
 forward_ref_partial_eq!(Int128, Int128);

--- a/packages/std/src/math/int256.rs
+++ b/packages/std/src/math/int256.rs
@@ -42,6 +42,7 @@ use super::num_consts::NumConsts;
 /// assert_eq!(a, b);
 /// ```
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, PartialOrd, Ord, schemars::JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema), schema(value_type = String))]
 pub struct Int256(#[schemars(with = "String")] pub(crate) I256);
 
 forward_ref_partial_eq!(Int256, Int256);

--- a/packages/std/src/math/int512.rs
+++ b/packages/std/src/math/int512.rs
@@ -45,6 +45,7 @@ use super::num_consts::NumConsts;
 /// assert_eq!(a, b);
 /// ```
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, PartialOrd, Ord, schemars::JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema), schema(value_type = String))]
 pub struct Int512(#[schemars(with = "String")] pub(crate) I512);
 
 forward_ref_partial_eq!(Int512, Int512);

--- a/packages/std/src/math/int64.rs
+++ b/packages/std/src/math/int64.rs
@@ -31,6 +31,7 @@ use super::num_consts::NumConsts;
 /// assert_eq!(a.i64(), 258);
 /// ```
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, PartialOrd, Ord, schemars::JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema), schema(value_type = String))]
 pub struct Int64(#[schemars(with = "String")] pub(crate) i64);
 
 forward_ref_partial_eq!(Int64, Int64);

--- a/packages/std/src/math/signed_decimal.rs
+++ b/packages/std/src/math/signed_decimal.rs
@@ -22,6 +22,7 @@ use super::Int128;
 /// The greatest possible value that can be represented is 170141183460469231731.687303715884105727 (which is (2^127 - 1) / 10^18)
 /// and the smallest is -170141183460469231731.687303715884105728 (which is -2^127 / 10^18).
 #[derive(Copy, Clone, Default, PartialEq, Eq, PartialOrd, Ord, schemars::JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema), schema(value_type = String))]
 pub struct SignedDecimal(#[schemars(with = "String")] Int128);
 
 forward_ref_partial_eq!(SignedDecimal, SignedDecimal);

--- a/packages/std/src/math/signed_decimal_256.rs
+++ b/packages/std/src/math/signed_decimal_256.rs
@@ -27,6 +27,7 @@ use super::Int256;
 /// -57896044618658097711785492504343953926634992332820282019728.792003956564819968
 /// (which is -2^255 / 10^18).
 #[derive(Copy, Clone, Default, PartialEq, Eq, PartialOrd, Ord, schemars::JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema), schema(value_type = String))]
 pub struct SignedDecimal256(#[schemars(with = "String")] Int256);
 
 forward_ref_partial_eq!(SignedDecimal256, SignedDecimal256);

--- a/packages/std/src/math/uint128.rs
+++ b/packages/std/src/math/uint128.rs
@@ -41,6 +41,7 @@ use super::num_consts::NumConsts;
 /// assert_eq!(c.u128(), 70);
 /// ```
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, PartialOrd, Ord, schemars::JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema), schema(value_type = String))]
 pub struct Uint128(#[schemars(with = "String")] pub(crate) u128);
 
 forward_ref_partial_eq!(Uint128, Uint128);

--- a/packages/std/src/math/uint256.rs
+++ b/packages/std/src/math/uint256.rs
@@ -45,6 +45,7 @@ use super::num_consts::NumConsts;
 /// assert_eq!(a, b);
 /// ```
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, PartialOrd, Ord, schemars::JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema), schema(value_type = String))]
 pub struct Uint256(#[schemars(with = "String")] pub(crate) U256);
 
 forward_ref_partial_eq!(Uint256, Uint256);

--- a/packages/std/src/math/uint512.rs
+++ b/packages/std/src/math/uint512.rs
@@ -47,6 +47,7 @@ use super::num_consts::NumConsts;
 /// assert_eq!(a, b);
 /// ```
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, PartialOrd, Ord, schemars::JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema), schema(value_type = String))]
 pub struct Uint512(#[schemars(with = "String")] pub(crate) U512);
 
 forward_ref_partial_eq!(Uint512, Uint512);

--- a/packages/std/src/math/uint64.rs
+++ b/packages/std/src/math/uint64.rs
@@ -36,6 +36,7 @@ use super::num_consts::NumConsts;
 /// assert_eq!(b.u64(), 70);
 /// ```
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, PartialOrd, Ord, schemars::JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema), schema(value_type = String))]
 pub struct Uint64(#[schemars(with = "String")] pub(crate) u64);
 
 forward_ref_partial_eq!(Uint64, Uint64);

--- a/packages/std/src/metadata.rs
+++ b/packages/std/src/metadata.rs
@@ -5,6 +5,7 @@ use crate::prelude::*;
 
 /// Replicates the cosmos-sdk bank module Metadata type
 #[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct DenomMetadata {
     pub description: String,
     pub denom_units: Vec<DenomUnit>,
@@ -18,6 +19,7 @@ pub struct DenomMetadata {
 
 /// Replicates the cosmos-sdk bank module DenomUnit type
 #[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct DenomUnit {
     pub denom: String,
     pub exponent: u32,

--- a/packages/std/src/pagination.rs
+++ b/packages/std/src/pagination.rs
@@ -5,6 +5,7 @@ use crate::Binary;
 
 /// Simplified version of the PageRequest type for pagination from the cosmos-sdk
 #[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct PageRequest {
     pub key: Option<Binary>,
     pub limit: u32,

--- a/packages/std/src/query/bank.rs
+++ b/packages/std/src/query/bank.rs
@@ -12,6 +12,7 @@ use super::query_response::QueryResponseType;
 
 #[non_exhaustive]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum BankQuery {
     /// This calls into the native bank module for querying the total supply of one denomination.
@@ -37,6 +38,7 @@ pub enum BankQuery {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub struct SupplyResponse {
@@ -50,6 +52,7 @@ impl_response_constructor!(SupplyResponse, amount: Coin);
 impl QueryResponseType for SupplyResponse {}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub struct BalanceResponse {
@@ -63,6 +66,7 @@ impl_response_constructor!(BalanceResponse, amount: Coin);
 impl QueryResponseType for BalanceResponse {}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub struct AllBalanceResponse {
@@ -75,6 +79,7 @@ impl_response_constructor!(AllBalanceResponse, amount: Vec<Coin>);
 impl QueryResponseType for AllBalanceResponse {}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub struct DenomMetadataResponse {
@@ -87,6 +92,7 @@ impl_response_constructor!(DenomMetadataResponse, metadata: DenomMetadata);
 impl QueryResponseType for DenomMetadataResponse {}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub struct AllDenomMetadataResponse {

--- a/packages/std/src/query/distribution.rs
+++ b/packages/std/src/query/distribution.rs
@@ -8,6 +8,7 @@ use super::query_response::QueryResponseType;
 
 #[non_exhaustive]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum DistributionQuery {
     /// See <https://github.com/cosmos/cosmos-sdk/blob/c74e2887b0b73e81d48c2f33e6b1020090089ee0/proto/cosmos/distribution/v1beta1/query.proto#L222-L230>
@@ -28,6 +29,7 @@ pub enum DistributionQuery {
 
 /// See <https://github.com/cosmos/cosmos-sdk/blob/c74e2887b0b73e81d48c2f33e6b1020090089ee0/proto/cosmos/distribution/v1beta1/query.proto#L232-L240>
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub struct DelegatorWithdrawAddressResponse {
@@ -39,6 +41,7 @@ impl QueryResponseType for DelegatorWithdrawAddressResponse {}
 
 /// See <https://github.com/cosmos/cosmos-sdk/blob/c74e2887b0b73e81d48c2f33e6b1020090089ee0/proto/cosmos/distribution/v1beta1/query.proto#L169-L178>
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub struct DelegationRewardsResponse {
@@ -58,6 +61,7 @@ impl QueryResponseType for DelegationRewardsResponse {}
 ///
 /// [DecCoin]: (https://github.com/cosmos/cosmos-sdk/blob/v0.47.4/proto/cosmos/base/v1beta1/coin.proto#L28-L38)
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 pub struct DecCoin {
     pub denom: String,
@@ -79,6 +83,7 @@ impl DecCoin {
 
 /// See <https://github.com/cosmos/cosmos-sdk/blob/c74e2887b0b73e81d48c2f33e6b1020090089ee0/proto/cosmos/distribution/v1beta1/query.proto#L189-L200>
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[non_exhaustive]
 pub struct DelegationTotalRewardsResponse {
     pub rewards: Vec<DelegatorReward>,
@@ -93,6 +98,7 @@ impl_response_constructor!(
 impl QueryResponseType for DelegationTotalRewardsResponse {}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[non_exhaustive]
 pub struct DelegatorReward {
     pub validator_address: String,
@@ -106,6 +112,7 @@ impl_response_constructor!(
 
 /// See <https://github.com/cosmos/cosmos-sdk/blob/b0acf60e6c39f7ab023841841fc0b751a12c13ff/proto/cosmos/distribution/v1beta1/query.proto#L212-L220>
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[non_exhaustive]
 pub struct DelegatorValidatorsResponse {
     pub validators: Vec<String>,

--- a/packages/std/src/query/ibc.rs
+++ b/packages/std/src/query/ibc.rs
@@ -9,6 +9,7 @@ use crate::prelude::*;
 /// Most of these will return errors if the contract is not "ibc enabled".
 #[non_exhaustive]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum IbcQuery {
     /// Gets the Port ID the current contract is bound to.
@@ -42,6 +43,7 @@ pub enum IbcQuery {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[non_exhaustive]
 pub struct PortIdResponse {
     pub port_id: String,
@@ -50,6 +52,7 @@ pub struct PortIdResponse {
 impl_response_constructor!(PortIdResponse, port_id: String);
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[non_exhaustive]
 pub struct ListChannelsResponse {
     pub channels: Vec<IbcChannel>,
@@ -58,6 +61,7 @@ pub struct ListChannelsResponse {
 impl_response_constructor!(ListChannelsResponse, channels: Vec<IbcChannel>);
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[non_exhaustive]
 pub struct ChannelResponse {
     pub channel: Option<IbcChannel>,
@@ -66,6 +70,7 @@ pub struct ChannelResponse {
 impl_response_constructor!(ChannelResponse, channel: Option<IbcChannel>);
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[non_exhaustive]
 pub struct FeeEnabledChannelResponse {
     pub fee_enabled: bool,

--- a/packages/std/src/query/mod.rs
+++ b/packages/std/src/query/mod.rs
@@ -42,6 +42,7 @@ pub use wasm::*;
 
 #[non_exhaustive]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum QueryRequest<C = Empty> {
     Bank(BankQuery),
@@ -85,6 +86,7 @@ pub enum QueryRequest<C = Empty> {
 /// you can query the chain's gRPC endpoint using a tool like
 /// [grpcurl](https://github.com/fullstorydev/grpcurl).
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct GrpcQuery {
     /// The fully qualified endpoint path used for routing.
     /// It follows the format `/service_path/method_name`,

--- a/packages/std/src/query/staking.rs
+++ b/packages/std/src/query/staking.rs
@@ -8,6 +8,7 @@ use super::query_response::QueryResponseType;
 
 #[non_exhaustive]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum StakingQuery {
     /// Returns the denomination that can be bonded (if there are multiple native tokens on the chain)
@@ -36,6 +37,7 @@ pub enum StakingQuery {
 
 /// BondedDenomResponse is data format returned from StakingRequest::BondedDenom query
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub struct BondedDenomResponse {
@@ -48,6 +50,7 @@ impl_response_constructor!(BondedDenomResponse, denom: String);
 
 /// DelegationsResponse is data format returned from StakingRequest::AllDelegations query
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub struct AllDelegationsResponse {
@@ -62,6 +65,7 @@ impl_response_constructor!(AllDelegationsResponse, delegations: Vec<Delegation>)
 ///
 /// Instances are created in the querier.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[non_exhaustive]
 pub struct Delegation {
     pub delegator: Addr,
@@ -85,6 +89,7 @@ impl From<FullDelegation> for Delegation {
 
 /// DelegationResponse is data format returned from StakingRequest::Delegation query
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub struct DelegationResponse {
@@ -100,6 +105,7 @@ impl_response_constructor!(DelegationResponse, delegation: Option<FullDelegation
 ///
 /// Instances are created in the querier.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[non_exhaustive]
 pub struct FullDelegation {
     pub delegator: Addr,
@@ -148,6 +154,7 @@ impl FullDelegation {
 
 /// The data format returned from StakingRequest::AllValidators query
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[non_exhaustive]
 pub struct AllValidatorsResponse {
     pub validators: Vec<Validator>,
@@ -159,6 +166,7 @@ impl_response_constructor!(AllValidatorsResponse, validators: Vec<Validator>);
 
 /// The data format returned from StakingRequest::Validator query
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[non_exhaustive]
 pub struct ValidatorResponse {
     pub validator: Option<Validator>,
@@ -170,6 +178,7 @@ impl_response_constructor!(ValidatorResponse, validator: Option<Validator>);
 
 /// Instances are created in the querier.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[non_exhaustive]
 pub struct Validator {
     /// The operator address of the validator (e.g. cosmosvaloper1...).

--- a/packages/std/src/query/wasm.rs
+++ b/packages/std/src/query/wasm.rs
@@ -8,6 +8,7 @@ use super::query_response::QueryResponseType;
 
 #[non_exhaustive]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum WasmQuery {
     /// this queries the public API of another contract at a known address (with known ABI)
@@ -34,6 +35,7 @@ pub enum WasmQuery {
 
 #[non_exhaustive]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct ContractInfoResponse {
     pub code_id: u64,
     /// address that instantiated this contract
@@ -66,6 +68,7 @@ impl_response_constructor!(
 /// [CodeInfoResponse]: https://github.com/CosmWasm/wasmd/blob/v0.30.0/proto/cosmwasm/wasm/v1/query.proto#L184-L199
 #[non_exhaustive]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct CodeInfoResponse {
     pub code_id: u64,
     /// The address that initially stored the code

--- a/packages/std/src/results/contract_result.rs
+++ b/packages/std/src/results/contract_result.rs
@@ -32,6 +32,7 @@ use crate::prelude::*;
 /// assert_eq!(to_vec(&result).unwrap(), br#"{"error":"Something went wrong"}"#);
 /// ```
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum ContractResult<S> {
     Ok(S),

--- a/packages/std/src/results/cosmos_msg.rs
+++ b/packages/std/src/results/cosmos_msg.rs
@@ -52,6 +52,7 @@ impl CustomMsg for Empty {}
 
 #[non_exhaustive]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 // See https://github.com/serde-rs/serde/issues/1296 why we cannot add De-Serialize trait bounds to T
 pub enum CosmosMsg<T = Empty> {
@@ -117,6 +118,7 @@ impl<T> CosmosMsg<T> {
 /// See https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto
 #[non_exhaustive]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum BankMsg {
     /// Sends native tokens from the contract to the given address.
@@ -139,6 +141,7 @@ pub enum BankMsg {
 #[cfg(feature = "staking")]
 #[non_exhaustive]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum StakingMsg {
     /// This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90).
@@ -162,6 +165,7 @@ pub enum StakingMsg {
 #[cfg(feature = "staking")]
 #[non_exhaustive]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum DistributionMsg {
     /// This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37).
@@ -188,6 +192,7 @@ pub enum DistributionMsg {
 /// A message encoded the same way as a protobuf [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto).
 /// This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct AnyMsg {
     pub type_url: String,
     pub value: Binary,
@@ -210,6 +215,7 @@ impl fmt::Display for BinaryToStringEncoder<'_> {
 /// See https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto
 #[non_exhaustive]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum WasmMsg {
     /// Dispatches a call to another contract at a known address (with known ABI).
@@ -368,6 +374,7 @@ pub enum WasmMsg {
 /// ```
 #[cfg(feature = "stargate")]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum GovMsg {
     /// This maps directly to [MsgVote](https://github.com/cosmos/cosmos-sdk/blob/v0.42.5/proto/cosmos/gov/v1beta1/tx.proto#L46-L56) in the Cosmos SDK with voter set to the contract address.
@@ -388,6 +395,7 @@ pub enum GovMsg {
 
 #[cfg(feature = "stargate")]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum VoteOption {
     Yes,
@@ -398,6 +406,7 @@ pub enum VoteOption {
 
 #[cfg(all(feature = "stargate", feature = "cosmwasm_1_2"))]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct WeightedVoteOption {
     pub option: VoteOption,
     pub weight: Decimal,

--- a/packages/std/src/results/empty.rs
+++ b/packages/std/src/results/empty.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 /// contains no meaningful data. Previously we used enums without cases,
 /// but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema, Default)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct Empty {}
 
 #[cfg(test)]

--- a/packages/std/src/results/events.rs
+++ b/packages/std/src/results/events.rs
@@ -13,6 +13,7 @@ use crate::prelude::*;
 /// [*Cosmos SDK* event]: https://docs.cosmos.network/main/learn/advanced/events
 /// [*Cosmos SDK* StringEvent]: https://github.com/cosmos/cosmos-sdk/blob/v0.42.5/proto/cosmos/base/abci/v1beta1/abci.proto#L56-L70
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[non_exhaustive]
 pub struct Event {
     /// The event type. This is renamed to "ty" because "type" is reserved in Rust. This sucks, we know.
@@ -61,6 +62,7 @@ impl Event {
 
 /// An key value pair that is used in the context of event attributes in logs
 #[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct Attribute {
     pub key: String,
     pub value: String,

--- a/packages/std/src/results/response.rs
+++ b/packages/std/src/results/response.rs
@@ -61,6 +61,7 @@ use super::{Attribute, CosmosMsg, Empty, Event, SubMsg};
 /// }
 /// ```
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[non_exhaustive]
 pub struct Response<T = Empty> {
     /// Optional list of messages to pass. These will be executed in order.

--- a/packages/std/src/results/submessages.rs
+++ b/packages/std/src/results/submessages.rs
@@ -10,6 +10,7 @@ use super::{CosmosMsg, Empty, Event};
 /// If you only need it for errors or success you can select just those in order
 /// to save gas.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum ReplyOn {
     /// Always perform a callback after SubMsg is processed
@@ -29,6 +30,7 @@ pub enum ReplyOn {
 /// but not revert any state changes in the calling contract. If this is required, it must be done
 /// manually in the `reply` entry point.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct SubMsg<T = Empty> {
     /// An arbitrary ID chosen by the contract.
     /// This is typically used to match `Reply`s in the `reply` entry point to the submessage.
@@ -167,6 +169,7 @@ impl<T> SubMsg<T> {
 /// The result object returned to `reply`. We always get the ID from the submessage
 /// back and then must handle success and error cases ourselves.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct Reply {
     /// The ID that the contract set when emitting the `SubMsg`.
     /// Use this to identify which submessage triggered the `reply`.
@@ -227,6 +230,7 @@ pub struct Reply {
 /// assert_eq!(to_json_string(&result).unwrap(), r#"{"error":"Something went wrong"}"#);
 /// ```
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum SubMsgResult {
     Ok(SubMsgResponse),
@@ -283,6 +287,7 @@ impl From<SubMsgResult> for Result<SubMsgResponse, String> {
 /// The information we get back from a successful sub message execution,
 /// with full Cosmos SDK events.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct SubMsgResponse {
     pub events: Vec<Event>,
     #[deprecated = "Deprecated in the Cosmos SDK in favor of msg_responses. If your chain is running on CosmWasm 2.0 or higher, msg_responses will be filled. For older versions, the data field is still needed since msg_responses is empty in those cases."]
@@ -299,6 +304,7 @@ pub struct SubMsgResponse {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct MsgResponse {
     pub type_url: String,
     pub value: Binary,

--- a/packages/std/src/results/system_result.rs
+++ b/packages/std/src/results/system_result.rs
@@ -31,6 +31,7 @@ use crate::SystemError;
 /// assert_eq!(to_vec(&result).unwrap(), br#"{"error":{"unknown":{}}}"#);
 /// ```
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum SystemResult<S> {
     Ok(S),

--- a/packages/std/src/stdack.rs
+++ b/packages/std/src/stdack.rs
@@ -35,6 +35,7 @@ use crate::Binary;
 /// assert!(ack2.is_error());
 /// ```
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum StdAck {
     #[serde(rename = "result")]

--- a/packages/std/src/timestamp.rs
+++ b/packages/std/src/timestamp.rs
@@ -34,6 +34,7 @@ use crate::Uint64;
     Ord,
     schemars::JsonSchema,
 )]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct Timestamp(Uint64);
 
 impl Timestamp {

--- a/packages/std/src/types.rs
+++ b/packages/std/src/types.rs
@@ -6,6 +6,7 @@ use crate::prelude::*;
 use crate::{Addr, Timestamp};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct Env {
     pub block: BlockInfo,
     /// Information on the transaction this message was executed in.
@@ -16,6 +17,7 @@ pub struct Env {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct TransactionInfo {
     /// The position of this transaction in the block. The first
     /// transaction has index 0.
@@ -27,6 +29,7 @@ pub struct TransactionInfo {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct BlockInfo {
     /// The height of a block is the number of blocks preceding it in the blockchain.
     pub height: u64,
@@ -106,6 +109,7 @@ pub struct MessageInfo {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct ContractInfo {
     pub address: Addr,
 }


### PR DESCRIPTION
Hello, everyone!

While working on a project, I noticed `cosmwasm`'s types don't support `utoipa`'s traits.

This is a problem because, in order to generate OpenAPI spec for [foreign types](https://github.com/juhaku/utoipa/issues/790#issuecomment-1787754185), those types need to derive [`utoipa::ToSchema`](https://docs.rs/utoipa/latest/utoipa/derive.ToSchema.html).
Since the overhead is basically the same as for `schemars` support (just adding a `derive` to supported structs), I figured I'd contribute the changes 

For context, `utoipa` is a [crate](https://github.com/juhaku/utoipa) for automatic OpenAPI generation for (amongst others) [`axum`](https://github.com/tokio-rs/axum) web framework.

Similar to what [`okapi`](https://github.com/GREsau/okapi/blob/master/README.md) +  `schemars` is for [`rocket`](https://github.com/rwf2/Rocket)



I added derives to `cosmwasm-std` in all places where there is a `schemars::JsonSchema`. 

In case people aren't using `utoipa`, I put the change behind a feature flag, so it's opt-in.


Would you be open to such a change?