### PR TITLE
New `mock_environment` function with valid contract address

### DIFF
--- a/contracts/burner/src/contract.rs
+++ b/contracts/burner/src/contract.rs
@@ -83,7 +83,7 @@ fn cleanup(storage: &mut dyn Storage, mut limit: usize) -> usize {
 mod tests {
     use super::*;
     use cosmwasm_std::testing::{
-        message_info, mock_dependencies, mock_dependencies_with_balance, mock_environment,
+        message_info, mock_dependencies, mock_dependencies_with_contract_balance, mock_environment,
     };
     use cosmwasm_std::{coins, Attribute, StdError, Storage, SubMsg};
 
@@ -119,7 +119,7 @@ mod tests {
 
     #[test]
     fn migrate_sends_funds() {
-        let mut deps = mock_dependencies_with_balance(&coins(123456, "gold"));
+        let mut deps = mock_dependencies_with_contract_balance(&coins(123456, "gold"));
         let env = mock_environment(&deps.api);
 
         // change the verifier via migrate
@@ -143,7 +143,7 @@ mod tests {
 
     #[test]
     fn migrate_with_delete() {
-        let mut deps = mock_dependencies_with_balance(&coins(123456, "gold"));
+        let mut deps = mock_dependencies_with_contract_balance(&coins(123456, "gold"));
         let env = mock_environment(&deps.api);
 
         // store some sample data
@@ -167,7 +167,7 @@ mod tests {
 
     #[test]
     fn execute_cleans_up_data() {
-        let mut deps = mock_dependencies_with_balance(&coins(123456, "gold"));
+        let mut deps = mock_dependencies_with_contract_balance(&coins(123456, "gold"));
         let env = mock_environment(&deps.api);
 
         let anon = deps.api.addr_make("anon");

--- a/contracts/cyberpunk/src/contract.rs
+++ b/contracts/cyberpunk/src/contract.rs
@@ -227,16 +227,17 @@ fn query_denom(deps: Deps, denom: String) -> StdResult<DenomMetadata> {
 mod tests {
     use super::*;
     use cosmwasm_std::testing::{
-        message_info, mock_dependencies, mock_env, MockApi, MockQuerier, MockStorage,
+        message_info, mock_dependencies, mock_environment, MockApi, MockQuerier, MockStorage,
     };
     use cosmwasm_std::{from_json, DenomMetadata, DenomUnit, OwnedDeps};
 
     fn setup() -> OwnedDeps<MockStorage, MockApi, MockQuerier> {
         let mut deps = mock_dependencies();
+        let env = mock_environment(&deps.api);
         let creator = deps.api.addr_make("creator");
         let msg = Empty {};
         let info = message_info(&creator, &[]);
-        let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
+        let res = instantiate(deps.as_mut(), env, info, msg).unwrap();
         assert_eq!(0, res.messages.len());
         deps
     }
@@ -249,15 +250,17 @@ mod tests {
     #[test]
     fn debug_works() {
         let mut deps = setup();
+        let env = mock_environment(&deps.api);
         let caller = deps.api.addr_make("caller");
 
         let msg = ExecuteMsg::Debug {};
-        execute(deps.as_mut(), mock_env(), message_info(&caller, &[]), msg).unwrap();
+        execute(deps.as_mut(), env.clone(), message_info(&caller, &[]), msg).unwrap();
     }
 
     #[test]
     fn query_denoms_works() {
         let mut deps = setup();
+        let env = mock_environment(&deps.api);
 
         deps.querier.bank.set_denom_metadata(
             &(0..98)
@@ -279,14 +282,14 @@ mod tests {
         );
 
         let symbols: Vec<DenomMetadata> =
-            from_json(query(deps.as_ref(), mock_env(), QueryMsg::Denoms {}).unwrap()).unwrap();
+            from_json(query(deps.as_ref(), env.clone(), QueryMsg::Denoms {}).unwrap()).unwrap();
 
         assert_eq!(symbols.len(), 98);
 
         let denom: DenomMetadata = from_json(
             query(
                 deps.as_ref(),
-                mock_env(),
+                env.clone(),
                 QueryMsg::Denom {
                     denom: "ufoo0".to_string(),
                 },

--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -295,7 +295,7 @@ fn query_int() -> IntResponse {
 mod tests {
     use super::*;
     use cosmwasm_std::testing::{
-        message_info, mock_dependencies, mock_dependencies_with_balances, mock_environment,
+        message_info, mock_dependencies, mock_dependencies_with_balances_valid, mock_environment,
         MOCK_CONTRACT_ADDR,
     };
     // import trait Storage to get access to read
@@ -428,16 +428,21 @@ mod tests {
 
     #[test]
     fn querier_callbacks_work() {
-        let rich_addr = String::from("foobar");
+        let rich_addr = "foobar";
         let rich_balance = coins(10000, "gold");
-        let deps = mock_dependencies_with_balances(&[(&rich_addr, &rich_balance)]);
+        let deps = mock_dependencies_with_balances_valid(&[(&rich_addr, &rich_balance)]);
 
         // querying with balance gets the balance
-        let bal = query_other_balance(deps.as_ref(), rich_addr).unwrap();
+        let bal =
+            query_other_balance(deps.as_ref(), deps.api.addr_make(rich_addr).to_string()).unwrap();
         assert_eq!(bal.amount, rich_balance);
 
         // querying other accounts gets none
-        let bal = query_other_balance(deps.as_ref(), String::from("someone else")).unwrap();
+        let bal = query_other_balance(
+            deps.as_ref(),
+            deps.api.addr_make("someone else").to_string(),
+        )
+        .unwrap();
         assert_eq!(bal.amount, vec![]);
     }
 

--- a/contracts/ibc-reflect-send/src/contract.rs
+++ b/contracts/ibc-reflect-send/src/contract.rs
@@ -202,17 +202,19 @@ fn query_admin(deps: Deps) -> StdResult<AdminResponse> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cosmwasm_std::testing::{message_info, mock_dependencies, mock_env};
+    use cosmwasm_std::testing::{message_info, mock_dependencies, mock_environment};
 
     const CREATOR: &str = "creator";
 
     #[test]
     fn instantiate_works() {
         let mut deps = mock_dependencies();
+        let env = mock_environment(&deps.api);
+
         let creator = deps.api.addr_make(CREATOR);
         let msg = InstantiateMsg {};
         let info = message_info(&creator, &[]);
-        let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
+        let res = instantiate(deps.as_mut(), env.clone(), info, msg).unwrap();
         assert_eq!(0, res.messages.len());
 
         let admin = query_admin(deps.as_ref()).unwrap();

--- a/contracts/queue/src/contract.rs
+++ b/contracts/queue/src/contract.rs
@@ -179,14 +179,14 @@ fn query_open_iterators(deps: Deps, count: u32) -> Empty {
 mod tests {
     use super::*;
     use cosmwasm_std::testing::{
-        message_info, mock_dependencies_with_balance, mock_environment, MockApi, MockQuerier,
-        MockStorage,
+        message_info, mock_dependencies_with_contract_balance, mock_environment, MockApi,
+        MockQuerier, MockStorage,
     };
     use cosmwasm_std::{coins, from_json, OwnedDeps};
 
     /// Instantiates a contract with no elements
     fn create_contract() -> (OwnedDeps<MockStorage, MockApi, MockQuerier>, MessageInfo) {
-        let mut deps = mock_dependencies_with_balance(&coins(1000, "earth"));
+        let mut deps = mock_dependencies_with_contract_balance(&coins(1000, "earth"));
         let env = mock_environment(&deps.api);
         let creator = deps.api.addr_make("creator");
         let info = message_info(&creator, &coins(1000, "earth"));

--- a/contracts/virus/src/contract.rs
+++ b/contracts/virus/src/contract.rs
@@ -96,17 +96,18 @@ pub fn execute_spread(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cosmwasm_std::testing::{message_info, mock_dependencies, mock_env};
+    use cosmwasm_std::testing::{message_info, mock_dependencies, mock_environment};
 
     const CREATOR: &str = "creator";
 
     #[test]
     fn instantiate_works() {
         let mut deps = mock_dependencies();
+        let env = mock_environment(&deps.api);
         let creator = deps.api.addr_make(CREATOR);
         let msg = InstantiateMsg {};
         let info = message_info(&creator, &[]);
-        let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
+        let res = instantiate(deps.as_mut(), env.clone(), info, msg).unwrap();
         assert_eq!(res.messages.len(), 0);
     }
 }

--- a/packages/std/src/coin.rs
+++ b/packages/std/src/coin.rs
@@ -62,9 +62,7 @@ impl fmt::Display for Coin {
 /// # Examples
 ///
 /// ```
-/// # use cosmwasm_std::{coins, BankMsg, CosmosMsg, Response, SubMsg};
-/// # use cosmwasm_std::testing::mock_env;
-/// # let env = mock_env();
+/// # use cosmwasm_std::{coins, BankMsg, Response, SubMsg};
 /// # let recipient = "blub".to_string();
 /// let tip = coins(123, "ucosm");
 ///
@@ -83,9 +81,7 @@ pub fn coins(amount: u128, denom: impl Into<String>) -> Vec<Coin> {
 /// # Examples
 ///
 /// ```
-/// # use cosmwasm_std::{coin, BankMsg, CosmosMsg, Response, SubMsg};
-/// # use cosmwasm_std::testing::{mock_env, mock_info};
-/// # let env = mock_env();
+/// # use cosmwasm_std::{coin, BankMsg, Response, SubMsg};
 /// # let recipient = "blub".to_string();
 /// let tip = vec![
 ///     coin(123, "ucosm"),

--- a/packages/std/src/testing/mock.rs
+++ b/packages/std/src/testing/mock.rs
@@ -70,20 +70,28 @@ pub fn mock_dependencies() -> OwnedDeps<MockStorage, MockApi, MockQuerier, Empty
 /// Creates all external requirements that can be injected for unit tests.
 ///
 /// It sets the given balance for the contract itself, nothing else.
+#[deprecated(
+    note = "This works only with mock_env, not mock_environment. Use mock_dependencies_with_contract_balance instead"
+)]
 pub fn mock_dependencies_with_balance(
     contract_balance: &[Coin],
 ) -> OwnedDeps<MockStorage, MockApi, MockQuerier, Empty> {
-    let mut deps = mock_dependencies();
-    deps.querier.bank.update_balance(
-        deps.api.addr_make(MOCK_CONTRACT_ADDR),
-        contract_balance.to_vec(),
-    );
+    #[allow(deprecated)]
+    mock_dependencies_with_balances(&[(MOCK_CONTRACT_ADDR, contract_balance)])
+}
 
-    deps
+/// Creates all external requirements that can be injected for unit tests.
+///
+/// It sets the given balance for the contract itself, nothing else.
+pub fn mock_dependencies_with_contract_balance(
+    contract_balance: &[Coin],
+) -> OwnedDeps<MockStorage, MockApi, MockQuerier, Empty> {
+    mock_dependencies_with_balances_valid(&[(MOCK_CONTRACT_ADDR, contract_balance)])
 }
 
 /// Initializes the querier along with the mock_dependencies.
 /// Sets all balances provided (you must explicitly set contract balance if desired).
+#[deprecated = "This works only with mock_env, not mock_environment. Use mock_dependencies_with_balances_valid instead"]
 pub fn mock_dependencies_with_balances(
     balances: &[(&str, &[Coin])],
 ) -> OwnedDeps<MockStorage, MockApi, MockQuerier> {
@@ -93,6 +101,20 @@ pub fn mock_dependencies_with_balances(
         querier: MockQuerier::new(balances),
         custom_query_type: PhantomData,
     }
+}
+
+/// Initializes the querier along with the mock_dependencies.
+/// Sets all balances provided (you must explicitly set contract balance if desired).
+pub fn mock_dependencies_with_balances_valid(
+    balances: &[(&str, &[Coin])],
+) -> OwnedDeps<MockStorage, MockApi, MockQuerier, Empty> {
+    let mut deps = mock_dependencies();
+    for (addr, coins) in balances {
+        deps.querier
+            .bank
+            .update_balance(deps.api.addr_make(addr), coins.to_vec());
+    }
+    deps
 }
 
 // Use MemoryStorage implementation (which is valid in non-testcode)

--- a/packages/std/src/testing/mock.rs
+++ b/packages/std/src/testing/mock.rs
@@ -342,6 +342,7 @@ fn validate_length(bytes: &[u8]) -> StdResult<()> {
 /// test for expiration.
 ///
 /// This is intended for use in test code only.
+#[deprecated = "This produces an invalid contract address. Use mock_environment instead."]
 pub fn mock_env() -> Env {
     Env {
         block: BlockInfo {
@@ -352,6 +353,25 @@ pub fn mock_env() -> Env {
         transaction: Some(TransactionInfo { index: 3 }),
         contract: ContractInfo {
             address: Addr::unchecked(MOCK_CONTRACT_ADDR),
+        },
+    }
+}
+
+/// Returns a default environment with height, time, chain_id, and contract address
+/// You can submit as is to most contracts, or modify height/time if you want to
+/// test for expiration.
+///
+/// This is intended for use in test code only.
+pub fn mock_environment(api: &MockApi) -> Env {
+    Env {
+        block: BlockInfo {
+            height: 12_345,
+            time: Timestamp::from_nanos(1_571_797_419_879_305_533),
+            chain_id: "cosmos-testnet-14002".to_string(),
+        },
+        transaction: Some(TransactionInfo { index: 3 }),
+        contract: ContractInfo {
+            address: api.addr_make(MOCK_CONTRACT_ADDR),
         },
     }
 }

--- a/packages/std/src/testing/mock.rs
+++ b/packages/std/src/testing/mock.rs
@@ -73,7 +73,13 @@ pub fn mock_dependencies() -> OwnedDeps<MockStorage, MockApi, MockQuerier, Empty
 pub fn mock_dependencies_with_balance(
     contract_balance: &[Coin],
 ) -> OwnedDeps<MockStorage, MockApi, MockQuerier, Empty> {
-    mock_dependencies_with_balances(&[(MOCK_CONTRACT_ADDR, contract_balance)])
+    let mut deps = mock_dependencies();
+    deps.querier.bank.update_balance(
+        deps.api.addr_make(MOCK_CONTRACT_ADDR),
+        contract_balance.to_vec(),
+    );
+
+    deps
 }
 
 /// Initializes the querier along with the mock_dependencies.

--- a/packages/std/src/testing/mod.rs
+++ b/packages/std/src/testing/mod.rs
@@ -18,10 +18,11 @@ pub use mock::mock_info;
 pub use mock::DistributionQuerier;
 #[cfg(feature = "staking")]
 pub use mock::StakingQuerier;
+#[allow(deprecated)]
 pub use mock::{
     mock_dependencies, mock_dependencies_with_balance, mock_dependencies_with_balances, mock_env,
-    mock_wasmd_attr, BankQuerier, MockApi, MockQuerier, MockQuerierCustomHandlerResult,
-    MockStorage, MOCK_CONTRACT_ADDR,
+    mock_environment, mock_wasmd_attr, BankQuerier, MockApi, MockQuerier,
+    MockQuerierCustomHandlerResult, MockStorage, MOCK_CONTRACT_ADDR,
 };
 #[cfg(feature = "stargate")]
 pub use mock::{

--- a/packages/std/src/testing/mod.rs
+++ b/packages/std/src/testing/mod.rs
@@ -20,7 +20,8 @@ pub use mock::DistributionQuerier;
 pub use mock::StakingQuerier;
 #[allow(deprecated)]
 pub use mock::{
-    mock_dependencies, mock_dependencies_with_balance, mock_dependencies_with_balances, mock_env,
+    mock_dependencies, mock_dependencies_with_balance, mock_dependencies_with_balances,
+    mock_dependencies_with_balances_valid, mock_dependencies_with_contract_balance, mock_env,
     mock_environment, mock_wasmd_attr, BankQuerier, MockApi, MockQuerier,
     MockQuerierCustomHandlerResult, MockStorage, MOCK_CONTRACT_ADDR,
 };

--- a/packages/vm/benches/main.rs
+++ b/packages/vm/benches/main.rs
@@ -8,7 +8,8 @@ use tempfile::TempDir;
 
 use cosmwasm_std::{coins, Checksum, Empty};
 use cosmwasm_vm::testing::{
-    mock_backend, mock_env, mock_info, mock_instance_options, MockApi, MockQuerier, MockStorage,
+    mock_backend, mock_environment, mock_info, mock_instance_options, MockApi, MockQuerier,
+    MockStorage,
 };
 use cosmwasm_vm::{
     call_execute, call_instantiate, capabilities_from_csv, Cache, CacheOptions, Instance,
@@ -64,19 +65,16 @@ fn bench_instance(c: &mut Criterion) {
         };
         let mut instance =
             Instance::from_code(HACKATOM, backend, much_gas, Some(DEFAULT_MEMORY_LIMIT)).unwrap();
+        let env = mock_environment(instance.api());
 
         b.iter(|| {
             let info = mock_info(&instance.api().addr_make("creator"), &coins(1000, "earth"));
             let verifier = instance.api().addr_make("verifies");
             let beneficiary = instance.api().addr_make("benefits");
             let msg = format!(r#"{{"verifier": "{verifier}", "beneficiary": "{beneficiary}"}}"#);
-            let contract_result = call_instantiate::<_, _, _, Empty>(
-                &mut instance,
-                &mock_env(),
-                &info,
-                msg.as_bytes(),
-            )
-            .unwrap();
+            let contract_result =
+                call_instantiate::<_, _, _, Empty>(&mut instance, &env, &info, msg.as_bytes())
+                    .unwrap();
             assert!(contract_result.into_result().is_ok());
         });
     });
@@ -89,20 +87,20 @@ fn bench_instance(c: &mut Criterion) {
         let mut instance =
             Instance::from_code(HACKATOM, backend, much_gas, Some(DEFAULT_MEMORY_LIMIT)).unwrap();
 
+        let env = mock_environment(instance.api());
         let info = mock_info(&instance.api().addr_make("creator"), &coins(1000, "earth"));
         let verifier = instance.api().addr_make("verifies");
         let beneficiary = instance.api().addr_make("benefits");
         let msg = format!(r#"{{"verifier": "{verifier}", "beneficiary": "{beneficiary}"}}"#);
         let contract_result =
-            call_instantiate::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg.as_bytes())
-                .unwrap();
+            call_instantiate::<_, _, _, Empty>(&mut instance, &env, &info, msg.as_bytes()).unwrap();
         assert!(contract_result.into_result().is_ok());
 
         b.iter(|| {
             let info = mock_info(&verifier, &coins(15, "earth"));
             let msg = br#"{"release":{}}"#;
             let contract_result =
-                call_execute::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg).unwrap();
+                call_execute::<_, _, _, Empty>(&mut instance, &env, &info, msg).unwrap();
             assert!(contract_result.into_result().is_ok());
         });
     });
@@ -115,9 +113,10 @@ fn bench_instance(c: &mut Criterion) {
         let mut instance =
             Instance::from_code(CYBERPUNK, backend, much_gas, Some(DEFAULT_MEMORY_LIMIT)).unwrap();
 
+        let env = mock_environment(instance.api());
         let info = mock_info("creator", &coins(1000, "earth"));
         let contract_result =
-            call_instantiate::<_, _, _, Empty>(&mut instance, &mock_env(), &info, b"{}").unwrap();
+            call_instantiate::<_, _, _, Empty>(&mut instance, &env, &info, b"{}").unwrap();
         assert!(contract_result.into_result().is_ok());
 
         let mut gas_used = 0;
@@ -126,7 +125,7 @@ fn bench_instance(c: &mut Criterion) {
             let info = mock_info("hasher", &[]);
             let msg = br#"{"argon2":{"mem_cost":256,"time_cost":3}}"#;
             let contract_result =
-                call_execute::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg).unwrap();
+                call_execute::<_, _, _, Empty>(&mut instance, &env, &info, msg).unwrap();
             assert!(contract_result.into_result().is_ok());
             gas_used = gas_before - instance.get_gas_left();
         });
@@ -400,10 +399,11 @@ fn bench_combined(c: &mut Criterion) {
             assert!(cache.stats().hits_fs_cache >= 1);
             assert_eq!(cache.stats().misses, 0);
 
+            let env = mock_environment(instance.api());
             let info = mock_info("guest", &[]);
             let msg = br#"{"noop":{}}"#;
             let contract_result =
-                call_execute::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg).unwrap();
+                call_execute::<_, _, _, Empty>(&mut instance, &env, &info, msg).unwrap();
             contract_result.into_result().unwrap();
         });
     });
@@ -427,10 +427,11 @@ fn bench_combined(c: &mut Criterion) {
             assert_eq!(cache.stats().hits_fs_cache, 1);
             assert_eq!(cache.stats().misses, 0);
 
+            let env = mock_environment(instance.api());
             let info = mock_info("guest", &[]);
             let msg = br#"{"noop":{}}"#;
             let contract_result =
-                call_execute::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg).unwrap();
+                call_execute::<_, _, _, Empty>(&mut instance, &env, &info, msg).unwrap();
             contract_result.into_result().unwrap();
         });
     });
@@ -452,10 +453,11 @@ fn bench_combined(c: &mut Criterion) {
             assert_eq!(cache.stats().hits_fs_cache, 1);
             assert_eq!(cache.stats().misses, 0);
 
+            let env = mock_environment(instance.api());
             let info = mock_info("guest", &[]);
             let msg = br#"{"noop":{}}"#;
             let contract_result =
-                call_execute::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg).unwrap();
+                call_execute::<_, _, _, Empty>(&mut instance, &env, &info, msg).unwrap();
             contract_result.into_result().unwrap();
         });
     });

--- a/packages/vm/examples/heap_profiling.rs
+++ b/packages/vm/examples/heap_profiling.rs
@@ -6,7 +6,9 @@ use tempfile::TempDir;
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
 use cosmwasm_std::{coins, Checksum, Empty};
-use cosmwasm_vm::testing::{mock_backend, mock_env, mock_info, MockApi, MockQuerier, MockStorage};
+use cosmwasm_vm::testing::{
+    mock_backend, mock_environment, mock_info, MockApi, MockQuerier, MockStorage,
+};
 use cosmwasm_vm::{
     call_execute, call_instantiate, capabilities_from_csv, Cache, CacheOptions, InstanceOptions,
     Size,
@@ -153,17 +155,18 @@ fn app(runtime: u64) {
 
                 if let Some(msg) = &contracts[idx].instantiate_msg {
                     let info = mock_info("creator", &coins(1000, "earth"));
+                    let env = mock_environment(instance.api());
                     let contract_result =
-                        call_instantiate::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg)
+                        call_instantiate::<_, _, _, Empty>(&mut instance, &env, &info, msg)
                             .unwrap();
                     assert!(contract_result.into_result().is_ok());
                 }
 
                 for (execution_idx, execute) in contracts[idx].execute_msgs.iter().enumerate() {
                     let info = mock_info("verifies", &coins(15, "earth"));
+                    let env = mock_environment(instance.api());
                     let msg = execute.msg;
-                    let res =
-                        call_execute::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg);
+                    let res = call_execute::<_, _, _, Empty>(&mut instance, &env, &info, msg);
 
                     if execute.expect_error {
                         if res.is_ok() {

--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -584,7 +584,9 @@ mod tests {
     use super::*;
     use crate::calls::{call_execute, call_instantiate};
     use crate::capabilities::capabilities_from_csv;
-    use crate::testing::{mock_backend, mock_env, mock_info, MockApi, MockQuerier, MockStorage};
+    use crate::testing::{
+        mock_backend, mock_environment, mock_info, MockApi, MockQuerier, MockStorage,
+    };
     use cosmwasm_std::{coins, Empty};
     use std::borrow::Cow;
     use std::fs::{create_dir_all, remove_dir_all};
@@ -640,21 +642,21 @@ mod tests {
         S: Storage + 'static,
         Q: Querier + 'static,
     {
+        let env = mock_environment(instance.api());
         // instantiate
         let info = mock_info(&instance.api().addr_make("creator"), &coins(1000, "earth"));
         let verifier = instance.api().addr_make("verifies");
         let beneficiary = instance.api().addr_make("benefits");
         let msg = format!(r#"{{"verifier": "{verifier}", "beneficiary": "{beneficiary}"}}"#);
-        let response =
-            call_instantiate::<_, _, _, Empty>(instance, &mock_env(), &info, msg.as_bytes())
-                .unwrap()
-                .unwrap();
+        let response = call_instantiate::<_, _, _, Empty>(instance, &env, &info, msg.as_bytes())
+            .unwrap()
+            .unwrap();
         assert_eq!(response.messages.len(), 0);
 
         // execute
         let info = mock_info(&verifier, &coins(15, "earth"));
         let msg = br#"{"release":{}}"#;
-        let response = call_execute::<_, _, _, Empty>(instance, &mock_env(), &info, msg)
+        let response = call_execute::<_, _, _, Empty>(instance, &env, &info, msg)
             .unwrap()
             .unwrap();
         assert_eq!(response.messages.len(), 1);
@@ -983,17 +985,14 @@ mod tests {
             assert_eq!(cache.stats().misses, 0);
 
             // instantiate
+            let env = mock_environment(instance.api());
             let info = mock_info(&instance.api().addr_make("creator"), &coins(1000, "earth"));
             let verifier = instance.api().addr_make("verifies");
             let beneficiary = instance.api().addr_make("benefits");
             let msg = format!(r#"{{"verifier": "{verifier}", "beneficiary": "{beneficiary}"}}"#);
-            let res = call_instantiate::<_, _, _, Empty>(
-                &mut instance,
-                &mock_env(),
-                &info,
-                msg.as_bytes(),
-            )
-            .unwrap();
+            let res =
+                call_instantiate::<_, _, _, Empty>(&mut instance, &env, &info, msg.as_bytes())
+                    .unwrap();
             let msgs = res.unwrap().messages;
             assert_eq!(msgs.len(), 0);
         }
@@ -1003,6 +1002,7 @@ mod tests {
             let mut instance = cache
                 .get_instance(&checksum, mock_backend(&[]), TESTING_OPTIONS)
                 .unwrap();
+            let env = mock_environment(instance.api());
             assert_eq!(cache.stats().hits_pinned_memory_cache, 0);
             assert_eq!(cache.stats().hits_memory_cache, 1);
             assert_eq!(cache.stats().hits_fs_cache, 1);
@@ -1013,13 +1013,9 @@ mod tests {
             let verifier = instance.api().addr_make("verifies");
             let beneficiary = instance.api().addr_make("benefits");
             let msg = format!(r#"{{"verifier": "{verifier}", "beneficiary": "{beneficiary}"}}"#);
-            let res = call_instantiate::<_, _, _, Empty>(
-                &mut instance,
-                &mock_env(),
-                &info,
-                msg.as_bytes(),
-            )
-            .unwrap();
+            let res =
+                call_instantiate::<_, _, _, Empty>(&mut instance, &env, &info, msg.as_bytes())
+                    .unwrap();
             let msgs = res.unwrap().messages;
             assert_eq!(msgs.len(), 0);
         }
@@ -1037,17 +1033,14 @@ mod tests {
             assert_eq!(cache.stats().misses, 0);
 
             // instantiate
+            let env = mock_environment(instance.api());
             let info = mock_info(&instance.api().addr_make("creator"), &coins(1000, "earth"));
             let verifier = instance.api().addr_make("verifies");
             let beneficiary = instance.api().addr_make("benefits");
             let msg = format!(r#"{{"verifier": "{verifier}", "beneficiary": "{beneficiary}"}}"#);
-            let res = call_instantiate::<_, _, _, Empty>(
-                &mut instance,
-                &mock_env(),
-                &info,
-                msg.as_bytes(),
-            )
-            .unwrap();
+            let res =
+                call_instantiate::<_, _, _, Empty>(&mut instance, &env, &info, msg.as_bytes())
+                    .unwrap();
             let msgs = res.unwrap().messages;
             assert_eq!(msgs.len(), 0);
         }
@@ -1063,6 +1056,7 @@ mod tests {
             let mut instance = cache
                 .get_instance(&checksum, mock_backend(&[]), TESTING_OPTIONS)
                 .unwrap();
+            let env = mock_environment(instance.api());
             assert_eq!(cache.stats().hits_pinned_memory_cache, 0);
             assert_eq!(cache.stats().hits_memory_cache, 0);
             assert_eq!(cache.stats().hits_fs_cache, 1);
@@ -1073,20 +1067,16 @@ mod tests {
             let verifier = instance.api().addr_make("verifies");
             let beneficiary = instance.api().addr_make("benefits");
             let msg = format!(r#"{{"verifier": "{verifier}", "beneficiary": "{beneficiary}"}}"#);
-            let response = call_instantiate::<_, _, _, Empty>(
-                &mut instance,
-                &mock_env(),
-                &info,
-                msg.as_bytes(),
-            )
-            .unwrap()
-            .unwrap();
+            let response =
+                call_instantiate::<_, _, _, Empty>(&mut instance, &env, &info, msg.as_bytes())
+                    .unwrap()
+                    .unwrap();
             assert_eq!(response.messages.len(), 0);
 
             // execute
             let info = mock_info(&verifier, &coins(15, "earth"));
             let msg = br#"{"release":{}}"#;
-            let response = call_execute::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg)
+            let response = call_execute::<_, _, _, Empty>(&mut instance, &env, &info, msg)
                 .unwrap()
                 .unwrap();
             assert_eq!(response.messages.len(), 1);
@@ -1097,6 +1087,7 @@ mod tests {
             let mut instance = cache
                 .get_instance(&checksum, mock_backend(&[]), TESTING_OPTIONS)
                 .unwrap();
+            let env = mock_environment(instance.api());
             assert_eq!(cache.stats().hits_pinned_memory_cache, 0);
             assert_eq!(cache.stats().hits_memory_cache, 1);
             assert_eq!(cache.stats().hits_fs_cache, 1);
@@ -1107,20 +1098,16 @@ mod tests {
             let verifier = instance.api().addr_make("verifies");
             let beneficiary = instance.api().addr_make("benefits");
             let msg = format!(r#"{{"verifier": "{verifier}", "beneficiary": "{beneficiary}"}}"#);
-            let response = call_instantiate::<_, _, _, Empty>(
-                &mut instance,
-                &mock_env(),
-                &info,
-                msg.as_bytes(),
-            )
-            .unwrap()
-            .unwrap();
+            let response =
+                call_instantiate::<_, _, _, Empty>(&mut instance, &env, &info, msg.as_bytes())
+                    .unwrap()
+                    .unwrap();
             assert_eq!(response.messages.len(), 0);
 
             // execute
             let info = mock_info(&verifier, &coins(15, "earth"));
             let msg = br#"{"release":{}}"#;
-            let response = call_execute::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg)
+            let response = call_execute::<_, _, _, Empty>(&mut instance, &env, &info, msg)
                 .unwrap()
                 .unwrap();
             assert_eq!(response.messages.len(), 1);
@@ -1133,6 +1120,7 @@ mod tests {
             let mut instance = cache
                 .get_instance(&checksum, mock_backend(&[]), TESTING_OPTIONS)
                 .unwrap();
+            let env = mock_environment(instance.api());
             assert_eq!(cache.stats().hits_pinned_memory_cache, 1);
             assert_eq!(cache.stats().hits_memory_cache, 1);
             assert_eq!(cache.stats().hits_fs_cache, 2);
@@ -1143,20 +1131,16 @@ mod tests {
             let verifier = instance.api().addr_make("verifies");
             let beneficiary = instance.api().addr_make("benefits");
             let msg = format!(r#"{{"verifier": "{verifier}", "beneficiary": "{beneficiary}"}}"#);
-            let response = call_instantiate::<_, _, _, Empty>(
-                &mut instance,
-                &mock_env(),
-                &info,
-                msg.as_bytes(),
-            )
-            .unwrap()
-            .unwrap();
+            let response =
+                call_instantiate::<_, _, _, Empty>(&mut instance, &env, &info, msg.as_bytes())
+                    .unwrap()
+                    .unwrap();
             assert_eq!(response.messages.len(), 0);
 
             // execute
             let info = mock_info(&verifier, &coins(15, "earth"));
             let msg = br#"{"release":{}}"#;
-            let response = call_execute::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg)
+            let response = call_execute::<_, _, _, Empty>(&mut instance, &env, &info, msg)
                 .unwrap()
                 .unwrap();
             assert_eq!(response.messages.len(), 1);
@@ -1197,13 +1181,13 @@ mod tests {
         let mut instance = cache
             .get_instance(&checksum, backend1, TESTING_OPTIONS)
             .unwrap();
+        let env = mock_environment(instance.api());
         let info = mock_info("owner1", &coins(1000, "earth"));
         let sue = instance.api().addr_make("sue");
         let mary = instance.api().addr_make("mary");
         let msg = format!(r#"{{"verifier": "{sue}", "beneficiary": "{mary}"}}"#);
         let res =
-            call_instantiate::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg.as_bytes())
-                .unwrap();
+            call_instantiate::<_, _, _, Empty>(&mut instance, &env, &info, msg.as_bytes()).unwrap();
         let msgs = res.unwrap().messages;
         assert_eq!(msgs.len(), 0);
         let backend1 = instance.recycle().unwrap();
@@ -1212,13 +1196,13 @@ mod tests {
         let mut instance = cache
             .get_instance(&checksum, backend2, TESTING_OPTIONS)
             .unwrap();
+        let env = mock_environment(instance.api());
         let info = mock_info("owner2", &coins(500, "earth"));
         let bob = instance.api().addr_make("bob");
         let john = instance.api().addr_make("john");
         let msg = format!(r#"{{"verifier": "{bob}", "beneficiary": "{john}"}}"#);
         let res =
-            call_instantiate::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg.as_bytes())
-                .unwrap();
+            call_instantiate::<_, _, _, Empty>(&mut instance, &env, &info, msg.as_bytes()).unwrap();
         let msgs = res.unwrap().messages;
         assert_eq!(msgs.len(), 0);
         let backend2 = instance.recycle().unwrap();
@@ -1227,9 +1211,10 @@ mod tests {
         let mut instance = cache
             .get_instance(&checksum, backend2, TESTING_OPTIONS)
             .unwrap();
+        let env = mock_environment(instance.api());
         let info = mock_info(&bob, &coins(15, "earth"));
         let msg = br#"{"release":{}}"#;
-        let res = call_execute::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg).unwrap();
+        let res = call_execute::<_, _, _, Empty>(&mut instance, &env, &info, msg).unwrap();
         let msgs = res.unwrap().messages;
         assert_eq!(1, msgs.len());
 
@@ -1237,9 +1222,10 @@ mod tests {
         let mut instance = cache
             .get_instance(&checksum, backend1, TESTING_OPTIONS)
             .unwrap();
+        let env = mock_environment(instance.api());
         let info = mock_info(&sue, &coins(15, "earth"));
         let msg = br#"{"release":{}}"#;
-        let res = call_execute::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg).unwrap();
+        let res = call_execute::<_, _, _, Empty>(&mut instance, &env, &info, msg).unwrap();
         let msgs = res.unwrap().messages;
         assert_eq!(1, msgs.len());
     }
@@ -1263,11 +1249,12 @@ mod tests {
         let original_gas = instance1.get_gas_left();
 
         // Consume some gas
+        let env = mock_environment(instance1.api());
         let info = mock_info("owner1", &coins(1000, "earth"));
         let sue = instance1.api().addr_make("sue");
         let mary = instance1.api().addr_make("mary");
         let msg = format!(r#"{{"verifier": "{sue}", "beneficiary": "{mary}"}}"#);
-        call_instantiate::<_, _, _, Empty>(&mut instance1, &mock_env(), &info, msg.as_bytes())
+        call_instantiate::<_, _, _, Empty>(&mut instance1, &env, &info, msg.as_bytes())
             .unwrap()
             .unwrap();
         assert!(instance1.get_gas_left() < original_gas);
@@ -1298,18 +1285,14 @@ mod tests {
         assert_eq!(cache.stats().misses, 0);
 
         // Consume some gas. This fails
+        let env = mock_environment(instance1.api());
         let info1 = mock_info("owner1", &coins(1000, "earth"));
         let sue = instance1.api().addr_make("sue");
         let mary = instance1.api().addr_make("mary");
         let msg1 = format!(r#"{{"verifier": "{sue}", "beneficiary": "{mary}"}}"#);
 
-        match call_instantiate::<_, _, _, Empty>(
-            &mut instance1,
-            &mock_env(),
-            &info1,
-            msg1.as_bytes(),
-        )
-        .unwrap_err()
+        match call_instantiate::<_, _, _, Empty>(&mut instance1, &env, &info1, msg1.as_bytes())
+            .unwrap_err()
         {
             VmError::GasDepletion { .. } => (), // all good, continue
             e => panic!("unexpected error, {e:?}"),
@@ -1328,11 +1311,12 @@ mod tests {
         assert_eq!(instance2.get_gas_left(), TESTING_GAS_LIMIT);
 
         // Now it works
+        let env = mock_environment(instance2.api());
         let info2 = mock_info("owner2", &coins(500, "earth"));
         let bob = instance2.api().addr_make("bob");
         let john = instance2.api().addr_make("john");
         let msg2 = format!(r#"{{"verifier": "{bob}", "beneficiary": "{john}"}}"#);
-        call_instantiate::<_, _, _, Empty>(&mut instance2, &mock_env(), &info2, msg2.as_bytes())
+        call_instantiate::<_, _, _, Empty>(&mut instance2, &env, &info2, msg2.as_bytes())
             .unwrap()
             .unwrap();
     }

--- a/packages/vm/src/testing/instance.rs
+++ b/packages/vm/src/testing/instance.rs
@@ -127,13 +127,14 @@ pub fn mock_instance_with_options(
 ) -> Instance<MockApi, MockStorage, MockQuerier> {
     check_wasm(wasm, &options.available_capabilities).unwrap();
 
+    // we need to create the address up here because the failing api will panic
+    let contract_address = MockApi::default().addr_make(MOCK_CONTRACT_ADDR);
+
     let api = if let Some(backend_error) = options.backend_error {
         MockApi::new_failing(backend_error)
     } else {
         MockApi::default()
     };
-
-    let contract_address = api.addr_make(MOCK_CONTRACT_ADDR);
 
     // merge balances
     let mut balances = options.balances.to_vec();

--- a/packages/vm/src/testing/mock.rs
+++ b/packages/vm/src/testing/mock.rs
@@ -221,6 +221,7 @@ fn validate_length(bytes: &[u8]) -> Result<(), BackendError> {
 /// test for expiration.
 ///
 /// This is intended for use in test code only.
+#[deprecated = "This produces an invalid contract address. Use mock_environment instead."]
 pub fn mock_env() -> Env {
     Env {
         block: BlockInfo {
@@ -231,6 +232,25 @@ pub fn mock_env() -> Env {
         transaction: Some(TransactionInfo { index: 3 }),
         contract: ContractInfo {
             address: Addr::unchecked(MOCK_CONTRACT_ADDR),
+        },
+    }
+}
+
+/// Returns a default environment with height, time, chain_id, and contract address
+/// You can submit as is to most contracts, or modify height/time if you want to
+/// test for expiration.
+///
+/// This is intended for use in test code only.
+pub fn mock_environment(api: &MockApi) -> Env {
+    Env {
+        block: BlockInfo {
+            height: 12_345,
+            time: Timestamp::from_nanos(1_571_797_419_879_305_533),
+            chain_id: "cosmos-testnet-14002".to_string(),
+        },
+        transaction: Some(TransactionInfo { index: 3 }),
+        contract: ContractInfo {
+            address: Addr::unchecked(api.addr_make(MOCK_CONTRACT_ADDR)),
         },
     }
 }

--- a/packages/vm/src/testing/mod.rs
+++ b/packages/vm/src/testing/mod.rs
@@ -17,8 +17,10 @@ pub use instance::{
     mock_instance_with_failing_api, mock_instance_with_gas_limit, mock_instance_with_options,
     test_io, MockInstanceOptions,
 };
+#[allow(deprecated)]
 pub use mock::{
-    mock_backend, mock_backend_with_balances, mock_env, mock_info, MockApi, MOCK_CONTRACT_ADDR,
+    mock_backend, mock_backend_with_balances, mock_env, mock_environment, mock_info, MockApi,
+    MOCK_CONTRACT_ADDR,
 };
 pub use querier::MockQuerier;
 pub use storage::MockStorage;


### PR DESCRIPTION
an attempt at #2211

Problem is that this requires massive refactoring when changing existing tests. The borrow checker bites you whenever you use `mock_environment(&deps.api)` inside a call where you also pass `deps`, so you need to create the env first and then pass it to the function.
`mock_dependencies_with_balances` and `mock_dependencies_with_balance` are also affected by the invalid address problem and got new variants here too.