### PR TITLE
Finish `cosmwasm-check --verbose`

### DIFF
--- a/packages/check/src/main.rs
+++ b/packages/check/src/main.rs
@@ -8,7 +8,7 @@ use clap::{Arg, ArgAction, Command};
 use colored::Colorize;
 
 use cosmwasm_vm::capabilities_from_csv;
-use cosmwasm_vm::internals::{check_wasm_with_logs, compile, make_compiling_engine, Logs};
+use cosmwasm_vm::internals::{check_wasm_with_logs, compile, make_compiling_engine, Logger};
 
 const DEFAULT_AVAILABLE_CAPABILITIES: &str =
     "iterator,staking,stargate,cosmwasm_1_1,cosmwasm_1_2,cosmwasm_1_3,cosmwasm_1_4,cosmwasm_2_0,cosmwasm_2_1";
@@ -103,13 +103,9 @@ fn check_contract(
     let mut wasm = Vec::<u8>::new();
     file.read_to_end(&mut wasm)?;
 
-    let mut logs = if verbose { Logs::new() } else { Logs::Off };
+    let logs = if verbose { Logger::new() } else { Logger::Off };
     // Check wasm
-    let res = check_wasm_with_logs(&wasm, available_capabilities, &mut logs);
-    for line in logs {
-        eprintln!("{}", line);
-    }
-    res?;
+    check_wasm_with_logs(&wasm, available_capabilities, logs)?;
 
     // Compile module
     let engine = make_compiling_engine(None);

--- a/packages/check/src/main.rs
+++ b/packages/check/src/main.rs
@@ -95,10 +95,10 @@ fn check_contract(
     let mut wasm = Vec::<u8>::new();
     file.read_to_end(&mut wasm)?;
 
-    let logs = Logs::new();
+    let mut logs = Logs::new();
     // Check wasm
-    let res = check_wasm_with_logs(&wasm, available_capabilities, logs.clone());
-    for line in logs.iter() {
+    let res = check_wasm_with_logs(&wasm, available_capabilities, &mut logs);
+    for line in logs {
         eprintln!("{}", line);
     }
     res?;

--- a/packages/check/tests/cosmwasm_check_tests.rs
+++ b/packages/check/tests/cosmwasm_check_tests.rs
@@ -15,6 +15,19 @@ fn valid_contract_check() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
+fn contract_check_verbose() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::cargo_bin("cosmwasm-check")?;
+
+    cmd.arg("../vm/testdata/empty.wasm").arg("--verbose");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("pass"))
+        .stderr(predicate::str::contains("Max function parameters"));
+
+    Ok(())
+}
+
+#[test]
 fn empty_contract_check() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("cosmwasm-check")?;
 

--- a/packages/vm/src/compatibility.rs
+++ b/packages/vm/src/compatibility.rs
@@ -139,10 +139,10 @@ pub fn check_wasm(wasm_code: &[u8], available_capabilities: &HashSet<String>) ->
     check_wasm_with_logs(wasm_code, available_capabilities, Off)
 }
 
-pub fn check_wasm_with_logs<'a>(
+pub fn check_wasm_with_logs(
     wasm_code: &[u8],
     available_capabilities: &HashSet<String>,
-    logs: Logger<'a>,
+    logs: Logger<'_>,
 ) -> VmResult<()> {
     logs.add(|| format!("Size of Wasm blob: {}", wasm_code.len()));
 

--- a/packages/vm/src/compatibility.rs
+++ b/packages/vm/src/compatibility.rs
@@ -110,8 +110,8 @@ pub struct LogAccess<'a>(RefMut<'a, Vec<String>>);
 
 impl<'a> LogAccess<'a> {
     /// Adds a message to the logs
-    pub fn add(&mut self, msg: String) {
-        self.0.push(msg);
+    pub fn add(&mut self, msg: impl Into<String>) {
+        self.0.push(msg.into());
     }
 }
 
@@ -409,18 +409,16 @@ mod tests {
     fn logs_works() {
         let mut logs = Logs::new();
 
-        if let Some(mut logs) = logs.open() {
-            logs.add(format!("a test"));
-        }
+        logs.add(|| "a test".to_string());
 
         if let Some(mut logs) = logs.open() {
-            logs.add(format!("second test"));
-            logs.add(format!("third test"));
+            logs.add("second test");
+            logs.add("third test");
         }
 
         let mut logs_b = logs.clone();
         if let Some(mut logs) = logs_b.open() {
-            logs.add(format!("added in b"));
+            logs.add("added in b");
         }
 
         let mut iter = logs.into_iter();

--- a/packages/vm/src/compatibility.rs
+++ b/packages/vm/src/compatibility.rs
@@ -113,13 +113,6 @@ pub enum Logger<'a> {
 }
 
 impl<'a> Logger<'a> {
-    pub fn new() -> Self {
-        On {
-            output: LogOutput::StdOut,
-            prefix: "",
-        }
-    }
-
     pub fn with_config(output: LogOutput, prefix: &'a str) -> Self {
         On { output, prefix }
     }

--- a/packages/vm/src/lib.rs
+++ b/packages/vm/src/lib.rs
@@ -55,7 +55,7 @@ pub mod internals {
     //! Please don't use any of these types directly, as
     //! they might change frequently or be removed in the future.
 
-    pub use crate::compatibility::{check_wasm, check_wasm_with_logs, Logs};
+    pub use crate::compatibility::{check_wasm, check_wasm_with_logs, LogOutput, Logger};
     pub use crate::instance::instance_from_module;
     pub use crate::wasm_backend::{compile, make_compiling_engine, make_runtime_engine};
 }


### PR DESCRIPTION
Based on and merging into #2213

We could also opt for using `log` instead to avoid having to drag the `&mut Log` everywhere, but this works and is probably good enough.