### PR TITLE
Customizable limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,14 @@ and this project adheres to
 - cosmwasm-std: Add `IbcMsg::{PayPacketFee, PayPacketFeeAsync}` and
   `IbcQuery::FeeEnabledChannel` to allow contracts to incentivize IBC packets
   using IBC Fees. ([#2196])
+- cosmwasm-vm: Add `Config` that allows to configure the limits for static Wasm
+  validation. ([#2220])
+- cosmwasm-check: Add `--wasm-limits` flag to supply configured limits for
+  static validation. ([#2220])
 
 [#2118]: https://github.com/CosmWasm/cosmwasm/pull/2118
 [#2196]: https://github.com/CosmWasm/cosmwasm/pull/2196
+[#2220]: https://github.com/CosmWasm/cosmwasm/pull/2220
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,6 @@ dependencies = [
  "cosmwasm-std",
  "cosmwasm-vm",
  "predicates",
- "rmp-serde",
  "tempfile",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -559,6 +559,7 @@ dependencies = [
  "cosmwasm-vm",
  "predicates",
  "rmp-serde",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,6 +558,7 @@ dependencies = [
  "cosmwasm-std",
  "cosmwasm-vm",
  "predicates",
+ "rmp-serde",
 ]
 
 [[package]]
@@ -2323,9 +2324,9 @@ dependencies = [
 
 [[package]]
 name = "rmp-serde"
-version = "1.1.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5b13be192e0220b8afb7222aa5813cb62cc269ebb5cac346ca6487681d2913e"
+checksum = "52e599a477cf9840e92f2cde9a7189e67b42c57532749bf90aea6ec10facd4db"
 dependencies = [
  "byteorder",
  "rmp",

--- a/packages/check/Cargo.toml
+++ b/packages/check/Cargo.toml
@@ -13,6 +13,7 @@ clap = "4"
 colored = "2.1.0"
 cosmwasm-vm = { path = "../vm", version = "=2.1.3" }
 cosmwasm-std = { path = "../std", version = "=2.1.3" }
+rmp-serde = "1.1.2"
 
 [dev-dependencies]
 assert_cmd = "2.0.12"

--- a/packages/check/Cargo.toml
+++ b/packages/check/Cargo.toml
@@ -18,3 +18,4 @@ rmp-serde = "1.1.2"
 [dev-dependencies]
 assert_cmd = "2.0.12"
 predicates = "3"
+tempfile = "3.1.0"

--- a/packages/check/Cargo.toml
+++ b/packages/check/Cargo.toml
@@ -13,7 +13,6 @@ clap = "4"
 colored = "2.1.0"
 cosmwasm-vm = { path = "../vm", version = "=2.1.3" }
 cosmwasm-std = { path = "../std", version = "=2.1.3" }
-rmp-serde = "1.1.2"
 
 [dev-dependencies]
 assert_cmd = "2.0.12"

--- a/packages/check/src/main.rs
+++ b/packages/check/src/main.rs
@@ -7,10 +7,10 @@ use std::process::exit;
 use clap::{Arg, ArgAction, Command};
 use colored::Colorize;
 
-use cosmwasm_vm::capabilities_from_csv;
 use cosmwasm_vm::internals::{
-    check_wasm_with_logs, compile, make_compiling_engine, LogOutput, Logger,
+    check_wasm_with_limits, compile, make_compiling_engine, LogOutput, Logger,
 };
+use cosmwasm_vm::{capabilities_from_csv, WasmLimits};
 
 const DEFAULT_AVAILABLE_CAPABILITIES: &str =
     "iterator,staking,stargate,cosmwasm_1_1,cosmwasm_1_2,cosmwasm_1_3,cosmwasm_1_4,cosmwasm_2_0,cosmwasm_2_1";
@@ -120,7 +120,7 @@ fn check_contract(
         Logger::Off
     };
     // Check wasm
-    check_wasm_with_logs(&wasm, available_capabilities, logs)?;
+    check_wasm_with_limits(&wasm, available_capabilities, &WasmLimits::default(), logs)?;
 
     // Compile module
     let engine = make_compiling_engine(None);

--- a/packages/check/src/main.rs
+++ b/packages/check/src/main.rs
@@ -4,13 +4,14 @@ use std::io::Read;
 use std::path::Path;
 use std::process::exit;
 
+use anyhow::Context;
 use clap::{Arg, ArgAction, Command};
 use colored::Colorize;
 
 use cosmwasm_vm::internals::{
     check_wasm_with_limits, compile, make_compiling_engine, LogOutput, Logger,
 };
-use cosmwasm_vm::{capabilities_from_csv, WasmLimits};
+use cosmwasm_vm::{capabilities_from_csv, Config, WasmLimits};
 
 const DEFAULT_AVAILABLE_CAPABILITIES: &str =
     "iterator,staking,stargate,cosmwasm_1_1,cosmwasm_1_2,cosmwasm_1_3,cosmwasm_1_4,cosmwasm_2_0,cosmwasm_2_1";
@@ -38,6 +39,18 @@ pub fn main() {
                 .action(ArgAction::SetTrue),
         )
         .arg(
+            Arg::new("CONFIG")
+            .long("wasm-config")
+            .value_name("CONFIG_FILE")
+            .conflicts_with("CAPABILITIES")
+            .help("Provide a file with the chain's Wasmd configuration.")
+            .long_help("Provide a file with the chain's Wasmd configuration.
+You can query this configuration from the chain, using the WasmConfig query.
+If this is not provided, the default values are used. This conflicts with the --available-capabilities flag because the config also contains those.")
+            .num_args(1)
+            .action(ArgAction::Set)
+        )
+        .arg(
             Arg::new("WASM")
                 .help("Wasm file to read and compile")
                 .required(true)
@@ -47,12 +60,24 @@ pub fn main() {
         )
         .get_matches();
 
-    // Available capabilities
+    let config_file = matches.get_one::<String>("CONFIG");
     let available_capabilities_csv = matches
         .get_one::<String>("CAPABILITIES")
-        .map(|s| s.as_str())
-        .unwrap_or(DEFAULT_AVAILABLE_CAPABILITIES);
-    let available_capabilities = capabilities_from_csv(available_capabilities_csv);
+        .map(|s| s.as_str());
+
+    // Available capabilities and Wasm limits
+    let (wasm_limits, available_capabilities) = match (config_file, available_capabilities_csv) {
+        (Some(config_file), _) => {
+            let config = read_config(config_file).unwrap();
+            (config.wasm_limits, config.cache.available_capabilities)
+        }
+        (_, available_capabilities_csv) => {
+            let available_capabilities = capabilities_from_csv(
+                available_capabilities_csv.unwrap_or(DEFAULT_AVAILABLE_CAPABILITIES),
+            );
+            (WasmLimits::default(), available_capabilities)
+        }
+    };
     println!("Available capabilities: {available_capabilities:?}");
     println!();
 
@@ -63,7 +88,12 @@ pub fn main() {
 
     let (passes, failures): (Vec<_>, _) = paths
         .map(|p| {
-            let result = check_contract(p, &available_capabilities, matches.get_flag("VERBOSE"));
+            let result = check_contract(
+                p,
+                &available_capabilities,
+                matches.get_flag("VERBOSE"),
+                &wasm_limits,
+            );
             match &result {
                 Ok(_) => println!("{}: {}", p, "pass".green()),
                 Err(e) => {
@@ -94,10 +124,17 @@ pub fn main() {
     }
 }
 
+fn read_config(path: &str) -> anyhow::Result<Config> {
+    let file = File::open(path).context("error opening config file")?;
+    let config = rmp_serde::from_read(file).context("error parsing config file")?;
+    Ok(config)
+}
+
 fn check_contract(
     path: &str,
     available_capabilities: &HashSet<String>,
     verbose: bool,
+    wasm_limits: &WasmLimits,
 ) -> anyhow::Result<()> {
     let mut file = File::open(path)?;
 
@@ -120,7 +157,7 @@ fn check_contract(
         Logger::Off
     };
     // Check wasm
-    check_wasm_with_limits(&wasm, available_capabilities, &WasmLimits::default(), logs)?;
+    check_wasm_with_limits(&wasm, available_capabilities, wasm_limits, logs)?;
 
     // Compile module
     let engine = make_compiling_engine(None);

--- a/packages/check/src/main.rs
+++ b/packages/check/src/main.rs
@@ -9,9 +9,7 @@ use clap::{Arg, ArgAction, Command};
 use colored::Colorize;
 
 use cosmwasm_std::from_json;
-use cosmwasm_vm::internals::{
-    check_wasm_with_limits, compile, make_compiling_engine, LogOutput, Logger,
-};
+use cosmwasm_vm::internals::{check_wasm, compile, make_compiling_engine, LogOutput, Logger};
 use cosmwasm_vm::{capabilities_from_csv, WasmLimits};
 
 const DEFAULT_AVAILABLE_CAPABILITIES: &str =
@@ -155,7 +153,7 @@ fn check_contract(
         Logger::Off
     };
     // Check wasm
-    check_wasm_with_limits(&wasm, available_capabilities, wasm_limits, logs)?;
+    check_wasm(&wasm, available_capabilities, wasm_limits, logs)?;
 
     // Compile module
     let engine = make_compiling_engine(None);

--- a/packages/check/src/main.rs
+++ b/packages/check/src/main.rs
@@ -72,7 +72,7 @@ If this is not provided, the default values are used.")
     let wasm_limits = matches
         .get_one::<String>("LIMITS")
         .map(|input| read_wasm_limits(input).unwrap())
-        .unwrap_or(WasmLimits::default());
+        .unwrap_or_default();
 
     // File
     let paths = matches

--- a/packages/check/tests/cosmwasm_check_tests.rs
+++ b/packages/check/tests/cosmwasm_check_tests.rs
@@ -1,5 +1,5 @@
 use assert_cmd::prelude::*;
-use cosmwasm_std::{to_base64, to_msgpack_vec};
+use cosmwasm_std::{to_json_string, to_json_vec};
 use cosmwasm_vm::WasmLimits;
 use predicates::prelude::*;
 use std::{io::Write, process::Command};
@@ -106,7 +106,7 @@ fn wasm_limits_base64_check() -> Result<(), Box<dyn std::error::Error>> {
     limits.initial_memory_limit = Some(10);
 
     cmd.arg("--wasm-limits")
-        .arg(to_base64(to_msgpack_vec(&limits).unwrap()))
+        .arg(to_json_string(&limits).unwrap())
         .arg("../vm/testdata/hackatom.wasm");
     cmd.assert()
         .failure()
@@ -121,7 +121,7 @@ fn wasm_limits_file_check() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut limits = WasmLimits::default();
     limits.max_functions = Some(15);
-    let limits = to_msgpack_vec(&limits)?;
+    let limits = to_json_vec(&limits)?;
 
     let mut tmp_file = NamedTempFile::new()?;
     tmp_file.write_all(&limits)?;

--- a/packages/check/tests/cosmwasm_check_tests.rs
+++ b/packages/check/tests/cosmwasm_check_tests.rs
@@ -1,6 +1,9 @@
 use assert_cmd::prelude::*;
+use cosmwasm_std::{to_base64, to_msgpack_vec};
+use cosmwasm_vm::WasmLimits;
 use predicates::prelude::*;
-use std::process::Command;
+use std::{io::Write, process::Command};
+use tempfile::NamedTempFile;
 
 #[test]
 fn valid_contract_check() -> Result<(), Box<dyn std::error::Error>> {
@@ -91,6 +94,44 @@ fn custom_capabilities_check() -> Result<(), Box<dyn std::error::Error>> {
         .stdout(predicate::str::contains("iterator"))
         .stdout(predicate::str::contains("osmosis"))
         .stdout(predicate::str::contains("friendship"));
+
+    Ok(())
+}
+
+#[test]
+fn wasm_limits_base64_check() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::cargo_bin("cosmwasm-check")?;
+
+    let mut limits = WasmLimits::default();
+    limits.initial_memory_limit = Some(10);
+
+    cmd.arg("--wasm-limits")
+        .arg(to_base64(to_msgpack_vec(&limits).unwrap()))
+        .arg("../vm/testdata/hackatom.wasm");
+    cmd.assert()
+        .failure()
+        .stdout(predicate::str::contains("must not exceed 10 pages"));
+
+    Ok(())
+}
+
+#[test]
+fn wasm_limits_file_check() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::cargo_bin("cosmwasm-check")?;
+
+    let mut limits = WasmLimits::default();
+    limits.max_functions = Some(15);
+    let limits = to_msgpack_vec(&limits)?;
+
+    let mut tmp_file = NamedTempFile::new()?;
+    tmp_file.write_all(&limits)?;
+
+    cmd.arg("--wasm-limits")
+        .arg(tmp_file.path())
+        .arg("../vm/testdata/hackatom.wasm");
+    cmd.assert()
+        .failure()
+        .stdout(predicate::str::contains("more than 15 functions"));
 
     Ok(())
 }

--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -11,7 +11,7 @@ use cosmwasm_std::Checksum;
 
 use crate::backend::{Backend, BackendApi, Querier, Storage};
 use crate::capabilities::required_capabilities_from_module;
-use crate::compatibility::check_wasm_with_limits;
+use crate::compatibility::check_wasm;
 use crate::config::{CacheOptions, Config, WasmLimits};
 use crate::errors::{VmError, VmResult};
 use crate::filesystem::mkdir_p;
@@ -229,7 +229,7 @@ where
     /// This does the same as [`save_wasm_unchecked`] plus the static checks.
     /// When a Wasm blob is stored the first time, use this function.
     pub fn save_wasm(&self, wasm: &[u8]) -> VmResult<Checksum> {
-        check_wasm_with_limits(
+        check_wasm(
             wasm,
             &self.available_capabilities,
             &self.wasm_limits,

--- a/packages/vm/src/compatibility.rs
+++ b/packages/vm/src/compatibility.rs
@@ -745,8 +745,8 @@ mod tests {
         .unwrap();
         check_wasm_imports(
             &ParsedWasm::parse(&wasm).unwrap(),
-            &WasmLimits::default(),
             SUPPORTED_IMPORTS,
+            &WasmLimits::default(),
             Off,
         )
         .unwrap();
@@ -862,8 +862,8 @@ mod tests {
         .unwrap();
         let err = check_wasm_imports(
             &ParsedWasm::parse(&wasm).unwrap(),
-            &WasmLimits::default(),
             SUPPORTED_IMPORTS,
+            &WasmLimits::default(),
             Off,
         )
         .unwrap_err();
@@ -905,8 +905,8 @@ mod tests {
         ];
         let result = check_wasm_imports(
             &ParsedWasm::parse(&wasm).unwrap(),
-            &WasmLimits::default(),
             supported_imports,
+            &WasmLimits::default(),
             Off,
         );
         match result.unwrap_err() {
@@ -924,7 +924,7 @@ mod tests {
     #[test]
     fn check_wasm_imports_of_old_contract() {
         let module = &ParsedWasm::parse(CONTRACT_0_7).unwrap();
-        let result = check_wasm_imports(module, &WasmLimits::default(), SUPPORTED_IMPORTS, Off);
+        let result = check_wasm_imports(module, SUPPORTED_IMPORTS, &WasmLimits::default(), Off);
         match result.unwrap_err() {
             VmError::StaticValidationErr { msg, .. } => {
                 assert!(
@@ -940,8 +940,8 @@ mod tests {
         let wasm = wat::parse_str(r#"(module (import "env" "db_read" (memory 1 1)))"#).unwrap();
         let result = check_wasm_imports(
             &ParsedWasm::parse(&wasm).unwrap(),
-            &WasmLimits::default(),
             SUPPORTED_IMPORTS,
+            &WasmLimits::default(),
             Off,
         );
         match result.unwrap_err() {

--- a/packages/vm/src/compatibility.rs
+++ b/packages/vm/src/compatibility.rs
@@ -110,6 +110,8 @@ pub fn check_wasm_with_limits(
     limits: &WasmLimits,
     logs: Logger<'_>,
 ) -> VmResult<()> {
+    logs.add(|| format!("Size of Wasm blob: {}", wasm_code.len()));
+
     let mut module = ParsedWasm::parse(wasm_code)?;
 
     check_wasm_tables(&module, limits)?;

--- a/packages/vm/src/compatibility.rs
+++ b/packages/vm/src/compatibility.rs
@@ -157,10 +157,10 @@ fn check_wasm_memories(module: &ParsedWasm, limits: &WasmLimits) -> VmResult<()>
     }
     let memory = &module.memories[0];
 
-    if memory.initial > limits.memory_page_limit() as u64 {
+    if memory.initial > limits.initial_memory_limit_in_pages() as u64 {
         return Err(VmError::static_validation_err(format!(
             "Wasm contract memory's minimum must not exceed {} pages.",
-            limits.memory_page_limit()
+            limits.initial_memory_limit_in_pages()
         )));
     }
 

--- a/packages/vm/src/compatibility.rs
+++ b/packages/vm/src/compatibility.rs
@@ -157,10 +157,10 @@ fn check_wasm_memories(module: &ParsedWasm, limits: &WasmLimits) -> VmResult<()>
     }
     let memory = &module.memories[0];
 
-    if memory.initial > limits.initial_memory_limit_in_pages() as u64 {
+    if memory.initial > limits.initial_memory_limit() as u64 {
         return Err(VmError::static_validation_err(format!(
             "Wasm contract memory's minimum must not exceed {} pages.",
-            limits.initial_memory_limit_in_pages()
+            limits.initial_memory_limit()
         )));
     }
 

--- a/packages/vm/src/config.rs
+++ b/packages/vm/src/config.rs
@@ -49,7 +49,7 @@ impl Config {
 #[non_exhaustive]
 pub struct WasmLimits {
     /// Maximum number of memory pages that a module can request.
-    memory_page_limit: Option<u32>,
+    pub memory_page_limit: Option<u32>,
     /// The upper limit for the `max` value of each table. CosmWasm contracts have
     /// initial=max for 1 table. See
     ///
@@ -61,27 +61,27 @@ pub struct WasmLimits {
     /// - table[0] type=funcref initial=161 max=161
     /// ```
     ///
-    table_size_limit: Option<u32>,
+    pub table_size_limit: Option<u32>,
     /// If the contract has more than this amount of imports, it will be rejected
     /// during static validation before even looking into the imports.
-    max_imports: Option<usize>,
+    pub max_imports: Option<usize>,
 
     /// The maximum number of functions a contract can have.
     /// Any contract with more functions than this will be rejected during static validation.
-    max_functions: Option<usize>,
+    pub max_functions: Option<usize>,
 
     /// The maximum number of parameters a Wasm function can have.
-    max_function_params: Option<usize>,
+    pub max_function_params: Option<usize>,
     /// The maximum total number of parameters of all functions in the Wasm.
     /// For each function in the Wasm, take the number of parameters and sum all of these up.
     /// If that sum exceeds this limit, the Wasm will be rejected during static validation.
     ///
     /// Be careful when adjusting this limit, as it prevents an attack where a small Wasm file
     /// explodes in size when compiled.
-    max_total_function_params: Option<usize>,
+    pub max_total_function_params: Option<usize>,
 
     /// The maximum number of results a Wasm function type can have.
-    max_function_results: Option<usize>,
+    pub max_function_results: Option<usize>,
 }
 
 impl WasmLimits {

--- a/packages/vm/src/config.rs
+++ b/packages/vm/src/config.rs
@@ -1,0 +1,150 @@
+use std::{collections::HashSet, path::PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::Size;
+
+const DEFAULT_MEMORY_LIMIT: u32 = 512; // in pages
+/// As of March 2023, on Juno mainnet the largest value for production contracts
+/// is 485. Most are between 100 and 300.
+const DEFAULT_TABLE_SIZE_LIMIT: u32 = 2500; // entries
+
+/// We keep this number high since failing early gives less detailed error messages. Especially
+/// when a user accidentally includes wasm-bindgen, they get a bunch of unsupported imports.
+const DEFAULT_MAX_IMPORTS: usize = 100;
+
+const DEFAULT_MAX_FUNCTIONS: usize = 20_000;
+
+const DEFAULT_MAX_FUNCTION_PARAMS: usize = 100;
+
+const DEFAULT_MAX_TOTAL_FUNCTION_PARAMS: usize = 10_000;
+
+const DEFAULT_MAX_FUNCTION_RESULTS: usize = 1;
+
+/// Various configurations for the VM.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct Config {
+    /// Configuration for limitations placed on Wasm files.
+    /// This defines a few limits on the Wasm file that are checked during static validation before
+    /// storing the Wasm file.
+    pub wasm_limits: WasmLimits,
+
+    /// Configuration for the cache.
+    pub cache: CacheOptions,
+}
+
+impl Config {
+    pub fn new(cache: CacheOptions) -> Self {
+        Self {
+            wasm_limits: WasmLimits::default(),
+            cache,
+        }
+    }
+}
+
+/// Limits for static validation of Wasm files. These are checked before storing the Wasm file.
+/// All limits are optional because they are coming from the Go-side and have default values.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct WasmLimits {
+    /// Maximum number of memory pages that a module can request.
+    memory_page_limit: Option<u32>,
+    /// The upper limit for the `max` value of each table. CosmWasm contracts have
+    /// initial=max for 1 table. See
+    ///
+    /// ```plain
+    /// $ wasm-objdump --section=table -x packages/vm/testdata/hackatom.wasm
+    /// Section Details:
+    ///
+    /// Table[1]:
+    /// - table[0] type=funcref initial=161 max=161
+    /// ```
+    ///
+    table_size_limit: Option<u32>,
+    /// If the contract has more than this amount of imports, it will be rejected
+    /// during static validation before even looking into the imports.
+    max_imports: Option<usize>,
+
+    /// The maximum number of functions a contract can have.
+    /// Any contract with more functions than this will be rejected during static validation.
+    max_functions: Option<usize>,
+
+    /// The maximum number of parameters a Wasm function can have.
+    max_function_params: Option<usize>,
+    /// The maximum total number of parameters of all functions in the Wasm.
+    /// For each function in the Wasm, take the number of parameters and sum all of these up.
+    /// If that sum exceeds this limit, the Wasm will be rejected during static validation.
+    ///
+    /// Be careful when adjusting this limit, as it prevents an attack where a small Wasm file
+    /// explodes in size when compiled.
+    max_total_function_params: Option<usize>,
+
+    /// The maximum number of results a Wasm function type can have.
+    max_function_results: Option<usize>,
+}
+
+impl WasmLimits {
+    pub fn memory_page_limit(&self) -> u32 {
+        self.memory_page_limit.unwrap_or(DEFAULT_MEMORY_LIMIT)
+    }
+
+    pub fn table_size_limit(&self) -> u32 {
+        self.table_size_limit.unwrap_or(DEFAULT_TABLE_SIZE_LIMIT)
+    }
+
+    pub fn max_imports(&self) -> usize {
+        self.max_imports.unwrap_or(DEFAULT_MAX_IMPORTS)
+    }
+
+    pub fn max_functions(&self) -> usize {
+        self.max_functions.unwrap_or(DEFAULT_MAX_FUNCTIONS)
+    }
+
+    pub fn max_function_params(&self) -> usize {
+        self.max_function_params
+            .unwrap_or(DEFAULT_MAX_FUNCTION_PARAMS)
+    }
+
+    pub fn max_total_function_params(&self) -> usize {
+        self.max_total_function_params
+            .unwrap_or(DEFAULT_MAX_TOTAL_FUNCTION_PARAMS)
+    }
+
+    pub fn max_function_results(&self) -> usize {
+        self.max_function_results
+            .unwrap_or(DEFAULT_MAX_FUNCTION_RESULTS)
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct CacheOptions {
+    /// The base directory of this cache.
+    ///
+    /// If this does not exist, it will be created. Not sure if this behaviour
+    /// is desired but wasmd relies on it.
+    pub base_dir: PathBuf,
+    pub available_capabilities: HashSet<String>,
+    /// Memory limit for the cache, in bytes.
+    pub memory_cache_size: Size,
+    /// Memory limit for instances, in bytes. Use a value that is divisible by the Wasm page size 65536,
+    /// e.g. full MiBs.
+    pub instance_memory_limit: Size,
+}
+
+impl CacheOptions {
+    pub fn new(
+        base_dir: impl Into<PathBuf>,
+        available_capabilities: impl Into<HashSet<String>>,
+        memory_cache_size: Size,
+        instance_memory_limit: Size,
+    ) -> Self {
+        Self {
+            base_dir: base_dir.into(),
+            available_capabilities: available_capabilities.into(),
+            memory_cache_size,
+            instance_memory_limit,
+        }
+    }
+}

--- a/packages/vm/src/config.rs
+++ b/packages/vm/src/config.rs
@@ -49,7 +49,10 @@ impl Config {
 #[non_exhaustive]
 pub struct WasmLimits {
     /// Maximum number of memory pages that a module can request.
-    pub memory_page_limit: Option<u32>,
+    ///
+    /// Every Wasm memory has an initial size and an optional maximum size,
+    /// both measured in Wasm pages. This limit applies to the initial size.
+    pub initial_memory_limit_in_pages: Option<u32>,
     /// The upper limit for the `max` value of each table. CosmWasm contracts have
     /// initial=max for 1 table. See
     ///
@@ -85,8 +88,9 @@ pub struct WasmLimits {
 }
 
 impl WasmLimits {
-    pub fn memory_page_limit(&self) -> u32 {
-        self.memory_page_limit.unwrap_or(DEFAULT_MEMORY_LIMIT)
+    pub fn initial_memory_limit_in_pages(&self) -> u32 {
+        self.initial_memory_limit_in_pages
+            .unwrap_or(DEFAULT_MEMORY_LIMIT)
     }
 
     pub fn table_size_limit(&self) -> u32 {

--- a/packages/vm/src/config.rs
+++ b/packages/vm/src/config.rs
@@ -52,7 +52,7 @@ pub struct WasmLimits {
     ///
     /// Every Wasm memory has an initial size and an optional maximum size,
     /// both measured in Wasm pages. This limit applies to the initial size.
-    pub initial_memory_limit_in_pages: Option<u32>,
+    pub initial_memory_limit: Option<u32>,
     /// The upper limit for the `max` value of each table. CosmWasm contracts have
     /// initial=max for 1 table. See
     ///
@@ -88,9 +88,8 @@ pub struct WasmLimits {
 }
 
 impl WasmLimits {
-    pub fn initial_memory_limit_in_pages(&self) -> u32 {
-        self.initial_memory_limit_in_pages
-            .unwrap_or(DEFAULT_MEMORY_LIMIT)
+    pub fn initial_memory_limit(&self) -> u32 {
+        self.initial_memory_limit.unwrap_or(DEFAULT_MEMORY_LIMIT)
     }
 
     pub fn table_size_limit(&self) -> u32 {

--- a/packages/vm/src/lib.rs
+++ b/packages/vm/src/lib.rs
@@ -55,7 +55,7 @@ pub mod internals {
     //! Please don't use any of these types directly, as
     //! they might change frequently or be removed in the future.
 
-    pub use crate::compatibility::{check_wasm, check_wasm_with_limits, LogOutput, Logger};
+    pub use crate::compatibility::{check_wasm, LogOutput, Logger};
     pub use crate::instance::instance_from_module;
     pub use crate::wasm_backend::{compile, make_compiling_engine, make_runtime_engine};
 }

--- a/packages/vm/src/lib.rs
+++ b/packages/vm/src/lib.rs
@@ -3,6 +3,7 @@ mod cache;
 mod calls;
 mod capabilities;
 mod compatibility;
+mod config;
 mod conversion;
 mod environment;
 mod errors;
@@ -23,9 +24,7 @@ mod wasm_backend;
 pub use crate::backend::{
     Backend, BackendApi, BackendError, BackendResult, GasInfo, Querier, Storage,
 };
-pub use crate::cache::{
-    AnalysisReport, Cache, CacheOptions, Metrics, PerModuleMetrics, PinnedMetrics, Stats,
-};
+pub use crate::cache::{AnalysisReport, Cache, Metrics, PerModuleMetrics, PinnedMetrics, Stats};
 pub use crate::calls::{
     call_execute, call_execute_raw, call_ibc_destination_callback,
     call_ibc_destination_callback_raw, call_ibc_source_callback, call_ibc_source_callback_raw,
@@ -40,6 +39,7 @@ pub use crate::calls::{
     call_ibc_packet_receive_raw, call_ibc_packet_timeout, call_ibc_packet_timeout_raw,
 };
 pub use crate::capabilities::capabilities_from_csv;
+pub use crate::config::{CacheOptions, Config, WasmLimits};
 pub use crate::errors::{
     CommunicationError, CommunicationResult, RegionValidationError, RegionValidationResult,
     VmError, VmResult,
@@ -55,7 +55,7 @@ pub mod internals {
     //! Please don't use any of these types directly, as
     //! they might change frequently or be removed in the future.
 
-    pub use crate::compatibility::{check_wasm, check_wasm_with_logs, LogOutput, Logger};
+    pub use crate::compatibility::{check_wasm, check_wasm_with_limits, LogOutput, Logger};
     pub use crate::instance::instance_from_module;
     pub use crate::wasm_backend::{compile, make_compiling_engine, make_runtime_engine};
 }

--- a/packages/vm/src/size.rs
+++ b/packages/vm/src/size.rs
@@ -1,4 +1,6 @@
-#[derive(Copy, Clone, Debug)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct Size(pub(crate) usize);
 
 impl Size {

--- a/packages/vm/src/testing/instance.rs
+++ b/packages/vm/src/testing/instance.rs
@@ -7,15 +7,16 @@ use std::collections::HashSet;
 use crate::capabilities::capabilities_from_csv;
 use crate::compatibility::check_wasm;
 use crate::instance::{Instance, InstanceOptions};
+use crate::internals::Logger;
 use crate::size::Size;
-use crate::{Backend, BackendApi, Querier, Storage};
+use crate::{Backend, BackendApi, Querier, Storage, WasmLimits};
 
 use super::mock::{MockApi, MOCK_CONTRACT_ADDR};
 use super::querier::MockQuerier;
 use super::storage::MockStorage;
 
 /// This gas limit is used in integration tests and should be high enough to allow a reasonable
-/// number of contract executions and queries on one instance. For this reason it is significatly
+/// number of contract executions and queries on one instance. For this reason it is significantly
 /// higher than the limit for a single execution that we have in the production setup.
 const DEFAULT_GAS_LIMIT: u64 = 2_000_000_000; // ~2.0ms
 const DEFAULT_MEMORY_LIMIT: Option<Size> = Some(Size::mebi(16));
@@ -125,7 +126,13 @@ pub fn mock_instance_with_options(
     wasm: &[u8],
     options: MockInstanceOptions,
 ) -> Instance<MockApi, MockStorage, MockQuerier> {
-    check_wasm(wasm, &options.available_capabilities).unwrap();
+    check_wasm(
+        wasm,
+        &options.available_capabilities,
+        &WasmLimits::default(),
+        Logger::Off,
+    )
+    .unwrap();
     let contract_address = MOCK_CONTRACT_ADDR;
 
     // merge balances


### PR DESCRIPTION
closes #2203 
For now, only the Wasm limits are added, but we could also add [read_limits and deserialization_limits](https://github.com/CosmWasm/cosmwasm/blob/b7fec87ac9c737a37e7b751f816d8088485458ba/packages/vm/src/calls.rs#L26-L106) and [some of these limits](https://github.com/CosmWasm/cosmwasm/blob/b7fec87ac9c737a37e7b751f816d8088485458ba/packages/vm/src/imports.rs#L37-L63) (if we really want to).