### PR TITLE
Show compile time in cosmwasm-check --verbose

### DIFF
--- a/packages/check/src/main.rs
+++ b/packages/check/src/main.rs
@@ -3,6 +3,7 @@ use std::fs::File;
 use std::io::Read;
 use std::path::Path;
 use std::process::exit;
+use std::time::Instant;
 
 use anyhow::Context;
 use clap::{Arg, ArgAction, Command};
@@ -156,8 +157,15 @@ fn check_contract(
     check_wasm(&wasm, available_capabilities, wasm_limits, logs)?;
 
     // Compile module
-    let engine = make_compiling_engine(None);
-    let _module = compile(&engine, &wasm)?;
+    let start = Instant::now();
+    {
+        let engine = make_compiling_engine(None);
+        let _module = compile(&engine, &wasm)?;
+    }
+    if verbose {
+        let duration = start.elapsed();
+        eprintln!("Compile time: {:?}", duration);
+    }
 
     Ok(())
 }


### PR DESCRIPTION
This shows the compile time like here for a big and a small contract

```
Available capabilities: {"neutron", "stargate", "cosmwasm_1_1", "foo", "cosmwasm_1_2", "iterator"}

    oracle.wasm: Size of Wasm blob: 3363135
    oracle.wasm: Exports: {"allocate", "deallocate", "execute", "instantiate", "interface_version_8", "migrate", "query", "reply", "requires_cosmwasm_1_1", "requires_cosmwasm_1_2", "requires_iterator", "requires_neutron", "requires_stargate", "sudo"}
    oracle.wasm: Imports (15): env.db_read, env.db_write, env.db_remove, env.db_scan, env.db_next, env.addr_validate, env.addr_canonicalize, env.addr_humanize, env.secp256k1_verify, env.secp256k1_recover_pubkey, env.ed25519_verify, env.ed25519_batch_verify, env.debug, env.query_chain, env.abort
    oracle.wasm: Required capabilities: {"cosmwasm_1_1", "cosmwasm_1_2", "iterator", "neutron", "stargate"}
    oracle.wasm: Function count: 3882
    oracle.wasm: Max function parameters: 15
    oracle.wasm: Max function results: 1
    oracle.wasm: Total function parameter count: 15140
Compile time: 3.716539291s
/Users/simon/Downloads/oracle.wasm: pass
    hackatom.wasm: Size of Wasm blob: 232040
    hackatom.wasm: Exports: {"allocate", "deallocate", "execute", "instantiate", "interface_version_8", "migrate", "query", "sudo"}
    hackatom.wasm: Imports (13): env.abort, env.db_read, env.db_write, env.db_remove, env.addr_validate, env.addr_canonicalize, env.addr_humanize, env.secp256k1_verify, env.secp256k1_recover_pubkey, env.ed25519_verify, env.ed25519_batch_verify, env.debug, env.query_chain
    hackatom.wasm: Required capabilities: {}
    hackatom.wasm: Function count: 354
    hackatom.wasm: Max function parameters: 12
    hackatom.wasm: Max function results: 1
    hackatom.wasm: Total function parameter count: 894
Compile time: 114.512917ms
../vm/testdata/hackatom.wasm: pass

All contracts (2) passed checks!
```