### PR TITLE
Add tests for NonZero types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -535,6 +535,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "corosensei"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -646,6 +655,7 @@ dependencies = [
  "hex",
  "hex-literal",
  "paste",
+ "proptest",
  "rand_core",
  "rmp-serde",
  "schemars",
@@ -1784,6 +1794,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1918,6 +1934,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2107,6 +2124,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
+dependencies = [
+ "bitflags 2.5.0",
+ "lazy_static",
+ "num-traits",
+ "proptest-macro",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "unarray",
+]
+
+[[package]]
+name = "proptest-macro"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37f29eb7ffe1011ed152b761e866c717244d37c10032f8cbdc08388d733a31b7"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2169,6 +2215,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -2921,10 +2976,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -645,6 +645,7 @@ dependencies = [
  "derive_more",
  "hex",
  "hex-literal",
+ "paste",
  "rand_core",
  "rmp-serde",
  "schemars",

--- a/contracts/nested-contracts/Cargo.toml
+++ b/contracts/nested-contracts/Cargo.toml
@@ -30,9 +30,9 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 [dependencies]
 cosmwasm-schema = "2.1.0"
 cosmwasm-std = { version = "2.1.0", features = [
-  "cosmwasm_1_4",
-  # Enable this if you only deploy to chains that have CosmWasm 2.0 or higher
-  # "cosmwasm_2_0",
+    "cosmwasm_1_4",
+    # Enable this if you only deploy to chains that have CosmWasm 2.0 or higher
+    # "cosmwasm_2_0",
 ] }
 cw-storage-plus = "2.0.0"
 cw2 = "2.0.0"

--- a/contracts/nested-contracts/inner-contract/Cargo.toml
+++ b/contracts/nested-contracts/inner-contract/Cargo.toml
@@ -30,9 +30,9 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 [dependencies]
 cosmwasm-schema = "2.1.0"
 cosmwasm-std = { version = "2.1.0", features = [
-  "cosmwasm_1_4",
-  # Enable this if you only deploy to chains that have CosmWasm 2.0 or higher
-  # "cosmwasm_2_0",
+    "cosmwasm_1_4",
+    # Enable this if you only deploy to chains that have CosmWasm 2.0 or higher
+    # "cosmwasm_2_0",
 ] }
 cw-storage-plus = "2.0.0"
 cw2 = "2.0.0"

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -87,4 +87,8 @@ chrono = { version = "0.4", default-features = false, features = [
 crc32fast = "1.3.2"
 hex-literal = "0.4.1"
 paste = "1.0.15"
+proptest = { version = "1.5.0", default-features = false, features = [
+    "attr-macro",
+    "std",
+] }
 serde_json = "1.0.81"

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -86,4 +86,5 @@ chrono = { version = "0.4", default-features = false, features = [
 ] }
 crc32fast = "1.3.2"
 hex-literal = "0.4.1"
+paste = "1.0.15"
 serde_json = "1.0.81"

--- a/packages/std/src/serde.rs
+++ b/packages/std/src/serde.rs
@@ -71,9 +71,10 @@ where
 mod tests {
     use super::*;
     use core::num::{
-        NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroU16, NonZeroU32, NonZeroU64,
-        NonZeroU8,
+        NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroU128, NonZeroU16,
+        NonZeroU32, NonZeroU64, NonZeroU8,
     };
+    use proptest::{prop_assert_eq, property_test};
     use serde::Deserialize;
 
     use crate::msgpack::{from_msgpack, to_msgpack_vec};
@@ -228,23 +229,30 @@ mod tests {
 
         (unsigned $ty:ty) => {
             ::paste::paste! {
-                #[test]
-                fn [<test_ $ty:snake:lower _encoding>]() {
-                    let one = $ty::new(1).unwrap();
+                #[property_test]
+                fn [<test_ $ty:snake:lower _encoding>](input: $ty) {
+                    let primitive = input.get();
 
-                    let serialized = to_json_string(&one).unwrap();
-                    assert_eq!(serialized, "1");
+                    // Verify that the serialization is the same as the primitive
+                    let serialized = to_json_string(&input).unwrap();
+                    let serialized_primitive = to_json_string(&primitive).unwrap();
+                    prop_assert_eq!(serialized.as_str(), serialized_primitive.as_str());
 
-                    let deserialized: $ty = from_json("1").unwrap();
-                    assert_eq!(deserialized, one);
+                    // Verify that the serialized primitive can be deserialized
+                    let deserialized: $ty = from_json(serialized_primitive).unwrap();
+                    assert_eq!(deserialized, input);
 
+                    // Verify that zero is not allowed
                     assert!(from_json::<$ty>("0").is_err());
 
-                    let serialized = to_msgpack_vec(&one).unwrap();
-                    assert_eq!(serialized, ONE_MSGPACK);
+                    // Verify that the msgpack encoding is the same as the primitive
+                    let serialized = to_msgpack_vec(&input).unwrap();
+                    let serialized_primitive = to_msgpack_vec(&primitive).unwrap();
+                    prop_assert_eq!(serialized.as_slice(), serialized_primitive.as_slice());
 
-                    let deserialized: $ty = from_msgpack(ONE_MSGPACK).unwrap();
-                    assert_eq!(deserialized, one);
+                    // Verify that the serialized primitive can be deserialized
+                    let deserialized: $ty = from_msgpack(&serialized_primitive).unwrap();
+                    prop_assert_eq!(deserialized, input);
                 }
             }
         };
@@ -261,10 +269,12 @@ mod tests {
         unsigned NonZeroU16,
         unsigned NonZeroU32,
         unsigned NonZeroU64,
+        unsigned NonZeroU128,
 
         signed NonZeroI8,
         signed NonZeroI16,
         signed NonZeroI32,
         signed NonZeroI64,
+        signed NonZeroI128,
     }
 }

--- a/packages/std/src/serde.rs
+++ b/packages/std/src/serde.rs
@@ -190,91 +190,53 @@ mod tests {
         );
     }
 
-    const MINUS_ONE_MSGPACK: &[u8] = &[0xFF];
-    const ONE_MSGPACK: &[u8] = &[0x01];
-
     macro_rules! test_integer {
-        (signed $ty:ty) => {
-            ::paste::paste! {
-                #[test]
-                fn [<test_ $ty:snake:lower _encoding>]() {
-                    let minus_one = $ty::new(-1).unwrap();
-                    let one = $ty::new(1).unwrap();
-
-                    let serialized = to_json_string(&minus_one).unwrap();
-                    assert_eq!(serialized, "-1");
-
-                    let serialized = to_json_string(&one).unwrap();
-                    assert_eq!(serialized, "1");
-
-                    let deserialized: $ty = from_json("-1").unwrap();
-                    assert_eq!(deserialized, minus_one);
-
-                    let deserialized: $ty = from_json("1").unwrap();
-                    assert_eq!(deserialized, one);
-
-                    assert!(from_json::<$ty>("0").is_err());
-
-                    let serialized = to_msgpack_vec(&one).unwrap();
-                    assert_eq!(serialized, ONE_MSGPACK);
-
-                    let serialized = to_msgpack_vec(&minus_one).unwrap();
-                    assert_eq!(serialized, MINUS_ONE_MSGPACK);
-
-                    let deserialized: $ty = from_msgpack(ONE_MSGPACK).unwrap();
-                    assert_eq!(deserialized, one);
-                }
-            }
-        };
-
-        (unsigned $ty:ty) => {
-            ::paste::paste! {
-                #[property_test]
-                fn [<test_ $ty:snake:lower _encoding>](input: $ty) {
-                    let primitive = input.get();
-
-                    // Verify that the serialization is the same as the primitive
-                    let serialized = to_json_string(&input).unwrap();
-                    let serialized_primitive = to_json_string(&primitive).unwrap();
-                    prop_assert_eq!(serialized.as_str(), serialized_primitive.as_str());
-
-                    // Verify that the serialized primitive can be deserialized
-                    let deserialized: $ty = from_json(serialized_primitive).unwrap();
-                    assert_eq!(deserialized, input);
-
-                    // Verify that zero is not allowed
-                    assert!(from_json::<$ty>("0").is_err());
-
-                    // Verify that the msgpack encoding is the same as the primitive
-                    let serialized = to_msgpack_vec(&input).unwrap();
-                    let serialized_primitive = to_msgpack_vec(&primitive).unwrap();
-                    prop_assert_eq!(serialized.as_slice(), serialized_primitive.as_slice());
-
-                    // Verify that the serialized primitive can be deserialized
-                    let deserialized: $ty = from_msgpack(&serialized_primitive).unwrap();
-                    prop_assert_eq!(deserialized, input);
-                }
-            }
-        };
-
-        ($($disc:ident $ty:ty),+$(,)?) => {
+        ($($ty:ty),+$(,)?) => {
             $(
-                test_integer!($disc $ty);
+                ::paste::paste! {
+                    #[property_test]
+                    fn [<test_ $ty:snake:lower _encoding>](input: $ty) {
+                        let primitive = input.get();
+
+                        // Verify that the serialization is the same as the primitive
+                        let serialized = to_json_string(&input).unwrap();
+                        let serialized_primitive = to_json_string(&primitive).unwrap();
+                        prop_assert_eq!(serialized.as_str(), serialized_primitive.as_str());
+
+                        // Verify that the serialized primitive can be deserialized
+                        let deserialized: $ty = from_json(serialized_primitive).unwrap();
+                        assert_eq!(deserialized, input);
+
+                        // Verify that zero is not allowed
+                        assert!(from_json::<$ty>("0").is_err());
+
+                        // Verify that the msgpack encoding is the same as the primitive
+                        let serialized = to_msgpack_vec(&input).unwrap();
+                        let serialized_primitive = to_msgpack_vec(&primitive).unwrap();
+                        prop_assert_eq!(serialized.as_slice(), serialized_primitive.as_slice());
+
+                        // Verify that the serialized primitive can be deserialized
+                        let deserialized: $ty = from_msgpack(&serialized_primitive).unwrap();
+                        prop_assert_eq!(deserialized, input);
+                    }
+                }
             )+
         };
     }
 
     test_integer! {
-        unsigned NonZeroU8,
-        unsigned NonZeroU16,
-        unsigned NonZeroU32,
-        unsigned NonZeroU64,
-        unsigned NonZeroU128,
+        NonZeroU8,
+        NonZeroU16,
+        NonZeroU32,
+        NonZeroU64,
+        NonZeroU128,
+    }
 
-        signed NonZeroI8,
-        signed NonZeroI16,
-        signed NonZeroI32,
-        signed NonZeroI64,
-        signed NonZeroI128,
+    test_integer! {
+        NonZeroI8,
+        NonZeroI16,
+        NonZeroI32,
+        NonZeroI64,
+        NonZeroI128,
     }
 }


### PR DESCRIPTION
This adds tests for the NonZero{I, U}{8, 16, 32, 64, 128} types for their encoding to and from JSON and MessagePack.

We use property tests here, generating random numbers inside the `NonZero` container and verifying their serializations are equivalent and that deserialization succeeds.