### PR TITLE
Suppress linter warning

### DIFF
--- a/packages/std/src/math/num_consts.rs
+++ b/packages/std/src/math/num_consts.rs
@@ -1,4 +1,5 @@
 /// Crate internal trait for all our signed and unsigned number types
+#[allow(dead_code)] // only used in tests for now
 pub(crate) trait NumConsts {
     const MAX: Self;
     const MIN: Self;


### PR DESCRIPTION
In latest Rust, this gets detected as unused. Adding `#[cfg(test)]` results in lots of changes through the codebase that don't really provide any benefit to readability, so let's just suppress the lint.