### PR TITLE
Add workspace notice to Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,12 @@ and this project adheres to
   match the contract address from `mock_env`. ([#2211])
 - cosmwasm-derive: Automatically detect whether the package is a dependency or
   the primary package, only expanding entrypoints for the primary package. This
-  effectively deprecates the usage of the `library` feature pattern. ([#2246])
+  effectively deprecates the usage of the `library` feature pattern.
+
+  Note: This feature does **NOT** interact well with workspaces due to a cargo
+  bug. If you have multiple contracts in a workspace, you might still want to
+  use the library feature ([#2246])
+
 - cosmwasm-std: Deprecate `BankQuery::AllBalances` and `IbcQuery::ListChannels`.
   Both are inherently problematic to use because the returned entries are
   unbounded. ([#2247])


### PR DESCRIPTION
This is the result of an internal discussion.

While #2284 is indeed a real problem, it is a problem due to a long-ish standing Cargo bug (where the `CARGO_PRIMARY_PACKAGE` variable isn't taken into consideration when invalidating the cache).

Cargo issue: https://github.com/rust-lang/cargo/issues/14678

---

While it doesn't work in 100% of cases, it does work when adding a contract as an external dependency. So we decided to ship this as an MVP of sorts, it _does_ fix some issues for some people, just not every issue unfortunately.