### PR TITLE
Fix replacement order

### DIFF
--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,3 +1,2 @@
 [formatting]
 indent_string = "    "
-reorder_arrays = true

--- a/packages/vm/Cargo.toml
+++ b/packages/vm/Cargo.toml
@@ -13,8 +13,8 @@ pre-release-replacements = [
     { file = "../../CHANGELOG.md", search = "## \\[Unreleased\\]", replace = "## [{{version}}] - {{date}}", exactly = 1 },
     { file = "../../CHANGELOG.md", search = "(U|u)nreleased", replace = "{{version}}" },
     { file = "../../CHANGELOG.md", search = "<!-- next-header -->", replace = "<!-- next-header -->\n\n## [Unreleased]", exactly = 1 },
-    { file = "../../CHANGELOG.md", search = "<!-- next-url -->\n", replace = "<!-- next-url -->\n\n[unreleased]: https://github.com/CosmWasm/cosmwasm/compare/{{tag_name}}...HEAD", exactly = 1 },
     { file = "../../CHANGELOG.md", search = "\\.\\.\\.HEAD", replace = "...{{tag_name}}", exactly = 1 },
+    { file = "../../CHANGELOG.md", search = "<!-- next-url -->\n", replace = "<!-- next-url -->\n\n[unreleased]: https://github.com/CosmWasm/cosmwasm/compare/{{tag_name}}...HEAD", exactly = 1 },
 ]
 
 [features]

--- a/packages/vm/Cargo.toml
+++ b/packages/vm/Cargo.toml
@@ -13,8 +13,8 @@ pre-release-replacements = [
     { file = "../../CHANGELOG.md", search = "## \\[Unreleased\\]", replace = "## [{{version}}] - {{date}}", exactly = 1 },
     { file = "../../CHANGELOG.md", search = "(U|u)nreleased", replace = "{{version}}" },
     { file = "../../CHANGELOG.md", search = "<!-- next-header -->", replace = "<!-- next-header -->\n\n## [Unreleased]", exactly = 1 },
-    { file = "../../CHANGELOG.md", search = "\\.\\.\\.HEAD", replace = "...{{tag_name}}", exactly = 1 },
     { file = "../../CHANGELOG.md", search = "<!-- next-url -->\n", replace = "<!-- next-url -->\n\n[unreleased]: https://github.com/CosmWasm/cosmwasm/compare/{{tag_name}}...HEAD", exactly = 1 },
+    { file = "../../CHANGELOG.md", search = "\\.\\.\\.HEAD", replace = "...{{tag_name}}", exactly = 1 },
 ]
 
 [features]


### PR DESCRIPTION
We need to replace the `...HEAD` before adding the new `[unreleased]` link, otherwise the `...HEAD` replacement finds two matches and fails.