### PR TITLE
[1.5] Fix CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ workflows:
 jobs:
   arm64:
     machine:
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2204:2024.01.1
     resource_class: arm.large
     steps:
       - checkout
@@ -848,7 +848,7 @@ jobs:
           command: apt update && apt install -y python3-pip
       - run:
           name: Install dependencies
-          command: pip3 install requests bs4
+          command: pip3 install requests bs4 --break-system-packages
       - run:
           name: Check dead links
           command: devtools/deadlinks.py

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -967,7 +967,7 @@ jobs:
 
   coverage:
     docker:
-      - image: rust:1.72.0
+      - image: rust:1.74.0
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codecov: codecov/codecov@3.2.5
+  codecov: codecov/codecov@4.1.0
   win: circleci/windows@5.0
 
 commands:
@@ -967,9 +967,18 @@ jobs:
 
   coverage:
     docker:
-      - image: rust:1.74.0
+      - image: rust:1.82.0-alpine3.19
+    environment:
+      # Limit the number of parallel jobs to avoid OOM crashes during doc testing
+      RUST_TEST_THREADS: 8
+    resource_class: medium+
     steps:
       - checkout
+      - run:
+          name: Install necessary packages
+          command: |
+            apk update
+            apk add mold clang curl coreutils gnupg
       - run:
           name: Install grcov
           command: |
@@ -990,6 +999,9 @@ jobs:
           environment:
             RUSTFLAGS: "-Cinstrument-coverage"
             LLVM_PROFILE_FILE: "cosmwasm-%p-%m.profraw"
+      - run:
+          name: Quick fix for GPG error in Codecov
+          command: mkdir -p ~/.gnupg
       - codecov/upload:
           file: reports/crypto.info
           flags: cosmwasm-crypto


### PR DESCRIPTION
Had to update the Rust version of the coverage job because one of grcov's dependencies now requires 1.74.
Also cherry-picked #2048