### PR TITLE
Fix typos in comment

### DIFF
--- a/packages/vm/src/calls.rs
+++ b/packages/vm/src/calls.rs
@@ -24,7 +24,7 @@ use crate::serde::{from_slice, to_vec};
 /// deserializing JSON is more expensive. As a consequence, any sane contract should hit
 /// the deserializer limit before the read limit.
 mod read_limits {
-    /// A mibi (mega binary)
+    /// A mebi (mega binary)
     const MI: usize = 1024 * 1024;
     /// Max length (in bytes) of the result data from an instantiate call.
     pub const RESULT_INSTANTIATE: usize = 64 * MI;

--- a/packages/vm/src/imports.rs
+++ b/packages/vm/src/imports.rs
@@ -32,7 +32,7 @@ use crate::GasInfo;
 
 /// A kibi (kilo binary)
 const KI: usize = 1024;
-/// A mibi (mega binary)
+/// A mebi (mega binary)
 const MI: usize = 1024 * 1024;
 /// Max key length for db_write/db_read/db_remove/db_scan (when VM reads the key argument from Wasm memory)
 const MAX_LENGTH_DB_KEY: usize = 64 * KI;


### PR DESCRIPTION
This PR fixes typos in doc comment about the constant referring to mega binary.