### PR TITLE
Revert reference-types support (main)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -655,8 +655,7 @@ jobs:
 
   contract_hackatom:
     docker:
-      # We compile this contract with the upper bound to detect issues with new Rust versions early
-      - image: rust:1.82
+      - image: rust:1.74
     environment:
       RUST_BACKTRACE: 1
     working_directory: ~/cosmwasm/contracts/hackatom
@@ -668,7 +667,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-v2-contract_hackatom-rust:1.82-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-contract_hackatom-rust:1.74-{{ checksum "Cargo.lock" }}
       - check_contract:
           min_version: "2.2"
       - save_cache:
@@ -680,7 +679,7 @@ jobs:
             - target/wasm32-unknown-unknown/release/.fingerprint
             - target/wasm32-unknown-unknown/release/build
             - target/wasm32-unknown-unknown/release/deps
-          key: cargocache-v2-contract_hackatom-rust:1.82-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-contract_hackatom-rust:1.74-{{ checksum "Cargo.lock" }}
 
   contract_ibc_callbacks:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,7 @@ workflows:
           matrix:
             parameters:
               # Run with MSRV and some modern stable Rust
-              rust-version: ["1.74.0", "1.82.0"]
+              rust-version: ["1.74.0", "1.78.0"]
       - benchmarking:
           requires:
             - package_vm
@@ -1142,7 +1142,7 @@ jobs:
 
   coverage:
     docker:
-      - image: rust:1.82.0-alpine3.19
+      - image: rust:1.78.0-alpine3.19
     environment:
       # Limit the number of parallel jobs to avoid OOM crashes during doc testing
       RUST_TEST_THREADS: 8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,15 +26,12 @@ and this project adheres to
 - cosmwasm-vm: Export a new `migrate_with_info` function ([#2212])
 - cosmwasm-derive: Add support for migrate method with
   `migrate_info: MigrateInfo` argument. ([#2212])
-- cosmwasm-vm: Enable support for reference-types proposal, required since Rust
-  1.82 ([#2288])
 - cosmwasm-vm: Add `Cache::store_code`
 
 [#2118]: https://github.com/CosmWasm/cosmwasm/pull/2118
 [#2196]: https://github.com/CosmWasm/cosmwasm/pull/2196
 [#2220]: https://github.com/CosmWasm/cosmwasm/pull/2220
 [#2212]: https://github.com/CosmWasm/cosmwasm/pull/2212
-[#2288]: https://github.com/CosmWasm/cosmwasm/pull/2288
 
 ### Changed
 

--- a/packages/vm/src/parsed_wasm.rs
+++ b/packages/vm/src/parsed_wasm.rs
@@ -79,7 +79,7 @@ impl<'a> ParsedWasm<'a> {
             multi_value: true,
             floats: true,
 
-            reference_types: true,
+            reference_types: false,
             bulk_memory: false,
             simd: false,
             relaxed_simd: false,

--- a/packages/vm/src/wasm_backend/gatekeeper.rs
+++ b/packages/vm/src/wasm_backend/gatekeeper.rs
@@ -59,7 +59,7 @@ impl Default for Gatekeeper {
         Self::new(GatekeeperConfig {
             allow_floats: true,
             allow_feature_bulk_memory_operations: false,
-            allow_feature_reference_types: true,
+            allow_feature_reference_types: false,
             allow_feature_simd: false,
             allow_feature_exception_handling: false,
             allow_feature_threads: false,


### PR DESCRIPTION
same as #2311, but for main.
supersedes #2316 because it was easier to do the cherry picking manually rather than fixing the conflicts