### PR TITLE
Fix Typo in `file_system_cache.rs`

### DIFF
--- a/packages/vm/src/modules/file_system_cache.rs
+++ b/packages/vm/src/modules/file_system_cache.rs
@@ -268,7 +268,7 @@ fn module_size(module_path: &Path) -> VmResult<usize> {
 }
 
 /// Creates an identifier for the Wasmer `Target` that is used for
-/// cache invalidation. The output is reasonable human friendly to be useable
+/// cache invalidation. The output is reasonable human friendly to be usable
 /// in file path component.
 fn target_id(target: &Target) -> String {
     // Use a custom Hasher implementation to avoid randomization.


### PR DESCRIPTION
# Pull Request Title
Fix Typo in `file_system_cache.rs`

## Description
Corrected a typo in the `file_system_cache.rs` file to enhance clarity in the code documentation.

### Changes Made:
- **File Modified:** `packages/vm/src/modules/file_system_cache.rs`
- **Summary of Changes:**  
  - Line 268: Replaced "useable" with "usable" for proper spelling in the comment.

## Related Issues
<!-- If applicable, link to any issues this PR addresses. -->
N/A

## Checklist
- [x] The change follows the project's [contributing guidelines](link-to-contributing-guidelines).
- [x] The documentation is now grammatically correct and clearer.
- [x] No functional code changes were made.

## Testing
<!-- Describe how you validated the change, if applicable. -->
- N/A (Comment update only)

## Additional Notes
<!-- Add any additional comments for reviewers. -->
This is a minor documentation update. Please let me know if there are other areas in the file needing similar corrections.

---

**Allow edits by maintainers:** [x]
<!-- Check this box to allow maintainers to modify the pull request if needed. -->
