### PR TITLE
typo fix addresses.rs

### DIFF
--- a/packages/std/src/addresses.rs
+++ b/packages/std/src/addresses.rs
@@ -272,7 +272,7 @@ impl fmt::Display for Instantiate2AddressError {
 /// cannot be pre-computed as it contains inputs from the chain's state at the time of
 /// message execution.
 ///
-/// The predicable address format of instantiate2 is stable. But bear in mind this is
+/// The predictable address format of instantiate2 is stable. But bear in mind this is
 /// a powerful tool that requires multiple software components to work together smoothly.
 /// It should be used carefully and tested thoroughly to avoid the loss of funds.
 ///


### PR DESCRIPTION
# Pull Request Title  
**Fix Typo in `addresses.rs`**

## Description  
This pull request addresses a typo in the `addresses.rs` file, where the word "predicable" was corrected to the intended "predictable."

### Changes Made:
- **File Modified:** `packages/std/src/addresses.rs`
- **Summary of Changes:**
  - Corrected the spelling of "predicable" to "predictable" in the comment regarding the address format.

## Checklist  
- [x] Fixed the typo in the comment.
- [x] Verified that no functionality was impacted by this change.

## Additional Notes  
The typo fix improves the clarity of the comment, ensuring that it aligns with the intended meaning about the address format's predictability.

---

**Allow edits by maintainers:** [x]
