### PR TITLE
Deprecate `abort` feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,9 +191,10 @@ extern "C" fn ibc_packet_timeout(env_ptr: u32, msg_ptr: u32) -> u32;
 ```
 
 `allocate` and `deallocate` allow the host to manage data within the Wasm VM. If
-you're using Rust, you can implement them by simply
-[re-exporting them from cosmwasm::exports](https://github.com/CosmWasm/cosmwasm/blob/v0.6.3/contracts/hackatom/src/lib.rs#L5).
-`instantiate`, `execute` and `query` must be defined by your contract.
+you're using Rust, you get them automatically by using the `cosmwasm-std` crate.
+Your contract can define the other entrypoints using the
+`cosmwasm_std::entry_point` macro to get strong typing instead of raw memory
+offsets.
 
 ### Imports
 

--- a/contracts/cyberpunk/Cargo.toml
+++ b/contracts/cyberpunk/Cargo.toml
@@ -23,7 +23,6 @@ overflow-checks = true
 [dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }
 cosmwasm-std = { path = "../../packages/std", default-features = false, features = [
-    "abort",
     "cosmwasm_1_3",
     "std",
 ] }

--- a/contracts/hackatom/Cargo.toml
+++ b/contracts/hackatom/Cargo.toml
@@ -25,7 +25,6 @@ overflow-checks = true
 [dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }
 cosmwasm-std = { path = "../../packages/std", default-features = false, features = [
-    "abort",
     "cosmwasm_2_2",
     "std",
 ] }

--- a/devtools/check_workspace.sh
+++ b/devtools/check_workspace.sh
@@ -10,7 +10,7 @@ cargo fmt
   # default, min, all
   cargo check
   cargo check --no-default-features --features std
-  cargo check --features std,abort,iterator,staking,stargate,cosmwasm_1_2
+  cargo check --features std,iterator,staking,stargate,cosmwasm_1_2
   cargo wasm-debug
   cargo wasm-debug --features std,iterator,staking,stargate
   cargo clippy --all-targets --features std,iterator,staking,stargate -- -D warnings

--- a/docs/USING_COSMWASM_STD.md
+++ b/docs/USING_COSMWASM_STD.md
@@ -16,7 +16,6 @@ extern "C" fn deallocate(pointer: u32) { /* ... */ }
 
 // Imports
 extern "C" {
-    #[cfg(feature = "abort")]
     fn abort(source_ptr: u32);
 
     fn db_read(key: u32) -> u32;
@@ -34,16 +33,16 @@ in the dependency tree. Otherwise conflicting C exports are created.
 
 The library comes with the following features:
 
-| Feature      | Enabled by default | Description                                                               |
-| ------------ | ------------------ | ------------------------------------------------------------------------- |
-| iterator     | x                  | Storage iterators                                                         |
-| abort        | x                  | A panic handler that aborts the contract execution with a helpful message |
-| stargate     |                    | Cosmos SDK 0.40+ features and IBC                                         |
-| staking      |                    | Access to the staking module                                              |
-| cosmwasm_1_1 |                    | Features that require CosmWasm 1.1+ on the chain                          |
-| cosmwasm_1_2 |                    | Features that require CosmWasm 1.2+ on the chain                          |
-| cosmwasm_1_3 |                    | Features that require CosmWasm 1.3+ on the chain                          |
-| cosmwasm_1_4 |                    | Features that require CosmWasm 1.4+ on the chain                          |
+| Feature      | Enabled by default | Description                                                                          |
+| ------------ | ------------------ | ------------------------------------------------------------------------------------ |
+| iterator     | x                  | Storage iterators                                                                    |
+| abort        | x                  | DEPRECATED A panic handler that aborts the contract execution with a helpful message |
+| stargate     |                    | Cosmos SDK 0.40+ features and IBC                                                    |
+| staking      |                    | Access to the staking module                                                         |
+| cosmwasm_1_1 |                    | Features that require CosmWasm 1.1+ on the chain                                     |
+| cosmwasm_1_2 |                    | Features that require CosmWasm 1.2+ on the chain                                     |
+| cosmwasm_1_3 |                    | Features that require CosmWasm 1.3+ on the chain                                     |
+| cosmwasm_1_4 |                    | Features that require CosmWasm 1.4+ on the chain                                     |
 
 ## The cosmwasm-std dependency for contract developers
 
@@ -71,9 +70,9 @@ cosmwasm-std = { version = "1.2.0", features = ["stargate", "cosmwasm_1_2"] }
 When you are creating a library that uses cosmwasm-std, you should be incredibly
 careful with which features you require. The moment you add e.g. `cosmwasm_1_2`
 there it becomes impossible to use the contract in chains with lower CosmWasm
-versions. If you add `abort`, it becomes impossible for the contract developer
-to opt out of the abort feature due to your library. Since this affects the
-default features `abort` and `iterator`, you should always disable default
+versions. If you add `iterator`, it becomes impossible for the contract
+developer to opt out of the iterator feature due to your library. Since this
+affects the default feature `iterator`, you should always disable default
 features. However, you should make sure to keep the `std` feature enabled, as we
 might move certain existing functionality to that feature in the future.
 

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -12,7 +12,9 @@ readme = "README.md"
 features = ["abort", "cosmwasm_2_2", "staking", "stargate"]
 
 [features]
-default = ["abort", "iterator", "std"]
+default = ["iterator", "std"]
+# abort used to enable the panic handler that hands a nice error message back to the host.
+# The feature is now deprecated and the panic handler is always enabled.
 abort = []
 std = []
 # iterator allows us to iterate over all DB items in a given range

--- a/packages/std/src/exports.rs
+++ b/packages/std/src/exports.rs
@@ -22,7 +22,6 @@ use crate::ibc::{
 use crate::ibc::{IbcChannelOpenMsg, IbcChannelOpenResponse};
 use crate::imports::{ExternalApi, ExternalQuerier, ExternalStorage};
 use crate::memory::{Owned, Region};
-#[cfg(feature = "abort")]
 use crate::panic::install_panic_handler;
 use crate::query::CustomQuery;
 use crate::results::{ContractResult, QueryResponse, Reply, Response};
@@ -128,7 +127,6 @@ where
     C: CustomMsg,
     E: ToString,
 {
-    #[cfg(feature = "abort")]
     install_panic_handler();
     let res = _do_instantiate(
         instantiate_fn,
@@ -158,7 +156,6 @@ where
     C: CustomMsg,
     E: ToString,
 {
-    #[cfg(feature = "abort")]
     install_panic_handler();
     let res = _do_execute(
         execute_fn,
@@ -187,7 +184,6 @@ where
     C: CustomMsg,
     E: ToString,
 {
-    #[cfg(feature = "abort")]
     install_panic_handler();
     let res = _do_migrate(
         migrate_fn,
@@ -218,7 +214,6 @@ where
     C: CustomMsg,
     E: ToString,
 {
-    #[cfg(feature = "abort")]
     install_panic_handler();
     let res = _do_migrate_with_info(
         migrate_with_info_fn,
@@ -247,7 +242,6 @@ where
     C: CustomMsg,
     E: ToString,
 {
-    #[cfg(feature = "abort")]
     install_panic_handler();
     let res = _do_sudo(
         sudo_fn,
@@ -274,7 +268,6 @@ where
     C: CustomMsg,
     E: ToString,
 {
-    #[cfg(feature = "abort")]
     install_panic_handler();
     let res = _do_reply(
         reply_fn,
@@ -300,7 +293,6 @@ where
     M: DeserializeOwned,
     E: ToString,
 {
-    #[cfg(feature = "abort")]
     install_panic_handler();
     let res = _do_query(
         query_fn,
@@ -327,7 +319,6 @@ where
     Q: CustomQuery,
     E: ToString,
 {
-    #[cfg(feature = "abort")]
     install_panic_handler();
     let res = _do_ibc_channel_open(
         contract_fn,
@@ -356,7 +347,6 @@ where
     C: CustomMsg,
     E: ToString,
 {
-    #[cfg(feature = "abort")]
     install_panic_handler();
     let res = _do_ibc_channel_connect(
         contract_fn,
@@ -385,7 +375,6 @@ where
     C: CustomMsg,
     E: ToString,
 {
-    #[cfg(feature = "abort")]
     install_panic_handler();
     let res = _do_ibc_channel_close(
         contract_fn,
@@ -415,7 +404,6 @@ where
     C: CustomMsg,
     E: ToString,
 {
-    #[cfg(feature = "abort")]
     install_panic_handler();
     let res = _do_ibc_packet_receive(
         contract_fn,
@@ -445,7 +433,6 @@ where
     C: CustomMsg,
     E: ToString,
 {
-    #[cfg(feature = "abort")]
     install_panic_handler();
     let res = _do_ibc_packet_ack(
         contract_fn,
@@ -476,7 +463,6 @@ where
     C: CustomMsg,
     E: ToString,
 {
-    #[cfg(feature = "abort")]
     install_panic_handler();
     let res = _do_ibc_packet_timeout(
         contract_fn,
@@ -497,7 +483,6 @@ where
     C: CustomMsg,
     E: ToString,
 {
-    #[cfg(feature = "abort")]
     install_panic_handler();
     let res = _do_ibc_source_callback(
         contract_fn,
@@ -522,7 +507,6 @@ where
     C: CustomMsg,
     E: ToString,
 {
-    #[cfg(feature = "abort")]
     install_panic_handler();
     let res = _do_ibc_destination_callback(
         contract_fn,

--- a/packages/std/src/imports.rs
+++ b/packages/std/src/imports.rs
@@ -27,7 +27,7 @@ const HUMAN_ADDRESS_BUFFER_LENGTH: usize = 90;
 // A complete documentation those functions is available in the VM that provides them:
 // https://github.com/CosmWasm/cosmwasm/blob/v1.0.0-beta/packages/vm/src/instance.rs#L89-L206
 extern "C" {
-    #[cfg(feature = "abort")]
+
     fn abort(source_ptr: u32);
 
     fn db_read(key: u32) -> u32;
@@ -744,7 +744,6 @@ impl Querier for ExternalQuerier {
     }
 }
 
-#[cfg(feature = "abort")]
 pub fn handle_panic(message: &str) {
     let region = Region::from_slice(message.as_bytes());
     let region_ptr = region.as_ptr() as u32;

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -118,8 +118,18 @@ pub use crate::timestamp::Timestamp;
 pub use crate::traits::{Api, HashFunction, Querier, QuerierResult, QuerierWrapper, Storage};
 pub use crate::types::{BlockInfo, ContractInfo, Env, MessageInfo, MigrateInfo, TransactionInfo};
 
-// Exposed in wasm build only
+#[cfg(feature = "abort")]
+mod _warning {
+    #[must_use = "cosmwasm-std feature `abort` is deprecated and will be removed in the next release. You can just remove the feature as this functionality is now the default"]
+    struct CompileWarning;
 
+    #[allow(dead_code)]
+    fn trigger_warning() {
+        CompileWarning;
+    }
+}
+
+// Exposed in wasm build only
 #[cfg(target_arch = "wasm32")]
 mod exports;
 #[cfg(target_arch = "wasm32")]

--- a/packages/std/src/panic.rs
+++ b/packages/std/src/panic.rs
@@ -3,7 +3,7 @@
 ///
 /// This overrides any previous panic handler. See <https://doc.rust-lang.org/std/panic/fn.set_hook.html>
 /// for details.
-#[cfg(all(feature = "abort", target_arch = "wasm32"))]
+#[cfg(target_arch = "wasm32")]
 pub fn install_panic_handler() {
     use super::imports::handle_panic;
     std::panic::set_hook(Box::new(|info| {


### PR DESCRIPTION
closes #2243

Unfortunately there is no native way to cause a compiler warning, so this is a bit of a hack.