### PR TITLE
Allow subset of reference-types

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ workflows:
           matrix:
             parameters:
               # Run with MSRV and some modern stable Rust
-              rust-version: ["1.74.0", "1.78.0"]
+              rust-version: ["1.74.0", "1.82.0"]
       - benchmarking:
           requires:
             - package_vm
@@ -684,7 +684,8 @@ jobs:
 
   contract_hackatom:
     docker:
-      - image: rust:1.74
+      # We compile this contract with the upper bound to detect issues with new Rust versions early
+      - image: rust:1.82
     environment:
       RUST_BACKTRACE: 1
     working_directory: ~/cosmwasm/contracts/hackatom
@@ -696,9 +697,9 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-v2-contract_hackatom-rust:1.74-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-contract_hackatom-rust:1.82-{{ checksum "Cargo.lock" }}
       - check_contract:
-          min_version: "2.2"
+          min_version: "2.2.1"
       - save_cache:
           paths:
             - /usr/local/cargo/registry
@@ -708,7 +709,7 @@ jobs:
             - target/wasm32-unknown-unknown/release/.fingerprint
             - target/wasm32-unknown-unknown/release/build
             - target/wasm32-unknown-unknown/release/deps
-          key: cargocache-v2-contract_hackatom-rust:1.74-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-contract_hackatom-rust:1.82-{{ checksum "Cargo.lock" }}
 
   contract_ibc_callbacks:
     docker:

--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -777,6 +777,24 @@ mod tests {
     }
 
     #[test]
+    fn func_ref_in_type_fails() {
+        let wasm = wat::parse_str(
+            r#"(module
+                (type $x1 (func (param funcref)))
+                (export "memory" (memory 0))
+                (import "env" "abort" (func $f (type $x1)))
+                (memory 3)
+            )"#,
+        )
+        .unwrap();
+
+        let cache: Cache<MockApi, MockStorage, MockQuerier> =
+            unsafe { Cache::new(make_testing_options()).unwrap() };
+
+        cache.store_code(&wasm, true, true).unwrap_err();
+    }
+
+    #[test]
     fn load_wasm_works() {
         let cache: Cache<MockApi, MockStorage, MockQuerier> =
             unsafe { Cache::new(make_testing_options()).unwrap() };

--- a/packages/vm/src/errors/vm_error.rs
+++ b/packages/vm/src/errors/vm_error.rs
@@ -284,6 +284,19 @@ impl From<wasmer::wasmparser::BinaryReaderError> for VmError {
     }
 }
 
+impl From<crate::parsed_wasm::ValidatorError> for VmError {
+    fn from(value: crate::parsed_wasm::ValidatorError) -> Self {
+        match value {
+            crate::parsed_wasm::ValidatorError::BinaryReaderError(e) => e.into(),
+            crate::parsed_wasm::ValidatorError::Custom(msg) => {
+                VmError::static_validation_err(format!(
+                    "Wasm bytecode could not be deserialized. Deserialization error: \"{msg}\""
+                ))
+            }
+        }
+    }
+}
+
 impl From<wasmer::ExportError> for VmError {
     fn from(original: wasmer::ExportError) -> Self {
         VmError::resolve_err(format!("Could not get export: {original}"))


### PR DESCRIPTION
This allows the new `call_indirect` binary layout during validation, which should make it possible to upload and use contracts compiled with latest Rust.
At the same time, this does not enable any other reference-types features that aren't supported by wasmer yet.