### PR TITLE
Implement from_be_bytes/from_le_bytes for Uint64 and Uint128 (backport to 2.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,11 @@ and this project adheres to
 - cosmwasm-std: Implement `From<Uint64> for u{64,128}`,
   `From<Uint128> for u128`, `From<Int64> for i{64,128}`, and
   `From<Int128> for i128` ([#2268])
+- cosmwasm-std: Implement `Uint128::from_{be,le}_bytes` and
+  `Uint64::from_{be,le}_bytes`. ([#2269])
 
 [#2268]: https://github.com/CosmWasm/cosmwasm/issues/2268
+[#2269]: https://github.com/CosmWasm/cosmwasm/issues/2269
 
 ## [2.2.0] - 2024-12-17
 

--- a/packages/std/src/math/conversion.rs
+++ b/packages/std/src/math/conversion.rs
@@ -326,6 +326,35 @@ macro_rules! try_from_int_to_uint {
 }
 pub(crate) use try_from_int_to_uint;
 
+macro_rules! from_and_to_bytes {
+    ($inner: ty, $byte_size: literal) => {
+        /// Constructs new value from big endian bytes
+        #[must_use]
+        pub const fn from_be_bytes(data: [u8; $byte_size]) -> Self {
+            Self(<$inner>::from_be_bytes(data))
+        }
+
+        /// Constructs new value from little endian bytes
+        #[must_use]
+        pub const fn from_le_bytes(data: [u8; $byte_size]) -> Self {
+            Self(<$inner>::from_le_bytes(data))
+        }
+
+        /// Returns a copy of the number as big endian bytes.
+        #[must_use = "this returns the result of the operation, without modifying the original"]
+        pub const fn to_be_bytes(self) -> [u8; $byte_size] {
+            self.0.to_be_bytes()
+        }
+
+        /// Returns a copy of the number as little endian bytes.
+        #[must_use = "this returns the result of the operation, without modifying the original"]
+        pub const fn to_le_bytes(self) -> [u8; $byte_size] {
+            self.0.to_le_bytes()
+        }
+    };
+}
+pub(crate) use from_and_to_bytes;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/packages/std/src/math/int128.rs
+++ b/packages/std/src/math/int128.rs
@@ -521,16 +521,64 @@ mod tests {
 
     #[test]
     fn int128_from_be_bytes_works() {
-        let num = Int128::from_be_bytes([1; 16]);
-        let a: [u8; 16] = num.to_be_bytes();
-        assert_eq!(a, [1; 16]);
+        // zero
+        let original = [0; 16];
+        let num = Int128::from_be_bytes(original);
+        assert!(num.is_zero());
 
-        let be_bytes = [
+        // one
+        let original = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
+        let num = Int128::from_be_bytes(original);
+        assert_eq!(num.i128(), 1);
+
+        // 258
+        let original = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2];
+        let num = Int128::from_be_bytes(original);
+        assert_eq!(num.i128(), 258);
+
+        // 2x roundtrip
+        let original = [1; 16];
+        let num = Int128::from_be_bytes(original);
+        let a: [u8; 16] = num.to_be_bytes();
+        assert_eq!(a, original);
+
+        let original = [
             0u8, 222u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 1u8, 2u8, 3u8,
         ];
-        let num = Int128::from_be_bytes(be_bytes);
+        let num = Int128::from_be_bytes(original);
         let resulting_bytes: [u8; 16] = num.to_be_bytes();
-        assert_eq!(be_bytes, resulting_bytes);
+        assert_eq!(resulting_bytes, original);
+    }
+
+    #[test]
+    fn int128_from_le_bytes_works() {
+        // zero
+        let original = [0; 16];
+        let num = Int128::from_le_bytes(original);
+        assert!(num.is_zero());
+
+        // one
+        let original = [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        let num = Int128::from_le_bytes(original);
+        assert_eq!(num.i128(), 1);
+
+        // 258
+        let original = [2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        let num = Int128::from_le_bytes(original);
+        assert_eq!(num.i128(), 258);
+
+        // 2x roundtrip
+        let original = [1; 16];
+        let num = Int128::from_le_bytes(original);
+        let a: [u8; 16] = num.to_le_bytes();
+        assert_eq!(a, original);
+
+        let original = [
+            0u8, 222u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 1u8, 2u8, 3u8,
+        ];
+        let num = Int128::from_le_bytes(original);
+        let resulting_bytes: [u8; 16] = num.to_le_bytes();
+        assert_eq!(resulting_bytes, original);
     }
 
     #[test]

--- a/packages/std/src/math/int128.rs
+++ b/packages/std/src/math/int128.rs
@@ -14,7 +14,8 @@ use crate::{
 };
 
 use super::conversion::{
-    forward_try_from, primitive_to_wrapped_int, try_from_int_to_int, wrapped_int_to_primitive,
+    forward_try_from, from_and_to_bytes, primitive_to_wrapped_int, try_from_int_to_int,
+    wrapped_int_to_primitive,
 };
 use super::impl_int_serde;
 use super::num_consts::NumConsts;
@@ -67,27 +68,7 @@ impl Int128 {
         self.0
     }
 
-    #[must_use]
-    pub const fn from_be_bytes(data: [u8; 16]) -> Self {
-        Self(i128::from_be_bytes(data))
-    }
-
-    #[must_use]
-    pub const fn from_le_bytes(data: [u8; 16]) -> Self {
-        Self(i128::from_le_bytes(data))
-    }
-
-    /// Returns a copy of the number as big endian bytes.
-    #[must_use = "this returns the result of the operation, without modifying the original"]
-    pub const fn to_be_bytes(self) -> [u8; 16] {
-        self.0.to_be_bytes()
-    }
-
-    /// Returns a copy of the number as little endian bytes.
-    #[must_use = "this returns the result of the operation, without modifying the original"]
-    pub const fn to_le_bytes(self) -> [u8; 16] {
-        self.0.to_le_bytes()
-    }
+    from_and_to_bytes!(i128, 16);
 
     #[must_use]
     pub const fn is_zero(&self) -> bool {

--- a/packages/std/src/math/int64.rs
+++ b/packages/std/src/math/int64.rs
@@ -14,7 +14,8 @@ use crate::{
 };
 
 use super::conversion::{
-    forward_try_from, primitive_to_wrapped_int, try_from_int_to_int, wrapped_int_to_primitive,
+    forward_try_from, from_and_to_bytes, primitive_to_wrapped_int, try_from_int_to_int,
+    wrapped_int_to_primitive,
 };
 use super::impl_int_serde;
 use super::num_consts::NumConsts;
@@ -67,27 +68,7 @@ impl Int64 {
         self.0
     }
 
-    #[must_use]
-    pub const fn from_be_bytes(data: [u8; 8]) -> Self {
-        Self(i64::from_be_bytes(data))
-    }
-
-    #[must_use]
-    pub const fn from_le_bytes(data: [u8; 8]) -> Self {
-        Self(i64::from_le_bytes(data))
-    }
-
-    /// Returns a copy of the number as big endian bytes.
-    #[must_use = "this returns the result of the operation, without modifying the original"]
-    pub const fn to_be_bytes(self) -> [u8; 8] {
-        self.0.to_be_bytes()
-    }
-
-    /// Returns a copy of the number as little endian bytes.
-    #[must_use = "this returns the result of the operation, without modifying the original"]
-    pub const fn to_le_bytes(self) -> [u8; 8] {
-        self.0.to_le_bytes()
-    }
+    from_and_to_bytes!(i64, 8);
 
     #[must_use]
     pub const fn is_zero(&self) -> bool {

--- a/packages/std/src/math/int64.rs
+++ b/packages/std/src/math/int64.rs
@@ -511,14 +511,60 @@ mod tests {
 
     #[test]
     fn int64_from_be_bytes_works() {
-        let num = Int64::from_be_bytes([1; 8]);
-        let a: [u8; 8] = num.to_be_bytes();
-        assert_eq!(a, [1; 8]);
+        // zero
+        let original = [0; 8];
+        let num = Int64::from_be_bytes(original);
+        assert!(num.is_zero());
 
-        let be_bytes = [0u8, 222u8, 0u8, 0u8, 0u8, 1u8, 2u8, 3u8];
-        let num = Int64::from_be_bytes(be_bytes);
-        let resulting_bytes: [u8; 8] = num.to_be_bytes();
-        assert_eq!(be_bytes, resulting_bytes);
+        // one
+        let original = [0, 0, 0, 0, 0, 0, 0, 1];
+        let num = Int64::from_be_bytes(original);
+        assert_eq!(num.i64(), 1);
+
+        // 258
+        let original = [0, 0, 0, 0, 0, 0, 1, 2];
+        let num = Int64::from_be_bytes(original);
+        assert_eq!(num.i64(), 258);
+
+        // 2x roundtrip
+        let original = [1; 8];
+        let num = Int64::from_be_bytes(original);
+        let a: [u8; 8] = num.to_be_bytes();
+        assert_eq!(a, original);
+
+        let original = [0u8, 222u8, 0u8, 0u8, 0u8, 1u8, 2u8, 3u8];
+        let num = Int64::from_be_bytes(original);
+        let a: [u8; 8] = num.to_be_bytes();
+        assert_eq!(a, original);
+    }
+
+    #[test]
+    fn int64_from_le_bytes_works() {
+        // zero
+        let original = [0; 8];
+        let num = Int64::from_le_bytes(original);
+        assert!(num.is_zero());
+
+        // one
+        let original = [1, 0, 0, 0, 0, 0, 0, 0];
+        let num = Int64::from_le_bytes(original);
+        assert_eq!(num.i64(), 1);
+
+        // 258
+        let original = [2, 1, 0, 0, 0, 0, 0, 0];
+        let num = Int64::from_le_bytes(original);
+        assert_eq!(num.i64(), 258);
+
+        // 2x roundtrip
+        let original = [1; 8];
+        let num = Int64::from_le_bytes(original);
+        let a: [u8; 8] = num.to_le_bytes();
+        assert_eq!(a, original);
+
+        let original = [0u8, 222u8, 0u8, 0u8, 0u8, 1u8, 2u8, 3u8];
+        let num = Int64::from_le_bytes(original);
+        let a: [u8; 8] = num.to_le_bytes();
+        assert_eq!(a, original);
     }
 
     #[test]

--- a/packages/std/src/math/uint128.rs
+++ b/packages/std/src/math/uint128.rs
@@ -16,7 +16,9 @@ use crate::{
     Uint256, Uint64,
 };
 
-use super::conversion::{forward_try_from, primitive_to_wrapped_int, wrapped_int_to_primitive};
+use super::conversion::{
+    forward_try_from, from_and_to_bytes, primitive_to_wrapped_int, wrapped_int_to_primitive,
+};
 use super::impl_int_serde;
 use super::num_consts::NumConsts;
 
@@ -73,17 +75,7 @@ impl Uint128 {
         self.0
     }
 
-    /// Returns a copy of the number as big endian bytes.
-    #[must_use = "this returns the result of the operation, without modifying the original"]
-    pub const fn to_be_bytes(self) -> [u8; 16] {
-        self.0.to_be_bytes()
-    }
-
-    /// Returns a copy of the number as little endian bytes.
-    #[must_use = "this returns the result of the operation, without modifying the original"]
-    pub const fn to_le_bytes(self) -> [u8; 16] {
-        self.0.to_le_bytes()
-    }
+    from_and_to_bytes!(u128, 16);
 
     #[must_use]
     pub const fn is_zero(&self) -> bool {
@@ -603,6 +595,68 @@ mod tests {
             one.to_be_bytes(),
             [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]
         );
+    }
+
+    #[test]
+    fn uint128_from_be_bytes_works() {
+        // zero
+        let original = [0; 16];
+        let num = Uint128::from_be_bytes(original);
+        assert!(num.is_zero());
+
+        // one
+        let original = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
+        let num = Uint128::from_be_bytes(original);
+        assert_eq!(num.u128(), 1);
+
+        // 258
+        let original = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2];
+        let num = Uint128::from_be_bytes(original);
+        assert_eq!(num.u128(), 258);
+
+        // 2x roundtrip
+        let original = [1; 16];
+        let num = Uint128::from_be_bytes(original);
+        let a: [u8; 16] = num.to_be_bytes();
+        assert_eq!(a, original);
+
+        let original = [
+            0u8, 222u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 1u8, 2u8, 3u8,
+        ];
+        let num = Uint128::from_be_bytes(original);
+        let resulting_bytes: [u8; 16] = num.to_be_bytes();
+        assert_eq!(resulting_bytes, original);
+    }
+
+    #[test]
+    fn uint128_from_le_bytes_works() {
+        // zero
+        let original = [0; 16];
+        let num = Uint128::from_le_bytes(original);
+        assert!(num.is_zero());
+
+        // one
+        let original = [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        let num = Uint128::from_le_bytes(original);
+        assert_eq!(num.u128(), 1);
+
+        // 258
+        let original = [2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        let num = Uint128::from_le_bytes(original);
+        assert_eq!(num.u128(), 258);
+
+        // 2x roundtrip
+        let original = [1; 16];
+        let num = Uint128::from_le_bytes(original);
+        let a: [u8; 16] = num.to_le_bytes();
+        assert_eq!(a, original);
+
+        let original = [
+            0u8, 222u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 1u8, 2u8, 3u8,
+        ];
+        let num = Uint128::from_le_bytes(original);
+        let resulting_bytes: [u8; 16] = num.to_le_bytes();
+        assert_eq!(resulting_bytes, original);
     }
 
     #[test]

--- a/packages/std/src/math/uint64.rs
+++ b/packages/std/src/math/uint64.rs
@@ -15,7 +15,9 @@ use crate::{
     Uint128,
 };
 
-use super::conversion::{forward_try_from, primitive_to_wrapped_int, wrapped_int_to_primitive};
+use super::conversion::{
+    forward_try_from, from_and_to_bytes, primitive_to_wrapped_int, wrapped_int_to_primitive,
+};
 use super::impl_int_serde;
 use super::num_consts::NumConsts;
 
@@ -69,17 +71,7 @@ impl Uint64 {
         self.0
     }
 
-    /// Returns a copy of the number as big endian bytes.
-    #[must_use = "this returns the result of the operation, without modifying the original"]
-    pub const fn to_be_bytes(self) -> [u8; 8] {
-        self.0.to_be_bytes()
-    }
-
-    /// Returns a copy of the number as little endian bytes.
-    #[must_use = "this returns the result of the operation, without modifying the original"]
-    pub const fn to_le_bytes(self) -> [u8; 8] {
-        self.0.to_le_bytes()
-    }
+    from_and_to_bytes!(u64, 8);
 
     #[must_use]
     pub const fn is_zero(&self) -> bool {
@@ -570,6 +562,64 @@ mod tests {
     fn uint64_one_works() {
         let one = Uint64::one();
         assert_eq!(one.to_be_bytes(), [0, 0, 0, 0, 0, 0, 0, 1]);
+    }
+
+    #[test]
+    fn uint64_from_be_bytes_works() {
+        // zero
+        let original = [0; 8];
+        let num = Uint64::from_be_bytes(original);
+        assert!(num.is_zero());
+
+        // one
+        let original = [0, 0, 0, 0, 0, 0, 0, 1];
+        let num = Uint64::from_be_bytes(original);
+        assert_eq!(num.u64(), 1);
+
+        // 258
+        let original = [0, 0, 0, 0, 0, 0, 1, 2];
+        let num = Uint64::from_be_bytes(original);
+        assert_eq!(num.u64(), 258);
+
+        // 2x roundtrip
+        let original = [1; 8];
+        let num = Uint64::from_be_bytes(original);
+        let a: [u8; 8] = num.to_be_bytes();
+        assert_eq!(a, original);
+
+        let original = [0u8, 222u8, 0u8, 0u8, 0u8, 1u8, 2u8, 3u8];
+        let num = Uint64::from_be_bytes(original);
+        let resulting_bytes: [u8; 8] = num.to_be_bytes();
+        assert_eq!(resulting_bytes, original);
+    }
+
+    #[test]
+    fn uint64_from_le_bytes_works() {
+        // zero
+        let original = [0; 8];
+        let num = Uint64::from_le_bytes(original);
+        assert!(num.is_zero());
+
+        // one
+        let original = [1, 0, 0, 0, 0, 0, 0, 0];
+        let num = Uint64::from_le_bytes(original);
+        assert_eq!(num.u64(), 1);
+
+        // 258
+        let original = [2, 1, 0, 0, 0, 0, 0, 0];
+        let num = Uint64::from_le_bytes(original);
+        assert_eq!(num.u64(), 258);
+
+        // 2x roundtrip
+        let original = [1; 8];
+        let num = Uint64::from_le_bytes(original);
+        let a: [u8; 8] = num.to_le_bytes();
+        assert_eq!(a, original);
+
+        let original = [0u8, 222u8, 0u8, 0u8, 0u8, 1u8, 2u8, 3u8];
+        let num = Uint64::from_le_bytes(original);
+        let resulting_bytes: [u8; 8] = num.to_le_bytes();
+        assert_eq!(resulting_bytes, original);
     }
 
     #[test]


### PR DESCRIPTION
Backport of #2351 for 2.2.x