### PR TITLE
Fix spelling errors in JSON schema files

### DIFF
--- a/contracts/ibc-reflect-send/schema/raw/migrate.json
+++ b/contracts/ibc-reflect-send/schema/raw/migrate.json
@@ -404,7 +404,7 @@
                   ]
                 },
                 "channel_id": {
-                  "description": "exisiting channel to send the tokens over",
+                  "description": "existing channel to send the tokens over",
                   "type": "string"
                 },
                 "timeout": {
@@ -522,7 +522,7 @@
           "minimum": 0.0
         },
         "revision": {
-          "description": "the version that the client is currently on (eg. after reseting the chain this could increment 1 as height drops to 0)",
+          "description": "the version that the client is currently on (eg. after resetting the chain this could increment 1 as height drops to 0)",
           "type": "integer",
           "format": "uint64",
           "minimum": 0.0

--- a/contracts/ibc-reflect-send/schema/raw/sudo.json
+++ b/contracts/ibc-reflect-send/schema/raw/sudo.json
@@ -404,7 +404,7 @@
                   ]
                 },
                 "channel_id": {
-                  "description": "exisiting channel to send the tokens over",
+                  "description": "existing channel to send the tokens over",
                   "type": "string"
                 },
                 "timeout": {
@@ -522,7 +522,7 @@
           "minimum": 0.0
         },
         "revision": {
-          "description": "the version that the client is currently on (eg. after reseting the chain this could increment 1 as height drops to 0)",
+          "description": "the version that the client is currently on (eg. after resetting the chain this could increment 1 as height drops to 0)",
           "type": "integer",
           "format": "uint64",
           "minimum": 0.0

--- a/contracts/reflect/schema/raw/migrate.json
+++ b/contracts/reflect/schema/raw/migrate.json
@@ -399,7 +399,7 @@
                   ]
                 },
                 "channel_id": {
-                  "description": "exisiting channel to send the tokens over",
+                  "description": "existing channel to send the tokens over",
                   "type": "string"
                 },
                 "timeout": {
@@ -517,7 +517,7 @@
           "minimum": 0.0
         },
         "revision": {
-          "description": "the version that the client is currently on (eg. after reseting the chain this could increment 1 as height drops to 0)",
+          "description": "the version that the client is currently on (eg. after resetting the chain this could increment 1 as height drops to 0)",
           "type": "integer",
           "format": "uint64",
           "minimum": 0.0

--- a/contracts/reflect/schema/raw/sudo.json
+++ b/contracts/reflect/schema/raw/sudo.json
@@ -399,7 +399,7 @@
                   ]
                 },
                 "channel_id": {
-                  "description": "exisiting channel to send the tokens over",
+                  "description": "existing channel to send the tokens over",
                   "type": "string"
                 },
                 "timeout": {
@@ -517,7 +517,7 @@
           "minimum": 0.0
         },
         "revision": {
-          "description": "the version that the client is currently on (eg. after reseting the chain this could increment 1 as height drops to 0)",
+          "description": "the version that the client is currently on (eg. after resetting the chain this could increment 1 as height drops to 0)",
           "type": "integer",
           "format": "uint64",
           "minimum": 0.0


### PR DESCRIPTION
- **"exisiting"** → **"existing"**  
- **"reseting"** → **"resetting"**  

#### Files modified:  
- `contracts/ibc-reflect-send/schema/raw/migrate.json`  
- `contracts/ibc-reflect-send/schema/raw/sudo.json`  
- `contracts/reflect/schema/raw/migrate.json`  
- `contracts/reflect/schema/raw/sudo.json`  
