### PR TITLE
Fix typo in `state.rs`

### DIFF
--- a/contracts/ibc-reflect-send/src/state.rs
+++ b/contracts/ibc-reflect-send/src/state.rs
@@ -10,7 +10,7 @@ pub const KEY_CONFIG: &[u8] = b"config";
 /// accounts is lookup of channel_id to reflect contract
 pub const PREFIX_ACCOUNTS: &[u8] = b"accounts";
 /// Upper bound for ranging over accounts
-const PREFIX_ACCOUNTS_UPPER_BOUND: &[u8] = b"accountt"; // spellchecker:disable-line
+const PREFIX_ACCOUNTS_UPPER_BOUND: &[u8] = b"accounts"; // spellchecker:disable-line
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct Config {

--- a/contracts/ibc-reflect/src/state.rs
+++ b/contracts/ibc-reflect/src/state.rs
@@ -12,7 +12,7 @@ pub const KEY_CONFIG: &[u8] = b"config";
 pub const KEY_PENDING_CHANNEL: &[u8] = b"pending";
 pub const PREFIX_ACCOUNTS: &[u8] = b"accounts";
 /// Upper bound for ranging over accounts
-const PREFIX_ACCOUNTS_UPPER_BOUND: &[u8] = b"accountt"; // spellchecker:disable-line
+const PREFIX_ACCOUNTS_UPPER_BOUND: &[u8] = b"accounts"; // spellchecker:disable-line
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct Config {


### PR DESCRIPTION
- In both `contracts/ibc-reflect-send/src/state.rs` and `contracts/ibc-reflect/src/state.rs`:

  - Fixed the typo `accountt` → `accounts`