### PR TITLE
Fix spelling errors in multiple files

### DIFF
--- a/contracts/crypto-verify/src/ethereum.rs
+++ b/contracts/crypto-verify/src/ethereum.rs
@@ -117,7 +117,7 @@ pub fn decode_address(input: &str) -> StdResult<[u8; 20]> {
         ));
     }
     if !input.starts_with("0x") {
-        return Err(StdError::generic_err("Ethereum address must start wit 0x"));
+        return Err(StdError::generic_err("Ethereum address must start with 0x"));
     }
     let data = hex::decode(&input[2..]).map_err(|_| StdError::generic_err("hex decoding error"))?;
     Ok(data.try_into().unwrap())

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -162,7 +162,7 @@ where
         // Four parameters, "ps", "qs", "r", "s", which all represent elements on the BLS12-381 curve (where "ps" and "r" are elements of the G1 subgroup, and "qs" and "s" elements of G2).
         // The "ps" and "qs" are interpreted as a continuous list of points in the subgroups G1 and G2 respectively.
         // Returns a single u32 which signifies the validity of the pairing equality.
-        // Returns 0 if the pairing equality exists, 1 if it doesnt, and any other code may be interpreted as a `CryptoError`.
+        // Returns 0 if the pairing equality exists, 1 if it doesn't, and any other code may be interpreted as a `CryptoError`.
         env_imports.insert(
             "bls12_381_pairing_equality",
             Function::new_typed_with_env(&mut store, &fe, do_bls12_381_pairing_equality),

--- a/packages/vm/src/modules/file_system_cache.rs
+++ b/packages/vm/src/modules/file_system_cache.rs
@@ -52,7 +52,7 @@ use super::CachedModule;
 ///   [issues with module deserialization](https://github.com/CosmWasm/wasmvm/issues/426).
 ///   To work around this, the version was bumped to "v5" here to invalidate these corrupt caches.
 /// - **v6**:<br>
-///   Version for cosmwasm_vm 1.3+ which adds a sub-folder with the target identier for the modules.
+///   Version for cosmwasm_vm 1.3+ which adds a sub-folder with the target identifier for the modules.
 /// - **v7**:<br>
 ///   New version because of Wasmer 2.3.0 -> 4 upgrade.
 ///   This internally changes how rkyv is used for module serialization, making compatibility unlikely.
@@ -268,7 +268,7 @@ fn module_size(module_path: &Path) -> VmResult<usize> {
 }
 
 /// Creates an identifier for the Wasmer `Target` that is used for
-/// cache invalidation. The output is reasonable human friendly to be useable
+/// cache invalidation. The output is reasonable human friendly to be usable
 /// in file path component.
 fn target_id(target: &Target) -> String {
     // Use a custom Hasher implementation to avoid randomization.


### PR DESCRIPTION
Fix spelling errors in multiple files (`file_system_cache.rs`, `instance.rs`, `ethereum.rs`)

