### PR TITLE
Change {Int256,Int512,Uint256,Uint512}::new argument from bytes to i128/u128

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,8 @@ and this project adheres to
   makes the use of `schemars` optional for contracts. ([#2201])
 - cosmwasm-std: Remove `schemars::JsonSchema` requirement from `CustomMsg`.
   ([#2201])
-- cosmwasm-std: `Int256::new` now takes an `i128` argument instead of bytes. Use
-  `Int256::from_be_bytes` if you need the old behaviour.
+- cosmwasm-std: `Int256::new`/`Int512::new` now take an `i128` argument instead
+  of bytes. Use `::from_be_bytes` if you need the old behaviour.
 
 ## Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,9 +42,10 @@ and this project adheres to
 - cosmwasm-std: Remove `schemars::JsonSchema` requirement from `CustomMsg`.
   ([#2201])
 - cosmwasm-std: `Int256::new`/`Int512::new` now take an `i128` argument instead
-  of bytes. Use `::from_be_bytes` if you need the old behaviour.
+  of bytes. Use `::from_be_bytes` if you need the old behaviour. ([#2367])
 - cosmwasm-std: `Uint256::new`/`Uint512::new` now take an `u128` argument
   instead of bytes. Use `::from_be_bytes` if you need the old behaviour.
+  ([#2367])
 
 ## Fixed
 
@@ -62,6 +63,7 @@ and this project adheres to
 [#2337]: https://github.com/CosmWasm/cosmwasm/issues/2337
 [#2340]: https://github.com/CosmWasm/cosmwasm/pull/2340
 [#2344]: https://github.com/CosmWasm/cosmwasm/pull/2344
+[#2367]: https://github.com/CosmWasm/cosmwasm/issues/2367
 [#2374]: https://github.com/CosmWasm/cosmwasm/issues/2374
 [#2378]: https://github.com/CosmWasm/cosmwasm/issues/2378
 [#2383]: https://github.com/CosmWasm/cosmwasm/issues/2383

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ and this project adheres to
 - cosmwasm-std: Deprecate `{Decimal,Decimal256}::raw` and
   `{SignedDecimal,SignedDecimal256}::raw` in favour of e.g.
   `Decimal::new(Uint128::new(value))`. ([#2399])
+- cosmwasm-std: Deprecate `Uint256::from_u128` and `Int256::from_i128` in favour
+  of `::new`. ([#2399])
 
 ## Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,8 @@ and this project adheres to
   ([#2201])
 - cosmwasm-std: `Int256::new`/`Int512::new` now take an `i128` argument instead
   of bytes. Use `::from_be_bytes` if you need the old behaviour.
-- cosmwasm-std: `Uint256::new` now takes an `u128` argument instead of bytes.
-  Use `::from_be_bytes` if you need the old behaviour.
+- cosmwasm-std: `Uint256::new`/`Uint512::new` now take an `u128` argument
+  instead of bytes. Use `::from_be_bytes` if you need the old behaviour.
 
 ## Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@ and this project adheres to
 - cosmwasm-std: `Uint256::new`/`Uint512::new` now take an `u128` argument
   instead of bytes. Use `::from_be_bytes` if you need the old behaviour.
   ([#2367])
+- cosmwasm-std: Deprecate `{Decimal,Decimal256}::raw` and
+  `{SignedDecimal,SignedDecimal256}::raw` in favour of e.g.
+  `Decimal::new(Uint128::new(value))`. ([#2399])
 
 ## Fixed
 
@@ -68,6 +71,7 @@ and this project adheres to
 [#2378]: https://github.com/CosmWasm/cosmwasm/issues/2378
 [#2383]: https://github.com/CosmWasm/cosmwasm/issues/2383
 [#2390]: https://github.com/CosmWasm/cosmwasm/issues/2390
+[#2399]: https://github.com/CosmWasm/cosmwasm/pull/2399
 
 ## [2.2.0] - 2024-12-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to
   makes the use of `schemars` optional for contracts. ([#2201])
 - cosmwasm-std: Remove `schemars::JsonSchema` requirement from `CustomMsg`.
   ([#2201])
+- cosmwasm-std: `Int256::new` now takes an `i128` argument instead of bytes. Use
+  `Int256::from_be_bytes` if you need the old behaviour.
 
 ## Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ and this project adheres to
   ([#2201])
 - cosmwasm-std: `Int256::new`/`Int512::new` now take an `i128` argument instead
   of bytes. Use `::from_be_bytes` if you need the old behaviour.
+- cosmwasm-std: `Uint256::new` now takes an `u128` argument instead of bytes.
+  Use `::from_be_bytes` if you need the old behaviour.
 
 ## Fixed
 

--- a/packages/std/src/math/decimal.rs
+++ b/packages/std/src/math/decimal.rs
@@ -43,6 +43,15 @@ impl Decimal {
 
     /// Creates a Decimal(value)
     /// This is equivalent to `Decimal::from_atomics(value, 18)` but usable in a const context.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// # use cosmwasm_std::{Uint128, Decimal};
+    /// let atoms = Uint128::new(141_183_460_469_231_731_687_303_715_884_105_727_125);
+    /// let value = Decimal::new(atoms);
+    /// assert_eq!(value.to_string(), "141183460469231731687.303715884105727125");
+    /// ```
     pub const fn new(value: Uint128) -> Self {
         Self(value)
     }

--- a/packages/std/src/math/decimal.rs
+++ b/packages/std/src/math/decimal.rs
@@ -52,6 +52,7 @@ impl Decimal {
     /// let value = Decimal::new(atoms);
     /// assert_eq!(value.to_string(), "141183460469231731687.303715884105727125");
     /// ```
+    #[inline]
     pub const fn new(value: Uint128) -> Self {
         Self(value)
     }

--- a/packages/std/src/math/decimal.rs
+++ b/packages/std/src/math/decimal.rs
@@ -59,6 +59,10 @@ impl Decimal {
 
     /// Creates a Decimal(Uint128(value))
     /// This is equivalent to `Decimal::from_atomics(value, 18)` but usable in a const context.
+    #[deprecated(
+        since = "3.0.0",
+        note = "Use Decimal::new(Uint128::new(value)) instead"
+    )]
     pub const fn raw(value: u128) -> Self {
         Self(Uint128::new(value))
     }
@@ -805,6 +809,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn decimal_raw() {
         let value = 300u128;
         assert_eq!(Decimal::raw(value).0.u128(), value);
@@ -867,7 +872,7 @@ mod tests {
     fn decimal_try_from_signed_works() {
         assert_eq!(
             Decimal::try_from(SignedDecimal::MAX).unwrap(),
-            Decimal::raw(SignedDecimal::MAX.atomics().i128() as u128)
+            Decimal::new(Uint128::new(SignedDecimal::MAX.atomics().i128() as u128))
         );
         assert_eq!(
             Decimal::try_from(SignedDecimal::zero()).unwrap(),

--- a/packages/std/src/math/decimal.rs
+++ b/packages/std/src/math/decimal.rs
@@ -53,6 +53,7 @@ impl Decimal {
     /// assert_eq!(value.to_string(), "141183460469231731687.303715884105727125");
     /// ```
     #[inline]
+    #[must_use]
     pub const fn new(value: Uint128) -> Self {
         Self(value)
     }

--- a/packages/std/src/math/decimal256.rs
+++ b/packages/std/src/math/decimal256.rs
@@ -34,9 +34,9 @@ pub struct Decimal256RangeExceeded;
 
 impl Decimal256 {
     const DECIMAL_FRACTIONAL: Uint256 = // 1*10**18
-        Uint256::from_u128(1_000_000_000_000_000_000);
+        Uint256::new(1_000_000_000_000_000_000);
     const DECIMAL_FRACTIONAL_SQUARED: Uint256 = // 1*10**36
-        Uint256::from_u128(1_000_000_000_000_000_000_000_000_000_000_000_000);
+        Uint256::new(1_000_000_000_000_000_000_000_000_000_000_000_000);
 
     /// The number of decimal places. Since decimal types are fixed-point rather than
     /// floating-point, this is a constant.
@@ -70,7 +70,7 @@ impl Decimal256 {
         note = "Use Decimal256::new(Uint256::new(value)) instead"
     )]
     pub const fn raw(value: u128) -> Self {
-        Self(Uint256::from_u128(value))
+        Self(Uint256::new(value))
     }
 
     /// Create a 1.0 Decimal256
@@ -99,7 +99,7 @@ impl Decimal256 {
     pub const fn percent(x: u64) -> Self {
         // multiplication does not overflow since `u64::MAX` * 10**16 is well in u128 range
         let atomics = (x as u128) * 10_000_000_000_000_000;
-        Self(Uint256::from_u128(atomics))
+        Self(Uint256::new(atomics))
     }
 
     /// Convert permille (x/1000) into Decimal256
@@ -116,7 +116,7 @@ impl Decimal256 {
     pub const fn permille(x: u64) -> Self {
         // multiplication does not overflow since `u64::MAX` * 10**15 is well in u128 range
         let atomics = (x as u128) * 1_000_000_000_000_000;
-        Self(Uint256::from_u128(atomics))
+        Self(Uint256::new(atomics))
     }
 
     /// Convert basis points (x/10000) into Decimal256
@@ -135,7 +135,7 @@ impl Decimal256 {
     pub const fn bps(x: u64) -> Self {
         // multiplication does not overflow since `u64::MAX` * 10**14 is well in u128 range
         let atomics = (x as u128) * 100_000_000_000_000;
-        Self(Uint256::from_u128(atomics))
+        Self(Uint256::new(atomics))
     }
 
     /// Creates a decimal from a number of atomic units and the number
@@ -2234,18 +2234,18 @@ mod tests {
     #[test]
     fn decimal256_to_uint_floor_works() {
         let d = Decimal256::from_str("12.000000000000000001").unwrap();
-        assert_eq!(d.to_uint_floor(), Uint256::from_u128(12));
+        assert_eq!(d.to_uint_floor(), Uint256::new(12));
         let d = Decimal256::from_str("12.345").unwrap();
-        assert_eq!(d.to_uint_floor(), Uint256::from_u128(12));
+        assert_eq!(d.to_uint_floor(), Uint256::new(12));
         let d = Decimal256::from_str("12.999").unwrap();
-        assert_eq!(d.to_uint_floor(), Uint256::from_u128(12));
+        assert_eq!(d.to_uint_floor(), Uint256::new(12));
         let d = Decimal256::from_str("0.98451384").unwrap();
-        assert_eq!(d.to_uint_floor(), Uint256::from_u128(0));
+        assert_eq!(d.to_uint_floor(), Uint256::new(0));
 
         let d = Decimal256::from_str("75.0").unwrap();
-        assert_eq!(d.to_uint_floor(), Uint256::from_u128(75));
+        assert_eq!(d.to_uint_floor(), Uint256::new(75));
         let d = Decimal256::from_str("0.0").unwrap();
-        assert_eq!(d.to_uint_floor(), Uint256::from_u128(0));
+        assert_eq!(d.to_uint_floor(), Uint256::new(0));
 
         let d = Decimal256::MAX;
         assert_eq!(
@@ -2283,16 +2283,16 @@ mod tests {
     #[test]
     fn decimal256_to_uint_ceil_works() {
         let d = Decimal256::from_str("12.000000000000000001").unwrap();
-        assert_eq!(d.to_uint_ceil(), Uint256::from_u128(13));
+        assert_eq!(d.to_uint_ceil(), Uint256::new(13));
         let d = Decimal256::from_str("12.345").unwrap();
-        assert_eq!(d.to_uint_ceil(), Uint256::from_u128(13));
+        assert_eq!(d.to_uint_ceil(), Uint256::new(13));
         let d = Decimal256::from_str("12.999").unwrap();
-        assert_eq!(d.to_uint_ceil(), Uint256::from_u128(13));
+        assert_eq!(d.to_uint_ceil(), Uint256::new(13));
 
         let d = Decimal256::from_str("75.0").unwrap();
-        assert_eq!(d.to_uint_ceil(), Uint256::from_u128(75));
+        assert_eq!(d.to_uint_ceil(), Uint256::new(75));
         let d = Decimal256::from_str("0.0").unwrap();
-        assert_eq!(d.to_uint_ceil(), Uint256::from_u128(0));
+        assert_eq!(d.to_uint_ceil(), Uint256::new(0));
 
         let d = Decimal256::MAX;
         assert_eq!(

--- a/packages/std/src/math/decimal256.rs
+++ b/packages/std/src/math/decimal256.rs
@@ -64,6 +64,10 @@ impl Decimal256 {
 
     /// Creates a Decimal256 from u128
     /// This is equivalent to `Decimal256::from_atomics(value, 18)` but usable in a const context.
+    #[deprecated(
+        since = "3.0.0",
+        note = "Use Decimal256::new(Uint256::new(value)) instead"
+    )]
     pub const fn raw(value: u128) -> Self {
         Self(Uint256::from_u128(value))
     }
@@ -808,6 +812,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn decimal256_raw() {
         let value = 300u128;
         let expected = Uint256::from(value);

--- a/packages/std/src/math/decimal256.rs
+++ b/packages/std/src/math/decimal256.rs
@@ -57,6 +57,7 @@ impl Decimal256 {
     /// let value = Decimal256::new(atoms);
     /// assert_eq!(value.to_string(), "141183460469231731687.303715884105727125");
     /// ```
+    #[inline]
     pub const fn new(value: Uint256) -> Self {
         Self(value)
     }

--- a/packages/std/src/math/decimal256.rs
+++ b/packages/std/src/math/decimal256.rs
@@ -48,6 +48,15 @@ impl Decimal256 {
 
     /// Creates a Decimal256 from Uint256
     /// This is equivalent to `Decimal256::from_atomics(value, 18)` but usable in a const context.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// # use cosmwasm_std::{Uint256, Decimal256};
+    /// let atoms = Uint256::new(141_183_460_469_231_731_687_303_715_884_105_727_125);
+    /// let value = Decimal256::new(atoms);
+    /// assert_eq!(value.to_string(), "141183460469231731687.303715884105727125");
+    /// ```
     pub const fn new(value: Uint256) -> Self {
         Self(value)
     }

--- a/packages/std/src/math/decimal256.rs
+++ b/packages/std/src/math/decimal256.rs
@@ -58,6 +58,7 @@ impl Decimal256 {
     /// assert_eq!(value.to_string(), "141183460469231731687.303715884105727125");
     /// ```
     #[inline]
+    #[must_use]
     pub const fn new(value: Uint256) -> Self {
         Self(value)
     }

--- a/packages/std/src/math/int128.rs
+++ b/packages/std/src/math/int128.rs
@@ -47,6 +47,7 @@ impl Int128 {
     ///
     /// This method is less flexible than `from` but can be called in a const context.
     #[inline]
+    #[must_use]
     pub const fn new(value: i128) -> Self {
         Self(value)
     }

--- a/packages/std/src/math/int256.rs
+++ b/packages/std/src/math/int256.rs
@@ -65,20 +65,7 @@ impl Int256 {
     /// [`from_be_bytes`]: Self::from_be_bytes
     #[inline]
     pub const fn new(value: i128) -> Self {
-        // See https://en.wikipedia.org/wiki/Sign_extension
-        let b = value.to_be_bytes();
-        if value.is_negative() {
-            Self::from_be_bytes([
-                0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-                0xFF, 0xFF, b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7], b[8], b[9], b[10],
-                b[11], b[12], b[13], b[14], b[15],
-            ])
-        } else {
-            Self::from_be_bytes([
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, b[0], b[1], b[2], b[3], b[4], b[5],
-                b[6], b[7], b[8], b[9], b[10], b[11], b[12], b[13], b[14], b[15],
-            ])
-        }
+        Self::from_be_bytes(grow_be_int(value.to_be_bytes()))
     }
 
     /// Creates a Int256(0)

--- a/packages/std/src/math/int256.rs
+++ b/packages/std/src/math/int256.rs
@@ -29,19 +29,21 @@ use super::num_consts::NumConsts;
 ///
 /// # Examples
 ///
-/// Use `from` to create instances out of primitive uint types or `new` to provide big
-/// endian bytes:
+/// Use `new` to create instances out of i128, `from` for other primitive uint/int types
+/// or `from_be_bytes` to provide big endian bytes:
 ///
 /// ```
 /// # use cosmwasm_std::Int256;
-/// let a = Int256::from(258u128);
-/// let b = Int256::new([
+/// let a = Int256::new(258i128);
+/// let b = Int256::from(258u16);
+/// let c = Int256::from_be_bytes([
 ///     0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
 ///     0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
 ///     0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
 ///     0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 1u8, 2u8,
 /// ]);
 /// assert_eq!(a, b);
+/// assert_eq!(a, c);
 /// ```
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, PartialOrd, Ord, schemars::JsonSchema)]
 pub struct Int256(#[schemars(with = "String")] pub(crate) I256);
@@ -53,11 +55,30 @@ impl Int256 {
     pub const MAX: Int256 = Int256(I256::MAX);
     pub const MIN: Int256 = Int256(I256::MIN);
 
-    /// Creates a Int256(value) from a big endian representation. It's just an alias for
-    /// `from_be_bytes`.
+    /// Creates a Int256(value).
+    ///
+    /// This method is less flexible than `from` but can be called in a const context.
+    ///
+    /// Before CosmWasm 3 this took a byte array as an argument. You can get this behaviour
+    /// with [`from_be_bytes`].
+    ///
+    /// [`from_be_bytes`]: Self::from_be_bytes
     #[inline]
-    pub const fn new(value: [u8; 32]) -> Self {
-        Self::from_be_bytes(value)
+    pub const fn new(value: i128) -> Self {
+        // See https://en.wikipedia.org/wiki/Sign_extension
+        let b = value.to_be_bytes();
+        if value.is_negative() {
+            Self::from_be_bytes([
+                0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+                0xFF, 0xFF, b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7], b[8], b[9], b[10],
+                b[11], b[12], b[13], b[14], b[15],
+            ])
+        } else {
+            Self::from_be_bytes([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, b[0], b[1], b[2], b[3], b[4], b[5],
+                b[6], b[7], b[8], b[9], b[10], b[11], b[12], b[13], b[14], b[15],
+            ])
+        }
     }
 
     /// Creates a Int256(0)
@@ -588,7 +609,34 @@ mod tests {
 
     #[test]
     fn int256_new_works() {
-        let num = Int256::new([1; 32]);
+        let num = Int256::new(1);
+        assert_eq!(
+            num.to_be_bytes(),
+            [
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 1
+            ]
+        );
+
+        let num = Int256::new(-1);
+        assert_eq!(
+            num.to_be_bytes(),
+            [
+                255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+                255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+            ]
+        );
+
+        for v in [0, 1, -4, 18, 875786576, -11763498739, i128::MAX, i128::MIN] {
+            // From is implemented by bnum, so we test two independent implementations against each other
+            let uut = Int256::new(v);
+            assert_eq!(uut, Int256::from(v));
+        }
+    }
+
+    #[test]
+    fn int256_from_be_bytes_works() {
+        let num = Int256::from_be_bytes([1; 32]);
         let a: [u8; 32] = num.to_be_bytes();
         assert_eq!(a, [1; 32]);
 
@@ -596,14 +644,14 @@ mod tests {
             0u8, 222u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
             0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 1u8, 2u8, 3u8,
         ];
-        let num = Int256::new(be_bytes);
+        let num = Int256::from_be_bytes(be_bytes);
         let resulting_bytes: [u8; 32] = num.to_be_bytes();
         assert_eq!(be_bytes, resulting_bytes);
     }
 
     #[test]
     fn int256_not_works() {
-        let num = Int256::new([1; 32]);
+        let num = Int256::from_be_bytes([1; 32]);
         let a = (!num).to_be_bytes();
         assert_eq!(a, [254; 32]);
 
@@ -640,12 +688,10 @@ mod tests {
         ];
 
         // These should all be the same.
-        let num1 = Int256::new(be_bytes);
-        let num2 = Int256::from_be_bytes(be_bytes);
-        let num3 = Int256::from_le_bytes(le_bytes);
-        assert_eq!(num1, Int256::from(65536u32 + 512 + 3));
-        assert_eq!(num1, num2);
-        assert_eq!(num1, num3);
+        let a = Int256::from_be_bytes(be_bytes);
+        let b = Int256::from_le_bytes(le_bytes);
+        assert_eq!(a, Int256::from(65536u32 + 512 + 3));
+        assert_eq!(a, b);
     }
 
     #[test]
@@ -1059,12 +1105,12 @@ mod tests {
 
     #[test]
     fn int256_shr_works() {
-        let original = Int256::new([
+        let original = Int256::from_be_bytes([
             0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
             0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 2u8, 0u8, 4u8, 2u8,
         ]);
 
-        let shifted = Int256::new([
+        let shifted = Int256::from_be_bytes([
             0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
             0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 128u8, 1u8, 0u8,
         ]);

--- a/packages/std/src/math/int256.rs
+++ b/packages/std/src/math/int256.rs
@@ -64,6 +64,7 @@ impl Int256 {
     ///
     /// [`from_be_bytes`]: Self::from_be_bytes
     #[inline]
+    #[must_use]
     pub const fn new(value: i128) -> Self {
         Self::from_be_bytes(grow_be_int(value.to_be_bytes()))
     }

--- a/packages/std/src/math/int256.rs
+++ b/packages/std/src/math/int256.rs
@@ -83,8 +83,9 @@ impl Int256 {
 
     /// A conversion from `i128` that, unlike the one provided by the `From` trait,
     /// can be used in a `const` context.
-    pub const fn from_i128(v: i128) -> Self {
-        Self::from_be_bytes(grow_be_int(v.to_be_bytes()))
+    #[deprecated(since = "3.0.0", note = "Use Int256::new(value) instead")]
+    pub const fn from_i128(value: i128) -> Self {
+        Self::new(value)
     }
 
     #[must_use]
@@ -731,6 +732,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn int256_from_i128() {
         assert_eq!(Int256::from_i128(123i128), Int256::from_str("123").unwrap());
 
@@ -1034,7 +1036,7 @@ mod tests {
 
     #[test]
     fn int256_checked_multiply_ratio_works() {
-        let base = Int256::from_i128(500);
+        let base = Int256::new(500);
 
         // factor 1/1
         assert_eq!(base.checked_multiply_ratio(1i128, 1i128).unwrap(), base);
@@ -1051,38 +1053,38 @@ mod tests {
         // factor 3/2
         assert_eq!(
             base.checked_multiply_ratio(3i128, 2i128).unwrap(),
-            Int256::from_i128(750)
+            Int256::new(750)
         );
         assert_eq!(
             base.checked_multiply_ratio(333333i128, 222222i128).unwrap(),
-            Int256::from_i128(750)
+            Int256::new(750)
         );
 
         // factor 2/3 (integer division always floors the result)
         assert_eq!(
             base.checked_multiply_ratio(2i128, 3i128).unwrap(),
-            Int256::from_i128(333)
+            Int256::new(333)
         );
         assert_eq!(
             base.checked_multiply_ratio(222222i128, 333333i128).unwrap(),
-            Int256::from_i128(333)
+            Int256::new(333)
         );
 
         // factor 5/6 (integer division always floors the result)
         assert_eq!(
             base.checked_multiply_ratio(5i128, 6i128).unwrap(),
-            Int256::from_i128(416)
+            Int256::new(416)
         );
         assert_eq!(
             base.checked_multiply_ratio(100i128, 120i128).unwrap(),
-            Int256::from_i128(416)
+            Int256::new(416)
         );
     }
 
     #[test]
     fn int256_checked_multiply_ratio_does_not_panic() {
         assert_eq!(
-            Int256::from_i128(500i128).checked_multiply_ratio(1i128, 0i128),
+            Int256::new(500i128).checked_multiply_ratio(1i128, 0i128),
             Err(CheckedMultiplyRatioError::DivideByZero),
         );
         assert_eq!(

--- a/packages/std/src/math/int512.rs
+++ b/packages/std/src/math/int512.rs
@@ -65,6 +65,7 @@ impl Int512 {
     ///
     /// [`from_be_bytes`]: Self::from_be_bytes
     #[inline]
+    #[must_use]
     pub const fn new(value: i128) -> Self {
         Self::from_be_bytes(grow_be_int(value.to_be_bytes()))
     }

--- a/packages/std/src/math/int512.rs
+++ b/packages/std/src/math/int512.rs
@@ -26,13 +26,14 @@ use super::num_consts::NumConsts;
 ///
 /// # Examples
 ///
-/// Use `from` to create instances out of primitive uint types or `new` to provide big
-/// endian bytes:
+/// Use `new` to create instances out of i128, `from` for other primitive uint/int types
+/// or `from_be_bytes` to provide big endian bytes:
 ///
 /// ```
 /// # use cosmwasm_std::Int512;
-/// let a = Int512::from(258u128);
-/// let b = Int512::new([
+/// let a = Int512::new(258i128);
+/// let b = Int512::from(258u128);
+/// let c = Int512::from_be_bytes([
 ///     0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
 ///     0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
 ///     0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
@@ -43,6 +44,7 @@ use super::num_consts::NumConsts;
 ///     0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 1u8, 2u8,
 /// ]);
 /// assert_eq!(a, b);
+/// assert_eq!(a, c);
 /// ```
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, PartialOrd, Ord, schemars::JsonSchema)]
 pub struct Int512(#[schemars(with = "String")] pub(crate) I512);
@@ -54,11 +56,33 @@ impl Int512 {
     pub const MAX: Int512 = Int512(I512::MAX);
     pub const MIN: Int512 = Int512(I512::MIN);
 
-    /// Creates a Int512(value) from a big endian representation. It's just an alias for
-    /// `from_be_bytes`.
+    /// Creates a Int512(value).
+    ///
+    /// This method is less flexible than `from` but can be called in a const context.
+    ///
+    /// Before CosmWasm 3 this took a byte array as an argument. You can get this behaviour
+    /// with [`from_be_bytes`].
+    ///
+    /// [`from_be_bytes`]: Self::from_be_bytes
     #[inline]
-    pub const fn new(value: [u8; 64]) -> Self {
-        Self::from_be_bytes(value)
+    pub const fn new(value: i128) -> Self {
+        // See https://en.wikipedia.org/wiki/Sign_extension
+        let b = value.to_be_bytes();
+        if value.is_negative() {
+            Self::from_be_bytes([
+                0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+                0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+                0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+                0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7],
+                b[8], b[9], b[10], b[11], b[12], b[13], b[14], b[15],
+            ])
+        } else {
+            Self::from_be_bytes([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, b[0], b[1], b[2], b[3],
+                b[4], b[5], b[6], b[7], b[8], b[9], b[10], b[11], b[12], b[13], b[14], b[15],
+            ])
+        }
     }
 
     /// Creates a Int512(0)
@@ -585,7 +609,37 @@ mod tests {
 
     #[test]
     fn int512_new_works() {
-        let num = Int512::new([1; 64]);
+        let num = Int512::new(1);
+        assert_eq!(
+            num.to_be_bytes(),
+            [
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 1
+            ]
+        );
+
+        let num = Int512::new(-1);
+        assert_eq!(
+            num.to_be_bytes(),
+            [
+                255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+                255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+                255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+                255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+            ]
+        );
+
+        for v in [0, 1, -4, 18, 875786576, -11763498739, i128::MAX, i128::MIN] {
+            // From is implemented by bnum, so we test two independent implementations against each other
+            let uut = Int512::new(v);
+            assert_eq!(uut, Int512::from(v));
+        }
+    }
+
+    #[test]
+    fn int512_from_be_bytes_works() {
+        let num = Int512::from_be_bytes([1; 64]);
         let a: [u8; 64] = num.to_be_bytes();
         assert_eq!(a, [1; 64]);
 
@@ -595,14 +649,14 @@ mod tests {
             0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
             0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 1u8, 2u8, 3u8,
         ];
-        let num = Int512::new(be_bytes);
+        let num = Int512::from_be_bytes(be_bytes);
         let resulting_bytes: [u8; 64] = num.to_be_bytes();
         assert_eq!(be_bytes, resulting_bytes);
     }
 
     #[test]
     fn int512_not_works() {
-        let num = Int512::new([1; 64]);
+        let num = Int512::from_be_bytes([1; 64]);
         let a = (!num).to_be_bytes();
         assert_eq!(a, [254; 64]);
 
@@ -643,12 +697,10 @@ mod tests {
         ];
 
         // These should all be the same.
-        let num1 = Int512::new(be_bytes);
-        let num2 = Int512::from_be_bytes(be_bytes);
-        let num3 = Int512::from_le_bytes(le_bytes);
-        assert_eq!(num1, Int512::from(65536u32 + 512 + 3));
-        assert_eq!(num1, num2);
-        assert_eq!(num1, num3);
+        let a = Int512::from_be_bytes(be_bytes);
+        let b = Int512::from_le_bytes(le_bytes);
+        assert_eq!(a, Int512::from(65536u32 + 512 + 3));
+        assert_eq!(a, b);
     }
 
     #[test]
@@ -1028,14 +1080,14 @@ mod tests {
 
     #[test]
     fn int512_shr_works() {
-        let original = Int512::new([
+        let original = Int512::from_be_bytes([
             0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
             0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
             0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
             0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 2u8, 0u8, 4u8, 2u8,
         ]);
 
-        let shifted = Int512::new([
+        let shifted = Int512::from_be_bytes([
             0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
             0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
             0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,

--- a/packages/std/src/math/int512.rs
+++ b/packages/std/src/math/int512.rs
@@ -66,23 +66,7 @@ impl Int512 {
     /// [`from_be_bytes`]: Self::from_be_bytes
     #[inline]
     pub const fn new(value: i128) -> Self {
-        // See https://en.wikipedia.org/wiki/Sign_extension
-        let b = value.to_be_bytes();
-        if value.is_negative() {
-            Self::from_be_bytes([
-                0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-                0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-                0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-                0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7],
-                b[8], b[9], b[10], b[11], b[12], b[13], b[14], b[15],
-            ])
-        } else {
-            Self::from_be_bytes([
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, b[0], b[1], b[2], b[3],
-                b[4], b[5], b[6], b[7], b[8], b[9], b[10], b[11], b[12], b[13], b[14], b[15],
-            ])
-        }
+        Self::from_be_bytes(grow_be_int(value.to_be_bytes()))
     }
 
     /// Creates a Int512(0)

--- a/packages/std/src/math/int64.rs
+++ b/packages/std/src/math/int64.rs
@@ -47,6 +47,7 @@ impl Int64 {
     ///
     /// This method is less flexible than `from` but can be called in a const context.
     #[inline]
+    #[must_use]
     pub const fn new(value: i64) -> Self {
         Self(value)
     }

--- a/packages/std/src/math/signed_decimal.rs
+++ b/packages/std/src/math/signed_decimal.rs
@@ -73,6 +73,7 @@ impl SignedDecimal {
     /// assert_eq!(value.to_string(), "-141183460469231731687.303715884105727125");
     /// ```
     #[inline]
+    #[must_use]
     pub const fn new(value: Int128) -> Self {
         Self(value)
     }

--- a/packages/std/src/math/signed_decimal.rs
+++ b/packages/std/src/math/signed_decimal.rs
@@ -68,6 +68,7 @@ impl SignedDecimal {
     /// # use cosmwasm_std::{SignedDecimal, Int128};
     /// assert_eq!(SignedDecimal::new(Int128::one()).to_string(), "0.000000000000000001");
     /// ```
+    #[inline]
     pub const fn new(value: Int128) -> Self {
         Self(value)
     }

--- a/packages/std/src/math/signed_decimal.rs
+++ b/packages/std/src/math/signed_decimal.rs
@@ -86,6 +86,10 @@ impl SignedDecimal {
     /// # use cosmwasm_std::SignedDecimal;
     /// assert_eq!(SignedDecimal::raw(1234i128).to_string(), "0.000000000000001234");
     /// ```
+    #[deprecated(
+        since = "3.0.0",
+        note = "Use SignedDecimal::new(Int128::new(value)) instead"
+    )]
     pub const fn raw(value: i128) -> Self {
         Self(Int128::new(value))
     }
@@ -910,6 +914,8 @@ impl de::Visitor<'_> for SignedDecimalVisitor {
 
 #[cfg(test)]
 mod tests {
+    use crate::Uint128;
+
     use super::*;
 
     use alloc::vec::Vec;
@@ -928,6 +934,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn signed_decimal_raw() {
         let value = 300i128;
         assert_eq!(SignedDecimal::raw(value).0.i128(), value);
@@ -1461,8 +1468,8 @@ mod tests {
             SignedDecimal::try_from(Decimal::MAX).unwrap_err(),
             SignedDecimalRangeExceeded
         );
-        let max = Decimal::raw(SignedDecimal::MAX.atomics().i128() as u128);
-        let too_big = max + Decimal::raw(1);
+        let max = Decimal::new(Uint128::new(SignedDecimal::MAX.atomics().i128() as u128));
+        let too_big = max + Decimal::new(Uint128::one());
         assert_eq!(
             SignedDecimal::try_from(too_big).unwrap_err(),
             SignedDecimalRangeExceeded

--- a/packages/std/src/math/signed_decimal.rs
+++ b/packages/std/src/math/signed_decimal.rs
@@ -67,6 +67,10 @@ impl SignedDecimal {
     /// ```
     /// # use cosmwasm_std::{SignedDecimal, Int128};
     /// assert_eq!(SignedDecimal::new(Int128::one()).to_string(), "0.000000000000000001");
+    ///
+    /// let atoms = Int128::new(-141_183_460_469_231_731_687_303_715_884_105_727_125);
+    /// let value = SignedDecimal::new(atoms);
+    /// assert_eq!(value.to_string(), "-141183460469231731687.303715884105727125");
     /// ```
     #[inline]
     pub const fn new(value: Int128) -> Self {

--- a/packages/std/src/math/signed_decimal_256.rs
+++ b/packages/std/src/math/signed_decimal_256.rs
@@ -80,6 +80,7 @@ impl SignedDecimal256 {
     /// # use cosmwasm_std::{SignedDecimal256, Int256};
     /// assert_eq!(SignedDecimal256::new(Int256::one()).to_string(), "0.000000000000000001");
     /// ```
+    #[inline]
     pub const fn new(value: Int256) -> Self {
         Self(value)
     }

--- a/packages/std/src/math/signed_decimal_256.rs
+++ b/packages/std/src/math/signed_decimal_256.rs
@@ -37,9 +37,9 @@ pub struct SignedDecimal256RangeExceeded;
 
 impl SignedDecimal256 {
     const DECIMAL_FRACTIONAL: Int256 = // 1*10**18
-        Int256::from_i128(1_000_000_000_000_000_000);
+        Int256::new(1_000_000_000_000_000_000);
     const DECIMAL_FRACTIONAL_SQUARED: Int256 = // 1*10**36
-        Int256::from_i128(1_000_000_000_000_000_000_000_000_000_000_000_000);
+        Int256::new(1_000_000_000_000_000_000_000_000_000_000_000_000);
 
     /// The number of decimal places. Since decimal types are fixed-point rather than
     /// floating-point, this is a constant.
@@ -104,7 +104,7 @@ impl SignedDecimal256 {
         note = "Use SignedDecimal256::new(Int256::new(value)) instead"
     )]
     pub const fn raw(value: i128) -> Self {
-        Self(Int256::from_i128(value))
+        Self(Int256::new(value))
     }
 
     /// Create a 1.0 SignedDecimal256
@@ -117,7 +117,7 @@ impl SignedDecimal256 {
     #[inline]
     pub const fn negative_one() -> Self {
         // -DECIMAL_FRACTIONAL
-        Self(Int256::from_i128(-1_000_000_000_000_000_000))
+        Self(Int256::new(-1_000_000_000_000_000_000))
     }
 
     /// Create a 0.0 SignedDecimal256
@@ -926,7 +926,7 @@ mod tests {
 
     #[test]
     fn try_from_integer() {
-        let int = Int256::from_i128(0xDEADBEEF);
+        let int = Int256::new(0xDEADBEEF);
         let decimal = SignedDecimal256::try_from(int).unwrap();
         assert_eq!(int.to_string(), decimal.to_string());
     }
@@ -1481,7 +1481,7 @@ mod tests {
         );
         assert_eq!(
             SignedDecimal256::from(SignedDecimal::MAX),
-            SignedDecimal256::new(Int256::from_i128(i128::MAX))
+            SignedDecimal256::new(Int256::new(i128::MAX))
         );
         assert_eq!(
             SignedDecimal256::from(SignedDecimal::percent(-50)),
@@ -1489,7 +1489,7 @@ mod tests {
         );
         assert_eq!(
             SignedDecimal256::from(SignedDecimal::MIN),
-            SignedDecimal256::new(Int256::from_i128(i128::MIN))
+            SignedDecimal256::new(Int256::new(i128::MIN))
         );
     }
 

--- a/packages/std/src/math/signed_decimal_256.rs
+++ b/packages/std/src/math/signed_decimal_256.rs
@@ -79,6 +79,10 @@ impl SignedDecimal256 {
     /// ```
     /// # use cosmwasm_std::{SignedDecimal256, Int256};
     /// assert_eq!(SignedDecimal256::new(Int256::one()).to_string(), "0.000000000000000001");
+    ///
+    /// let atoms = Int256::new(-141_183_460_469_231_731_687_303_715_884_105_727_125);
+    /// let value = SignedDecimal256::new(atoms);
+    /// assert_eq!(value.to_string(), "-141183460469231731687.303715884105727125");
     /// ```
     #[inline]
     pub const fn new(value: Int256) -> Self {

--- a/packages/std/src/math/signed_decimal_256.rs
+++ b/packages/std/src/math/signed_decimal_256.rs
@@ -85,6 +85,7 @@ impl SignedDecimal256 {
     /// assert_eq!(value.to_string(), "-141183460469231731687.303715884105727125");
     /// ```
     #[inline]
+    #[must_use]
     pub const fn new(value: Int256) -> Self {
         Self(value)
     }

--- a/packages/std/src/math/signed_decimal_256.rs
+++ b/packages/std/src/math/signed_decimal_256.rs
@@ -98,6 +98,10 @@ impl SignedDecimal256 {
     /// # use cosmwasm_std::SignedDecimal256;
     /// assert_eq!(SignedDecimal256::raw(1234i128).to_string(), "0.000000000000001234");
     /// ```
+    #[deprecated(
+        since = "3.0.0",
+        note = "Use SignedDecimal256::new(Int256::new(value)) instead"
+    )]
     pub const fn raw(value: i128) -> Self {
         Self(Int256::from_i128(value))
     }
@@ -936,6 +940,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn signed_decimal_256_raw() {
         let value = 300i128;
         assert_eq!(SignedDecimal256::raw(value).0, Int256::from(value));

--- a/packages/std/src/math/uint128.rs
+++ b/packages/std/src/math/uint128.rs
@@ -54,6 +54,8 @@ impl Uint128 {
     /// Creates a Uint128(value).
     ///
     /// This method is less flexible than `from` but can be called in a const context.
+    #[inline]
+    #[must_use]
     pub const fn new(value: u128) -> Self {
         Uint128(value)
     }

--- a/packages/std/src/math/uint256.rs
+++ b/packages/std/src/math/uint256.rs
@@ -64,6 +64,7 @@ impl Uint256 {
     /// with [`from_be_bytes`].
     ///
     /// [`from_be_bytes`]: Self::from_be_bytes
+    #[must_use]
     pub const fn new(value: u128) -> Self {
         let b = value.to_be_bytes();
         Self::from_be_bytes([

--- a/packages/std/src/math/uint256.rs
+++ b/packages/std/src/math/uint256.rs
@@ -126,21 +126,16 @@ impl Uint256 {
     /// A conversion from `u128` that, unlike the one provided by the `From` trait,
     /// can be used in a `const` context.
     #[must_use]
-    pub const fn from_u128(num: u128) -> Self {
-        let bytes = num.to_le_bytes();
-
-        Self::from_le_bytes([
-            bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
-            bytes[8], bytes[9], bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15],
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        ])
+    #[deprecated(since = "3.0.0", note = "Use Uint256::new(value) instead")]
+    pub const fn from_u128(value: u128) -> Self {
+        Self::new(value)
     }
 
     /// A conversion from `Uint128` that, unlike the one provided by the `From` trait,
     /// can be used in a `const` context.
     #[must_use]
     pub const fn from_uint128(num: Uint128) -> Self {
-        Self::from_u128(num.u128())
+        Self::new(num.u128())
     }
 
     /// Returns a copy of the number as big endian bytes.
@@ -1103,6 +1098,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn uint256_from_u128() {
         assert_eq!(
             Uint256::from_u128(123u128),

--- a/packages/std/src/math/uint256.rs
+++ b/packages/std/src/math/uint256.rs
@@ -30,19 +30,21 @@ use super::num_consts::NumConsts;
 ///
 /// # Examples
 ///
-/// Use `from` to create instances out of primitive uint types or `new` to provide big
-/// endian bytes:
+/// Use `new` to create instances out of u128, `from` for other primitive uint types
+/// or `from_be_bytes` to provide big endian bytes:
 ///
 /// ```
 /// # use cosmwasm_std::Uint256;
-/// let a = Uint256::from(258u128);
-/// let b = Uint256::new([
+/// let a = Uint256::new(258u128);
+/// let b = Uint256::from(258u16);
+/// let c = Uint256::from_be_bytes([
 ///     0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
 ///     0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
 ///     0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
 ///     0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 1u8, 2u8,
 /// ]);
 /// assert_eq!(a, b);
+/// assert_eq!(a, c);
 /// ```
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, PartialOrd, Ord, schemars::JsonSchema)]
 pub struct Uint256(#[schemars(with = "String")] pub(crate) U256);
@@ -54,12 +56,20 @@ impl Uint256 {
     pub const MAX: Uint256 = Uint256(U256::MAX);
     pub const MIN: Uint256 = Uint256(U256::ZERO);
 
-    /// Creates a Uint256(value) from a big endian representation. It's just an alias for
-    /// [`Uint256::from_be_bytes`].
+    /// Creates a Uint256(value).
     ///
     /// This method is less flexible than `from` but can be called in a const context.
-    pub const fn new(value: [u8; 32]) -> Self {
-        Self::from_be_bytes(value)
+    ///
+    /// Before CosmWasm 3 this took a byte array as an argument. You can get this behaviour
+    /// with [`from_be_bytes`].
+    ///
+    /// [`from_be_bytes`]: Self::from_be_bytes
+    pub const fn new(value: u128) -> Self {
+        let b = value.to_be_bytes();
+        Self::from_be_bytes([
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, b[0], b[1], b[2], b[3], b[4], b[5],
+            b[6], b[7], b[8], b[9], b[10], b[11], b[12], b[13], b[14], b[15],
+        ])
     }
 
     /// Creates a Uint256(0)
@@ -649,7 +659,25 @@ mod tests {
 
     #[test]
     fn uint256_new_works() {
-        let num = Uint256::new([1; 32]);
+        let num = Uint256::new(1);
+        assert_eq!(
+            num.to_be_bytes(),
+            [
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 1
+            ]
+        );
+
+        for v in [0, 1, 18, 875786576, u128::MAX] {
+            // From is implemented by bnum, so we test two independent implementations against each other
+            let uut = Uint256::new(v);
+            assert_eq!(uut, Uint256::from(v));
+        }
+    }
+
+    #[test]
+    fn uint256_from_be_bytes_works() {
+        let num = Uint256::from_be_bytes([1; 32]);
         let a: [u8; 32] = num.to_be_bytes();
         assert_eq!(a, [1; 32]);
 
@@ -657,14 +685,14 @@ mod tests {
             0u8, 222u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
             0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 1u8, 2u8, 3u8,
         ];
-        let num = Uint256::new(be_bytes);
+        let num = Uint256::from_be_bytes(be_bytes);
         let resulting_bytes: [u8; 32] = num.to_be_bytes();
         assert_eq!(be_bytes, resulting_bytes);
     }
 
     #[test]
     fn uint256_not_works() {
-        let num = Uint256::new([1; 32]);
+        let num = Uint256::from_be_bytes([1; 32]);
         let a = (!num).to_be_bytes();
         assert_eq!(a, [254; 32]);
 
@@ -1000,12 +1028,10 @@ mod tests {
         ];
 
         // These should all be the same.
-        let num1 = Uint256::new(be_bytes);
-        let num2 = Uint256::from_be_bytes(be_bytes);
-        let num3 = Uint256::from_le_bytes(le_bytes);
-        assert_eq!(num1, Uint256::from(65536u32 + 512 + 3));
-        assert_eq!(num1, num2);
-        assert_eq!(num1, num3);
+        let a = Uint256::from_be_bytes(be_bytes);
+        let b = Uint256::from_le_bytes(le_bytes);
+        assert_eq!(a, Uint256::from(65536u32 + 512 + 3));
+        assert_eq!(a, b);
     }
 
     #[test]
@@ -1335,7 +1361,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "attempt to add with overflow")]
     fn uint256_add_overflow_panics() {
-        let max = Uint256::new([255u8; 32]);
+        let max = Uint256::from_be_bytes([255u8; 32]);
         let _ = max + Uint256::from(12u32);
     }
 
@@ -1495,12 +1521,12 @@ mod tests {
 
     #[test]
     fn uint256_shr_works() {
-        let original = Uint256::new([
+        let original = Uint256::from_be_bytes([
             0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
             0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 2u8, 0u8, 4u8, 2u8,
         ]);
 
-        let shifted = Uint256::new([
+        let shifted = Uint256::from_be_bytes([
             0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
             0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 128u8, 1u8, 0u8,
         ]);
@@ -1516,12 +1542,12 @@ mod tests {
 
     #[test]
     fn uint256_shl_works() {
-        let original = Uint256::new([
+        let original = Uint256::from_be_bytes([
             64u8, 128u8, 1u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
             0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
         ]);
 
-        let shifted = Uint256::new([
+        let shifted = Uint256::from_be_bytes([
             2u8, 0u8, 4u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
             0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
         ]);

--- a/packages/std/src/math/uint512.rs
+++ b/packages/std/src/math/uint512.rs
@@ -66,6 +66,7 @@ impl Uint512 {
     /// with [`from_be_bytes`].
     ///
     /// [`from_be_bytes`]: Self::from_be_bytes
+    #[must_use]
     pub const fn new(value: u128) -> Self {
         let b = value.to_be_bytes();
         Self::from_be_bytes([

--- a/packages/std/src/math/uint512.rs
+++ b/packages/std/src/math/uint512.rs
@@ -28,13 +28,14 @@ use super::num_consts::NumConsts;
 ///
 /// # Examples
 ///
-/// Use `from` to create instances out of primitive uint types or `new` to provide big
-/// endian bytes:
+/// Use `new` to create instances out of u128, `from` for other primitive uint types
+/// or `from_be_bytes` to provide big endian bytes:
 ///
 /// ```
 /// # use cosmwasm_std::Uint512;
-/// let a = Uint512::from(258u128);
-/// let b = Uint512::new([
+/// let a = Uint512::new(258u128);
+/// let b = Uint512::from(258u16);
+/// let c = Uint512::from_be_bytes([
 ///     0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
 ///     0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
 ///     0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
@@ -45,6 +46,7 @@ use super::num_consts::NumConsts;
 ///     0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 1u8, 2u8,
 /// ]);
 /// assert_eq!(a, b);
+/// assert_eq!(a, c);
 /// ```
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, PartialOrd, Ord, schemars::JsonSchema)]
 pub struct Uint512(#[schemars(with = "String")] pub(crate) U512);
@@ -56,10 +58,21 @@ impl Uint512 {
     pub const MAX: Uint512 = Uint512(U512::MAX);
     pub const MIN: Uint512 = Uint512(U512::ZERO);
 
-    /// Creates a Uint512(value) from a big endian representation. It's just an alias for
-    /// `from_be_bytes`.
-    pub const fn new(value: [u8; 64]) -> Self {
-        Self::from_be_bytes(value)
+    /// Creates a Uint512(value).
+    ///
+    /// This method is less flexible than `from` but can be called in a const context.
+    ///
+    /// Before CosmWasm 3 this took a byte array as an argument. You can get this behaviour
+    /// with [`from_be_bytes`].
+    ///
+    /// [`from_be_bytes`]: Self::from_be_bytes
+    pub const fn new(value: u128) -> Self {
+        let b = value.to_be_bytes();
+        Self::from_be_bytes([
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, b[0], b[1], b[2], b[3], b[4],
+            b[5], b[6], b[7], b[8], b[9], b[10], b[11], b[12], b[13], b[14], b[15],
+        ])
     }
 
     /// Creates a Uint512(0)
@@ -622,7 +635,26 @@ mod tests {
 
     #[test]
     fn uint512_new_works() {
-        let num = Uint512::new([1; 64]);
+        let num = Uint512::new(1);
+        assert_eq!(
+            num.to_be_bytes(),
+            [
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 1
+            ]
+        );
+
+        for v in [0, 1, 18, 875786576, u128::MAX] {
+            // From is implemented by bnum, so we test two independent implementations against each other
+            let uut = Uint512::new(v);
+            assert_eq!(uut, Uint512::from(v));
+        }
+    }
+
+    #[test]
+    fn uint512_from_be_bytes_works() {
+        let num = Uint512::from_be_bytes([1; 64]);
         let a: [u8; 64] = num.to_be_bytes();
         assert_eq!(a, [1; 64]);
 
@@ -632,14 +664,14 @@ mod tests {
             0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
             0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 1u8, 2u8, 3u8,
         ];
-        let num = Uint512::new(be_bytes);
+        let num = Uint512::from_be_bytes(be_bytes);
         let resulting_bytes: [u8; 64] = num.to_be_bytes();
         assert_eq!(be_bytes, resulting_bytes);
     }
 
     #[test]
     fn uint512_not_works() {
-        let num = Uint512::new([1; 64]);
+        let num = Uint512::from_be_bytes([1; 64]);
         let a = (!num).to_be_bytes();
         assert_eq!(a, [254; 64]);
 
@@ -689,12 +721,10 @@ mod tests {
         ];
 
         // These should all be the same.
-        let num1 = Uint512::new(be_bytes);
-        let num2 = Uint512::from_be_bytes(be_bytes);
-        let num3 = Uint512::from_le_bytes(le_bytes);
-        assert_eq!(num1, Uint512::from(65536u32 + 512 + 3));
-        assert_eq!(num1, num2);
-        assert_eq!(num1, num3);
+        let a = Uint512::from_be_bytes(be_bytes);
+        let b = Uint512::from_le_bytes(le_bytes);
+        assert_eq!(a, Uint512::from(65536u32 + 512 + 3));
+        assert_eq!(a, b);
     }
 
     #[test]
@@ -1140,14 +1170,14 @@ mod tests {
 
     #[test]
     fn uint512_shr_works() {
-        let original = Uint512::new([
+        let original = Uint512::from_be_bytes([
             0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
             0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
             0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
             0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 2u8, 0u8, 4u8, 2u8,
         ]);
 
-        let shifted = Uint512::new([
+        let shifted = Uint512::from_be_bytes([
             0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
             0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
             0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
@@ -1165,14 +1195,14 @@ mod tests {
 
     #[test]
     fn uint512_shl_works() {
-        let original = Uint512::new([
+        let original = Uint512::from_be_bytes([
             64u8, 128u8, 1u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
             0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
             0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
             0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
         ]);
 
-        let shifted = Uint512::new([
+        let shifted = Uint512::from_be_bytes([
             2u8, 0u8, 4u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
             0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
             0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,

--- a/packages/std/src/math/uint64.rs
+++ b/packages/std/src/math/uint64.rs
@@ -50,6 +50,8 @@ impl Uint64 {
     /// Creates a Uint64(value).
     ///
     /// This method is less flexible than `from` but can be called in a const context.
+    #[inline]
+    #[must_use]
     pub const fn new(value: u64) -> Self {
         Uint64(value)
     }


### PR DESCRIPTION
Closes #2367

Please note this also deprecates `{Decimal,Decimal256}::raw` and `{SignedDecimal,SignedDecimal256}::raw` which as far as I can see only make sense if the Int**/Uint** types are hard to construct.