### PR TITLE
Remove obsolete cranelift feature documentation

### DIFF
--- a/packages/vm/Cargo.toml
+++ b/packages/vm/Cargo.toml
@@ -73,9 +73,9 @@ dhat = { version = "0.3.3", optional = true }
 tracing = "0.1.32"
 
 # Wasmer git/local (used for quick local debugging or patching)
-# wasmer = { git = "https://github.com/wasmerio/wasmer", rev = "877ce1f7c44fad853c", default-features = false, features = ["cranelift", "singlepass"] }
+# wasmer = { git = "https://github.com/wasmerio/wasmer", rev = "877ce1f7c44fad853c", default-features = false, features = ["singlepass"] }
 # wasmer-middlewares = { git = "https://github.com/wasmerio/wasmer", rev = "877ce1f7c44fad853c" }
-# wasmer = { path = "../../../wasmer/lib/api", default-features = false, features = ["cranelift", "singlepass"] }
+# wasmer = { path = "../../../wasmer/lib/api", default-features = false, features = ["singlepass"] }
 # wasmer-middlewares = { path = "../../../wasmer/lib/middlewares" }
 
 [dev-dependencies]

--- a/packages/vm/README.md
+++ b/packages/vm/README.md
@@ -100,30 +100,18 @@ cp target/wasm32-unknown-unknown/release/floaty.wasm ../../packages/vm/testdata/
 
 ## Testing
 
-By default, this repository is built and tested with the singlepass backend. You
-can enable the `cranelift` feature to override the default backend with
-Cranelift
+By default, this repository is built and tested with the singlepass backend.
 
 ```sh
 cd packages/vm
 cargo test --features iterator
-cargo test --features cranelift,iterator
 ```
 
 ## Benchmarking
 
-Using Singlepass:
-
 ```
 cd packages/vm
 cargo bench --no-default-features
-```
-
-Using Cranelift:
-
-```
-cd packages/vm
-cargo bench --no-default-features --features cranelift
 ```
 
 ## Tools


### PR DESCRIPTION
Closes #2400

This PR removes the cranelift feature that was previously deprecated:
- Removed cranelift references from commented-out wasmer dependencies in packages/vm/Cargo.toml
- Removed all mentions of cranelift in packages/vm/README.md

The cranelift feature was already effectively removed in v2.2.0 (doing nothing since then), and this completes the removal process as requested in the issue.