### PR TITLE
Improve documentation consistency and fix minor typos in MIGRATING.md and cosmos_msg.rs

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -24,7 +24,7 @@ major releases of `cosmwasm`. Note that you can also view the
   `stargate` feature instead, since it was previously implied by `ibc3`.
 
   Also remove any uses of the `backtraces` feature. You can use a
-  `RUST_BACKTRACE=1` env variable for this now.
+  `RUST_BACKTRACE=1` environment variable for this now.
 
   If you were using `cosmwasm-std` with `default-features = false`, you probably
   want to enable the `std` feature now, as we might move certain existing
@@ -156,10 +156,10 @@ major releases of `cosmwasm`. Note that you can also view the
   +StdError::generic_err(msg)
   ```
 
-- Replace addresses in unit tests with valid bech32 addresses. This has to be
+- Replace addresses in unit tests with valid Bech32 addresses. This has to be
   done for all addresses that are validated or canonicalized during the test or
   within the contract. The easiest way to do this is by using
-  `MockApi::addr_make`. It generates a bech32 address from any string:
+  `MockApi::addr_make`. It generates a Bech32 address from any string:
 
   ```diff
   -let msg = InstantiateMsg {
@@ -172,10 +172,10 @@ major releases of `cosmwasm`. Note that you can also view the
   +};
   ```
 
-- Replace addresses in integration tests using `cosmwasm-vm` with valid bech32
+- Replace addresses in integration tests using `cosmwasm-vm` with valid Bech32
   addresses. This has to be done for all addresses that are validated or
   canonicalized during the test or within the contract. The easiest way to do
-  this is by using `MockApi::addr_make`. It generates a bech32 address from any
+  this is by using `MockApi::addr_make`. It generates a Bech32 address from any
   string:
 
   ```diff
@@ -206,9 +206,9 @@ major releases of `cosmwasm`. Note that you can also view the
 
 - If you were using `QueryRequest::Stargate`, you might want to enable the
   `cosmwasm_2_0` cargo feature and migrate to `QueryRequest::Grpc` instead.
-  While the stargate query sometimes returns protobuf encoded data and sometimes
+  While the stargate query sometimes returns protobuf-encoded data and sometimes
   JSON encoded data, depending on the chain, the gRPC query always returns
-  protobuf encoded data.
+  protobuf-encoded data.
 
   ```diff
   -deps.querier.query(&QueryRequest::Stargate {
@@ -1311,7 +1311,7 @@ arbitrary ones.
 
   The existing `CanonicalAddr` remains unchanged and can be used in cases in
   which a compact binary representation is desired. For JSON state this does not
-  save much data (e.g. the bech32 address
+  save much data (e.g. the Bech32 address
   cosmos1pfq05em6sfkls66ut4m2257p7qwlk448h8mysz takes 45 bytes as direct ASCII
   and 28 bytes when its canonical representation is base64 encoded). For
   fixed-length database keys `CanonicalAddr` remains handy though.

--- a/contracts/ibc-reflect-send/schema/ibc-reflect-send.json
+++ b/contracts/ibc-reflect-send/schema/ibc-reflect-send.json
@@ -335,7 +335,7 @@
             "additionalProperties": false
           },
           {
-            "description": "This is translated to a [[MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
+            "description": "This is translated to a [MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
             "required": [
               "withdraw_delegator_reward"

--- a/contracts/ibc-reflect-send/schema/ibc/packet_msg.json
+++ b/contracts/ibc-reflect-send/schema/ibc/packet_msg.json
@@ -276,7 +276,7 @@
           "additionalProperties": false
         },
         {
-          "description": "This is translated to a [[MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
+          "description": "This is translated to a [MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "withdraw_delegator_reward"

--- a/contracts/ibc-reflect-send/schema/raw/execute.json
+++ b/contracts/ibc-reflect-send/schema/raw/execute.json
@@ -324,7 +324,7 @@
           "additionalProperties": false
         },
         {
-          "description": "This is translated to a [[MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
+          "description": "This is translated to a [MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "withdraw_delegator_reward"

--- a/contracts/ibc-reflect/schema/ibc/packet_msg.json
+++ b/contracts/ibc-reflect/schema/ibc/packet_msg.json
@@ -275,7 +275,7 @@
           "additionalProperties": false
         },
         {
-          "description": "`CosmosMsg::Any` is the replaces the \"stargate message\" – a message wrapped in a [protobuf Any](https://protobuf.dev/programming-guides/proto3/#any) that is supported by the chain. It behaves the same as `CosmosMsg::Stargate` but has a better name and slightly improved syntax.\n\nThis is feature-gated at compile time with `cosmwasm_2_0` because a chain running CosmWasm < 2.0 cannot process this.",
+          "description": "`CosmosMsg::Any` replaces the \"stargate message\" – a message wrapped in a [protobuf Any](https://protobuf.dev/programming-guides/proto3/#any) that is supported by the chain. It behaves the same as `CosmosMsg::Stargate` but has a better name and slightly improved syntax.\n\nThis is feature-gated at compile time with `cosmwasm_2_0` because a chain running CosmWasm < 2.0 cannot process this.",
           "type": "object",
           "required": [
             "any"

--- a/contracts/reflect/schema/raw/execute.json
+++ b/contracts/reflect/schema/raw/execute.json
@@ -247,7 +247,7 @@
           "additionalProperties": false
         },
         {
-          "description": "`CosmosMsg::Any` is the replaces the \"stargate message\" – a message wrapped in a [protobuf Any](https://protobuf.dev/programming-guides/proto3/#any) that is supported by the chain. It behaves the same as `CosmosMsg::Stargate` but has a better name and slightly improved syntax.\n\nThis is feature-gated at compile time with `cosmwasm_2_0` because a chain running CosmWasm < 2.0 cannot process this.",
+          "description": "`CosmosMsg::Any` replaces the \"stargate message\" – a message wrapped in a [protobuf Any](https://protobuf.dev/programming-guides/proto3/#any) that is supported by the chain. It behaves the same as `CosmosMsg::Stargate` but has a better name and slightly improved syntax.\n\nThis is feature-gated at compile time with `cosmwasm_2_0` because a chain running CosmWasm < 2.0 cannot process this.",
           "type": "object",
           "required": [
             "any"
@@ -357,7 +357,7 @@
           "additionalProperties": false
         },
         {
-          "description": "This is translated to a [[MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
+          "description": "This is translated to a [MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
           "required": [
             "withdraw_delegator_reward"

--- a/contracts/reflect/schema/reflect.json
+++ b/contracts/reflect/schema/reflect.json
@@ -257,7 +257,7 @@
             "additionalProperties": false
           },
           {
-            "description": "`CosmosMsg::Any` is the replaces the \"stargate message\" – a message wrapped in a [protobuf Any](https://protobuf.dev/programming-guides/proto3/#any) that is supported by the chain. It behaves the same as `CosmosMsg::Stargate` but has a better name and slightly improved syntax.\n\nThis is feature-gated at compile time with `cosmwasm_2_0` because a chain running CosmWasm < 2.0 cannot process this.",
+            "description": "`CosmosMsg::Any` replaces the \"stargate message\" – a message wrapped in a [protobuf Any](https://protobuf.dev/programming-guides/proto3/#any) that is supported by the chain. It behaves the same as `CosmosMsg::Stargate` but has a better name and slightly improved syntax.\n\nThis is feature-gated at compile time with `cosmwasm_2_0` because a chain running CosmWasm < 2.0 cannot process this.",
             "type": "object",
             "required": [
               "any"
@@ -367,7 +367,7 @@
             "additionalProperties": false
           },
           {
-            "description": "This is translated to a [[MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
+            "description": "This is translated to a [MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
             "required": [
               "withdraw_delegator_reward"

--- a/packages/std/src/results/cosmos_msg.rs
+++ b/packages/std/src/results/cosmos_msg.rs
@@ -72,7 +72,7 @@ pub enum CosmosMsg<T = Empty> {
         type_url: String,
         value: Binary,
     },
-    /// `CosmosMsg::Any` is the replaces the "stargate message" – a message wrapped
+    /// `CosmosMsg::Any` replaces the "stargate message" – a message wrapped
     /// in a [protobuf Any](https://protobuf.dev/programming-guides/proto3/#any)
     /// that is supported by the chain. It behaves the same as
     /// `CosmosMsg::Stargate` but has a better name and slightly improved syntax.
@@ -176,7 +176,7 @@ pub enum DistributionMsg {
         /// The `withdraw_address`
         address: String,
     },
-    /// This is translated to a [[MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50).
+    /// This is translated to a [MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50).
     /// `delegator_address` is automatically filled with the current contract's address.
     WithdrawDelegatorReward {
         /// The `validator_address`


### PR DESCRIPTION
1 .MIGRATING.md:
  - Replaced lowercase `bech32` with proper `Bech32` capitalization for consistency.
  - Updated wording to clarify *"protobuf-encoded"* instead of *"protobuf encoded"*.
  - Improved phrasing of the `RUST_BACKTRACE` explanation.

2. cosmos_msg.rs:
  - Fixed a typo in the `CosmosMsg::Any` docstring:  
    Changed `is the replaces` → `replaces`.
  - Fixed Markdown syntax for `MsgWithdrawDelegatorReward` doc link:
    Changed `[[Link]]` → `[Link]` to comply with rustdoc standards.

