### PR TITLE
Add new entrypoint for IBCv2 Timeout

### DIFF
--- a/contracts/ibc2/schema/raw/query.json
+++ b/contracts/ibc2/schema/raw/query.json
@@ -14,6 +14,19 @@
         }
       },
       "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "query_timeout_counter"
+      ],
+      "properties": {
+        "query_timeout_counter": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
     }
   ]
 }

--- a/contracts/ibc2/src/contract.rs
+++ b/contracts/ibc2/src/contract.rs
@@ -1,7 +1,8 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{
-    entry_point, from_json, to_json_vec, Binary, Deps, DepsMut, Empty, Env, Ibc2PacketReceiveMsg,
-    IbcReceiveResponse, MessageInfo, QueryResponse, Response, StdError, StdResult, do_ibc2_timeout,
+    do_ibc2_timeout, entry_point, from_json, to_json_vec, Binary, Deps, DepsMut, Empty, Env,
+    Ibc2PacketReceiveMsg, IbcReceiveResponse, MessageInfo, QueryResponse, Response, StdError,
+    StdResult,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};

--- a/contracts/ibc2/src/contract.rs
+++ b/contracts/ibc2/src/contract.rs
@@ -1,6 +1,6 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{
-    ibc2_timeout, entry_point, from_json, to_json_vec, Binary, Deps, DepsMut, Empty, Env, Ibc2PacketReceiveMsg,
+    entry_point, from_json, to_json_vec, Binary, Deps, DepsMut, Empty, Env, Ibc2PacketReceiveMsg,
     IbcReceiveResponse, MessageInfo, QueryResponse, Response, StdError, StdResult,
 };
 use schemars::JsonSchema;
@@ -51,8 +51,8 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<QueryResponse> {
                 .storage
                 .get(STATE_KEY)
                 .ok_or_else(|| StdError::generic_err("State not found."))?;
-            let state: State = from_json(&data)?;
-            Ok(Binary::from(to_json_vec(&state.ibc2_timeout_counter)?))
+            let state: State = from_json(data)?;
+            Ok(to_json_vec(&state.ibc2_timeout_counter)?.into())
         }
     }
 }

--- a/contracts/ibc2/src/contract.rs
+++ b/contracts/ibc2/src/contract.rs
@@ -1,6 +1,6 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{
-    do_ibc2_timeout, entry_point, from_json, to_json_vec, Binary, Deps, DepsMut, Empty, Env, Ibc2PacketReceiveMsg,
+    ibc2_timeout, entry_point, from_json, to_json_vec, Binary, Deps, DepsMut, Empty, Env, Ibc2PacketReceiveMsg,
     IbcReceiveResponse, MessageInfo, QueryResponse, Response, StdError, StdResult,
 };
 use schemars::JsonSchema;

--- a/contracts/ibc2/src/contract.rs
+++ b/contracts/ibc2/src/contract.rs
@@ -1,6 +1,6 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{
-    do_ibc2_timeout, entry_point, from_json, to_json_vec, Binary, Deps, DepsMut, Empty, Env,
+    entry_point, from_json, to_json_vec, Binary, Deps, DepsMut, Empty, Env,
     Ibc2PacketReceiveMsg, IbcReceiveResponse, MessageInfo, QueryResponse, Response, StdError,
     StdResult,
 };

--- a/contracts/ibc2/src/contract.rs
+++ b/contracts/ibc2/src/contract.rs
@@ -1,7 +1,7 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{
     entry_point, from_json, to_json_vec, Binary, Deps, DepsMut, Empty, Env, Ibc2PacketReceiveMsg,
-    IbcReceiveResponse, MessageInfo, QueryResponse, Response, StdError, StdResult,
+    IbcReceiveResponse, MessageInfo, QueryResponse, Response, StdError, StdResult, do_ibc2_timeout,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};

--- a/contracts/ibc2/src/contract.rs
+++ b/contracts/ibc2/src/contract.rs
@@ -1,6 +1,6 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{
-    entry_point, from_json, to_json_vec, Binary, Deps, DepsMut, Empty, Env, Ibc2PacketReceiveMsg,
+    do_ibc2_timeout, entry_point, from_json, to_json_vec, Binary, Deps, DepsMut, Empty, Env, Ibc2PacketReceiveMsg,
     IbcReceiveResponse, MessageInfo, QueryResponse, Response, StdError, StdResult,
 };
 use schemars::JsonSchema;

--- a/contracts/ibc2/src/contract.rs
+++ b/contracts/ibc2/src/contract.rs
@@ -1,8 +1,7 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{
-    entry_point, from_json, to_json_vec, Binary, Deps, DepsMut, Empty, Env,
-    Ibc2PacketReceiveMsg, IbcReceiveResponse, MessageInfo, QueryResponse, Response, StdError,
-    StdResult,
+    entry_point, from_json, to_json_vec, Binary, Deps, DepsMut, Empty, Env, Ibc2PacketReceiveMsg,
+    IbcReceiveResponse, MessageInfo, QueryResponse, Response, StdError, StdResult,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};

--- a/contracts/ibc2/tests/integration.rs
+++ b/contracts/ibc2/tests/integration.rs
@@ -38,7 +38,8 @@ fn test_ibc2_timeout_counter_increments() {
     // Call ibc2_timeout multiple times and verify the timeout counter increments correctly
     let msg = Ibc2PacketReceiveMsg::default();
     for i in 1..=3 {
-        let res: IbcReceiveResponse = ibc2_timeout(deps.as_mut(), env.clone(), msg.clone()).unwrap();
+        let res: IbcReceiveResponse =
+            ibc2_timeout(deps.as_mut(), env.clone(), msg.clone()).unwrap();
         assert_eq!(res, IbcReceiveResponse::new([1, 2, 3]));
 
         let query_msg = QueryMsg::QueryTimeoutCounter {};

--- a/contracts/ibc2/tests/integration.rs
+++ b/contracts/ibc2/tests/integration.rs
@@ -1,5 +1,7 @@
 use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
-use cosmwasm_std::{from_binary, Ibc2PacketReceiveMsg, IbcReceiveResponse, Response, StdError, Empty};
+use cosmwasm_std::{
+    from_binary, Empty, Ibc2PacketReceiveMsg, IbcReceiveResponse, Response, StdError,
+};
 
 use crate::contract::{ibc2_packet_receive, ibc2_timeout, instantiate, query};
 use crate::contract::{QueryMsg, State};
@@ -11,29 +13,9 @@ fn test_ibc2_timeout() {
     let info = mock_info("sender", &[]);
 
     // Instantiate the contract
-    let res = instantiate(deps.as_mut(), env.clone(), info.clone(), Empty {}).unwrap();
-    assert_eq!(res, Response::default());
-
-    // Call ibc2_timeout and verify the timeout counter increments
-    let msg = Ibc2PacketReceiveMsg::default();
-    let res: IbcReceiveResponse = ibc2_timeout(deps.as_mut(), env.clone(), msg).unwrap();
-    assert_eq!(res, IbcReceiveResponse::new([1, 2, 3]));
-
-    let query_msg = QueryMsg::QueryTimeoutCounter {};
-    let bin = query(deps.as_ref(), env.clone(), query_msg).unwrap();
-    let counter: u32 = from_binary(&bin).unwrap();
-    assert_eq!(counter, 1);
-}
-
-#[test]
-fn test_ibc2_timeout_counter_increments() {
-    let mut deps = mock_dependencies();
-    let env = mock_env();
-    let info = mock_info("sender", &[]);
-
-    // Instantiate the contract
-    let res = instantiate(deps.as_mut(), env.clone(), info.clone(), Empty {}).unwrap();
-    assert_eq!(res, Response::default());
+    let msg = Empty {};
+    let res = instantiate(deps.as_mut(), env.clone(), info, msg).unwrap();
+    assert_eq!(res, Response::new());
 
     // Call ibc2_timeout multiple times and verify the timeout counter increments correctly
     let msg = Ibc2PacketReceiveMsg::default();
@@ -43,30 +25,8 @@ fn test_ibc2_timeout_counter_increments() {
         assert_eq!(res, IbcReceiveResponse::new([1, 2, 3]));
 
         let query_msg = QueryMsg::QueryTimeoutCounter {};
-        let bin = query(deps.as_ref(), env.clone(), query_msg).unwrap();
-        let counter: u32 = from_binary(&bin).unwrap();
-        assert_eq!(counter, i);
+        let query_res = query(deps.as_ref(), env.clone(), query_msg).unwrap();
+        let timeout_counter: u32 = from_binary(&query_res).unwrap();
+        assert_eq!(timeout_counter, i);
     }
-}
-
-#[test]
-fn test_query_timeout_counter() {
-    let mut deps = mock_dependencies();
-    let env = mock_env();
-    let info = mock_info("sender", &[]);
-
-    // Instantiate the contract
-    let res = instantiate(deps.as_mut(), env.clone(), info.clone(), Empty {}).unwrap();
-    assert_eq!(res, Response::default());
-
-    // Call ibc2_timeout and verify the timeout counter increments
-    let msg = Ibc2PacketReceiveMsg::default();
-    let res: IbcReceiveResponse = ibc2_timeout(deps.as_mut(), env.clone(), msg).unwrap();
-    assert_eq!(res, IbcReceiveResponse::new([1, 2, 3]));
-
-    // Query the timeout counter
-    let query_msg = QueryMsg::QueryTimeoutCounter {};
-    let bin = query(deps.as_ref(), env.clone(), query_msg).unwrap();
-    let counter: u32 = from_binary(&bin).unwrap();
-    assert_eq!(counter, 1);
 }

--- a/contracts/ibc2/tests/integration.rs
+++ b/contracts/ibc2/tests/integration.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
-use cosmwasm_std::{from_binary, Ibc2PacketReceiveMsg, IbcReceiveResponse, Response, StdError};
+use cosmwasm_std::{from_binary, Ibc2PacketReceiveMsg, IbcReceiveResponse, Response, StdError, Empty};
 
 use crate::contract::{ibc2_packet_receive, ibc2_timeout, instantiate, query};
 use crate::contract::{QueryMsg, State};

--- a/contracts/ibc2/tests/integration.rs
+++ b/contracts/ibc2/tests/integration.rs
@@ -1,1 +1,71 @@
+use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
+use cosmwasm_std::{from_binary, Ibc2PacketReceiveMsg, IbcReceiveResponse, Response, StdError};
 
+use crate::contract::{ibc2_packet_receive, ibc2_timeout, instantiate, query};
+use crate::contract::{QueryMsg, State};
+
+#[test]
+fn test_ibc2_timeout() {
+    let mut deps = mock_dependencies();
+    let env = mock_env();
+    let info = mock_info("sender", &[]);
+
+    // Instantiate the contract
+    let res = instantiate(deps.as_mut(), env.clone(), info.clone(), Empty {}).unwrap();
+    assert_eq!(res, Response::default());
+
+    // Call ibc2_timeout and verify the timeout counter increments
+    let msg = Ibc2PacketReceiveMsg::default();
+    let res: IbcReceiveResponse = ibc2_timeout(deps.as_mut(), env.clone(), msg).unwrap();
+    assert_eq!(res, IbcReceiveResponse::new([1, 2, 3]));
+
+    let query_msg = QueryMsg::QueryTimeoutCounter {};
+    let bin = query(deps.as_ref(), env.clone(), query_msg).unwrap();
+    let counter: u32 = from_binary(&bin).unwrap();
+    assert_eq!(counter, 1);
+}
+
+#[test]
+fn test_ibc2_timeout_counter_increments() {
+    let mut deps = mock_dependencies();
+    let env = mock_env();
+    let info = mock_info("sender", &[]);
+
+    // Instantiate the contract
+    let res = instantiate(deps.as_mut(), env.clone(), info.clone(), Empty {}).unwrap();
+    assert_eq!(res, Response::default());
+
+    // Call ibc2_timeout multiple times and verify the timeout counter increments correctly
+    let msg = Ibc2PacketReceiveMsg::default();
+    for i in 1..=3 {
+        let res: IbcReceiveResponse = ibc2_timeout(deps.as_mut(), env.clone(), msg.clone()).unwrap();
+        assert_eq!(res, IbcReceiveResponse::new([1, 2, 3]));
+
+        let query_msg = QueryMsg::QueryTimeoutCounter {};
+        let bin = query(deps.as_ref(), env.clone(), query_msg).unwrap();
+        let counter: u32 = from_binary(&bin).unwrap();
+        assert_eq!(counter, i);
+    }
+}
+
+#[test]
+fn test_query_timeout_counter() {
+    let mut deps = mock_dependencies();
+    let env = mock_env();
+    let info = mock_info("sender", &[]);
+
+    // Instantiate the contract
+    let res = instantiate(deps.as_mut(), env.clone(), info.clone(), Empty {}).unwrap();
+    assert_eq!(res, Response::default());
+
+    // Call ibc2_timeout and verify the timeout counter increments
+    let msg = Ibc2PacketReceiveMsg::default();
+    let res: IbcReceiveResponse = ibc2_timeout(deps.as_mut(), env.clone(), msg).unwrap();
+    assert_eq!(res, IbcReceiveResponse::new([1, 2, 3]));
+
+    // Query the timeout counter
+    let query_msg = QueryMsg::QueryTimeoutCounter {};
+    let bin = query(deps.as_ref(), env.clone(), query_msg).unwrap();
+    let counter: u32 = from_binary(&bin).unwrap();
+    assert_eq!(counter, 1);
+}


### PR DESCRIPTION
Fixes #2422

Add new entry point for IBCv2 Timeout in `contracts/ibc2/src/contract.rs`.

* **State Struct**
  - Add `ibc2_timeout_counter` field to `State` struct.
* **QueryMsg Enum**
  - Add `QueryTimeoutCounter` message to retrieve the timeout counter.
* **Query Function**
  - Update `query` function to handle `QueryTimeoutCounter` message.
* **ibc2_timeout Function**
  - Add `ibc2_timeout` entry point function to handle IBCv2 timeouts.
  - Increment `ibc2_timeout_counter` in `State` struct within `ibc2_timeout`.
* **Tests**
  - Add test for `ibc2_timeout` entry point function.
  - Verify `ibc2_timeout_counter` increments correctly.
  - Add test for `QueryTimeoutCounter` message.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/CosmWasm/cosmwasm/pull/2435?shareId=3ce8bb86-9efe-4a0d-880f-4a0cdb1b280d).