### PR TITLE
Rename contract variables to the name of the contract 

### DIFF
--- a/packages/vm/examples/multi_threaded_cache.rs
+++ b/packages/vm/examples/multi_threaded_cache.rs
@@ -18,7 +18,7 @@ const DEFAULT_INSTANCE_OPTIONS: InstanceOptions = InstanceOptions {
 // Cache
 const MEMORY_CACHE_SIZE: Size = Size::mebi(200);
 
-static CONTRACT: &[u8] = include_bytes!("../testdata/hackatom.wasm");
+static HACKATOM: &[u8] = include_bytes!("../testdata/hackatom.wasm");
 
 const STORE_CODE_THREADS: usize = 32;
 const INSTANTIATION_THREADS: usize = 2048;
@@ -35,14 +35,14 @@ pub fn main() {
     let cache: Cache<MockApi, MockStorage, MockQuerier> = unsafe { Cache::new(options).unwrap() };
     let cache = Arc::new(cache);
 
-    let checksum = cache.store_code(CONTRACT, true, true).unwrap();
+    let checksum = cache.store_code(HACKATOM, true, true).unwrap();
 
     let mut threads = Vec::with_capacity(THREADS);
     for _ in 0..STORE_CODE_THREADS {
         let cache = Arc::clone(&cache);
 
         threads.push(thread::spawn(move || {
-            let checksum = cache.store_code(CONTRACT, true, true).unwrap();
+            let checksum = cache.store_code(HACKATOM, true, true).unwrap();
             println!("Done saving Wasm {checksum}");
         }));
     }

--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -626,10 +626,10 @@ mod tests {
     };
     const TESTING_MEMORY_CACHE_SIZE: Size = Size::mebi(200);
 
-    static CONTRACT: &[u8] = include_bytes!("../testdata/hackatom.wasm");
-    static IBC_CONTRACT: &[u8] = include_bytes!("../testdata/ibc_reflect.wasm");
-    static IBC2_CONTRACT: &[u8] = include_bytes!("../testdata/ibc2.wasm");
-    static EMPTY_CONTRACT: &[u8] = include_bytes!("../testdata/empty.wasm");
+    static HACKATOM: &[u8] = include_bytes!("../testdata/hackatom.wasm");
+    static IBC_REFLECT: &[u8] = include_bytes!("../testdata/ibc_reflect.wasm");
+    static IBC2: &[u8] = include_bytes!("../testdata/ibc2.wasm");
+    static EMPTY: &[u8] = include_bytes!("../testdata/empty.wasm");
     // Invalid because it doesn't contain required memory and exports
     static INVALID_CONTRACT_WAT: &str = r#"(module
         (type $t0 (func (param i32) (result i32)))
@@ -719,14 +719,14 @@ mod tests {
     fn store_code_checked_works() {
         let cache: Cache<MockApi, MockStorage, MockQuerier> =
             unsafe { Cache::new(make_testing_options()).unwrap() };
-        cache.store_code(CONTRACT, true, true).unwrap();
+        cache.store_code(HACKATOM, true, true).unwrap();
     }
 
     #[test]
     fn store_code_without_persist_works() {
         let cache: Cache<MockApi, MockStorage, MockQuerier> =
             unsafe { Cache::new(make_testing_options()).unwrap() };
-        let checksum = cache.store_code(CONTRACT, true, false).unwrap();
+        let checksum = cache.store_code(HACKATOM, true, false).unwrap();
 
         assert!(
             cache.load_wasm(&checksum).is_err(),
@@ -739,8 +739,8 @@ mod tests {
     fn store_code_allows_saving_multiple_times() {
         let cache: Cache<MockApi, MockStorage, MockQuerier> =
             unsafe { Cache::new(make_testing_options()).unwrap() };
-        cache.store_code(CONTRACT, true, true).unwrap();
-        cache.store_code(CONTRACT, true, true).unwrap();
+        cache.store_code(HACKATOM, true, true).unwrap();
+        cache.store_code(HACKATOM, true, true).unwrap();
     }
 
     #[test]
@@ -764,7 +764,7 @@ mod tests {
         // memory cache before the init call.
 
         let cache = unsafe { Cache::new(make_testing_options()).unwrap() };
-        let checksum = cache.store_code(CONTRACT, true, true).unwrap();
+        let checksum = cache.store_code(HACKATOM, true, true).unwrap();
 
         let backend = mock_backend(&[]);
         let _ = cache
@@ -780,7 +780,7 @@ mod tests {
     fn store_code_unchecked_works() {
         let cache: Cache<MockApi, MockStorage, MockQuerier> =
             unsafe { Cache::new(make_testing_options()).unwrap() };
-        cache.store_code(CONTRACT, false, true).unwrap();
+        cache.store_code(HACKATOM, false, true).unwrap();
     }
 
     #[test]
@@ -796,10 +796,10 @@ mod tests {
     fn load_wasm_works() {
         let cache: Cache<MockApi, MockStorage, MockQuerier> =
             unsafe { Cache::new(make_testing_options()).unwrap() };
-        let checksum = cache.store_code(CONTRACT, true, true).unwrap();
+        let checksum = cache.store_code(HACKATOM, true, true).unwrap();
 
         let restored = cache.load_wasm(&checksum).unwrap();
-        assert_eq!(restored, CONTRACT);
+        assert_eq!(restored, HACKATOM);
     }
 
     #[test]
@@ -816,7 +816,7 @@ mod tests {
             };
             let cache1: Cache<MockApi, MockStorage, MockQuerier> =
                 unsafe { Cache::new(options1).unwrap() };
-            id = cache1.store_code(CONTRACT, true, true).unwrap();
+            id = cache1.store_code(HACKATOM, true, true).unwrap();
         }
 
         {
@@ -829,7 +829,7 @@ mod tests {
             let cache2: Cache<MockApi, MockStorage, MockQuerier> =
                 unsafe { Cache::new(options2).unwrap() };
             let restored = cache2.load_wasm(&id).unwrap();
-            assert_eq!(restored, CONTRACT);
+            assert_eq!(restored, HACKATOM);
         }
     }
 
@@ -861,7 +861,7 @@ mod tests {
         };
         let cache: Cache<MockApi, MockStorage, MockQuerier> =
             unsafe { Cache::new(options).unwrap() };
-        let checksum = cache.store_code(CONTRACT, true, true).unwrap();
+        let checksum = cache.store_code(HACKATOM, true, true).unwrap();
 
         // Corrupt cache file
         let filepath = tmp_dir
@@ -887,7 +887,7 @@ mod tests {
             unsafe { Cache::new(make_testing_options()).unwrap() };
 
         // Store
-        let checksum = cache.store_code(CONTRACT, true, true).unwrap();
+        let checksum = cache.store_code(HACKATOM, true, true).unwrap();
 
         // Exists
         cache.load_wasm(&checksum).unwrap();
@@ -915,7 +915,7 @@ mod tests {
     #[test]
     fn get_instance_finds_cached_module() {
         let cache = unsafe { Cache::new(make_testing_options()).unwrap() };
-        let checksum = cache.store_code(CONTRACT, true, true).unwrap();
+        let checksum = cache.store_code(HACKATOM, true, true).unwrap();
         let backend = mock_backend(&[]);
         let _instance = cache
             .get_instance(&checksum, backend, TESTING_OPTIONS)
@@ -929,7 +929,7 @@ mod tests {
     #[test]
     fn get_instance_finds_cached_modules_and_stores_to_memory() {
         let cache = unsafe { Cache::new(make_testing_options()).unwrap() };
-        let checksum = cache.store_code(CONTRACT, true, true).unwrap();
+        let checksum = cache.store_code(HACKATOM, true, true).unwrap();
         let backend1 = mock_backend(&[]);
         let backend2 = mock_backend(&[]);
         let backend3 = mock_backend(&[]);
@@ -993,7 +993,7 @@ mod tests {
     fn get_instance_recompiles_module() {
         let options = make_testing_options();
         let cache = unsafe { Cache::new(options.clone()).unwrap() };
-        let checksum = cache.store_code(CONTRACT, true, true).unwrap();
+        let checksum = cache.store_code(HACKATOM, true, true).unwrap();
 
         // Remove compiled module from disk
         remove_dir_all(options.base_dir.join(CACHE_DIR).join(MODULES_DIR)).unwrap();
@@ -1022,7 +1022,7 @@ mod tests {
     #[test]
     fn call_instantiate_on_cached_contract() {
         let cache = unsafe { Cache::new(make_testing_options()).unwrap() };
-        let checksum = cache.store_code(CONTRACT, true, true).unwrap();
+        let checksum = cache.store_code(HACKATOM, true, true).unwrap();
 
         // from file system
         {
@@ -1108,7 +1108,7 @@ mod tests {
     #[test]
     fn call_execute_on_cached_contract() {
         let cache = unsafe { Cache::new(make_testing_options()).unwrap() };
-        let checksum = cache.store_code(CONTRACT, true, true).unwrap();
+        let checksum = cache.store_code(HACKATOM, true, true).unwrap();
 
         // from file system
         {
@@ -1219,7 +1219,7 @@ mod tests {
     fn call_execute_on_recompiled_contract() {
         let options = make_testing_options();
         let cache = unsafe { Cache::new(options.clone()).unwrap() };
-        let checksum = cache.store_code(CONTRACT, true, true).unwrap();
+        let checksum = cache.store_code(HACKATOM, true, true).unwrap();
 
         // Remove compiled module from disk
         remove_dir_all(options.base_dir.join(CACHE_DIR).join(MODULES_DIR)).unwrap();
@@ -1239,7 +1239,7 @@ mod tests {
     #[test]
     fn use_multiple_cached_instances_of_same_contract() {
         let cache = unsafe { Cache::new(make_testing_options()).unwrap() };
-        let checksum = cache.store_code(CONTRACT, true, true).unwrap();
+        let checksum = cache.store_code(HACKATOM, true, true).unwrap();
 
         // these differentiate the two instances of the same contract
         let backend1 = mock_backend(&[]);
@@ -1299,7 +1299,7 @@ mod tests {
     #[test]
     fn resets_gas_when_reusing_instance() {
         let cache = unsafe { Cache::new(make_testing_options()).unwrap() };
-        let checksum = cache.store_code(CONTRACT, true, true).unwrap();
+        let checksum = cache.store_code(HACKATOM, true, true).unwrap();
 
         let backend1 = mock_backend(&[]);
         let backend2 = mock_backend(&[]);
@@ -1338,7 +1338,7 @@ mod tests {
     #[test]
     fn recovers_from_out_of_gas() {
         let cache = unsafe { Cache::new(make_testing_options()).unwrap() };
-        let checksum = cache.store_code(CONTRACT, true, true).unwrap();
+        let checksum = cache.store_code(HACKATOM, true, true).unwrap();
 
         let backend1 = mock_backend(&[]);
         let backend2 = mock_backend(&[]);
@@ -1454,7 +1454,7 @@ mod tests {
         let cache: Cache<MockApi, MockStorage, MockQuerier> =
             unsafe { Cache::new(make_stargate_testing_options()).unwrap() };
 
-        let checksum1 = cache.store_code(CONTRACT, true, true).unwrap();
+        let checksum1 = cache.store_code(HACKATOM, true, true).unwrap();
         let report1 = cache.analyze(&checksum1).unwrap();
         assert_eq!(
             report1,
@@ -1473,7 +1473,7 @@ mod tests {
             }
         );
 
-        let checksum2 = cache.store_code(IBC_CONTRACT, true, true).unwrap();
+        let checksum2 = cache.store_code(IBC_REFLECT, true, true).unwrap();
         let report2 = cache.analyze(&checksum2).unwrap();
         let mut ibc_contract_entrypoints =
             BTreeSet::from([E::Instantiate, E::Migrate, E::Reply, E::Query]);
@@ -1492,7 +1492,7 @@ mod tests {
             }
         );
 
-        let checksum3 = cache.store_code(EMPTY_CONTRACT, true, true).unwrap();
+        let checksum3 = cache.store_code(EMPTY, true, true).unwrap();
         let report3 = cache.analyze(&checksum3).unwrap();
         assert_eq!(
             report3,
@@ -1505,7 +1505,7 @@ mod tests {
             }
         );
 
-        let mut wasm_with_version = EMPTY_CONTRACT.to_vec();
+        let mut wasm_with_version = EMPTY.to_vec();
         let custom_section = wasm_encoder::CustomSection {
             name: Cow::Borrowed("cw_migrate_version"),
             data: Cow::Borrowed(b"21"),
@@ -1527,7 +1527,7 @@ mod tests {
 
         let cache: Cache<MockApi, MockStorage, MockQuerier> =
             unsafe { Cache::new(make_ibc2_testing_options()).unwrap() };
-        let checksum5 = cache.store_code(IBC2_CONTRACT, true, true).unwrap();
+        let checksum5 = cache.store_code(IBC2, true, true).unwrap();
         let report5 = cache.analyze(&checksum5).unwrap();
         let mut ibc2_contract_entrypoints = BTreeSet::from([E::Instantiate, E::Query]);
         ibc2_contract_entrypoints.extend([REQUIRED_IBC2_EXPORT]);
@@ -1549,7 +1549,7 @@ mod tests {
     #[test]
     fn pinned_metrics_works() {
         let cache = unsafe { Cache::new(make_testing_options()).unwrap() };
-        let checksum = cache.store_code(CONTRACT, true, true).unwrap();
+        let checksum = cache.store_code(HACKATOM, true, true).unwrap();
 
         cache.pin(&checksum).unwrap();
 
@@ -1568,7 +1568,7 @@ mod tests {
         assert_eq!(pinned_metrics.per_module[0].0, checksum);
         assert_eq!(pinned_metrics.per_module[0].1.hits, 1);
 
-        let empty_checksum = cache.store_code(EMPTY_CONTRACT, true, true).unwrap();
+        let empty_checksum = cache.store_code(EMPTY, true, true).unwrap();
         cache.pin(&empty_checksum).unwrap();
 
         let pinned_metrics = cache.pinned_metrics();
@@ -1591,7 +1591,7 @@ mod tests {
     #[test]
     fn pin_unpin_works() {
         let cache = unsafe { Cache::new(make_testing_options()).unwrap() };
-        let checksum = cache.store_code(CONTRACT, true, true).unwrap();
+        let checksum = cache.store_code(HACKATOM, true, true).unwrap();
 
         // check not pinned
         let backend = mock_backend(&[]);
@@ -1656,7 +1656,7 @@ mod tests {
         let options = make_testing_options();
         let cache: Cache<MockApi, MockStorage, MockQuerier> =
             unsafe { Cache::new(options.clone()).unwrap() };
-        let checksum = cache.store_code(CONTRACT, true, true).unwrap();
+        let checksum = cache.store_code(HACKATOM, true, true).unwrap();
 
         // Remove compiled module from disk
         remove_dir_all(options.base_dir.join(CACHE_DIR).join(MODULES_DIR)).unwrap();
@@ -1691,7 +1691,7 @@ mod tests {
         };
         let cache: Cache<MockApi, MockStorage, MockQuerier> =
             unsafe { Cache::new(options).unwrap() };
-        let checksum = cache.store_code(CONTRACT, true, true).unwrap();
+        let checksum = cache.store_code(HACKATOM, true, true).unwrap();
 
         // Move the saved wasm to the old path (without extension)
         let old_path = tmp_dir
@@ -1704,7 +1704,7 @@ mod tests {
 
         // loading wasm from before the wasm extension was added should still work
         let restored = cache.load_wasm(&checksum).unwrap();
-        assert_eq!(restored, CONTRACT);
+        assert_eq!(restored, HACKATOM);
     }
 
     #[test]
@@ -1726,7 +1726,7 @@ mod tests {
 
         let cache: Cache<MockApi, MockStorage, MockQuerier> =
             unsafe { Cache::new_with_config(config).unwrap() };
-        let err = cache.store_code(CONTRACT, true, true).unwrap_err();
+        let err = cache.store_code(HACKATOM, true, true).unwrap_err();
         assert!(matches!(err, VmError::StaticValidationErr { .. }));
     }
 }

--- a/packages/vm/src/calls.rs
+++ b/packages/vm/src/calls.rs
@@ -790,14 +790,14 @@ mod tests {
     use cosmwasm_std::{coins, from_json, to_json_string, Addr, Empty};
     use sha2::{Digest, Sha256};
 
-    static CONTRACT: &[u8] = include_bytes!("../testdata/hackatom.wasm");
+    static HACKATOM: &[u8] = include_bytes!("../testdata/hackatom.wasm");
     static CYBERPUNK: &[u8] = include_bytes!("../testdata/cyberpunk.wasm");
     static FLOATY2: &[u8] = include_bytes!("../testdata/floaty_2.0.wasm");
     static EMPTY: &[u8] = include_bytes!("../testdata/empty.wasm");
 
     #[test]
     fn call_instantiate_works() {
-        let mut instance = mock_instance(CONTRACT, &[]);
+        let mut instance = mock_instance(HACKATOM, &[]);
 
         // init
         let info = mock_info(&instance.api().addr_make("creator"), &coins(1000, "earth"));
@@ -833,7 +833,7 @@ mod tests {
 
     #[test]
     fn call_execute_works() {
-        let mut instance = mock_instance(CONTRACT, &[]);
+        let mut instance = mock_instance(HACKATOM, &[]);
 
         // init
         let info = mock_info(&instance.api().addr_make("creator"), &coins(1000, "earth"));
@@ -919,7 +919,7 @@ mod tests {
 
     #[test]
     fn call_migrate_works() {
-        let mut instance = mock_instance(CONTRACT, &[]);
+        let mut instance = mock_instance(HACKATOM, &[]);
 
         // init
         let info = mock_info(&instance.api().addr_make("creator"), &coins(1000, "earth"));
@@ -949,7 +949,7 @@ mod tests {
 
     #[test]
     fn call_migrate_with_info_works() {
-        let mut instance = mock_instance(CONTRACT, &[]);
+        let mut instance = mock_instance(HACKATOM, &[]);
 
         // init
         let info = mock_info(&instance.api().addr_make("creator"), &coins(1000, "earth"));
@@ -988,7 +988,7 @@ mod tests {
 
     #[test]
     fn call_query_works() {
-        let mut instance = mock_instance(CONTRACT, &[]);
+        let mut instance = mock_instance(HACKATOM, &[]);
 
         // init
         let info = mock_info(&instance.api().addr_make("creator"), &coins(1000, "earth"));
@@ -1102,8 +1102,8 @@ mod tests {
             Event, IbcAckCallbackMsg, IbcAcknowledgement, IbcOrder, IbcTimeoutCallbackMsg, ReplyOn,
             SubMsgResponse, SubMsgResult,
         };
-        const CONTRACT: &[u8] = include_bytes!("../testdata/ibc_reflect.wasm");
-        const IBC_CALLBACKS: &[u8] = include_bytes!("../testdata/ibc_callbacks.wasm");
+        static IBC_REFLECT: &[u8] = include_bytes!("../testdata/ibc_reflect.wasm");
+        static IBC_CALLBACKS: &[u8] = include_bytes!("../testdata/ibc_callbacks.wasm");
         const IBC_VERSION: &str = "ibc-reflect-v1";
 
         fn setup(
@@ -1165,13 +1165,13 @@ mod tests {
 
         #[test]
         fn call_ibc_channel_open_and_connect_works() {
-            let mut instance = mock_instance(CONTRACT, &[]);
+            let mut instance = mock_instance(IBC_REFLECT, &[]);
             setup(&mut instance, CHANNEL_ID, ACCOUNT);
         }
 
         #[test]
         fn call_ibc_channel_close_works() {
-            let mut instance = mock_instance(CONTRACT, &[]);
+            let mut instance = mock_instance(IBC_REFLECT, &[]);
             let account = instance.api().addr_make(ACCOUNT);
             setup(&mut instance, CHANNEL_ID, &account);
             let handshake_close =
@@ -1183,7 +1183,7 @@ mod tests {
 
         #[test]
         fn call_ibc_packet_ack_works() {
-            let mut instance = mock_instance(CONTRACT, &[]);
+            let mut instance = mock_instance(IBC_REFLECT, &[]);
             setup(&mut instance, CHANNEL_ID, ACCOUNT);
             let ack = IbcAcknowledgement::new(br#"{}"#);
             let msg = mock_ibc_packet_ack(CHANNEL_ID, br#"{}"#, ack).unwrap();
@@ -1194,7 +1194,7 @@ mod tests {
 
         #[test]
         fn call_ibc_packet_timeout_works() {
-            let mut instance = mock_instance(CONTRACT, &[]);
+            let mut instance = mock_instance(IBC_REFLECT, &[]);
             setup(&mut instance, CHANNEL_ID, ACCOUNT);
             let msg = mock_ibc_packet_timeout(CHANNEL_ID, br#"{}"#).unwrap();
             call_ibc_packet_timeout::<_, _, _, Empty>(&mut instance, &mock_env(), &msg)
@@ -1204,7 +1204,7 @@ mod tests {
 
         #[test]
         fn call_ibc_packet_receive_works() {
-            let mut instance = mock_instance(CONTRACT, &[]);
+            let mut instance = mock_instance(IBC_REFLECT, &[]);
             setup(&mut instance, CHANNEL_ID, ACCOUNT);
             let who_am_i = br#"{"who_am_i":{}}"#;
             let msg = mock_ibc_packet_recv(CHANNEL_ID, who_am_i).unwrap();
@@ -1277,12 +1277,12 @@ mod tests {
     mod ibc2 {
         use super::*;
         use cosmwasm_std::testing::mock_ibc2_packet_recv;
-        const CONTRACT: &[u8] = include_bytes!("../testdata/ibc2.wasm");
+        static IBC2: &[u8] = include_bytes!("../testdata/ibc2.wasm");
 
         #[test]
         fn call_ibc2_packet_receive_works() {
             // init
-            let mut instance = mock_instance(CONTRACT, &[]);
+            let mut instance = mock_instance(IBC2, &[]);
             let info = mock_info("creator", &[]);
             let instantiate_msg = br#"{}"#;
             call_instantiate::<_, _, _, Empty>(&mut instance, &mock_env(), &info, instantiate_msg)

--- a/packages/vm/src/compatibility.rs
+++ b/packages/vm/src/compatibility.rs
@@ -337,9 +337,9 @@ mod tests {
     static CONTRACT_0_12: &[u8] = include_bytes!("../testdata/hackatom_0.12.wasm");
     static CONTRACT_0_14: &[u8] = include_bytes!("../testdata/hackatom_0.14.wasm");
     static CONTRACT_0_15: &[u8] = include_bytes!("../testdata/hackatom_0.15.wasm");
-    static CONTRACT: &[u8] = include_bytes!("../testdata/hackatom.wasm");
+    static HACKATOM: &[u8] = include_bytes!("../testdata/hackatom.wasm");
     static CYBERPUNK: &[u8] = include_bytes!("../testdata/cyberpunk.wasm");
-    static CONTRACT_RUST_170: &[u8] = include_bytes!("../testdata/cyberpunk_rust170.wasm");
+    static CYBERPUNK_RUST_170: &[u8] = include_bytes!("../testdata/cyberpunk_rust170.wasm");
 
     fn default_capabilities() -> HashSet<String> {
         capabilities_from_csv("cosmwasm_1_1,cosmwasm_1_2,cosmwasm_1_3,iterator,staking,stargate")
@@ -349,7 +349,7 @@ mod tests {
     fn check_wasm_passes_for_latest_contract() {
         // this is our reference check, must pass
         check_wasm(
-            CONTRACT,
+            HACKATOM,
             &default_capabilities(),
             &WasmLimits::default(),
             Off,
@@ -368,7 +368,7 @@ mod tests {
     fn check_wasm_allows_sign_ext() {
         // See https://github.com/CosmWasm/cosmwasm/issues/1727
         check_wasm(
-            CONTRACT_RUST_170,
+            CYBERPUNK_RUST_170,
             &default_capabilities(),
             &WasmLimits::default(),
             Off,

--- a/packages/vm/src/environment.rs
+++ b/packages/vm/src/environment.rs
@@ -560,7 +560,7 @@ mod tests {
     };
     use wasmer::{imports, Function, Instance as WasmerInstance, Store};
 
-    static CONTRACT: &[u8] = include_bytes!("../testdata/hackatom.wasm");
+    static HACKATOM: &[u8] = include_bytes!("../testdata/hackatom.wasm");
 
     // prepared data
     const INIT_KEY: &[u8] = b"foo";
@@ -584,7 +584,7 @@ mod tests {
         let env = Environment::new(MockApi::default(), gas_limit);
 
         let engine = make_compiling_engine(TESTING_MEMORY_LIMIT);
-        let module = compile(&engine, CONTRACT).unwrap();
+        let module = compile(&engine, HACKATOM).unwrap();
         let mut store = Store::new(engine);
 
         // we need stubs for all required imports

--- a/packages/vm/src/imports.rs
+++ b/packages/vm/src/imports.rs
@@ -1026,7 +1026,7 @@ mod tests {
     use crate::testing::{MockApi, MockQuerier, MockStorage};
     use crate::wasm_backend::{compile, make_compiling_engine};
 
-    static CONTRACT: &[u8] = include_bytes!("../testdata/hackatom.wasm");
+    static HACKATOM: &[u8] = include_bytes!("../testdata/hackatom.wasm");
 
     // prepared data
     const KEY1: &[u8] = b"ant";
@@ -1067,7 +1067,7 @@ mod tests {
         let env = Environment::new(api, gas_limit);
 
         let engine = make_compiling_engine(TESTING_MEMORY_LIMIT);
-        let module = compile(&engine, CONTRACT).unwrap();
+        let module = compile(&engine, HACKATOM).unwrap();
         let mut store = Store::new(engine);
 
         let fe = FunctionEnv::new(&mut store, env);

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -549,7 +549,7 @@ mod tests {
     const KIB: usize = 1024;
     const MIB: usize = 1024 * 1024;
     const DEFAULT_QUERY_GAS_LIMIT: u64 = 300_000;
-    static CONTRACT: &[u8] = include_bytes!("../testdata/hackatom.wasm");
+    static HACKATOM: &[u8] = include_bytes!("../testdata/hackatom.wasm");
     static CYBERPUNK: &[u8] = include_bytes!("../testdata/cyberpunk.wasm");
 
     #[test]
@@ -557,7 +557,7 @@ mod tests {
         let backend = mock_backend(&[]);
         let (instance_options, memory_limit) = mock_instance_options();
         let _instance =
-            Instance::from_code(CONTRACT, backend, instance_options, memory_limit).unwrap();
+            Instance::from_code(HACKATOM, backend, instance_options, memory_limit).unwrap();
     }
 
     #[test]
@@ -602,7 +602,7 @@ mod tests {
         let backend = mock_backend(&[]);
         let (instance_options, memory_limit) = mock_instance_options();
         let instance =
-            Instance::from_code(CONTRACT, backend, instance_options, memory_limit).unwrap();
+            Instance::from_code(HACKATOM, backend, instance_options, memory_limit).unwrap();
         assert_eq!(instance.required_capabilities().len(), 0);
     }
 
@@ -694,7 +694,7 @@ mod tests {
 
     #[test]
     fn call_function0_works() {
-        let mut instance = mock_instance(CONTRACT, &[]);
+        let mut instance = mock_instance(HACKATOM, &[]);
 
         instance
             .call_function0("interface_version_8", &[])
@@ -703,7 +703,7 @@ mod tests {
 
     #[test]
     fn call_function1_works() {
-        let mut instance = mock_instance(CONTRACT, &[]);
+        let mut instance = mock_instance(HACKATOM, &[]);
 
         // can call function few times
         let result = instance
@@ -725,7 +725,7 @@ mod tests {
     #[test]
     fn allocate_deallocate_works() {
         let mut instance = mock_instance_with_options(
-            CONTRACT,
+            HACKATOM,
             MockInstanceOptions {
                 memory_limit: Some(Size::mebi(500)),
                 ..Default::default()
@@ -752,7 +752,7 @@ mod tests {
 
     #[test]
     fn write_and_read_memory_works() {
-        let mut instance = mock_instance_with_gas_limit(CONTRACT, 6_000_000_000);
+        let mut instance = mock_instance_with_gas_limit(HACKATOM, 6_000_000_000);
 
         let sizes: Vec<usize> = vec![
             0,
@@ -785,7 +785,7 @@ mod tests {
     fn errors_in_imports() {
         // set up an instance that will experience an error in an import
         let error_message = "Api failed intentionally";
-        let mut instance = mock_instance_with_failing_api(CONTRACT, &[], error_message);
+        let mut instance = mock_instance_with_failing_api(HACKATOM, &[], error_message);
         let init_result = call_instantiate::<_, _, _, Empty>(
             &mut instance,
             &mock_env(),
@@ -803,7 +803,7 @@ mod tests {
     fn read_memory_errors_when_when_length_is_too_long() {
         let length = 6;
         let max_length = 5;
-        let mut instance = mock_instance(CONTRACT, &[]);
+        let mut instance = mock_instance(HACKATOM, &[]);
 
         // Allocate sets length to 0. Write some data to increase length.
         let region_ptr = instance.allocate(length).expect("error allocating");
@@ -871,7 +871,7 @@ mod tests {
 
     #[test]
     fn memory_pages_grows_with_usage() {
-        let mut instance = mock_instance(CONTRACT, &[]);
+        let mut instance = mock_instance(HACKATOM, &[]);
 
         assert_eq!(instance.memory_pages(), 17);
 
@@ -887,7 +887,7 @@ mod tests {
 
     #[test]
     fn get_gas_left_works() {
-        let mut instance = mock_instance_with_gas_limit(CONTRACT, 123321);
+        let mut instance = mock_instance_with_gas_limit(HACKATOM, 123321);
         let orig_gas = instance.get_gas_left();
         assert_eq!(orig_gas, 123321);
     }
@@ -895,7 +895,7 @@ mod tests {
     #[test]
     fn create_gas_report_works() {
         const LIMIT: u64 = 700_000_000;
-        let mut instance = mock_instance_with_gas_limit(CONTRACT, LIMIT);
+        let mut instance = mock_instance_with_gas_limit(HACKATOM, LIMIT);
 
         let report1 = instance.create_gas_report();
         assert_eq!(report1.used_externally, 0);
@@ -924,7 +924,7 @@ mod tests {
 
     #[test]
     fn set_storage_readonly_works() {
-        let mut instance = mock_instance(CONTRACT, &[]);
+        let mut instance = mock_instance(HACKATOM, &[]);
 
         assert!(instance.is_storage_readonly());
 
@@ -940,7 +940,7 @@ mod tests {
 
     #[test]
     fn with_storage_works() {
-        let mut instance = mock_instance(CONTRACT, &[]);
+        let mut instance = mock_instance(HACKATOM, &[]);
 
         // initial check
         instance
@@ -971,7 +971,7 @@ mod tests {
     #[should_panic]
     fn with_storage_safe_for_panic() {
         // this should fail with the assertion, but not cause a double-free crash (issue #59)
-        let mut instance = mock_instance(CONTRACT, &[]);
+        let mut instance = mock_instance(HACKATOM, &[]);
         instance
             .with_storage::<_, ()>(|_store| panic!("trigger failure"))
             .unwrap();
@@ -982,7 +982,7 @@ mod tests {
     fn with_querier_works_readonly() {
         let rich_addr = String::from("foobar");
         let rich_balance = vec![coin(10000, "gold"), coin(8000, "silver")];
-        let mut instance = mock_instance_with_balances(CONTRACT, &[(&rich_addr, &rich_balance)]);
+        let mut instance = mock_instance_with_balances(HACKATOM, &[(&rich_addr, &rich_balance)]);
 
         // query one
         instance
@@ -1038,7 +1038,7 @@ mod tests {
         let rich_addr = String::from("foobar");
         let rich_balance1 = vec![coin(10000, "gold"), coin(500, "silver")];
         let rich_balance2 = vec![coin(10000, "gold"), coin(8000, "silver")];
-        let mut instance = mock_instance_with_balances(CONTRACT, &[(&rich_addr, &rich_balance1)]);
+        let mut instance = mock_instance_with_balances(HACKATOM, &[(&rich_addr, &rich_balance1)]);
 
         // Get initial state
         instance
@@ -1093,7 +1093,7 @@ mod tests {
 
     #[test]
     fn contract_deducts_gas_init() {
-        let mut instance = mock_instance(CONTRACT, &[]);
+        let mut instance = mock_instance(HACKATOM, &[]);
         let orig_gas = instance.get_gas_left();
 
         // init contract
@@ -1111,7 +1111,7 @@ mod tests {
 
     #[test]
     fn contract_deducts_gas_execute() {
-        let mut instance = mock_instance(CONTRACT, &[]);
+        let mut instance = mock_instance(HACKATOM, &[]);
 
         // init contract
         let info = mock_info(&instance.api().addr_make("creator"), &coins(1000, "earth"));
@@ -1136,7 +1136,7 @@ mod tests {
 
     #[test]
     fn contract_enforces_gas_limit() {
-        let mut instance = mock_instance_with_gas_limit(CONTRACT, 20_000);
+        let mut instance = mock_instance_with_gas_limit(HACKATOM, 20_000);
 
         // init contract
         let info = mock_info(&instance.api().addr_make("creator"), &coins(1000, "earth"));
@@ -1150,7 +1150,7 @@ mod tests {
 
     #[test]
     fn query_works_with_gas_metering() {
-        let mut instance = mock_instance(CONTRACT, &[]);
+        let mut instance = mock_instance(HACKATOM, &[]);
 
         // init contract
         let info = mock_info(&instance.api().addr_make("creator"), &coins(1000, "earth"));

--- a/packages/vm/src/static_analysis.rs
+++ b/packages/vm/src/static_analysis.rs
@@ -117,12 +117,12 @@ mod tests {
     use super::*;
     use wasmer::Store;
 
-    static CONTRACT: &[u8] = include_bytes!("../testdata/hackatom.wasm");
+    static HACKATOM: &[u8] = include_bytes!("../testdata/hackatom.wasm");
     static CORRUPTED: &[u8] = include_bytes!("../testdata/corrupted.wasm");
 
     #[test]
     fn deserialize_exports_works() {
-        let module = ParsedWasm::parse(CONTRACT).unwrap();
+        let module = ParsedWasm::parse(HACKATOM).unwrap();
         assert_eq!(module.version, 1);
 
         let exported_functions = module

--- a/packages/vm/src/wasm_backend/compile.rs
+++ b/packages/vm/src/wasm_backend/compile.rs
@@ -13,11 +13,11 @@ mod tests {
     use super::*;
     use crate::wasm_backend::make_compiling_engine;
 
-    static CONTRACT: &[u8] = include_bytes!("../../testdata/floaty.wasm");
+    static FLOATY: &[u8] = include_bytes!("../../testdata/floaty.wasm");
 
     #[test]
     fn contract_with_floats_passes_check() {
         let engine = make_compiling_engine(None);
-        assert!(compile(&engine, CONTRACT).is_ok());
+        assert!(compile(&engine, FLOATY).is_ok());
     }
 }


### PR DESCRIPTION
and make them static. For consistency.

This somewhat needed for https://github.com/CosmWasm/cosmwasm/pull/2433