### PR TITLE
Disable core coverage for now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1258,7 +1258,7 @@ jobs:
             # List of package directories and their flags
             set -- \
               "check:cosmwasm-check" \
-              "core:cosmwasm-core" \
+              #"core:cosmwasm-core" \
               "crypto:cosmwasm-crypto" \
               "derive:cosmwasm-derive" \
               "schema:cosmwasm-schema" \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1256,9 +1256,9 @@ jobs:
             cargo llvm-cov nextest --lcov --output-path lcov.info
 
             # List of package directories and their flags
+            # ToDo: Re-add "core:cosmwasm-core" when enabling core coverage again
             set -- \
               "check:cosmwasm-check" \
-              #"core:cosmwasm-core" \
               "crypto:cosmwasm-crypto" \
               "derive:cosmwasm-derive" \
               "schema:cosmwasm-schema" \

--- a/codecov.yml
+++ b/codecov.yml
@@ -16,9 +16,9 @@ flags:
   cosmwasm-check:
     paths:
       - packages/check/
-  cosmwasm-core:
-    paths:
-      - packages/core/
+  #cosmwasm-core:
+  #  paths:
+  #    - packages/core/
   cosmwasm-crypto:
     paths:
       - packages/crypto/


### PR DESCRIPTION
`cosmwasm-core` doesn't contain any code that would need testing (just a few constants for BLS12-381), and since the empty coverage file trips up Codecov, we can just disable it for now