### PR TITLE
Use contains instead of any in compatibility check

### DIFF
--- a/packages/vm/src/compatibility.rs
+++ b/packages/vm/src/compatibility.rs
@@ -175,9 +175,7 @@ fn check_interface_version(module: &ParsedWasm) -> VmResult<()> {
         } else {
             // Exactly one interface version found
             let version_str = first_interface_version_export.as_str();
-            if SUPPORTED_INTERFACE_VERSIONS
-                .iter()
-                .any(|&v| v == version_str)
+            if SUPPORTED_INTERFACE_VERSIONS.contains(&version_str)
             {
                 Ok(())
             } else {

--- a/packages/vm/src/compatibility.rs
+++ b/packages/vm/src/compatibility.rs
@@ -175,8 +175,7 @@ fn check_interface_version(module: &ParsedWasm) -> VmResult<()> {
         } else {
             // Exactly one interface version found
             let version_str = first_interface_version_export.as_str();
-            if SUPPORTED_INTERFACE_VERSIONS.contains(&version_str)
-            {
+            if SUPPORTED_INTERFACE_VERSIONS.contains(&version_str) {
                 Ok(())
             } else {
                 Err(VmError::static_validation_err(


### PR DESCRIPTION
Fix clippy warning by using `.contains()` instead of `.iter().any()` in compatibility check