### PR TITLE
Remove downcast-rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,6 @@ and this project adheres to
   `Uint64::from_{be,le}_bytes`. ([#2269])
 - cosmwasm-std: Added new `Ibc2Msg` and `CosmosMsg::Ibc2` variant ([#2340],
   [#2390], [#2403])
-- cosmwasm-std: Implement downcasting for `Api` trait. This allows using
-  `MockApi::addr_make` from `DepsMut`. ([#2457])
 - cosmwasm-std: Added `ibc2_port` to `ContractInfoResponse`. ([#2390], [#2403])
 - cosmwasm-vm: Added `ibc2_packet_receive` entrypoint ([#2403])
 - cosmwasm-vm: Add IBC Callbacks entrypoints to the `Entrypoints` enum.
@@ -99,7 +97,6 @@ and this project adheres to
 [#2432]: https://github.com/CosmWasm/cosmwasm/pull/2432
 [#2433]: https://github.com/CosmWasm/cosmwasm/pull/2433
 [#2438]: https://github.com/CosmWasm/cosmwasm/pull/2438
-[#2457]: https://github.com/CosmWasm/cosmwasm/issues/2457
 
 ## [2.2.0] - 2024-12-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,10 @@ and this project adheres to
   `From<Int128> for i128` ([#2268])
 - cosmwasm-std: Implement `Uint128::from_{be,le}_bytes` and
   `Uint64::from_{be,le}_bytes`. ([#2269])
-- cosmwasm-std: Added new `Ibc2Msg` and `CosmosMsg::Ibc2` variant ([#2390],
-  [#2403])
+- cosmwasm-std: Added new `Ibc2Msg` and `CosmosMsg::Ibc2` variant ([#2340],
+  [#2390], [#2403])
 - cosmwasm-std: Implement downcasting for `Api` trait. This allows using
-  `MockApi::addr_make` from `DepsMut`. ([#2383])
+  `MockApi::addr_make` from `DepsMut`. ([#2457])
 - cosmwasm-std: Added `ibc2_port` to `ContractInfoResponse`. ([#2390], [#2403])
 - cosmwasm-vm: Added `ibc2_packet_receive` entrypoint ([#2403])
 - cosmwasm-vm: Add IBC Callbacks entrypoints to the `Entrypoints` enum.
@@ -91,7 +91,6 @@ and this project adheres to
 [#2367]: https://github.com/CosmWasm/cosmwasm/issues/2367
 [#2374]: https://github.com/CosmWasm/cosmwasm/issues/2374
 [#2378]: https://github.com/CosmWasm/cosmwasm/issues/2378
-[#2383]: https://github.com/CosmWasm/cosmwasm/issues/2383
 [#2390]: https://github.com/CosmWasm/cosmwasm/issues/2390
 [#2393]: https://github.com/CosmWasm/cosmwasm/issues/2393
 [#2399]: https://github.com/CosmWasm/cosmwasm/pull/2399
@@ -100,6 +99,7 @@ and this project adheres to
 [#2432]: https://github.com/CosmWasm/cosmwasm/pull/2432
 [#2433]: https://github.com/CosmWasm/cosmwasm/pull/2433
 [#2438]: https://github.com/CosmWasm/cosmwasm/pull/2438
+[#2457]: https://github.com/CosmWasm/cosmwasm/issues/2457
 
 ## [2.2.0] - 2024-12-17
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,7 +787,6 @@ dependencies = [
  "proptest",
  "rand_core",
  "rmp-serde",
- "rustversion",
  "schemars",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -781,13 +781,13 @@ dependencies = [
  "cosmwasm-schema",
  "crc32fast",
  "derive_more 1.0.0-beta.6",
- "downcast-rs",
  "hex",
  "hex-literal",
  "paste",
  "proptest",
  "rand_core",
  "rmp-serde",
+ "rustversion",
  "schemars",
  "serde",
  "serde_json",
@@ -1169,12 +1169,6 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
-
-[[package]]
-name = "downcast-rs"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea8a8b81cacc08888170eef4d13b775126db426d0b348bee9d18c2c1eaf123cf"
 
 [[package]]
 name = "dyn-clone"

--- a/contracts/burner/Cargo.lock
+++ b/contracts/burner/Cargo.lock
@@ -551,7 +551,6 @@ dependencies = [
  "hex",
  "rand_core",
  "rmp-serde",
- "rustversion",
  "schemars",
  "serde",
  "serde_json",

--- a/contracts/burner/Cargo.lock
+++ b/contracts/burner/Cargo.lock
@@ -548,10 +548,10 @@ dependencies = [
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derive_more 1.0.0-beta.6",
- "downcast-rs",
  "hex",
  "rand_core",
  "rmp-serde",
+ "rustversion",
  "schemars",
  "serde",
  "serde_json",
@@ -851,12 +851,6 @@ dependencies = [
  "quote",
  "syn 2.0.87",
 ]
-
-[[package]]
-name = "downcast-rs"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea8a8b81cacc08888170eef4d13b775126db426d0b348bee9d18c2c1eaf123cf"
 
 [[package]]
 name = "dyn-clone"

--- a/contracts/crypto-verify/Cargo.lock
+++ b/contracts/crypto-verify/Cargo.lock
@@ -543,10 +543,10 @@ dependencies = [
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derive_more 1.0.0-beta.6",
- "downcast-rs",
  "hex",
  "rand_core",
  "rmp-serde",
+ "rustversion",
  "schemars",
  "serde",
  "serde_json",
@@ -864,12 +864,6 @@ dependencies = [
  "quote",
  "syn 2.0.87",
 ]
-
-[[package]]
-name = "downcast-rs"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea8a8b81cacc08888170eef4d13b775126db426d0b348bee9d18c2c1eaf123cf"
 
 [[package]]
 name = "dyn-clone"

--- a/contracts/crypto-verify/Cargo.lock
+++ b/contracts/crypto-verify/Cargo.lock
@@ -546,7 +546,6 @@ dependencies = [
  "hex",
  "rand_core",
  "rmp-serde",
- "rustversion",
  "schemars",
  "serde",
  "serde_json",

--- a/contracts/cyberpunk/Cargo.lock
+++ b/contracts/cyberpunk/Cargo.lock
@@ -560,10 +560,10 @@ dependencies = [
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derive_more 1.0.0-beta.6",
- "downcast-rs",
  "hex",
  "rand_core",
  "rmp-serde",
+ "rustversion",
  "schemars",
  "serde",
  "serde_json",
@@ -875,12 +875,6 @@ dependencies = [
  "quote",
  "syn 2.0.87",
 ]
-
-[[package]]
-name = "downcast-rs"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea8a8b81cacc08888170eef4d13b775126db426d0b348bee9d18c2c1eaf123cf"
 
 [[package]]
 name = "dyn-clone"

--- a/contracts/cyberpunk/Cargo.lock
+++ b/contracts/cyberpunk/Cargo.lock
@@ -563,7 +563,6 @@ dependencies = [
  "hex",
  "rand_core",
  "rmp-serde",
- "rustversion",
  "schemars",
  "serde",
  "serde_json",

--- a/contracts/empty/Cargo.lock
+++ b/contracts/empty/Cargo.lock
@@ -540,7 +540,6 @@ dependencies = [
  "hex",
  "rand_core",
  "rmp-serde",
- "rustversion",
  "schemars",
  "serde",
  "serde_json",

--- a/contracts/empty/Cargo.lock
+++ b/contracts/empty/Cargo.lock
@@ -537,10 +537,10 @@ dependencies = [
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derive_more 1.0.0-beta.6",
- "downcast-rs",
  "hex",
  "rand_core",
  "rmp-serde",
+ "rustversion",
  "schemars",
  "serde",
  "serde_json",
@@ -840,12 +840,6 @@ dependencies = [
  "quote",
  "syn 2.0.87",
 ]
-
-[[package]]
-name = "downcast-rs"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea8a8b81cacc08888170eef4d13b775126db426d0b348bee9d18c2c1eaf123cf"
 
 [[package]]
 name = "dyn-clone"

--- a/contracts/floaty/Cargo.lock
+++ b/contracts/floaty/Cargo.lock
@@ -540,7 +540,6 @@ dependencies = [
  "hex",
  "rand_core",
  "rmp-serde",
- "rustversion",
  "schemars",
  "serde",
  "serde_json",

--- a/contracts/floaty/Cargo.lock
+++ b/contracts/floaty/Cargo.lock
@@ -537,10 +537,10 @@ dependencies = [
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derive_more 1.0.0-beta.6",
- "downcast-rs",
  "hex",
  "rand_core",
  "rmp-serde",
+ "rustversion",
  "schemars",
  "serde",
  "serde_json",
@@ -840,12 +840,6 @@ dependencies = [
  "quote",
  "syn 2.0.87",
 ]
-
-[[package]]
-name = "downcast-rs"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea8a8b81cacc08888170eef4d13b775126db426d0b348bee9d18c2c1eaf123cf"
 
 [[package]]
 name = "dyn-clone"

--- a/contracts/hackatom/Cargo.lock
+++ b/contracts/hackatom/Cargo.lock
@@ -540,7 +540,6 @@ dependencies = [
  "hex",
  "rand_core",
  "rmp-serde",
- "rustversion",
  "schemars",
  "serde",
  "serde_json",

--- a/contracts/hackatom/Cargo.lock
+++ b/contracts/hackatom/Cargo.lock
@@ -537,10 +537,10 @@ dependencies = [
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derive_more 1.0.0-beta.6",
- "downcast-rs",
  "hex",
  "rand_core",
  "rmp-serde",
+ "rustversion",
  "schemars",
  "serde",
  "serde_json",
@@ -840,12 +840,6 @@ dependencies = [
  "quote",
  "syn 2.0.87",
 ]
-
-[[package]]
-name = "downcast-rs"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea8a8b81cacc08888170eef4d13b775126db426d0b348bee9d18c2c1eaf123cf"
 
 [[package]]
 name = "dyn-clone"

--- a/contracts/ibc-callbacks/Cargo.lock
+++ b/contracts/ibc-callbacks/Cargo.lock
@@ -540,7 +540,6 @@ dependencies = [
  "hex",
  "rand_core",
  "rmp-serde",
- "rustversion",
  "schemars",
  "serde",
  "serde_json",

--- a/contracts/ibc-callbacks/Cargo.lock
+++ b/contracts/ibc-callbacks/Cargo.lock
@@ -537,10 +537,10 @@ dependencies = [
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derive_more 1.0.0-beta.6",
- "downcast-rs",
  "hex",
  "rand_core",
  "rmp-serde",
+ "rustversion",
  "schemars",
  "serde",
  "serde_json",
@@ -840,12 +840,6 @@ dependencies = [
  "quote",
  "syn 2.0.87",
 ]
-
-[[package]]
-name = "downcast-rs"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea8a8b81cacc08888170eef4d13b775126db426d0b348bee9d18c2c1eaf123cf"
 
 [[package]]
 name = "dyn-clone"

--- a/contracts/ibc-reflect-send/Cargo.lock
+++ b/contracts/ibc-reflect-send/Cargo.lock
@@ -540,7 +540,6 @@ dependencies = [
  "hex",
  "rand_core",
  "rmp-serde",
- "rustversion",
  "schemars",
  "serde",
  "serde_json",

--- a/contracts/ibc-reflect-send/Cargo.lock
+++ b/contracts/ibc-reflect-send/Cargo.lock
@@ -537,10 +537,10 @@ dependencies = [
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derive_more 1.0.0-beta.6",
- "downcast-rs",
  "hex",
  "rand_core",
  "rmp-serde",
+ "rustversion",
  "schemars",
  "serde",
  "serde_json",
@@ -840,12 +840,6 @@ dependencies = [
  "quote",
  "syn 2.0.87",
 ]
-
-[[package]]
-name = "downcast-rs"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea8a8b81cacc08888170eef4d13b775126db426d0b348bee9d18c2c1eaf123cf"
 
 [[package]]
 name = "dyn-clone"

--- a/contracts/ibc-reflect/Cargo.lock
+++ b/contracts/ibc-reflect/Cargo.lock
@@ -540,7 +540,6 @@ dependencies = [
  "hex",
  "rand_core",
  "rmp-serde",
- "rustversion",
  "schemars",
  "serde",
  "serde_json",

--- a/contracts/ibc-reflect/Cargo.lock
+++ b/contracts/ibc-reflect/Cargo.lock
@@ -537,10 +537,10 @@ dependencies = [
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derive_more 1.0.0-beta.6",
- "downcast-rs",
  "hex",
  "rand_core",
  "rmp-serde",
+ "rustversion",
  "schemars",
  "serde",
  "serde_json",
@@ -840,12 +840,6 @@ dependencies = [
  "quote",
  "syn 2.0.87",
 ]
-
-[[package]]
-name = "downcast-rs"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea8a8b81cacc08888170eef4d13b775126db426d0b348bee9d18c2c1eaf123cf"
 
 [[package]]
 name = "dyn-clone"

--- a/contracts/ibc2/Cargo.lock
+++ b/contracts/ibc2/Cargo.lock
@@ -281,7 +281,6 @@ dependencies = [
  "hex",
  "rand_core",
  "rmp-serde",
- "rustversion",
  "schemars",
  "serde",
  "serde_json",
@@ -831,12 +830,6 @@ checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
-
-[[package]]
-name = "rustversion"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"

--- a/contracts/ibc2/Cargo.lock
+++ b/contracts/ibc2/Cargo.lock
@@ -278,10 +278,10 @@ dependencies = [
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derive_more",
- "downcast-rs",
  "hex",
  "rand_core",
  "rmp-serde",
+ "rustversion",
  "schemars",
  "serde",
  "serde_json",
@@ -415,12 +415,6 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
-
-[[package]]
-name = "downcast-rs"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea8a8b81cacc08888170eef4d13b775126db426d0b348bee9d18c2c1eaf123cf"
 
 [[package]]
 name = "dyn-clone"
@@ -837,6 +831,12 @@ checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"

--- a/contracts/queue/Cargo.lock
+++ b/contracts/queue/Cargo.lock
@@ -540,7 +540,6 @@ dependencies = [
  "hex",
  "rand_core",
  "rmp-serde",
- "rustversion",
  "schemars",
  "serde",
  "serde_json",

--- a/contracts/queue/Cargo.lock
+++ b/contracts/queue/Cargo.lock
@@ -537,10 +537,10 @@ dependencies = [
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derive_more 1.0.0-beta.6",
- "downcast-rs",
  "hex",
  "rand_core",
  "rmp-serde",
+ "rustversion",
  "schemars",
  "serde",
  "serde_json",
@@ -840,12 +840,6 @@ dependencies = [
  "quote",
  "syn 2.0.87",
 ]
-
-[[package]]
-name = "downcast-rs"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea8a8b81cacc08888170eef4d13b775126db426d0b348bee9d18c2c1eaf123cf"
 
 [[package]]
 name = "dyn-clone"

--- a/contracts/reflect/Cargo.lock
+++ b/contracts/reflect/Cargo.lock
@@ -540,7 +540,6 @@ dependencies = [
  "hex",
  "rand_core",
  "rmp-serde",
- "rustversion",
  "schemars",
  "serde",
  "serde_json",

--- a/contracts/reflect/Cargo.lock
+++ b/contracts/reflect/Cargo.lock
@@ -537,10 +537,10 @@ dependencies = [
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derive_more 1.0.0-beta.6",
- "downcast-rs",
  "hex",
  "rand_core",
  "rmp-serde",
+ "rustversion",
  "schemars",
  "serde",
  "serde_json",
@@ -840,12 +840,6 @@ dependencies = [
  "quote",
  "syn 2.0.87",
 ]
-
-[[package]]
-name = "downcast-rs"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea8a8b81cacc08888170eef4d13b775126db426d0b348bee9d18c2c1eaf123cf"
 
 [[package]]
 name = "dyn-clone"

--- a/contracts/replier/Cargo.lock
+++ b/contracts/replier/Cargo.lock
@@ -281,7 +281,6 @@ dependencies = [
  "hex",
  "rand_core",
  "rmp-serde",
- "rustversion",
  "schemars",
  "serde",
  "serde_json",
@@ -827,12 +826,6 @@ checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
 ]
-
-[[package]]
-name = "rustversion"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"

--- a/contracts/replier/Cargo.lock
+++ b/contracts/replier/Cargo.lock
@@ -278,10 +278,10 @@ dependencies = [
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derive_more",
- "downcast-rs",
  "hex",
  "rand_core",
  "rmp-serde",
+ "rustversion",
  "schemars",
  "serde",
  "serde_json",
@@ -415,12 +415,6 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
-
-[[package]]
-name = "downcast-rs"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea8a8b81cacc08888170eef4d13b775126db426d0b348bee9d18c2c1eaf123cf"
 
 [[package]]
 name = "dyn-clone"
@@ -833,6 +827,12 @@ checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"

--- a/contracts/staking/Cargo.lock
+++ b/contracts/staking/Cargo.lock
@@ -540,7 +540,6 @@ dependencies = [
  "hex",
  "rand_core",
  "rmp-serde",
- "rustversion",
  "schemars",
  "serde",
  "serde_json",

--- a/contracts/staking/Cargo.lock
+++ b/contracts/staking/Cargo.lock
@@ -537,10 +537,10 @@ dependencies = [
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derive_more 1.0.0-beta.6",
- "downcast-rs",
  "hex",
  "rand_core",
  "rmp-serde",
+ "rustversion",
  "schemars",
  "serde",
  "serde_json",
@@ -840,12 +840,6 @@ dependencies = [
  "quote",
  "syn 2.0.87",
 ]
-
-[[package]]
-name = "downcast-rs"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea8a8b81cacc08888170eef4d13b775126db426d0b348bee9d18c2c1eaf123cf"
 
 [[package]]
 name = "dyn-clone"

--- a/contracts/virus/Cargo.lock
+++ b/contracts/virus/Cargo.lock
@@ -540,7 +540,6 @@ dependencies = [
  "hex",
  "rand_core",
  "rmp-serde",
- "rustversion",
  "schemars",
  "serde",
  "serde_json",

--- a/contracts/virus/Cargo.lock
+++ b/contracts/virus/Cargo.lock
@@ -537,10 +537,10 @@ dependencies = [
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derive_more 1.0.0-beta.6",
- "downcast-rs",
  "hex",
  "rand_core",
  "rmp-serde",
+ "rustversion",
  "schemars",
  "serde",
  "serde_json",
@@ -840,12 +840,6 @@ dependencies = [
  "quote",
  "syn 2.0.87",
 ]
-
-[[package]]
-name = "downcast-rs"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea8a8b81cacc08888170eef4d13b775126db426d0b348bee9d18c2c1eaf123cf"
 
 [[package]]
 name = "dyn-clone"

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -69,7 +69,6 @@ serde_json = "1.0.140"
 static_assertions = "1.1.0"
 thiserror = "1.0.26"
 rmp-serde = "1.3.0"
-rustversion = "1.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 bech32 = "0.11.0"

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -69,7 +69,7 @@ serde_json = "1.0.140"
 static_assertions = "1.1.0"
 thiserror = "1.0.26"
 rmp-serde = "1.3.0"
-downcast-rs = { version = "2.0.1", default-features = false }
+rustversion = "1.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 bech32 = "0.11.0"

--- a/packages/std/src/testing/mock.rs
+++ b/packages/std/src/testing/mock.rs
@@ -2715,16 +2715,4 @@ mod tests {
         // we are not interested in the exact humanization, just that it works
         mock_api.addr_humanize(&canonical_addr).unwrap();
     }
-
-    #[rustversion::since(1.86)]
-    #[test]
-    fn mock_api_downcast() {
-        let mut deps = mock_dependencies();
-        let deps_mut = deps.as_mut();
-
-        let mock_api = deps_mut.api.cast_to_mockapi().unwrap();
-
-        let addr = mock_api.addr_make("input");
-        assert_eq!(mock_api.addr_validate(addr.as_str()).unwrap(), addr);
-    }
 }

--- a/packages/std/src/testing/mock.rs
+++ b/packages/std/src/testing/mock.rs
@@ -2716,12 +2716,13 @@ mod tests {
         mock_api.addr_humanize(&canonical_addr).unwrap();
     }
 
+    #[rustversion::since(1.86)]
     #[test]
     fn mock_api_downcast() {
         let mut deps = mock_dependencies();
         let deps_mut = deps.as_mut();
 
-        let mock_api = deps_mut.api.downcast_ref::<MockApi>().unwrap();
+        let mock_api = deps_mut.api.cast_to_mockapi().unwrap();
 
         let addr = mock_api.addr_make("input");
         assert_eq!(mock_api.addr_validate(addr.as_str()).unwrap(), addr);

--- a/packages/std/src/traits.rs
+++ b/packages/std/src/traits.rs
@@ -1,6 +1,6 @@
+use core::any::Any;
 use core::marker::PhantomData;
 use core::ops::Deref;
-use downcast_rs::{impl_downcast, Downcast};
 use serde::{de::DeserializeOwned, Serialize};
 
 use crate::coin::Coin;
@@ -129,7 +129,7 @@ pub trait Storage {
 ///
 /// We can use feature flags to opt-in to non-essential methods
 /// for backwards compatibility in systems that don't have them all.
-pub trait Api: Downcast {
+pub trait Api: Any {
     /// Takes a human readable address and validates if it is valid.
     /// If it the validation succeeds, a `Addr` containing the same data as the input is returned.
     ///
@@ -328,7 +328,34 @@ pub trait Api: Downcast {
     /// Those messages are not persisted to chain.
     fn debug(&self, message: &str);
 }
-impl_downcast!(Api);
+
+#[rustversion::since(1.86)]
+impl dyn Api {
+    /// Casts the Api trait object to the underlying [`MockApi`] type.
+    /// Returns `None` if the underlying type is not a [`MockApi`].
+    /// This function is only available since Rust 1.86.0.
+    ///
+    /// This is useful in places where you only have access to `Deps` or `DepsMut` during testing,
+    /// but need to use features from the [`MockApi`]:
+    ///
+    /// ```rust
+    /// use cosmwasm_std::{testing::mock_dependencies, Addr, Deps, Api};
+    ///
+    /// fn admin_address(deps: Deps) -> Addr {
+    ///    let mock_api = deps.api.cast_to_mockapi().unwrap();
+    ///    mock_api.addr_make("admin")
+    /// }
+    ///
+    /// let mut deps = mock_dependencies();
+    /// let addr = admin_address(deps.as_ref());
+    /// assert_eq!(deps.api.addr_validate(addr.as_str()).unwrap(), addr);
+    /// ```
+    ///
+    /// [`MockApi`]: crate::testing::MockApi
+    pub fn cast_to_mockapi(&self) -> Option<&crate::testing::MockApi> {
+        (self as &dyn Any).downcast_ref()
+    }
+}
 
 /// A short-hand alias for the two-level query result (1. accessing the contract, 2. executing query in the contract)
 pub type QuerierResult = SystemResult<ContractResult<Binary>>;

--- a/packages/std/src/traits.rs
+++ b/packages/std/src/traits.rs
@@ -329,34 +329,6 @@ pub trait Api: Any {
     fn debug(&self, message: &str);
 }
 
-#[rustversion::since(1.86)]
-impl dyn Api {
-    /// Casts the Api trait object to the underlying [`MockApi`] type.
-    /// Returns `None` if the underlying type is not a [`MockApi`].
-    /// This function is only available since Rust 1.86.0.
-    ///
-    /// This is useful in places where you only have access to `Deps` or `DepsMut` during testing,
-    /// but need to use features from the [`MockApi`]:
-    ///
-    /// ```rust
-    /// use cosmwasm_std::{testing::mock_dependencies, Addr, Deps, Api};
-    ///
-    /// fn admin_address(deps: Deps) -> Addr {
-    ///    let mock_api = deps.api.cast_to_mockapi().unwrap();
-    ///    mock_api.addr_make("admin")
-    /// }
-    ///
-    /// let mut deps = mock_dependencies();
-    /// let addr = admin_address(deps.as_ref());
-    /// assert_eq!(deps.api.addr_validate(addr.as_str()).unwrap(), addr);
-    /// ```
-    ///
-    /// [`MockApi`]: crate::testing::MockApi
-    pub fn cast_to_mockapi(&self) -> Option<&crate::testing::MockApi> {
-        (self as &dyn Any).downcast_ref()
-    }
-}
-
 /// A short-hand alias for the two-level query result (1. accessing the contract, 2. executing query in the contract)
 pub type QuerierResult = SystemResult<ContractResult<Binary>>;
 


### PR DESCRIPTION
closes #2448
related to #2157 and #1375
replacement for #2383

I manually ran the test on 1.86 and it passed, so should be fine.

Little bit unsure about introducing the `rustversion` conditional, but I don't see another way to introduce this now without bumping our MSRV to 1.86.