### PR TITLE
docs: replace dead Tendermint encoding link

### DIFF
--- a/packages/crypto/src/ed25519.rs
+++ b/packages/crypto/src/ed25519.rs
@@ -12,7 +12,7 @@ pub const EDDSA_PUBKEY_LEN: usize = 32;
 /// using the ed25519 elliptic curve digital signature parametrization / algorithm.
 ///
 /// The maximum currently supported message length is 4096 bytes.
-/// The signature and public key are in [Tendermint](https://docs.tendermint.com/v0.32/spec/blockchain/encoding.html#public-key-cryptography)
+/// The signature and public key are in [Tendermint](https://github.com/tendermint/tendermint/blob/v0.32.x/docs/spec/blockchain/encoding.md#public-key-cryptography)
 /// format:
 /// - signature: raw ED25519 signature (64 bytes).
 /// - public key: raw ED25519 public key (32 bytes).


### PR DESCRIPTION
Swap outdated URL `https://docs.tendermint.com/v0.32/spec/blockchain/encoding.html#public-key-cryptography` for the live GitHub source `https://github.com/tendermint/tendermint/blob/v0.32.x/docs/spec/blockchain/encoding.md#public-key-cryptography`. No code changes.