### PR TITLE
Unpublish `External*` deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,9 @@ and this project adheres to
 - cosmwasm-std: source_client instead of channel_id in IBCv2 - ([#2450])
 - cosmwasm-std: Remove previously deprecated `IbcQuery::ListChannels` and
   `ListChannelsResponse`. ([#2223])
+- cosmwasm-std: Remove export of `ExternalApi`, `ExternalQuerier` and
+  `ExternalStorage` as those are only needed by export implementations in
+  cosmwasm-std. ([#2467])
 
 ## Fixed
 
@@ -114,6 +117,7 @@ and this project adheres to
 [#2450]: https://github.com/CosmWasm/cosmwasm/pull/2450
 [#2454]: https://github.com/CosmWasm/cosmwasm/pull/2454
 [#2458]: https://github.com/CosmWasm/cosmwasm/pull/2458
+[#2467]: https://github.com/CosmWasm/cosmwasm/pull/2467
 
 ## [2.2.0] - 2024-12-17
 

--- a/packages/std/src/exports.rs
+++ b/packages/std/src/exports.rs
@@ -938,19 +938,6 @@ where
     contract_fn(deps.as_mut(), env, msg).into()
 }
 
-/// Makes all bridges to external dependencies (i.e. Wasm imports) that are injected by the VM
-fn deps_from_imports<Q>() -> OwnedDeps<ExternalStorage, ExternalApi, ExternalQuerier, Q>
-where
-    Q: CustomQuery,
-{
-    OwnedDeps {
-        storage: ExternalStorage::new(),
-        api: ExternalApi::new(),
-        querier: ExternalQuerier::new(),
-        custom_query_type: PhantomData,
-    }
-}
-
 #[cfg(feature = "ibc2")]
 fn _do_ibc2_packet_receive<Q, C, E>(
     contract_fn: &dyn Fn(DepsMut<Q>, Env, Ibc2PacketReceiveMsg) -> Result<IbcReceiveResponse<C>, E>,
@@ -995,4 +982,17 @@ where
 
     let mut deps = deps_from_imports();
     contract_fn(deps.as_mut(), env, msg).into()
+}
+
+/// Makes all bridges to external dependencies (i.e. Wasm imports) that are injected by the VM
+fn deps_from_imports<Q>() -> OwnedDeps<ExternalStorage, ExternalApi, ExternalQuerier, Q>
+where
+    Q: CustomQuery,
+{
+    OwnedDeps {
+        storage: ExternalStorage::new(),
+        api: ExternalApi::new(),
+        querier: ExternalQuerier::new(),
+        custom_query_type: PhantomData,
+    }
 }

--- a/packages/std/src/exports.rs
+++ b/packages/std/src/exports.rs
@@ -606,7 +606,7 @@ where
     let info: MessageInfo = try_into_contract_result!(from_json(info));
     let msg: M = try_into_contract_result!(from_json(msg));
 
-    let mut deps = make_dependencies();
+    let mut deps = deps_from_imports();
     instantiate_fn(deps.as_mut(), env, info, msg).into()
 }
 
@@ -633,7 +633,7 @@ where
     let info: MessageInfo = try_into_contract_result!(from_json(info));
     let msg: M = try_into_contract_result!(from_json(msg));
 
-    let mut deps = make_dependencies();
+    let mut deps = deps_from_imports();
     execute_fn(deps.as_mut(), env, info, msg).into()
 }
 
@@ -656,7 +656,7 @@ where
     let env: Env = try_into_contract_result!(from_json(env));
     let msg: M = try_into_contract_result!(from_json(msg));
 
-    let mut deps = make_dependencies();
+    let mut deps = deps_from_imports();
     migrate_fn(deps.as_mut(), env, msg).into()
 }
 
@@ -683,7 +683,7 @@ where
     let msg: M = try_into_contract_result!(from_json(msg));
     let migrate_info: MigrateInfo = try_into_contract_result!(from_json(migrate_info));
 
-    let mut deps = make_dependencies();
+    let mut deps = deps_from_imports();
     migrate_with_info_fn(deps.as_mut(), env, msg, migrate_info).into()
 }
 
@@ -706,7 +706,7 @@ where
     let env: Env = try_into_contract_result!(from_json(env));
     let msg: M = try_into_contract_result!(from_json(msg));
 
-    let mut deps = make_dependencies();
+    let mut deps = deps_from_imports();
     sudo_fn(deps.as_mut(), env, msg).into()
 }
 
@@ -728,7 +728,7 @@ where
     let env: Env = try_into_contract_result!(from_json(env));
     let msg: Reply = try_into_contract_result!(from_json(msg));
 
-    let mut deps = make_dependencies();
+    let mut deps = deps_from_imports();
     reply_fn(deps.as_mut(), env, msg).into()
 }
 
@@ -750,7 +750,7 @@ where
     let env: Env = try_into_contract_result!(from_json(env));
     let msg: M = try_into_contract_result!(from_json(msg));
 
-    let deps = make_dependencies();
+    let deps = deps_from_imports();
     query_fn(deps.as_ref(), env, msg).into()
 }
 
@@ -771,7 +771,7 @@ where
     let env: Env = try_into_contract_result!(from_json(env));
     let msg: IbcChannelOpenMsg = try_into_contract_result!(from_json(msg));
 
-    let mut deps = make_dependencies();
+    let mut deps = deps_from_imports();
     contract_fn(deps.as_mut(), env, msg).into()
 }
 
@@ -794,7 +794,7 @@ where
     let env: Env = try_into_contract_result!(from_json(env));
     let msg: IbcChannelConnectMsg = try_into_contract_result!(from_json(msg));
 
-    let mut deps = make_dependencies();
+    let mut deps = deps_from_imports();
     contract_fn(deps.as_mut(), env, msg).into()
 }
 
@@ -817,7 +817,7 @@ where
     let env: Env = try_into_contract_result!(from_json(env));
     let msg: IbcChannelCloseMsg = try_into_contract_result!(from_json(msg));
 
-    let mut deps = make_dependencies();
+    let mut deps = deps_from_imports();
     contract_fn(deps.as_mut(), env, msg).into()
 }
 
@@ -840,7 +840,7 @@ where
     let env: Env = try_into_contract_result!(from_json(env));
     let msg: IbcPacketReceiveMsg = try_into_contract_result!(from_json(msg));
 
-    let mut deps = make_dependencies();
+    let mut deps = deps_from_imports();
     contract_fn(deps.as_mut(), env, msg).into()
 }
 
@@ -863,7 +863,7 @@ where
     let env: Env = try_into_contract_result!(from_json(env));
     let msg: IbcPacketAckMsg = try_into_contract_result!(from_json(msg));
 
-    let mut deps = make_dependencies();
+    let mut deps = deps_from_imports();
     contract_fn(deps.as_mut(), env, msg).into()
 }
 
@@ -886,7 +886,7 @@ where
     let env: Env = try_into_contract_result!(from_json(env));
     let msg: IbcPacketTimeoutMsg = try_into_contract_result!(from_json(msg));
 
-    let mut deps = make_dependencies();
+    let mut deps = deps_from_imports();
     contract_fn(deps.as_mut(), env, msg).into()
 }
 
@@ -908,7 +908,7 @@ where
     let env: Env = try_into_contract_result!(from_json(env));
     let msg: IbcSourceCallbackMsg = try_into_contract_result!(from_json(msg));
 
-    let mut deps = make_dependencies();
+    let mut deps = deps_from_imports();
     contract_fn(deps.as_mut(), env, msg).into()
 }
 
@@ -934,12 +934,12 @@ where
     let env: Env = try_into_contract_result!(from_json(env));
     let msg: IbcDestinationCallbackMsg = try_into_contract_result!(from_json(msg));
 
-    let mut deps = make_dependencies();
+    let mut deps = deps_from_imports();
     contract_fn(deps.as_mut(), env, msg).into()
 }
 
 /// Makes all bridges to external dependencies (i.e. Wasm imports) that are injected by the VM
-pub(crate) fn make_dependencies<Q>() -> OwnedDeps<ExternalStorage, ExternalApi, ExternalQuerier, Q>
+fn deps_from_imports<Q>() -> OwnedDeps<ExternalStorage, ExternalApi, ExternalQuerier, Q>
 where
     Q: CustomQuery,
 {
@@ -970,7 +970,7 @@ where
     let env: Env = try_into_contract_result!(from_json(env));
     let msg: Ibc2PacketReceiveMsg = try_into_contract_result!(from_json(msg));
 
-    let mut deps = make_dependencies();
+    let mut deps = deps_from_imports();
     contract_fn(deps.as_mut(), env, msg).into()
 }
 
@@ -993,6 +993,6 @@ where
     let env: Env = try_into_contract_result!(from_json(env));
     let msg: Ibc2PacketTimeoutMsg = try_into_contract_result!(from_json(msg));
 
-    let mut deps = make_dependencies();
+    let mut deps = deps_from_imports();
     contract_fn(deps.as_mut(), env, msg).into()
 }

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -137,8 +137,6 @@ pub use crate::exports::{
     do_ibc_channel_close, do_ibc_channel_connect, do_ibc_channel_open, do_ibc_packet_ack,
     do_ibc_packet_receive, do_ibc_packet_timeout,
 };
-#[cfg(target_arch = "wasm32")]
-pub use crate::imports::{ExternalApi, ExternalQuerier, ExternalStorage};
 
 /// Exposed for testing only
 /// Both unit tests and integration tests are compiled to native code, so everything in here does not need to compile to Wasm.


### PR DESCRIPTION
This is a follow up to https://github.com/CosmWasm/cosmwasm/commit/5ab586b6251a98bf60816fb87e0c02403374ab7f. The realisation here is that the imports are only used by exports. No other user of cosmwasm-std than calls of a VM into a contract can use them. This PR does a few small things
* Rename `make_dependencies` to `deps_from_imports` to express that the resulting `OwnedDeps` is implemented through imports
* Make `deps_from_imports` non-public because only exports use it
* Unpublish `ExternalApi`, `ExternalQuerier` and `ExternalStorage` which are only used by `deps_from_imports` and exports
* Move `deps_from_imports` to the end of the file again

This then allows us to deactivate all imports and all exports even for target=wasm32-unknown-unknown which later can solve #1962.