### PR TITLE
Bump min time version to 0.3.35

### DIFF
--- a/packages/vm/Cargo.toml
+++ b/packages/vm/Cargo.toml
@@ -91,7 +91,7 @@ wasm-encoder = "0.205.0"
 clap = "4"
 leb128 = "0.2"
 target-lexicon = "0.12"
-time = { version = "0.3.28", features = ["formatting"] }
+time = { version = "0.3.35", features = ["formatting"] }
 
 [[bench]]
 name = "main"


### PR DESCRIPTION
to avoid

```
   Compiling time v0.3.28
error[E0282]: type annotations needed for `Box<_>`
  --> /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/time-0.3.28/src/format_description/parse/mod.rs:83:9
   |
83 |     let items = format_items
   |         ^^^^^
...
86 |     Ok(items.into())
   |              ---- type must be known at this point
   |
   = note: this is an inference error on crate `time` caused by an API change in Rust 1.80.0; update `time` to version `>=0.3.35` by calling `cargo update`

For more information about this error, try `rustc --explain E0282`.
```