### PR TITLE
Update comment regarding ecdsa dependency in cosmwasm-crypto

### DIFF
--- a/packages/crypto/Cargo.toml
+++ b/packages/crypto/Cargo.toml
@@ -18,11 +18,11 @@ ark-ff = { version = "0.5.0", features = ["asm", "parallel"] }
 ark-serialize = "0.5.0"
 cosmwasm-core = { version = "3.0.0-rc.0", path = "../core" }
 digest = "0.10"
-ecdsa = "0.16.2"                                                              # Not used directly, but needed to bump transitive dependency, see: https://github.com/CosmWasm/cosmwasm/pull/1899 for details.
 ed25519-zebra = { version = "4.0.3", default-features = false }
 k256 = { version = "0.13.3", default-features = false, features = ["ecdsa"] }
 num-traits = "0.2.18"
 p256 = { version = "0.13.2", default-features = false, features = ["ecdsa"] }
+ecdsa = "0.16.8" # Needed for RecoveryId in secp256r1_recover_pubkey, see https://github.com/RustCrypto/elliptic-curves/issues/1215
 rand_core = "0.6"
 rayon = "1.9.0"
 sha2 = "0.10"


### PR DESCRIPTION
[k256 0.13.3 already has the dependency on ^0.16.8](https://crates.io/crates/k256/0.13.3/dependencies) so we don't need it for the patch version anymore. But we use `ecdsa::RecoveryId` due to https://github.com/RustCrypto/elliptic-curves/issues/1215