### PR TITLE
Remove unnecessary brackets and incorrect indent to make clippy 1.87 happy

### DIFF
--- a/contracts/burner/tests/integration.rs
+++ b/contracts/burner/tests/integration.rs
@@ -1,21 +1,6 @@
 //! This integration test tries to run and call the generated wasm.
 //! It depends on a Wasm build being available, which you can create with `cargo wasm`.
 //! Then running `cargo integration-test` will validate we can properly call into that generated Wasm.
-//!
-//! You can easily convert unit tests to integration tests.
-//! 1. First copy them over verbatim,
-//! 2. Then change
-//!      let mut deps = mock_dependencies(20, &[]);
-//!    to
-//!      let mut deps = mock_instance(WASM, &[]);
-//! 3. If you access raw storage, where ever you see something like:
-//!      deps.storage.get(CONFIG_KEY).expect("no data stored");
-//!    replace it with:
-//!      deps.with_storage(|store| {
-//!          let data = store.get(CONFIG_KEY).expect("no data stored");
-//!          //...
-//!      });
-//! 4. Anywhere you see query(&deps, ...) you must replace it with query(&mut deps, ...)
 
 use cosmwasm_std::{coins, Attribute, BankMsg, ContractResult, Order, Response, SubMsg};
 use cosmwasm_vm::testing::{execute, instantiate, migrate, mock_env, mock_info, mock_instance};

--- a/contracts/crypto-verify/tests/integration.rs
+++ b/contracts/crypto-verify/tests/integration.rs
@@ -1,23 +1,6 @@
 //! This integration test tries to run and call the generated wasm.
 //! It depends on a Wasm build being available, which you can create with `cargo wasm`.
 //! Then running `cargo integration-test` will validate we can properly call into that generated Wasm.
-//!
-//! You can easily convert unit tests to integration tests.
-//! 1. First copy them over verbatim,
-//! 2. Then change
-//!      let mut deps = mock_dependencies(20, &[]);
-//!    to
-//!      let mut deps = mock_instance(WASM, &[]);
-//! 3. If you access raw storage, where ever you see something like:
-//!      deps.storage.get(CONFIG_KEY).expect("no data stored");
-//!    replace it with:
-//!      deps.with_storage(|store| {
-//!          let data = store.get(CONFIG_KEY).expect("no data stored");
-//!          //...
-//!      });
-//! 4. Anywhere you see init/execute(deps.as_mut(), ...) you must replace it with init/execute(&mut deps, ...)
-//! 5. Anywhere you see query(deps.as_ref(), ...) you must replace it with query(&mut deps, ...)
-//!    (Use cosmwasm_vm::testing::{init, execute, query}, instead of the contract variants).
 
 use cosmwasm_std::{Binary, Response, Uint128};
 use cosmwasm_vm::testing::{

--- a/contracts/cyberpunk/tests/integration.rs
+++ b/contracts/cyberpunk/tests/integration.rs
@@ -1,21 +1,6 @@
 //! This integration test tries to run and call the generated wasm.
 //! It depends on a Wasm build being available, which you can create with `cargo wasm`.
 //! Then running `cargo integration-test` will validate we can properly call into that generated Wasm.
-//!
-//! You can easily convert unit tests to integration tests as follows:
-//! 1. Copy them over verbatim
-//! 2. Then change
-//!      let mut deps = mock_dependencies(20, &[]);
-//!    to
-//!      let mut deps = mock_instance(WASM, &[]);
-//! 3. If you access raw storage, where ever you see something like:
-//!      deps.storage.get(CONFIG_KEY).expect("no data stored");
-//!    replace it with:
-//!      deps.with_storage(|store| {
-//!          let data = store.get(CONFIG_KEY).expect("no data stored");
-//!          //...
-//!      });
-//! 4. Anywhere you see query(&deps, ...) you must replace it with query(&mut deps, ...)
 
 use cosmwasm_std::{from_json, Empty, Env, Response};
 use cosmwasm_vm::testing::{

--- a/contracts/empty/tests/integration.rs
+++ b/contracts/empty/tests/integration.rs
@@ -1,21 +1,6 @@
 //! This integration test tries to run and call the generated wasm.
 //! It depends on a Wasm build being available, which you can create with `cargo wasm`.
 //! Then running `cargo integration-test` will validate we can properly call into that generated Wasm.
-//!
-//! You can easily convert unit tests to integration tests.
-//! 1. First copy them over verbatim,
-//! 2. Then change
-//!      let mut deps = mock_dependencies(20, &[]);
-//!    to
-//!      let mut deps = mock_instance(WASM, &[]);
-//! 3. If you access raw storage, where ever you see something like:
-//!      deps.storage.get(CONFIG_KEY).expect("no data stored");
-//!    replace it with:
-//!      deps.with_storage(|store| {
-//!          let data = store.get(CONFIG_KEY).expect("no data stored");
-//!          //...
-//!      });
-//! 4. Anywhere you see query(&deps, ...) you must replace it with query(&mut deps, ...)
 
 use cosmwasm_vm::testing::mock_instance;
 

--- a/contracts/hackatom/tests/integration.rs
+++ b/contracts/hackatom/tests/integration.rs
@@ -1,21 +1,6 @@
 //! This integration test tries to run and call the generated wasm.
 //! It depends on a Wasm build being available, which you can create with `cargo wasm`.
 //! Then running `cargo integration-test` will validate we can properly call into that generated Wasm.
-//!
-//! You can easily convert unit tests to integration tests as follows:
-//! 1. Copy them over verbatim
-//! 2. Then change
-//!      let mut deps = mock_dependencies(20, &[]);
-//!    to
-//!      let mut deps = mock_instance(WASM, &[]);
-//! 3. If you access raw storage, where ever you see something like:
-//!      deps.storage.get(CONFIG_KEY).expect("no data stored");
-//!    replace it with:
-//!      deps.with_storage(|store| {
-//!          let data = store.get(CONFIG_KEY).expect("no data stored");
-//!          //...
-//!      });
-//! 4. Anywhere you see query(&deps, ...) you must replace it with query(&mut deps, ...)
 
 use cosmwasm_std::{
     assert_approx_eq, coins, to_json_vec, Addr, BankMsg, Binary, ContractResult, Empty,

--- a/contracts/ibc-callbacks/tests/integration.rs
+++ b/contracts/ibc-callbacks/tests/integration.rs
@@ -1,21 +1,6 @@
 //! This integration test tries to run and call the generated wasm.
 //! It depends on a Wasm build being available, which you can create with `cargo wasm`.
 //! Then running `cargo integration-test` will validate we can properly call into that generated Wasm.
-//!
-//! You can easily convert unit tests to integration tests.
-//! 1. First copy them over verbatim,
-//! 2. Then change
-//!      let mut deps = mock_dependencies(20, &[]);
-//!    to
-//!      let mut deps = mock_instance(WASM, &[]);
-//! 3. If you access raw storage, where ever you see something like:
-//!      deps.storage.get(CONFIG_KEY).expect("no data stored");
-//!    replace it with:
-//!      deps.with_storage(|store| {
-//!          let data = store.get(CONFIG_KEY).expect("no data stored");
-//!          //...
-//!      });
-//! 4. Anywhere you see query(&deps, ...) you must replace it with query(&mut deps, ...)
 
 use cosmwasm_vm::testing::mock_instance;
 

--- a/contracts/ibc-reflect-send/tests/integration.rs
+++ b/contracts/ibc-reflect-send/tests/integration.rs
@@ -1,21 +1,6 @@
 //! This integration test tries to run and call the generated wasm.
 //! It depends on a Wasm build being available, which you can create with `cargo wasm`.
 //! Then running `cargo integration-test` will validate we can properly call into that generated Wasm.
-//!
-//! You can easily convert unit tests to integration tests.
-//! 1. First copy them over verbatim,
-//! 2. Then change
-//!      let mut deps = mock_dependencies(20, &[]);
-//!    to
-//!      let mut deps = mock_instance(WASM, &[]);
-//! 3. If you access raw storage, where ever you see something like:
-//!      deps.storage.get(CONFIG_KEY).expect("no data stored");
-//!    replace it with:
-//!      deps.with_storage(|store| {
-//!          let data = store.get(CONFIG_KEY).expect("no data stored");
-//!          //...
-//!      });
-//! 4. Anywhere you see query(&deps, ...) you must replace it with query(&mut deps, ...)
 
 use cosmwasm_std::testing::{
     mock_ibc_channel_connect_ack, mock_ibc_channel_open_init, mock_ibc_channel_open_try,

--- a/contracts/ibc-reflect/tests/integration.rs
+++ b/contracts/ibc-reflect/tests/integration.rs
@@ -1,21 +1,6 @@
 //! This integration test tries to run and call the generated wasm.
 //! It depends on a Wasm build being available, which you can create with `cargo wasm`.
 //! Then running `cargo integration-test` will validate we can properly call into that generated Wasm.
-//!
-//! You can easily convert unit tests to integration tests.
-//! 1. First copy them over verbatim,
-//! 2. Then change
-//!      let mut deps = mock_dependencies(20, &[]);
-//!    to
-//!      let mut deps = mock_instance(WASM, &[]);
-//! 3. If you access raw storage, where ever you see something like:
-//!      deps.storage.get(CONFIG_KEY).expect("no data stored");
-//!    replace it with:
-//!      deps.with_storage(|store| {
-//!          let data = store.get(CONFIG_KEY).expect("no data stored");
-//!          //...
-//!      });
-//! 4. Anywhere you see query(&deps, ...) you must replace it with query(&mut deps, ...)
 
 use cosmwasm_std::testing::{
     mock_ibc_channel_connect_ack, mock_ibc_channel_open_init, mock_ibc_channel_open_try,

--- a/contracts/queue/tests/integration.rs
+++ b/contracts/queue/tests/integration.rs
@@ -1,21 +1,6 @@
 //! This integration test tries to run and call the generated wasm.
 //! It depends on a Wasm build being available, which you can create with `cargo wasm`.
 //! Then running `cargo integration-test` will validate we can properly call into that generated Wasm.
-//!
-//! You can easily convert unit tests to integration tests as follows:
-//! 1. Copy them over verbatim
-//! 2. Then change
-//!      let mut deps = mock_dependencies(20, &[]);
-//!    to
-//!      let mut deps = mock_instance(WASM, &[]);
-//! 3. If you access raw storage, where ever you see something like:
-//!      deps.storage.get(CONFIG_KEY).expect("no data stored");
-//!    replace it with:
-//!      deps.with_storage(|store| {
-//!          let data = store.get(CONFIG_KEY).expect("no data stored");
-//!          //...
-//!      });
-//! 4. Anywhere you see query(&deps, ...) you must replace it with query(&mut deps, ...)
 
 use cosmwasm_std::{from_json, MessageInfo, Response};
 use cosmwasm_vm::{

--- a/contracts/reflect/tests/integration.rs
+++ b/contracts/reflect/tests/integration.rs
@@ -1,21 +1,6 @@
 //! This integration test tries to run and call the generated wasm.
 //! It depends on a Wasm build being available, which you can create with `cargo wasm`.
 //! Then running `cargo integration-test` will validate we can properly call into that generated Wasm.
-//!
-//! You can easily convert unit tests to integration tests as follows:
-//! 1. Copy them over verbatim
-//! 2. Then change
-//!      let mut deps = mock_dependencies(20, &[]);
-//!    to
-//!      let mut deps = mock_instance(WASM, &[]);
-//! 3. If you access raw storage, where ever you see something like:
-//!      deps.storage.get(CONFIG_KEY).expect("no data stored");
-//!    replace it with:
-//!      deps.with_storage(|store| {
-//!          let data = store.get(CONFIG_KEY).expect("no data stored");
-//!          //...
-//!      });
-//! 4. Anywhere you see query(&deps, ...) you must replace it with query(&mut deps, ...)
 
 use cosmwasm_std::{
     coin, coins, from_json, BankMsg, BankQuery, Binary, Coin, ContractResult, Event, QueryRequest,

--- a/contracts/staking/tests/integration.rs
+++ b/contracts/staking/tests/integration.rs
@@ -1,21 +1,6 @@
 //! This integration test tries to run and call the generated wasm.
 //! It depends on a Wasm build being available, which you can create with `cargo wasm`.
 //! Then running `cargo integration-test` will validate we can properly call into that generated Wasm.
-//!
-//! You can easily convert unit tests to integration tests as follows:
-//! 1. Copy them over verbatim
-//! 2. Then change
-//!      let mut deps = mock_dependencies(20, &[]);
-//!    to
-//!      let mut deps = mock_instance(WASM, &[]);
-//! 3. If you access raw storage, where ever you see something like:
-//!      deps.storage.get(CONFIG_KEY).expect("no data stored");
-//!    replace it with:
-//!      deps.with_storage(|store| {
-//!          let data = store.get(CONFIG_KEY).expect("no data stored");
-//!          //...
-//!      });
-//! 4. Anywhere you see query(&deps, ...) you must replace it with query(&mut deps, ...)
 
 use cosmwasm_std::{coin, from_json, ContractResult, Decimal, Response, Uint128, Validator};
 use cosmwasm_vm::testing::{

--- a/packages/std/src/math/decimal.rs
+++ b/packages/std/src/math/decimal.rs
@@ -2063,11 +2063,11 @@ mod tests {
         );
         assert!(matches!(
             Decimal::MAX.checked_div(Decimal::zero()),
-            Err(CheckedFromRatioError::DivideByZero {})
+            Err(CheckedFromRatioError::DivideByZero)
         ));
         assert!(matches!(
             Decimal::MAX.checked_div(Decimal::percent(1)),
-            Err(CheckedFromRatioError::Overflow {})
+            Err(CheckedFromRatioError::Overflow)
         ));
 
         // checked rem

--- a/packages/std/src/math/decimal256.rs
+++ b/packages/std/src/math/decimal256.rs
@@ -2127,11 +2127,11 @@ mod tests {
         );
         assert!(matches!(
             Decimal256::MAX.checked_div(Decimal256::zero()),
-            Err(CheckedFromRatioError::DivideByZero { .. })
+            Err(CheckedFromRatioError::DivideByZero)
         ));
         assert!(matches!(
             Decimal256::MAX.checked_div(Decimal256::percent(1)),
-            Err(CheckedFromRatioError::Overflow { .. })
+            Err(CheckedFromRatioError::Overflow)
         ));
 
         // checked rem

--- a/packages/std/src/math/signed_decimal.rs
+++ b/packages/std/src/math/signed_decimal.rs
@@ -2672,11 +2672,11 @@ mod tests {
         );
         assert!(matches!(
             SignedDecimal::MAX.checked_div(SignedDecimal::zero()),
-            Err(CheckedFromRatioError::DivideByZero {})
+            Err(CheckedFromRatioError::DivideByZero)
         ));
         assert!(matches!(
             SignedDecimal::MAX.checked_div(SignedDecimal::percent(1)),
-            Err(CheckedFromRatioError::Overflow {})
+            Err(CheckedFromRatioError::Overflow)
         ));
         assert_eq!(
             SignedDecimal::percent(-88)

--- a/packages/std/src/math/signed_decimal_256.rs
+++ b/packages/std/src/math/signed_decimal_256.rs
@@ -2773,11 +2773,11 @@ mod tests {
         );
         assert!(matches!(
             SignedDecimal256::MAX.checked_div(SignedDecimal256::zero()),
-            Err(CheckedFromRatioError::DivideByZero {})
+            Err(CheckedFromRatioError::DivideByZero)
         ));
         assert!(matches!(
             SignedDecimal256::MAX.checked_div(SignedDecimal256::percent(1)),
-            Err(CheckedFromRatioError::Overflow {})
+            Err(CheckedFromRatioError::Overflow)
         ));
         assert_eq!(
             SignedDecimal256::percent(-88)


### PR DESCRIPTION
See https://rust-lang.github.io/rust-clippy/master/index.html#unneeded_struct_pattern
and https://rust-lang.github.io/rust-clippy/master/index.html#doc_overindented_list_items