### PR TITLE
Fix broken EntryPoints.md link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ points, and no access to the outside world by default. To make them useful, we
 need to add a few elements.
 
 If you haven't worked with WebAssembly before, please read an overview on
-[how to create imports and exports](./EntryPoints.md) in general.
+[how to create imports and exports](docs/idl.md) in general.
 
 ### Exports
 


### PR DESCRIPTION
Replaced the outdated link to the missing EntryPoints.md file in the README with a reference to docs/idl.md, which now contains the relevant information about contract entry points and interface structure. This ensures users can access up-to-date documentation without encountering a broken link.