### PR TITLE
Replace generic with `dyn CustomMsg`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,6 +725,8 @@ dependencies = [
  "cosmwasm-schema",
  "crc32fast",
  "derive_more 2.0.1",
+ "dyn_partial_eq",
+ "erased-serde",
  "hex",
  "hex-literal",
  "paste",
@@ -1109,6 +1111,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
+name = "dyn_partial_eq"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a07039d197226c4b9a3810c4f165328fb4e715258a4b8584f143d38e9de04301"
+dependencies = [
+ "dyn_partial_eq_derive",
+]
+
+[[package]]
+name = "dyn_partial_eq_derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e217c6c1435ebf9b88662354589d339192b8eaf506edd22951e75e045c8e8bd"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "dynasm"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1285,6 +1306,16 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "erased-serde"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
+dependencies = [
+ "serde",
+ "typeid",
+]
 
 [[package]]
 name = "errno"
@@ -3043,6 +3074,12 @@ dependencies = [
  "cfg-if",
  "static_assertions",
 ]
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"

--- a/contracts/burner/Cargo.lock
+++ b/contracts/burner/Cargo.lock
@@ -490,6 +490,8 @@ dependencies = [
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derive_more 2.0.1",
+ "dyn_partial_eq",
+ "erased-serde",
  "hex",
  "rand_core",
  "rmp-serde",
@@ -780,6 +782,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
+name = "dyn_partial_eq"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a07039d197226c4b9a3810c4f165328fb4e715258a4b8584f143d38e9de04301"
+dependencies = [
+ "dyn_partial_eq_derive",
+]
+
+[[package]]
+name = "dyn_partial_eq_derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e217c6c1435ebf9b88662354589d339192b8eaf506edd22951e75e045c8e8bd"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "dynasm"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -944,6 +965,16 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "erased-serde"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
+dependencies = [
+ "serde",
+ "typeid",
+]
 
 [[package]]
 name = "errno"
@@ -2316,6 +2347,12 @@ dependencies = [
  "cfg-if",
  "static_assertions",
 ]
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"

--- a/contracts/crypto-verify/Cargo.lock
+++ b/contracts/crypto-verify/Cargo.lock
@@ -485,6 +485,8 @@ dependencies = [
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derive_more 2.0.1",
+ "dyn_partial_eq",
+ "erased-serde",
  "hex",
  "rand_core",
  "rmp-serde",
@@ -793,6 +795,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
+name = "dyn_partial_eq"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a07039d197226c4b9a3810c4f165328fb4e715258a4b8584f143d38e9de04301"
+dependencies = [
+ "dyn_partial_eq_derive",
+]
+
+[[package]]
+name = "dyn_partial_eq_derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e217c6c1435ebf9b88662354589d339192b8eaf506edd22951e75e045c8e8bd"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "dynasm"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -959,6 +980,16 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "erased-serde"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
+dependencies = [
+ "serde",
+ "typeid",
+]
 
 [[package]]
 name = "errno"
@@ -2393,6 +2424,12 @@ dependencies = [
  "cfg-if",
  "static_assertions",
 ]
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"

--- a/contracts/cyberpunk/Cargo.lock
+++ b/contracts/cyberpunk/Cargo.lock
@@ -508,6 +508,8 @@ dependencies = [
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derive_more 2.0.1",
+ "dyn_partial_eq",
+ "erased-serde",
  "hex",
  "rand_core",
  "rmp-serde",
@@ -810,6 +812,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
+name = "dyn_partial_eq"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a07039d197226c4b9a3810c4f165328fb4e715258a4b8584f143d38e9de04301"
+dependencies = [
+ "dyn_partial_eq_derive",
+]
+
+[[package]]
+name = "dyn_partial_eq_derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e217c6c1435ebf9b88662354589d339192b8eaf506edd22951e75e045c8e8bd"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "dynasm"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -974,6 +995,16 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "erased-serde"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
+dependencies = [
+ "serde",
+ "typeid",
+]
 
 [[package]]
 name = "errno"
@@ -2375,6 +2406,12 @@ dependencies = [
  "cfg-if",
  "static_assertions",
 ]
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"

--- a/contracts/empty/Cargo.lock
+++ b/contracts/empty/Cargo.lock
@@ -479,6 +479,8 @@ dependencies = [
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derive_more 2.0.1",
+ "dyn_partial_eq",
+ "erased-serde",
  "hex",
  "rand_core",
  "rmp-serde",
@@ -769,6 +771,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
+name = "dyn_partial_eq"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a07039d197226c4b9a3810c4f165328fb4e715258a4b8584f143d38e9de04301"
+dependencies = [
+ "dyn_partial_eq_derive",
+]
+
+[[package]]
+name = "dyn_partial_eq_derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e217c6c1435ebf9b88662354589d339192b8eaf506edd22951e75e045c8e8bd"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "dynasm"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -943,6 +964,16 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "erased-serde"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
+dependencies = [
+ "serde",
+ "typeid",
+]
 
 [[package]]
 name = "errno"
@@ -2315,6 +2346,12 @@ dependencies = [
  "cfg-if",
  "static_assertions",
 ]
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"

--- a/contracts/floaty/Cargo.lock
+++ b/contracts/floaty/Cargo.lock
@@ -479,6 +479,8 @@ dependencies = [
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derive_more 2.0.1",
+ "dyn_partial_eq",
+ "erased-serde",
  "hex",
  "rand_core",
  "rmp-serde",
@@ -769,6 +771,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
+name = "dyn_partial_eq"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a07039d197226c4b9a3810c4f165328fb4e715258a4b8584f143d38e9de04301"
+dependencies = [
+ "dyn_partial_eq_derive",
+]
+
+[[package]]
+name = "dyn_partial_eq_derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e217c6c1435ebf9b88662354589d339192b8eaf506edd22951e75e045c8e8bd"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "dynasm"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,6 +954,16 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "erased-serde"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
+dependencies = [
+ "serde",
+ "typeid",
+]
 
 [[package]]
 name = "errno"
@@ -2317,6 +2348,12 @@ dependencies = [
  "cfg-if",
  "static_assertions",
 ]
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"

--- a/contracts/hackatom/Cargo.lock
+++ b/contracts/hackatom/Cargo.lock
@@ -479,6 +479,8 @@ dependencies = [
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derive_more 2.0.1",
+ "dyn_partial_eq",
+ "erased-serde",
  "hex",
  "rand_core",
  "rmp-serde",
@@ -769,6 +771,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
+name = "dyn_partial_eq"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a07039d197226c4b9a3810c4f165328fb4e715258a4b8584f143d38e9de04301"
+dependencies = [
+ "dyn_partial_eq_derive",
+]
+
+[[package]]
+name = "dyn_partial_eq_derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e217c6c1435ebf9b88662354589d339192b8eaf506edd22951e75e045c8e8bd"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "dynasm"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,6 +954,16 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "erased-serde"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
+dependencies = [
+ "serde",
+ "typeid",
+]
 
 [[package]]
 name = "errno"
@@ -2318,6 +2349,12 @@ dependencies = [
  "cfg-if",
  "static_assertions",
 ]
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"

--- a/contracts/hackatom/tests/integration.rs
+++ b/contracts/hackatom/tests/integration.rs
@@ -3,8 +3,8 @@
 //! Then running `cargo integration-test` will validate we can properly call into that generated Wasm.
 
 use cosmwasm_std::{
-    assert_approx_eq, coins, to_json_vec, Addr, BankMsg, Binary, ContractResult, Empty,
-    MigrateInfo, Response, SubMsg,
+    assert_approx_eq, coins, to_json_vec, Addr, BankMsg, Binary, ContractResult, MigrateInfo,
+    Response, SubMsg,
 };
 use cosmwasm_vm::{
     call_execute, from_slice,
@@ -306,7 +306,7 @@ fn execute_cpu_loop() {
 
     let execute_info = mock_info(creator.as_str(), &[]);
     // Note: we need to use the production-call, not the testing call (which unwraps any vm error)
-    let execute_res = call_execute::<_, _, _, Empty>(
+    let execute_res = call_execute::<_, _, _>(
         &mut deps,
         &mock_env(),
         &execute_info,
@@ -328,7 +328,7 @@ fn execute_storage_loop() {
 
     let execute_info = mock_info(creator.as_str(), &[]);
     // Note: we need to use the production-call, not the testing call (which unwraps any vm error)
-    let execute_res = call_execute::<_, _, _, Empty>(
+    let execute_res = call_execute::<_, _, _>(
         &mut deps,
         &mock_env(),
         &execute_info,
@@ -350,7 +350,7 @@ fn execute_memory_loop() {
 
     let execute_info = mock_info(creator.as_str(), &[]);
     // Note: we need to use the production-call, not the testing call (which unwraps any vm error)
-    let execute_res = call_execute::<_, _, _, Empty>(
+    let execute_res = call_execute::<_, _, _>(
         &mut deps,
         &mock_env(),
         &execute_info,
@@ -430,7 +430,7 @@ fn execute_panic() {
     let execute_info = mock_info(creator.as_str(), &[]);
     // panic inside contract should not panic out here
     // Note: we need to use the production-call, not the testing call (which unwraps any vm error)
-    let execute_res = call_execute::<_, _, _, Empty>(
+    let execute_res = call_execute::<_, _, _>(
         &mut deps,
         &mock_env(),
         &execute_info,

--- a/contracts/ibc-callbacks/Cargo.lock
+++ b/contracts/ibc-callbacks/Cargo.lock
@@ -479,6 +479,8 @@ dependencies = [
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derive_more 2.0.1",
+ "dyn_partial_eq",
+ "erased-serde",
  "hex",
  "rand_core",
  "rmp-serde",
@@ -769,6 +771,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
+name = "dyn_partial_eq"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a07039d197226c4b9a3810c4f165328fb4e715258a4b8584f143d38e9de04301"
+dependencies = [
+ "dyn_partial_eq_derive",
+]
+
+[[package]]
+name = "dyn_partial_eq_derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e217c6c1435ebf9b88662354589d339192b8eaf506edd22951e75e045c8e8bd"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "dynasm"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,6 +954,16 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "erased-serde"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
+dependencies = [
+ "serde",
+ "typeid",
+]
 
 [[package]]
 name = "errno"
@@ -2301,6 +2332,12 @@ dependencies = [
  "cfg-if",
  "static_assertions",
 ]
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"

--- a/contracts/ibc-reflect-send/Cargo.lock
+++ b/contracts/ibc-reflect-send/Cargo.lock
@@ -479,6 +479,8 @@ dependencies = [
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derive_more 2.0.1",
+ "dyn_partial_eq",
+ "erased-serde",
  "hex",
  "rand_core",
  "rmp-serde",
@@ -769,6 +771,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
+name = "dyn_partial_eq"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a07039d197226c4b9a3810c4f165328fb4e715258a4b8584f143d38e9de04301"
+dependencies = [
+ "dyn_partial_eq_derive",
+]
+
+[[package]]
+name = "dyn_partial_eq_derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e217c6c1435ebf9b88662354589d339192b8eaf506edd22951e75e045c8e8bd"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "dynasm"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,6 +954,16 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "erased-serde"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
+dependencies = [
+ "serde",
+ "typeid",
+]
 
 [[package]]
 name = "errno"
@@ -2316,6 +2347,12 @@ dependencies = [
  "cfg-if",
  "static_assertions",
 ]
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"

--- a/contracts/ibc-reflect-send/schema/ibc-reflect-send.json
+++ b/contracts/ibc-reflect-send/schema/ibc-reflect-send.json
@@ -214,7 +214,7 @@
             ],
             "properties": {
               "custom": {
-                "$ref": "#/definitions/CustomMsg"
+                "$ref": "#/definitions/CustomMsgContainer"
               }
             },
             "additionalProperties": false
@@ -308,7 +308,9 @@
           }
         ]
       },
-      "CustomMsg": true,
+      "CustomMsgContainer": {
+        "description": "A wrapper type for CustomMsg to allow deserialization of any custom message, without knowing its type."
+      },
       "DistributionMsg": {
         "description": "The message types of the distribution module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto",
         "oneOf": [

--- a/contracts/ibc-reflect-send/schema/ibc-reflect-send.json
+++ b/contracts/ibc-reflect-send/schema/ibc-reflect-send.json
@@ -54,7 +54,7 @@
               "msgs": {
                 "type": "array",
                 "items": {
-                  "$ref": "#/definitions/CosmosMsg_for_Empty"
+                  "$ref": "#/definitions/CosmosMsg"
                 }
               }
             },
@@ -193,7 +193,7 @@
         },
         "additionalProperties": false
       },
-      "CosmosMsg_for_Empty": {
+      "CosmosMsg": {
         "oneOf": [
           {
             "type": "object",
@@ -214,7 +214,7 @@
             ],
             "properties": {
               "custom": {
-                "$ref": "#/definitions/Empty"
+                "$ref": "#/definitions/CustomMsg"
               }
             },
             "additionalProperties": false
@@ -308,6 +308,7 @@
           }
         ]
       },
+      "CustomMsg": true,
       "DistributionMsg": {
         "description": "The message types of the distribution module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto",
         "oneOf": [
@@ -358,11 +359,6 @@
             "additionalProperties": false
           }
         ]
-      },
-      "Empty": {
-        "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
-        "type": "object",
-        "additionalProperties": false
       },
       "GovMsg": {
         "description": "This message type allows the contract interact with the [x/gov] module in order to cast votes.\n\n[x/gov]: https://github.com/cosmos/cosmos-sdk/tree/v0.45.12/x/gov\n\n## Examples\n\nCast a simple vote:\n\n``` # use cosmwasm_std::{ #     HexBinary, #     Storage, Api, Querier, DepsMut, Deps, entry_point, Env, StdError, MessageInfo, #     Response, QueryResponse, # }; # type ExecuteMsg = (); use cosmwasm_std::{GovMsg, VoteOption};\n\n#[entry_point] pub fn execute( deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg, ) -> Result<Response, StdError> { // ... Ok(Response::new().add_message(GovMsg::Vote { proposal_id: 4, option: VoteOption::Yes, })) } ```\n\nCast a weighted vote:\n\n``` # use cosmwasm_std::{ #     HexBinary, #     Storage, Api, Querier, DepsMut, Deps, entry_point, Env, StdError, MessageInfo, #     Response, QueryResponse, # }; # type ExecuteMsg = (); # #[cfg(feature = \"cosmwasm_1_2\")] use cosmwasm_std::{Decimal, GovMsg, VoteOption, WeightedVoteOption};\n\n# #[cfg(feature = \"cosmwasm_1_2\")] #[entry_point] pub fn execute( deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg, ) -> Result<Response, StdError> { // ... Ok(Response::new().add_message(GovMsg::VoteWeighted { proposal_id: 4, options: vec![ WeightedVoteOption { option: VoteOption::Yes, weight: Decimal::percent(65), }, WeightedVoteOption { option: VoteOption::Abstain, weight: Decimal::percent(35), }, ], })) } ```",

--- a/contracts/ibc-reflect-send/schema/ibc/packet_msg.json
+++ b/contracts/ibc-reflect-send/schema/ibc/packet_msg.json
@@ -18,7 +18,7 @@
             "msgs": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/CosmosMsg_for_Empty"
+                "$ref": "#/definitions/CosmosMsg"
               }
             }
           },
@@ -134,7 +134,7 @@
       },
       "additionalProperties": false
     },
-    "CosmosMsg_for_Empty": {
+    "CosmosMsg": {
       "oneOf": [
         {
           "type": "object",
@@ -155,7 +155,7 @@
           ],
           "properties": {
             "custom": {
-              "$ref": "#/definitions/Empty"
+              "$ref": "#/definitions/CustomMsg"
             }
           },
           "additionalProperties": false
@@ -249,6 +249,7 @@
         }
       ]
     },
+    "CustomMsg": true,
     "DistributionMsg": {
       "description": "The message types of the distribution module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto",
       "oneOf": [
@@ -299,11 +300,6 @@
           "additionalProperties": false
         }
       ]
-    },
-    "Empty": {
-      "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
-      "type": "object",
-      "additionalProperties": false
     },
     "GovMsg": {
       "description": "This message type allows the contract interact with the [x/gov] module in order to cast votes.\n\n[x/gov]: https://github.com/cosmos/cosmos-sdk/tree/v0.45.12/x/gov\n\n## Examples\n\nCast a simple vote:\n\n``` # use cosmwasm_std::{ #     HexBinary, #     Storage, Api, Querier, DepsMut, Deps, entry_point, Env, StdError, MessageInfo, #     Response, QueryResponse, # }; # type ExecuteMsg = (); use cosmwasm_std::{GovMsg, VoteOption};\n\n#[entry_point] pub fn execute( deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg, ) -> Result<Response, StdError> { // ... Ok(Response::new().add_message(GovMsg::Vote { proposal_id: 4, option: VoteOption::Yes, })) } ```\n\nCast a weighted vote:\n\n``` # use cosmwasm_std::{ #     HexBinary, #     Storage, Api, Querier, DepsMut, Deps, entry_point, Env, StdError, MessageInfo, #     Response, QueryResponse, # }; # type ExecuteMsg = (); # #[cfg(feature = \"cosmwasm_1_2\")] use cosmwasm_std::{Decimal, GovMsg, VoteOption, WeightedVoteOption};\n\n# #[cfg(feature = \"cosmwasm_1_2\")] #[entry_point] pub fn execute( deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg, ) -> Result<Response, StdError> { // ... Ok(Response::new().add_message(GovMsg::VoteWeighted { proposal_id: 4, options: vec![ WeightedVoteOption { option: VoteOption::Yes, weight: Decimal::percent(65), }, WeightedVoteOption { option: VoteOption::Abstain, weight: Decimal::percent(35), }, ], })) } ```",

--- a/contracts/ibc-reflect-send/schema/ibc/packet_msg.json
+++ b/contracts/ibc-reflect-send/schema/ibc/packet_msg.json
@@ -155,7 +155,7 @@
           ],
           "properties": {
             "custom": {
-              "$ref": "#/definitions/CustomMsg"
+              "$ref": "#/definitions/CustomMsgContainer"
             }
           },
           "additionalProperties": false
@@ -249,7 +249,9 @@
         }
       ]
     },
-    "CustomMsg": true,
+    "CustomMsgContainer": {
+      "description": "A wrapper type for CustomMsg to allow deserialization of any custom message, without knowing its type."
+    },
     "DistributionMsg": {
       "description": "The message types of the distribution module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto",
       "oneOf": [

--- a/contracts/ibc-reflect-send/schema/raw/execute.json
+++ b/contracts/ibc-reflect-send/schema/raw/execute.json
@@ -43,7 +43,7 @@
             "msgs": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/CosmosMsg_for_Empty"
+                "$ref": "#/definitions/CosmosMsg"
               }
             }
           },
@@ -182,7 +182,7 @@
       },
       "additionalProperties": false
     },
-    "CosmosMsg_for_Empty": {
+    "CosmosMsg": {
       "oneOf": [
         {
           "type": "object",
@@ -203,7 +203,7 @@
           ],
           "properties": {
             "custom": {
-              "$ref": "#/definitions/Empty"
+              "$ref": "#/definitions/CustomMsg"
             }
           },
           "additionalProperties": false
@@ -297,6 +297,7 @@
         }
       ]
     },
+    "CustomMsg": true,
     "DistributionMsg": {
       "description": "The message types of the distribution module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto",
       "oneOf": [
@@ -347,11 +348,6 @@
           "additionalProperties": false
         }
       ]
-    },
-    "Empty": {
-      "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
-      "type": "object",
-      "additionalProperties": false
     },
     "GovMsg": {
       "description": "This message type allows the contract interact with the [x/gov] module in order to cast votes.\n\n[x/gov]: https://github.com/cosmos/cosmos-sdk/tree/v0.45.12/x/gov\n\n## Examples\n\nCast a simple vote:\n\n``` # use cosmwasm_std::{ #     HexBinary, #     Storage, Api, Querier, DepsMut, Deps, entry_point, Env, StdError, MessageInfo, #     Response, QueryResponse, # }; # type ExecuteMsg = (); use cosmwasm_std::{GovMsg, VoteOption};\n\n#[entry_point] pub fn execute( deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg, ) -> Result<Response, StdError> { // ... Ok(Response::new().add_message(GovMsg::Vote { proposal_id: 4, option: VoteOption::Yes, })) } ```\n\nCast a weighted vote:\n\n``` # use cosmwasm_std::{ #     HexBinary, #     Storage, Api, Querier, DepsMut, Deps, entry_point, Env, StdError, MessageInfo, #     Response, QueryResponse, # }; # type ExecuteMsg = (); # #[cfg(feature = \"cosmwasm_1_2\")] use cosmwasm_std::{Decimal, GovMsg, VoteOption, WeightedVoteOption};\n\n# #[cfg(feature = \"cosmwasm_1_2\")] #[entry_point] pub fn execute( deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg, ) -> Result<Response, StdError> { // ... Ok(Response::new().add_message(GovMsg::VoteWeighted { proposal_id: 4, options: vec![ WeightedVoteOption { option: VoteOption::Yes, weight: Decimal::percent(65), }, WeightedVoteOption { option: VoteOption::Abstain, weight: Decimal::percent(35), }, ], })) } ```",

--- a/contracts/ibc-reflect-send/schema/raw/execute.json
+++ b/contracts/ibc-reflect-send/schema/raw/execute.json
@@ -203,7 +203,7 @@
           ],
           "properties": {
             "custom": {
-              "$ref": "#/definitions/CustomMsg"
+              "$ref": "#/definitions/CustomMsgContainer"
             }
           },
           "additionalProperties": false
@@ -297,7 +297,9 @@
         }
       ]
     },
-    "CustomMsg": true,
+    "CustomMsgContainer": {
+      "description": "A wrapper type for CustomMsg to allow deserialization of any custom message, without knowing its type."
+    },
     "DistributionMsg": {
       "description": "The message types of the distribution module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto",
       "oneOf": [

--- a/contracts/ibc-reflect-send/src/msg.rs
+++ b/contracts/ibc-reflect-send/src/msg.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{Coin, CosmosMsg, Empty, Timestamp};
+use cosmwasm_std::{Coin, CosmosMsg, Timestamp};
 
 use crate::state::AccountData;
 
@@ -16,7 +16,7 @@ pub enum ExecuteMsg {
     SendMsgs {
         channel_id: String,
         // Note: we don't handle custom messages on remote chains
-        msgs: Vec<CosmosMsg<Empty>>,
+        msgs: Vec<CosmosMsg>,
     },
     CheckRemoteBalance {
         channel_id: String,

--- a/contracts/ibc-reflect-send/tests/integration.rs
+++ b/contracts/ibc-reflect-send/tests/integration.rs
@@ -7,8 +7,8 @@ use cosmwasm_std::testing::{
     mock_ibc_packet_ack,
 };
 use cosmwasm_std::{
-    attr, coin, coins, BankMsg, CosmosMsg, Empty, IbcAcknowledgement, IbcBasicResponse, IbcMsg,
-    IbcOrder, Response,
+    attr, coin, coins, BankMsg, CosmosMsg, IbcAcknowledgement, IbcBasicResponse, IbcMsg, IbcOrder,
+    Response,
 };
 use cosmwasm_vm::testing::{
     execute, ibc_channel_connect, ibc_channel_open, ibc_packet_ack, instantiate, mock_env,
@@ -195,7 +195,7 @@ fn send_remote_funds() {
         transfer_channel_id: transfer_channel_id.into(),
     };
     let info = mock_info(CREATOR, &coins(12344, "utrgd"));
-    execute::<_, _, _, _, Empty>(&mut deps, mock_env(), info, msg).unwrap_err();
+    execute::<_, _, _, _>(&mut deps, mock_env(), info, msg).unwrap_err();
 
     // let's try with no sent funds in the message
     let msg = ExecuteMsg::SendFunds {
@@ -203,7 +203,7 @@ fn send_remote_funds() {
         transfer_channel_id: transfer_channel_id.into(),
     };
     let info = mock_info(CREATOR, &[]);
-    execute::<_, _, _, _, Empty>(&mut deps, mock_env(), info, msg).unwrap_err();
+    execute::<_, _, _, _>(&mut deps, mock_env(), info, msg).unwrap_err();
 
     // 3rd times the charm
     let msg = ExecuteMsg::SendFunds {

--- a/contracts/ibc-reflect/Cargo.lock
+++ b/contracts/ibc-reflect/Cargo.lock
@@ -479,6 +479,8 @@ dependencies = [
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derive_more 2.0.1",
+ "dyn_partial_eq",
+ "erased-serde",
  "hex",
  "rand_core",
  "rmp-serde",
@@ -769,6 +771,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
+name = "dyn_partial_eq"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a07039d197226c4b9a3810c4f165328fb4e715258a4b8584f143d38e9de04301"
+dependencies = [
+ "dyn_partial_eq_derive",
+]
+
+[[package]]
+name = "dyn_partial_eq_derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e217c6c1435ebf9b88662354589d339192b8eaf506edd22951e75e045c8e8bd"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "dynasm"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,6 +954,16 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "erased-serde"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
+dependencies = [
+ "serde",
+ "typeid",
+]
 
 [[package]]
 name = "errno"
@@ -2316,6 +2347,12 @@ dependencies = [
  "cfg-if",
  "static_assertions",
 ]
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"

--- a/contracts/ibc-reflect/schema/ibc/packet_msg.json
+++ b/contracts/ibc-reflect/schema/ibc/packet_msg.json
@@ -17,7 +17,7 @@
             "msgs": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/CosmosMsg_for_Empty"
+                "$ref": "#/definitions/CosmosMsg"
               }
             }
           },
@@ -109,7 +109,7 @@
             "msgs": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/CosmosMsg_for_Empty"
+                "$ref": "#/definitions/CosmosMsg"
               }
             }
           },
@@ -229,7 +229,7 @@
       },
       "additionalProperties": false
     },
-    "CosmosMsg_for_Empty": {
+    "CosmosMsg": {
       "oneOf": [
         {
           "type": "object",
@@ -250,7 +250,7 @@
           ],
           "properties": {
             "custom": {
-              "$ref": "#/definitions/Empty"
+              "$ref": "#/definitions/CustomMsg"
             }
           },
           "additionalProperties": false
@@ -333,14 +333,10 @@
         }
       ]
     },
+    "CustomMsg": true,
     "Decimal": {
       "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
       "type": "string"
-    },
-    "Empty": {
-      "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
-      "type": "object",
-      "additionalProperties": false
     },
     "GovMsg": {
       "description": "This message type allows the contract interact with the [x/gov] module in order to cast votes.\n\n[x/gov]: https://github.com/cosmos/cosmos-sdk/tree/v0.45.12/x/gov\n\n## Examples\n\nCast a simple vote:\n\n``` # use cosmwasm_std::{ #     HexBinary, #     Storage, Api, Querier, DepsMut, Deps, entry_point, Env, StdError, MessageInfo, #     Response, QueryResponse, # }; # type ExecuteMsg = (); use cosmwasm_std::{GovMsg, VoteOption};\n\n#[entry_point] pub fn execute( deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg, ) -> Result<Response, StdError> { // ... Ok(Response::new().add_message(GovMsg::Vote { proposal_id: 4, option: VoteOption::Yes, })) } ```\n\nCast a weighted vote:\n\n``` # use cosmwasm_std::{ #     HexBinary, #     Storage, Api, Querier, DepsMut, Deps, entry_point, Env, StdError, MessageInfo, #     Response, QueryResponse, # }; # type ExecuteMsg = (); # #[cfg(feature = \"cosmwasm_1_2\")] use cosmwasm_std::{Decimal, GovMsg, VoteOption, WeightedVoteOption};\n\n# #[cfg(feature = \"cosmwasm_1_2\")] #[entry_point] pub fn execute( deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg, ) -> Result<Response, StdError> { // ... Ok(Response::new().add_message(GovMsg::VoteWeighted { proposal_id: 4, options: vec![ WeightedVoteOption { option: VoteOption::Yes, weight: Decimal::percent(65), }, WeightedVoteOption { option: VoteOption::Abstain, weight: Decimal::percent(35), }, ], })) } ```",

--- a/contracts/ibc-reflect/schema/ibc/packet_msg.json
+++ b/contracts/ibc-reflect/schema/ibc/packet_msg.json
@@ -250,7 +250,7 @@
           ],
           "properties": {
             "custom": {
-              "$ref": "#/definitions/CustomMsg"
+              "$ref": "#/definitions/CustomMsgContainer"
             }
           },
           "additionalProperties": false
@@ -333,7 +333,9 @@
         }
       ]
     },
-    "CustomMsg": true,
+    "CustomMsgContainer": {
+      "description": "A wrapper type for CustomMsg to allow deserialization of any custom message, without knowing its type."
+    },
     "Decimal": {
       "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
       "type": "string"

--- a/contracts/ibc2/Cargo.lock
+++ b/contracts/ibc2/Cargo.lock
@@ -82,7 +82,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -95,7 +95,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -135,7 +135,7 @@ checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -245,7 +245,7 @@ version = "3.0.0-rc.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -265,7 +265,7 @@ version = "3.0.0-rc.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -279,6 +279,8 @@ dependencies = [
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derive_more",
+ "dyn_partial_eq",
+ "erased-serde",
  "hex",
  "rand_core",
  "rmp-serde",
@@ -370,7 +372,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -400,7 +402,7 @@ checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.98",
  "unicode-xid",
 ]
 
@@ -421,6 +423,25 @@ name = "dyn-clone"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "feeef44e73baff3a26d371801df019877a9866a8c493d315ab00177843314f35"
+
+[[package]]
+name = "dyn_partial_eq"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a07039d197226c4b9a3810c4f165328fb4e715258a4b8584f143d38e9de04301"
+dependencies = [
+ "dyn_partial_eq_derive",
+]
+
+[[package]]
+name = "dyn_partial_eq_derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e217c6c1435ebf9b88662354589d339192b8eaf506edd22951e75e045c8e8bd"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "ecdsa"
@@ -468,7 +489,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -512,7 +533,17 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "erased-serde"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
+dependencies = [
+ "serde",
+ "typeid",
 ]
 
 [[package]]
@@ -859,7 +890,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -898,7 +929,7 @@ checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -909,7 +940,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -959,6 +990,17 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
@@ -985,8 +1027,14 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.98",
 ]
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
@@ -1036,7 +1084,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1056,5 +1104,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.98",
 ]

--- a/contracts/queue/Cargo.lock
+++ b/contracts/queue/Cargo.lock
@@ -479,6 +479,8 @@ dependencies = [
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derive_more 2.0.1",
+ "dyn_partial_eq",
+ "erased-serde",
  "hex",
  "rand_core",
  "rmp-serde",
@@ -769,6 +771,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
+name = "dyn_partial_eq"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a07039d197226c4b9a3810c4f165328fb4e715258a4b8584f143d38e9de04301"
+dependencies = [
+ "dyn_partial_eq_derive",
+]
+
+[[package]]
+name = "dyn_partial_eq_derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e217c6c1435ebf9b88662354589d339192b8eaf506edd22951e75e045c8e8bd"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "dynasm"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,6 +954,16 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "erased-serde"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
+dependencies = [
+ "serde",
+ "typeid",
+]
 
 [[package]]
 name = "errno"
@@ -2316,6 +2347,12 @@ dependencies = [
  "cfg-if",
  "static_assertions",
 ]
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"

--- a/contracts/reflect/Cargo.lock
+++ b/contracts/reflect/Cargo.lock
@@ -479,6 +479,8 @@ dependencies = [
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derive_more 2.0.1",
+ "dyn_partial_eq",
+ "erased-serde",
  "hex",
  "rand_core",
  "rmp-serde",
@@ -769,6 +771,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
+name = "dyn_partial_eq"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a07039d197226c4b9a3810c4f165328fb4e715258a4b8584f143d38e9de04301"
+dependencies = [
+ "dyn_partial_eq_derive",
+]
+
+[[package]]
+name = "dyn_partial_eq_derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e217c6c1435ebf9b88662354589d339192b8eaf506edd22951e75e045c8e8bd"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "dynasm"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,6 +954,16 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "erased-serde"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
+dependencies = [
+ "serde",
+ "typeid",
+]
 
 [[package]]
 name = "errno"
@@ -1764,6 +1795,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-vm",
+ "dyn_partial_eq",
  "schemars",
  "serde",
  "thiserror",
@@ -2317,6 +2349,12 @@ dependencies = [
  "cfg-if",
  "static_assertions",
 ]
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"

--- a/contracts/reflect/Cargo.toml
+++ b/contracts/reflect/Cargo.toml
@@ -32,6 +32,7 @@ cosmwasm-std = { path = "../../packages/std", default-features = false, features
     "stargate",
     "std",
 ] }
+dyn_partial_eq = { version = "0.1.2", default-features = false }
 schemars = "0.8.12"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = "1.0.26"

--- a/contracts/reflect/schema/raw/execute.json
+++ b/contracts/reflect/schema/raw/execute.json
@@ -190,7 +190,7 @@
           ],
           "properties": {
             "custom": {
-              "$ref": "#/definitions/CustomMsg"
+              "$ref": "#/definitions/CustomMsgContainer"
             }
           },
           "additionalProperties": false
@@ -297,7 +297,9 @@
         }
       ]
     },
-    "CustomMsg": true,
+    "CustomMsgContainer": {
+      "description": "A wrapper type for CustomMsg to allow deserialization of any custom message, without knowing its type."
+    },
     "Decimal": {
       "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
       "type": "string"

--- a/contracts/reflect/schema/raw/execute.json
+++ b/contracts/reflect/schema/raw/execute.json
@@ -17,7 +17,7 @@
             "msgs": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/CosmosMsg_for_CustomMsg"
+                "$ref": "#/definitions/CosmosMsg"
               }
             }
           },
@@ -41,7 +41,7 @@
             "msgs": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/SubMsg_for_CustomMsg"
+                "$ref": "#/definitions/SubMsg"
               }
             }
           },
@@ -169,7 +169,7 @@
       },
       "additionalProperties": false
     },
-    "CosmosMsg_for_CustomMsg": {
+    "CosmosMsg": {
       "oneOf": [
         {
           "type": "object",
@@ -297,35 +297,7 @@
         }
       ]
     },
-    "CustomMsg": {
-      "description": "CustomMsg is an override of CosmosMsg::Custom to show this works and can be extended in the contract",
-      "oneOf": [
-        {
-          "type": "object",
-          "required": [
-            "debug"
-          ],
-          "properties": {
-            "debug": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "required": [
-            "raw"
-          ],
-          "properties": {
-            "raw": {
-              "$ref": "#/definitions/Binary"
-            }
-          },
-          "additionalProperties": false
-        }
-      ]
-    },
+    "CustomMsg": true,
     "Decimal": {
       "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
       "type": "string"
@@ -812,7 +784,7 @@
         }
       ]
     },
-    "SubMsg_for_CustomMsg": {
+    "SubMsg": {
       "description": "A submessage that will guarantee a `reply` call on success or error, depending on the `reply_on` setting. If you do not need to process the result, use regular messages instead.\n\nNote: On error the submessage execution will revert any partial state changes due to this message, but not revert any state changes in the calling contract. If this is required, it must be done manually in the `reply` entry point.",
       "type": "object",
       "required": [
@@ -837,7 +809,7 @@
           "minimum": 0.0
         },
         "msg": {
-          "$ref": "#/definitions/CosmosMsg_for_CustomMsg"
+          "$ref": "#/definitions/CosmosMsg"
         },
         "payload": {
           "description": "Some arbitrary data that the contract can set in an application specific way. This is just passed into the `reply` entry point and is not stored to state. Any encoding can be used. If `id` is used to identify a particular action, the encoding can also be different for each of those actions since you can match `id` first and then start processing the `payload`.\n\nThe environment restricts the length of this field in order to avoid abuse. The limit is environment specific and can change over time. The initial default is 128 KiB.\n\nUnset/nil/null cannot be differentiated from empty data.\n\nOn chains running CosmWasm 1.x this field will be ignored.",

--- a/contracts/reflect/schema/reflect.json
+++ b/contracts/reflect/schema/reflect.json
@@ -200,7 +200,7 @@
             ],
             "properties": {
               "custom": {
-                "$ref": "#/definitions/CustomMsg"
+                "$ref": "#/definitions/CustomMsgContainer"
               }
             },
             "additionalProperties": false
@@ -307,7 +307,9 @@
           }
         ]
       },
-      "CustomMsg": true,
+      "CustomMsgContainer": {
+        "description": "A wrapper type for CustomMsg to allow deserialization of any custom message, without knowing its type."
+      },
       "Decimal": {
         "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
         "type": "string"

--- a/contracts/reflect/schema/reflect.json
+++ b/contracts/reflect/schema/reflect.json
@@ -27,7 +27,7 @@
               "msgs": {
                 "type": "array",
                 "items": {
-                  "$ref": "#/definitions/CosmosMsg_for_CustomMsg"
+                  "$ref": "#/definitions/CosmosMsg"
                 }
               }
             },
@@ -51,7 +51,7 @@
               "msgs": {
                 "type": "array",
                 "items": {
-                  "$ref": "#/definitions/SubMsg_for_CustomMsg"
+                  "$ref": "#/definitions/SubMsg"
                 }
               }
             },
@@ -179,7 +179,7 @@
         },
         "additionalProperties": false
       },
-      "CosmosMsg_for_CustomMsg": {
+      "CosmosMsg": {
         "oneOf": [
           {
             "type": "object",
@@ -307,35 +307,7 @@
           }
         ]
       },
-      "CustomMsg": {
-        "description": "CustomMsg is an override of CosmosMsg::Custom to show this works and can be extended in the contract",
-        "oneOf": [
-          {
-            "type": "object",
-            "required": [
-              "debug"
-            ],
-            "properties": {
-              "debug": {
-                "type": "string"
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "raw"
-            ],
-            "properties": {
-              "raw": {
-                "$ref": "#/definitions/Binary"
-              }
-            },
-            "additionalProperties": false
-          }
-        ]
-      },
+      "CustomMsg": true,
       "Decimal": {
         "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
         "type": "string"
@@ -822,7 +794,7 @@
           }
         ]
       },
-      "SubMsg_for_CustomMsg": {
+      "SubMsg": {
         "description": "A submessage that will guarantee a `reply` call on success or error, depending on the `reply_on` setting. If you do not need to process the result, use regular messages instead.\n\nNote: On error the submessage execution will revert any partial state changes due to this message, but not revert any state changes in the calling contract. If this is required, it must be done manually in the `reply` entry point.",
         "type": "object",
         "required": [
@@ -847,7 +819,7 @@
             "minimum": 0.0
           },
           "msg": {
-            "$ref": "#/definitions/CosmosMsg_for_CustomMsg"
+            "$ref": "#/definitions/CosmosMsg"
           },
           "payload": {
             "description": "Some arbitrary data that the contract can set in an application specific way. This is just passed into the `reply` entry point and is not stored to state. Any encoding can be used. If `id` is used to identify a particular action, the encoding can also be different for each of those actions since you can match `id` first and then start processing the `payload`.\n\nThe environment restricts the length of this field in order to avoid abuse. The limit is environment specific and can change over time. The initial default is 128 KiB.\n\nUnset/nil/null cannot be differentiated from empty data.\n\nOn chains running CosmWasm 1.x this field will be ignored.",

--- a/contracts/reflect/src/contract.rs
+++ b/contracts/reflect/src/contract.rs
@@ -17,7 +17,7 @@ pub fn instantiate(
     _env: Env,
     info: MessageInfo,
     _msg: InstantiateMsg,
-) -> StdResult<Response<CustomMsg>> {
+) -> StdResult<Response> {
     let state = State { owner: info.sender };
     save_config(deps.storage, &state)?;
     Ok(Response::default())
@@ -29,7 +29,7 @@ pub fn execute(
     env: Env,
     info: MessageInfo,
     msg: ExecuteMsg,
-) -> Result<Response<CustomMsg>, ReflectError> {
+) -> Result<Response, ReflectError> {
     match msg {
         ExecuteMsg::ReflectMsg { msgs } => try_reflect(deps, env, info, msgs),
         ExecuteMsg::ReflectSubMsg { msgs } => try_reflect_subcall(deps, env, info, msgs),
@@ -41,8 +41,8 @@ pub fn try_reflect(
     deps: DepsMut<SpecialQuery>,
     _env: Env,
     info: MessageInfo,
-    msgs: Vec<CosmosMsg<CustomMsg>>,
-) -> Result<Response<CustomMsg>, ReflectError> {
+    msgs: Vec<CosmosMsg>,
+) -> Result<Response, ReflectError> {
     let state = load_config(deps.storage)?;
 
     if info.sender != state.owner {
@@ -65,8 +65,8 @@ pub fn try_reflect_subcall(
     deps: DepsMut<SpecialQuery>,
     _env: Env,
     info: MessageInfo,
-    msgs: Vec<SubMsg<CustomMsg>>,
-) -> Result<Response<CustomMsg>, ReflectError> {
+    msgs: Vec<SubMsg>,
+) -> Result<Response, ReflectError> {
     let state = load_config(deps.storage)?;
     if info.sender != state.owner {
         return Err(ReflectError::NotCurrentOwner {
@@ -89,7 +89,7 @@ pub fn try_change_owner(
     _env: Env,
     info: MessageInfo,
     new_owner: String,
-) -> Result<Response<CustomMsg>, ReflectError> {
+) -> Result<Response, ReflectError> {
     let api = deps.api;
 
     let mut state = load_config(deps.storage)?;

--- a/contracts/reflect/src/contract.rs
+++ b/contracts/reflect/src/contract.rs
@@ -6,8 +6,8 @@ use cosmwasm_std::{
 
 use crate::errors::ReflectError;
 use crate::msg::{
-    CapitalizedResponse, ChainResponse, CustomMsg, ExecuteMsg, InstantiateMsg, OwnerResponse,
-    QueryMsg, RawResponse, SpecialQuery, SpecialResponse,
+    CapitalizedResponse, ChainResponse, ExecuteMsg, InstantiateMsg, OwnerResponse, QueryMsg,
+    RawResponse, SpecialQuery, SpecialResponse,
 };
 use crate::state::{load_config, load_reply, save_config, save_reply, State};
 
@@ -173,6 +173,7 @@ fn query_raw(deps: Deps<SpecialQuery>, contract: String, key: Binary) -> StdResu
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::msg::CustomMsg;
     use crate::testing::mock_dependencies_with_custom_querier;
     use cosmwasm_std::testing::{message_info, mock_env, MOCK_CONTRACT_ADDR};
     use cosmwasm_std::{

--- a/contracts/reflect/src/msg.rs
+++ b/contracts/reflect/src/msg.rs
@@ -1,5 +1,6 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Binary, CosmosMsg, CustomQuery, QueryRequest, SubMsg};
+use dyn_partial_eq::DynPartialEq;
 
 #[cw_serde]
 pub struct InstantiateMsg {}
@@ -56,6 +57,7 @@ pub struct RawResponse {
 }
 
 #[cw_serde]
+#[derive(DynPartialEq)]
 /// CustomMsg is an override of CosmosMsg::Custom to show this works and can be extended in the contract
 pub enum CustomMsg {
     Debug(String),
@@ -66,7 +68,7 @@ impl cosmwasm_std::CustomMsg for CustomMsg {}
 
 impl From<CustomMsg> for CosmosMsg {
     fn from(original: CustomMsg) -> Self {
-        CosmosMsg::Custom(original)
+        CosmosMsg::Custom(original.into())
     }
 }
 

--- a/contracts/reflect/src/msg.rs
+++ b/contracts/reflect/src/msg.rs
@@ -6,8 +6,8 @@ pub struct InstantiateMsg {}
 
 #[cw_serde]
 pub enum ExecuteMsg {
-    ReflectMsg { msgs: Vec<CosmosMsg<CustomMsg>> },
-    ReflectSubMsg { msgs: Vec<SubMsg<CustomMsg>> },
+    ReflectMsg { msgs: Vec<CosmosMsg> },
+    ReflectSubMsg { msgs: Vec<SubMsg> },
     ChangeOwner { owner: String },
 }
 
@@ -64,7 +64,7 @@ pub enum CustomMsg {
 
 impl cosmwasm_std::CustomMsg for CustomMsg {}
 
-impl From<CustomMsg> for CosmosMsg<CustomMsg> {
+impl From<CustomMsg> for CosmosMsg {
     fn from(original: CustomMsg) -> Self {
         CosmosMsg::Custom(original)
     }

--- a/contracts/reflect/tests/integration.rs
+++ b/contracts/reflect/tests/integration.rs
@@ -101,9 +101,13 @@ fn reflect() {
     let info = mock_info("creator", &[]);
     let res: Response = execute(&mut deps, mock_env(), info, msg).unwrap();
 
-    // should return payload
-    let payload: Vec<_> = payload.into_iter().map(SubMsg::new).collect();
-    assert_eq!(payload, res.messages);
+    // should return payload. We're comparing the JSON representation because the underlying
+    // CustomMsg type is not the same.
+    let payload =
+        cosmwasm_std::to_json_string(&payload.into_iter().map(SubMsg::new).collect::<Vec<_>>())
+            .unwrap();
+    let messages = cosmwasm_std::to_json_string(&res.messages).unwrap();
+    assert_eq!(payload, messages);
 }
 
 #[test]

--- a/contracts/reflect/tests/integration.rs
+++ b/contracts/reflect/tests/integration.rs
@@ -63,7 +63,7 @@ fn proper_initialization() {
     let info = mock_info("creator", &coins(1000, "earth"));
 
     // we can just call .unwrap() to assert this was a success
-    let res: Response<CustomMsg> = instantiate(&mut deps, mock_env(), info, msg).unwrap();
+    let res: Response = instantiate(&mut deps, mock_env(), info, msg).unwrap();
     assert_eq!(0, res.messages.len());
 
     // it worked, let's query the state
@@ -78,7 +78,7 @@ fn reflect() {
 
     let msg = InstantiateMsg {};
     let info = mock_info("creator", &coins(2, "token"));
-    let _res: Response<CustomMsg> = instantiate(&mut deps, mock_env(), info, msg).unwrap();
+    let _res: Response = instantiate(&mut deps, mock_env(), info, msg).unwrap();
 
     let payload = vec![
         BankMsg::Send {
@@ -99,7 +99,7 @@ fn reflect() {
         msgs: payload.clone(),
     };
     let info = mock_info("creator", &[]);
-    let res: Response<CustomMsg> = execute(&mut deps, mock_env(), info, msg).unwrap();
+    let res: Response = execute(&mut deps, mock_env(), info, msg).unwrap();
 
     // should return payload
     let payload: Vec<_> = payload.into_iter().map(SubMsg::new).collect();
@@ -112,7 +112,7 @@ fn reflect_requires_owner() {
 
     let msg = InstantiateMsg {};
     let info = mock_info("creator", &coins(2, "token"));
-    let _res: Response<CustomMsg> = instantiate(&mut deps, mock_env(), info, msg).unwrap();
+    let _res: Response = instantiate(&mut deps, mock_env(), info, msg).unwrap();
 
     // signer is not owner
     let payload = vec![BankMsg::Send {
@@ -123,7 +123,7 @@ fn reflect_requires_owner() {
     let msg = ExecuteMsg::ReflectMsg { msgs: payload };
 
     let info = mock_info("someone", &[]);
-    let res: ContractResult<Response<CustomMsg>> = execute(&mut deps, mock_env(), info, msg);
+    let res: ContractResult<Response> = execute(&mut deps, mock_env(), info, msg);
     let msg = res.unwrap_err();
     assert!(msg.contains("Permission denied: the sender is not the current owner"));
 }
@@ -134,14 +134,14 @@ fn transfer() {
 
     let msg = InstantiateMsg {};
     let info = mock_info("creator", &coins(2, "token"));
-    let _res: Response<CustomMsg> = instantiate(&mut deps, mock_env(), info, msg).unwrap();
+    let _res: Response = instantiate(&mut deps, mock_env(), info, msg).unwrap();
 
     let info = mock_info("creator", &[]);
     let new_owner = deps.api().addr_make("friend");
     let msg = ExecuteMsg::ChangeOwner {
         owner: new_owner.to_string(),
     };
-    let res: Response<CustomMsg> = execute(&mut deps, mock_env(), info, msg).unwrap();
+    let res: Response = execute(&mut deps, mock_env(), info, msg).unwrap();
 
     // should change state
     assert_eq!(0, res.messages.len());
@@ -156,7 +156,7 @@ fn transfer_requires_owner() {
 
     let msg = InstantiateMsg {};
     let info = mock_info("creator", &coins(2, "token"));
-    let _res: Response<CustomMsg> = instantiate(&mut deps, mock_env(), info, msg).unwrap();
+    let _res: Response = instantiate(&mut deps, mock_env(), info, msg).unwrap();
 
     let info = mock_info("random", &[]);
     let new_owner = String::from("friend");
@@ -237,7 +237,7 @@ fn reflect_subcall() {
         msgs: vec![payload.clone()],
     };
     let info = mock_info("creator", &[]);
-    let mut res: Response<CustomMsg> = execute(&mut deps, mock_env(), info, msg).unwrap();
+    let mut res: Response = execute(&mut deps, mock_env(), info, msg).unwrap();
     assert_eq!(1, res.messages.len());
     let msg = res.messages.pop().expect("must have a message");
     assert_eq!(payload, msg);

--- a/contracts/replier/Cargo.lock
+++ b/contracts/replier/Cargo.lock
@@ -82,7 +82,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -95,7 +95,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -135,7 +135,7 @@ checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -245,7 +245,7 @@ version = "3.0.0-rc.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -265,7 +265,7 @@ version = "3.0.0-rc.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -279,6 +279,8 @@ dependencies = [
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derive_more",
+ "dyn_partial_eq",
+ "erased-serde",
  "hex",
  "rand_core",
  "rmp-serde",
@@ -370,7 +372,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -400,7 +402,7 @@ checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.77",
  "unicode-xid",
 ]
 
@@ -421,6 +423,25 @@ name = "dyn-clone"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
+
+[[package]]
+name = "dyn_partial_eq"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a07039d197226c4b9a3810c4f165328fb4e715258a4b8584f143d38e9de04301"
+dependencies = [
+ "dyn_partial_eq_derive",
+]
+
+[[package]]
+name = "dyn_partial_eq_derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e217c6c1435ebf9b88662354589d339192b8eaf506edd22951e75e045c8e8bd"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "ecdsa"
@@ -468,7 +489,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -512,7 +533,17 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "erased-serde"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
+dependencies = [
+ "serde",
+ "typeid",
 ]
 
 [[package]]
@@ -855,7 +886,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -894,7 +925,7 @@ checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -905,7 +936,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -955,6 +986,17 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
@@ -981,8 +1023,14 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.77",
 ]
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
@@ -1031,7 +1079,7 @@ checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1051,5 +1099,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.77",
 ]

--- a/contracts/staking/Cargo.lock
+++ b/contracts/staking/Cargo.lock
@@ -479,6 +479,8 @@ dependencies = [
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derive_more 2.0.1",
+ "dyn_partial_eq",
+ "erased-serde",
  "hex",
  "rand_core",
  "rmp-serde",
@@ -769,6 +771,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
+name = "dyn_partial_eq"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a07039d197226c4b9a3810c4f165328fb4e715258a4b8584f143d38e9de04301"
+dependencies = [
+ "dyn_partial_eq_derive",
+]
+
+[[package]]
+name = "dyn_partial_eq_derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e217c6c1435ebf9b88662354589d339192b8eaf506edd22951e75e045c8e8bd"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "dynasm"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,6 +954,16 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "erased-serde"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
+dependencies = [
+ "serde",
+ "typeid",
+]
 
 [[package]]
 name = "errno"
@@ -2338,6 +2369,12 @@ dependencies = [
  "cfg-if",
  "static_assertions",
 ]
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"

--- a/contracts/virus/Cargo.lock
+++ b/contracts/virus/Cargo.lock
@@ -479,6 +479,8 @@ dependencies = [
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derive_more 2.0.1",
+ "dyn_partial_eq",
+ "erased-serde",
  "hex",
  "rand_core",
  "rmp-serde",
@@ -769,6 +771,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
+name = "dyn_partial_eq"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a07039d197226c4b9a3810c4f165328fb4e715258a4b8584f143d38e9de04301"
+dependencies = [
+ "dyn_partial_eq_derive",
+]
+
+[[package]]
+name = "dyn_partial_eq_derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e217c6c1435ebf9b88662354589d339192b8eaf506edd22951e75e045c8e8bd"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "dynasm"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,6 +954,16 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "erased-serde"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
+dependencies = [
+ "serde",
+ "typeid",
+]
 
 [[package]]
 name = "errno"
@@ -2305,6 +2336,12 @@ dependencies = [
  "cfg-if",
  "static_assertions",
 ]
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -68,11 +68,13 @@ derive_more = { version = "2.0.1", default-features = false, features = ["debug"
 hex = "0.4"
 schemars = { workspace = true }
 sha2 = "0.10.3"
-serde = { workspace = true, features = ["std"] }
+serde = { workspace = true, features = ["std", "rc"] }
 serde_json = "1.0.140"
 static_assertions = "1.1.0"
 thiserror = "1.0.26"
 rmp-serde = "1.3.0"
+erased-serde = { version = "0.4.6" }
+dyn_partial_eq = { version = "0.1.2", default-features = false }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 bech32 = "0.11.0"

--- a/packages/std/src/deps.rs
+++ b/packages/std/src/deps.rs
@@ -72,7 +72,7 @@ impl<'a, C: CustomQuery> DepsMut<'a, C> {
 
     /// This allows to convert any `DepsMut` into one generic over `Empty` custom
     /// query type.
-    pub fn into_empty(self) -> DepsMut<'a, Empty> {
+    pub fn into_empty(self) -> DepsMut<'a> {
         DepsMut {
             storage: self.storage,
             api: self.api,
@@ -84,7 +84,7 @@ impl<'a, C: CustomQuery> DepsMut<'a, C> {
 impl<'a, C: CustomQuery> Deps<'a, C> {
     /// This allows to convert any `Deps` into one generic over `Empty` custom
     /// query type.
-    pub fn into_empty(self) -> Deps<'a, Empty> {
+    pub fn into_empty(self) -> Deps<'a> {
         Deps {
             storage: self.storage,
             api: self.api,

--- a/packages/std/src/exports/exports.rs
+++ b/packages/std/src/exports/exports.rs
@@ -130,8 +130,8 @@ macro_rules! r#try_into_contract_result {
 /// - `M`: message type for request
 /// - `C`: custom response message type (see CosmosMsg)
 /// - `E`: error type for responses
-pub fn do_instantiate<Q, M, C, E>(
-    instantiate_fn: &dyn Fn(DepsMut<Q>, Env, MessageInfo, M) -> Result<Response<C>, E>,
+pub fn do_instantiate<Q, M, E>(
+    instantiate_fn: &dyn Fn(DepsMut<Q>, Env, MessageInfo, M) -> Result<Response, E>,
     env_ptr: u32,
     info_ptr: u32,
     msg_ptr: u32,
@@ -139,7 +139,6 @@ pub fn do_instantiate<Q, M, C, E>(
 where
     Q: CustomQuery,
     M: DeserializeOwned,
-    C: CustomMsg,
     E: ToString,
 {
     install_panic_handler();
@@ -159,8 +158,8 @@ where
 /// - `M`: message type for request
 /// - `C`: custom response message type (see CosmosMsg)
 /// - `E`: error type for responses
-pub fn do_execute<Q, M, C, E>(
-    execute_fn: &dyn Fn(DepsMut<Q>, Env, MessageInfo, M) -> Result<Response<C>, E>,
+pub fn do_execute<Q, M, E>(
+    execute_fn: &dyn Fn(DepsMut<Q>, Env, MessageInfo, M) -> Result<Response, E>,
     env_ptr: u32,
     info_ptr: u32,
     msg_ptr: u32,
@@ -168,7 +167,6 @@ pub fn do_execute<Q, M, C, E>(
 where
     Q: CustomQuery,
     M: DeserializeOwned,
-    C: CustomMsg,
     E: ToString,
 {
     install_panic_handler();
@@ -188,15 +186,14 @@ where
 /// - `M`: message type for request
 /// - `C`: custom response message type (see CosmosMsg)
 /// - `E`: error type for responses
-pub fn do_migrate<Q, M, C, E>(
-    migrate_fn: &dyn Fn(DepsMut<Q>, Env, M) -> Result<Response<C>, E>,
+pub fn do_migrate<Q, M, E>(
+    migrate_fn: &dyn Fn(DepsMut<Q>, Env, M) -> Result<Response, E>,
     env_ptr: u32,
     msg_ptr: u32,
 ) -> u32
 where
     Q: CustomQuery,
     M: DeserializeOwned,
-    C: CustomMsg,
     E: ToString,
 {
     install_panic_handler();
@@ -217,8 +214,8 @@ where
 /// - `C`: custom response message type (see CosmosMsg)
 /// - `E`: error type for responses
 #[cfg(feature = "cosmwasm_2_2")]
-pub fn do_migrate_with_info<Q, M, C, E>(
-    migrate_with_info_fn: &dyn Fn(DepsMut<Q>, Env, M, MigrateInfo) -> Result<Response<C>, E>,
+pub fn do_migrate_with_info<Q, M, E>(
+    migrate_with_info_fn: &dyn Fn(DepsMut<Q>, Env, M, MigrateInfo) -> Result<Response, E>,
     env_ptr: u32,
     msg_ptr: u32,
     migrate_info_ptr: u32,
@@ -226,7 +223,6 @@ pub fn do_migrate_with_info<Q, M, C, E>(
 where
     Q: CustomQuery,
     M: DeserializeOwned,
-    C: CustomMsg,
     E: ToString,
 {
     install_panic_handler();
@@ -246,15 +242,14 @@ where
 /// - `M`: message type for request
 /// - `C`: custom response message type (see CosmosMsg)
 /// - `E`: error type for responses
-pub fn do_sudo<Q, M, C, E>(
-    sudo_fn: &dyn Fn(DepsMut<Q>, Env, M) -> Result<Response<C>, E>,
+pub fn do_sudo<Q, M, E>(
+    sudo_fn: &dyn Fn(DepsMut<Q>, Env, M) -> Result<Response, E>,
     env_ptr: u32,
     msg_ptr: u32,
 ) -> u32
 where
     Q: CustomQuery,
     M: DeserializeOwned,
-    C: CustomMsg,
     E: ToString,
 {
     install_panic_handler();
@@ -273,14 +268,13 @@ where
 /// - `Q`: custom query type (see QueryRequest)
 /// - `C`: custom response message type (see CosmosMsg)
 /// - `E`: error type for responses
-pub fn do_reply<Q, C, E>(
-    reply_fn: &dyn Fn(DepsMut<Q>, Env, Reply) -> Result<Response<C>, E>,
+pub fn do_reply<Q, E>(
+    reply_fn: &dyn Fn(DepsMut<Q>, Env, Reply) -> Result<Response, E>,
     env_ptr: u32,
     msg_ptr: u32,
 ) -> u32
 where
     Q: CustomQuery,
-    C: CustomMsg,
     E: ToString,
 {
     install_panic_handler();
@@ -352,14 +346,13 @@ where
 /// - `C`: custom response message type (see CosmosMsg)
 /// - `E`: error type for responses
 #[cfg(feature = "stargate")]
-pub fn do_ibc_channel_connect<Q, C, E>(
-    contract_fn: &dyn Fn(DepsMut<Q>, Env, IbcChannelConnectMsg) -> Result<IbcBasicResponse<C>, E>,
+pub fn do_ibc_channel_connect<Q, E>(
+    contract_fn: &dyn Fn(DepsMut<Q>, Env, IbcChannelConnectMsg) -> Result<IbcBasicResponse, E>,
     env_ptr: u32,
     msg_ptr: u32,
 ) -> u32
 where
     Q: CustomQuery,
-    C: CustomMsg,
     E: ToString,
 {
     install_panic_handler();
@@ -380,14 +373,13 @@ where
 /// - `C`: custom response message type (see CosmosMsg)
 /// - `E`: error type for responses
 #[cfg(feature = "stargate")]
-pub fn do_ibc_channel_close<Q, C, E>(
-    contract_fn: &dyn Fn(DepsMut<Q>, Env, IbcChannelCloseMsg) -> Result<IbcBasicResponse<C>, E>,
+pub fn do_ibc_channel_close<Q, E>(
+    contract_fn: &dyn Fn(DepsMut<Q>, Env, IbcChannelCloseMsg) -> Result<IbcBasicResponse, E>,
     env_ptr: u32,
     msg_ptr: u32,
 ) -> u32
 where
     Q: CustomQuery,
-    C: CustomMsg,
     E: ToString,
 {
     install_panic_handler();
@@ -409,14 +401,13 @@ where
 /// - `C`: custom response message type (see CosmosMsg)
 /// - `E`: error type for responses
 #[cfg(feature = "stargate")]
-pub fn do_ibc_packet_receive<Q, C, E>(
-    contract_fn: &dyn Fn(DepsMut<Q>, Env, IbcPacketReceiveMsg) -> Result<IbcReceiveResponse<C>, E>,
+pub fn do_ibc_packet_receive<Q, E>(
+    contract_fn: &dyn Fn(DepsMut<Q>, Env, IbcPacketReceiveMsg) -> Result<IbcReceiveResponse, E>,
     env_ptr: u32,
     msg_ptr: u32,
 ) -> u32
 where
     Q: CustomQuery,
-    C: CustomMsg,
     E: ToString,
 {
     install_panic_handler();
@@ -438,14 +429,13 @@ where
 /// - `C`: custom response message type (see CosmosMsg)
 /// - `E`: error type for responses
 #[cfg(feature = "stargate")]
-pub fn do_ibc_packet_ack<Q, C, E>(
-    contract_fn: &dyn Fn(DepsMut<Q>, Env, IbcPacketAckMsg) -> Result<IbcBasicResponse<C>, E>,
+pub fn do_ibc_packet_ack<Q, E>(
+    contract_fn: &dyn Fn(DepsMut<Q>, Env, IbcPacketAckMsg) -> Result<IbcBasicResponse, E>,
     env_ptr: u32,
     msg_ptr: u32,
 ) -> u32
 where
     Q: CustomQuery,
-    C: CustomMsg,
     E: ToString,
 {
     install_panic_handler();
@@ -467,14 +457,13 @@ where
 /// - `C`: custom response message type (see CosmosMsg)
 /// - `E`: error type for responses
 #[cfg(feature = "stargate")]
-pub fn do_ibc_packet_timeout<Q, C, E>(
-    contract_fn: &dyn Fn(DepsMut<Q>, Env, IbcPacketTimeoutMsg) -> Result<IbcBasicResponse<C>, E>,
+pub fn do_ibc_packet_timeout<Q, E>(
+    contract_fn: &dyn Fn(DepsMut<Q>, Env, IbcPacketTimeoutMsg) -> Result<IbcBasicResponse, E>,
     env_ptr: u32,
     msg_ptr: u32,
 ) -> u32
 where
     Q: CustomQuery,
-    C: CustomMsg,
     E: ToString,
 {
     install_panic_handler();
@@ -487,14 +476,13 @@ where
     Region::from_vec(v).to_heap_ptr() as u32
 }
 
-pub fn do_ibc_source_callback<Q, C, E>(
-    contract_fn: &dyn Fn(DepsMut<Q>, Env, IbcSourceCallbackMsg) -> Result<IbcBasicResponse<C>, E>,
+pub fn do_ibc_source_callback<Q, E>(
+    contract_fn: &dyn Fn(DepsMut<Q>, Env, IbcSourceCallbackMsg) -> Result<IbcBasicResponse, E>,
     env_ptr: u32,
     msg_ptr: u32,
 ) -> u32
 where
     Q: CustomQuery,
-    C: CustomMsg,
     E: ToString,
 {
     install_panic_handler();
@@ -507,18 +495,13 @@ where
     Region::from_vec(v).to_heap_ptr() as u32
 }
 
-pub fn do_ibc_destination_callback<Q, C, E>(
-    contract_fn: &dyn Fn(
-        DepsMut<Q>,
-        Env,
-        IbcDestinationCallbackMsg,
-    ) -> Result<IbcBasicResponse<C>, E>,
+pub fn do_ibc_destination_callback<Q, E>(
+    contract_fn: &dyn Fn(DepsMut<Q>, Env, IbcDestinationCallbackMsg) -> Result<IbcBasicResponse, E>,
     env_ptr: u32,
     msg_ptr: u32,
 ) -> u32
 where
     Q: CustomQuery,
-    C: CustomMsg,
     E: ToString,
 {
     install_panic_handler();
@@ -540,14 +523,13 @@ where
 /// - `C`: custom response message type (see CosmosMsg)
 /// - `E`: error type for responses
 #[cfg(feature = "ibc2")]
-pub fn do_ibc2_packet_ack<Q, C, E>(
-    contract_fn: &dyn Fn(DepsMut<Q>, Env, Ibc2PacketAckMsg) -> Result<IbcBasicResponse<C>, E>,
+pub fn do_ibc2_packet_ack<Q, E>(
+    contract_fn: &dyn Fn(DepsMut<Q>, Env, Ibc2PacketAckMsg) -> Result<IbcBasicResponse, E>,
     env_ptr: u32,
     msg_ptr: u32,
 ) -> u32
 where
     Q: CustomQuery,
-    C: CustomMsg,
     E: ToString,
 {
     install_panic_handler();
@@ -569,14 +551,13 @@ where
 /// - `C`: custom response message type (see CosmosMsg)
 /// - `E`: error type for responses
 #[cfg(feature = "ibc2")]
-pub fn do_ibc2_packet_receive<Q, C, E>(
-    contract_fn: &dyn Fn(DepsMut<Q>, Env, Ibc2PacketReceiveMsg) -> Result<IbcReceiveResponse<C>, E>,
+pub fn do_ibc2_packet_receive<Q, E>(
+    contract_fn: &dyn Fn(DepsMut<Q>, Env, Ibc2PacketReceiveMsg) -> Result<IbcReceiveResponse, E>,
     env_ptr: u32,
     msg_ptr: u32,
 ) -> u32
 where
     Q: CustomQuery,
-    C: CustomMsg,
     E: ToString,
 {
     install_panic_handler();
@@ -598,14 +579,13 @@ where
 /// - `C`: custom response message type (see CosmosMsg)
 /// - `E`: error type for responses
 #[cfg(feature = "ibc2")]
-pub fn do_ibc2_packet_timeout<Q, C, E>(
-    contract_fn: &dyn Fn(DepsMut<Q>, Env, Ibc2PacketTimeoutMsg) -> Result<IbcBasicResponse<C>, E>,
+pub fn do_ibc2_packet_timeout<Q, E>(
+    contract_fn: &dyn Fn(DepsMut<Q>, Env, Ibc2PacketTimeoutMsg) -> Result<IbcBasicResponse, E>,
     env_ptr: u32,
     msg_ptr: u32,
 ) -> u32
 where
     Q: CustomQuery,
-    C: CustomMsg,
     E: ToString,
 {
     install_panic_handler();
@@ -628,14 +608,13 @@ where
 /// - `C`: custom response message type (see CosmosMsg)
 /// - `E`: error type for responses
 #[cfg(feature = "ibc2")]
-pub fn do_ibc2_packet_send<Q, C, E>(
-    contract_fn: &dyn Fn(DepsMut<Q>, Env, Ibc2PacketSendMsg) -> Result<IbcBasicResponse<C>, E>,
+pub fn do_ibc2_packet_send<Q, E>(
+    contract_fn: &dyn Fn(DepsMut<Q>, Env, Ibc2PacketSendMsg) -> Result<IbcBasicResponse, E>,
     env_ptr: u32,
     msg_ptr: u32,
 ) -> u32
 where
     Q: CustomQuery,
-    C: CustomMsg,
     E: ToString,
 {
     install_panic_handler();
@@ -648,16 +627,15 @@ where
     Region::from_vec(v).to_heap_ptr() as u32
 }
 
-fn _do_instantiate<Q, M, C, E>(
-    instantiate_fn: &dyn Fn(DepsMut<Q>, Env, MessageInfo, M) -> Result<Response<C>, E>,
+fn _do_instantiate<Q, M, E>(
+    instantiate_fn: &dyn Fn(DepsMut<Q>, Env, MessageInfo, M) -> Result<Response, E>,
     env_ptr: *mut Region<Owned>,
     info_ptr: *mut Region<Owned>,
     msg_ptr: *mut Region<Owned>,
-) -> ContractResult<Response<C>>
+) -> ContractResult<Response>
 where
     Q: CustomQuery,
     M: DeserializeOwned,
-    C: CustomMsg,
     E: ToString,
 {
     let env: Vec<u8> =
@@ -675,16 +653,15 @@ where
     instantiate_fn(deps.as_mut(), env, info, msg).into()
 }
 
-fn _do_execute<Q, M, C, E>(
-    execute_fn: &dyn Fn(DepsMut<Q>, Env, MessageInfo, M) -> Result<Response<C>, E>,
+fn _do_execute<Q, M, E>(
+    execute_fn: &dyn Fn(DepsMut<Q>, Env, MessageInfo, M) -> Result<Response, E>,
     env_ptr: *mut Region<Owned>,
     info_ptr: *mut Region<Owned>,
     msg_ptr: *mut Region<Owned>,
-) -> ContractResult<Response<C>>
+) -> ContractResult<Response>
 where
     Q: CustomQuery,
     M: DeserializeOwned,
-    C: CustomMsg,
     E: ToString,
 {
     let env: Vec<u8> =
@@ -702,15 +679,14 @@ where
     execute_fn(deps.as_mut(), env, info, msg).into()
 }
 
-fn _do_migrate<Q, M, C, E>(
-    migrate_fn: &dyn Fn(DepsMut<Q>, Env, M) -> Result<Response<C>, E>,
+fn _do_migrate<Q, M, E>(
+    migrate_fn: &dyn Fn(DepsMut<Q>, Env, M) -> Result<Response, E>,
     env_ptr: *mut Region<Owned>,
     msg_ptr: *mut Region<Owned>,
-) -> ContractResult<Response<C>>
+) -> ContractResult<Response>
 where
     Q: CustomQuery,
     M: DeserializeOwned,
-    C: CustomMsg,
     E: ToString,
 {
     let env: Vec<u8> =
@@ -725,16 +701,15 @@ where
     migrate_fn(deps.as_mut(), env, msg).into()
 }
 
-fn _do_migrate_with_info<Q, M, C, E>(
-    migrate_with_info_fn: &dyn Fn(DepsMut<Q>, Env, M, MigrateInfo) -> Result<Response<C>, E>,
+fn _do_migrate_with_info<Q, M, E>(
+    migrate_with_info_fn: &dyn Fn(DepsMut<Q>, Env, M, MigrateInfo) -> Result<Response, E>,
     env_ptr: *mut Region<Owned>,
     msg_ptr: *mut Region<Owned>,
     migrate_info_ptr: *mut Region<Owned>,
-) -> ContractResult<Response<C>>
+) -> ContractResult<Response>
 where
     Q: CustomQuery,
     M: DeserializeOwned,
-    C: CustomMsg,
     E: ToString,
 {
     let env: Vec<u8> =
@@ -752,15 +727,14 @@ where
     migrate_with_info_fn(deps.as_mut(), env, msg, migrate_info).into()
 }
 
-fn _do_sudo<Q, M, C, E>(
-    sudo_fn: &dyn Fn(DepsMut<Q>, Env, M) -> Result<Response<C>, E>,
+fn _do_sudo<Q, M, E>(
+    sudo_fn: &dyn Fn(DepsMut<Q>, Env, M) -> Result<Response, E>,
     env_ptr: *mut Region<Owned>,
     msg_ptr: *mut Region<Owned>,
-) -> ContractResult<Response<C>>
+) -> ContractResult<Response>
 where
     Q: CustomQuery,
     M: DeserializeOwned,
-    C: CustomMsg,
     E: ToString,
 {
     let env: Vec<u8> =
@@ -775,14 +749,13 @@ where
     sudo_fn(deps.as_mut(), env, msg).into()
 }
 
-fn _do_reply<Q, C, E>(
-    reply_fn: &dyn Fn(DepsMut<Q>, Env, Reply) -> Result<Response<C>, E>,
+fn _do_reply<Q, E>(
+    reply_fn: &dyn Fn(DepsMut<Q>, Env, Reply) -> Result<Response, E>,
     env_ptr: *mut Region<Owned>,
     msg_ptr: *mut Region<Owned>,
-) -> ContractResult<Response<C>>
+) -> ContractResult<Response>
 where
     Q: CustomQuery,
-    C: CustomMsg,
     E: ToString,
 {
     let env: Vec<u8> =
@@ -841,14 +814,13 @@ where
 }
 
 #[cfg(feature = "stargate")]
-fn _do_ibc_channel_connect<Q, C, E>(
-    contract_fn: &dyn Fn(DepsMut<Q>, Env, IbcChannelConnectMsg) -> Result<IbcBasicResponse<C>, E>,
+fn _do_ibc_channel_connect<Q, E>(
+    contract_fn: &dyn Fn(DepsMut<Q>, Env, IbcChannelConnectMsg) -> Result<IbcBasicResponse, E>,
     env_ptr: *mut Region<Owned>,
     msg_ptr: *mut Region<Owned>,
-) -> ContractResult<IbcBasicResponse<C>>
+) -> ContractResult<IbcBasicResponse>
 where
     Q: CustomQuery,
-    C: CustomMsg,
     E: ToString,
 {
     let env: Vec<u8> =
@@ -864,14 +836,13 @@ where
 }
 
 #[cfg(feature = "stargate")]
-fn _do_ibc_channel_close<Q, C, E>(
-    contract_fn: &dyn Fn(DepsMut<Q>, Env, IbcChannelCloseMsg) -> Result<IbcBasicResponse<C>, E>,
+fn _do_ibc_channel_close<Q, E>(
+    contract_fn: &dyn Fn(DepsMut<Q>, Env, IbcChannelCloseMsg) -> Result<IbcBasicResponse, E>,
     env_ptr: *mut Region<Owned>,
     msg_ptr: *mut Region<Owned>,
-) -> ContractResult<IbcBasicResponse<C>>
+) -> ContractResult<IbcBasicResponse>
 where
     Q: CustomQuery,
-    C: CustomMsg,
     E: ToString,
 {
     let env: Vec<u8> =
@@ -887,14 +858,13 @@ where
 }
 
 #[cfg(feature = "stargate")]
-fn _do_ibc_packet_receive<Q, C, E>(
-    contract_fn: &dyn Fn(DepsMut<Q>, Env, IbcPacketReceiveMsg) -> Result<IbcReceiveResponse<C>, E>,
+fn _do_ibc_packet_receive<Q, E>(
+    contract_fn: &dyn Fn(DepsMut<Q>, Env, IbcPacketReceiveMsg) -> Result<IbcReceiveResponse, E>,
     env_ptr: *mut Region<Owned>,
     msg_ptr: *mut Region<Owned>,
-) -> ContractResult<IbcReceiveResponse<C>>
+) -> ContractResult<IbcReceiveResponse>
 where
     Q: CustomQuery,
-    C: CustomMsg,
     E: ToString,
 {
     let env: Vec<u8> =
@@ -910,14 +880,13 @@ where
 }
 
 #[cfg(feature = "stargate")]
-fn _do_ibc_packet_ack<Q, C, E>(
-    contract_fn: &dyn Fn(DepsMut<Q>, Env, IbcPacketAckMsg) -> Result<IbcBasicResponse<C>, E>,
+fn _do_ibc_packet_ack<Q, E>(
+    contract_fn: &dyn Fn(DepsMut<Q>, Env, IbcPacketAckMsg) -> Result<IbcBasicResponse, E>,
     env_ptr: *mut Region<Owned>,
     msg_ptr: *mut Region<Owned>,
-) -> ContractResult<IbcBasicResponse<C>>
+) -> ContractResult<IbcBasicResponse>
 where
     Q: CustomQuery,
-    C: CustomMsg,
     E: ToString,
 {
     let env: Vec<u8> =
@@ -933,14 +902,13 @@ where
 }
 
 #[cfg(feature = "stargate")]
-fn _do_ibc_packet_timeout<Q, C, E>(
-    contract_fn: &dyn Fn(DepsMut<Q>, Env, IbcPacketTimeoutMsg) -> Result<IbcBasicResponse<C>, E>,
+fn _do_ibc_packet_timeout<Q, E>(
+    contract_fn: &dyn Fn(DepsMut<Q>, Env, IbcPacketTimeoutMsg) -> Result<IbcBasicResponse, E>,
     env_ptr: *mut Region<Owned>,
     msg_ptr: *mut Region<Owned>,
-) -> ContractResult<IbcBasicResponse<C>>
+) -> ContractResult<IbcBasicResponse>
 where
     Q: CustomQuery,
-    C: CustomMsg,
     E: ToString,
 {
     let env: Vec<u8> =
@@ -955,14 +923,13 @@ where
     contract_fn(deps.as_mut(), env, msg).into()
 }
 
-fn _do_ibc_source_callback<Q, C, E>(
-    contract_fn: &dyn Fn(DepsMut<Q>, Env, IbcSourceCallbackMsg) -> Result<IbcBasicResponse<C>, E>,
+fn _do_ibc_source_callback<Q, E>(
+    contract_fn: &dyn Fn(DepsMut<Q>, Env, IbcSourceCallbackMsg) -> Result<IbcBasicResponse, E>,
     env_ptr: *mut Region<Owned>,
     msg_ptr: *mut Region<Owned>,
-) -> ContractResult<IbcBasicResponse<C>>
+) -> ContractResult<IbcBasicResponse>
 where
     Q: CustomQuery,
-    C: CustomMsg,
     E: ToString,
 {
     let env: Vec<u8> =
@@ -977,18 +944,13 @@ where
     contract_fn(deps.as_mut(), env, msg).into()
 }
 
-fn _do_ibc_destination_callback<Q, C, E>(
-    contract_fn: &dyn Fn(
-        DepsMut<Q>,
-        Env,
-        IbcDestinationCallbackMsg,
-    ) -> Result<IbcBasicResponse<C>, E>,
+fn _do_ibc_destination_callback<Q, E>(
+    contract_fn: &dyn Fn(DepsMut<Q>, Env, IbcDestinationCallbackMsg) -> Result<IbcBasicResponse, E>,
     env_ptr: *mut Region<Owned>,
     msg_ptr: *mut Region<Owned>,
-) -> ContractResult<IbcBasicResponse<C>>
+) -> ContractResult<IbcBasicResponse>
 where
     Q: CustomQuery,
-    C: CustomMsg,
     E: ToString,
 {
     let env: Vec<u8> =
@@ -1004,14 +966,13 @@ where
 }
 
 #[cfg(feature = "ibc2")]
-fn _do_ibc2_packet_ack<Q, C, E>(
-    contract_fn: &dyn Fn(DepsMut<Q>, Env, Ibc2PacketAckMsg) -> Result<IbcBasicResponse<C>, E>,
+fn _do_ibc2_packet_ack<Q, E>(
+    contract_fn: &dyn Fn(DepsMut<Q>, Env, Ibc2PacketAckMsg) -> Result<IbcBasicResponse, E>,
     env_ptr: *mut Region<Owned>,
     msg_ptr: *mut Region<Owned>,
-) -> ContractResult<IbcBasicResponse<C>>
+) -> ContractResult<IbcBasicResponse>
 where
     Q: CustomQuery,
-    C: CustomMsg,
     E: ToString,
 {
     let env: Vec<u8> =
@@ -1027,14 +988,13 @@ where
 }
 
 #[cfg(feature = "ibc2")]
-fn _do_ibc2_packet_receive<Q, C, E>(
-    contract_fn: &dyn Fn(DepsMut<Q>, Env, Ibc2PacketReceiveMsg) -> Result<IbcReceiveResponse<C>, E>,
+fn _do_ibc2_packet_receive<Q, E>(
+    contract_fn: &dyn Fn(DepsMut<Q>, Env, Ibc2PacketReceiveMsg) -> Result<IbcReceiveResponse, E>,
     env_ptr: *mut Region<Owned>,
     msg_ptr: *mut Region<Owned>,
-) -> ContractResult<IbcReceiveResponse<C>>
+) -> ContractResult<IbcReceiveResponse>
 where
     Q: CustomQuery,
-    C: CustomMsg,
     E: ToString,
 {
     let env: Vec<u8> =
@@ -1050,14 +1010,13 @@ where
 }
 
 #[cfg(feature = "ibc2")]
-fn _do_ibc2_packet_timeout<Q, C, E>(
-    contract_fn: &dyn Fn(DepsMut<Q>, Env, Ibc2PacketTimeoutMsg) -> Result<IbcBasicResponse<C>, E>,
+fn _do_ibc2_packet_timeout<Q, E>(
+    contract_fn: &dyn Fn(DepsMut<Q>, Env, Ibc2PacketTimeoutMsg) -> Result<IbcBasicResponse, E>,
     env_ptr: *mut Region<Owned>,
     msg_ptr: *mut Region<Owned>,
-) -> ContractResult<IbcBasicResponse<C>>
+) -> ContractResult<IbcBasicResponse>
 where
     Q: CustomQuery,
-    C: CustomMsg,
     E: ToString,
 {
     let env: Vec<u8> =
@@ -1073,14 +1032,13 @@ where
 }
 
 #[cfg(feature = "ibc2")]
-fn _do_ibc2_packet_send<Q, C, E>(
-    contract_fn: &dyn Fn(DepsMut<Q>, Env, Ibc2PacketSendMsg) -> Result<IbcBasicResponse<C>, E>,
+fn _do_ibc2_packet_send<Q, E>(
+    contract_fn: &dyn Fn(DepsMut<Q>, Env, Ibc2PacketSendMsg) -> Result<IbcBasicResponse, E>,
     env_ptr: *mut Region<Owned>,
     msg_ptr: *mut Region<Owned>,
-) -> ContractResult<IbcBasicResponse<C>>
+) -> ContractResult<IbcBasicResponse>
 where
     Q: CustomQuery,
-    C: CustomMsg,
     E: ToString,
 {
     let env: Vec<u8> =

--- a/packages/std/src/exports/exports.rs
+++ b/packages/std/src/exports/exports.rs
@@ -33,7 +33,7 @@ use crate::query::CustomQuery;
 use crate::results::{ContractResult, QueryResponse, Reply, Response};
 use crate::serde::{from_json, to_json_vec};
 use crate::types::Env;
-use crate::{CustomMsg, Deps, DepsMut, MessageInfo, MigrateInfo};
+use crate::{Deps, DepsMut, MessageInfo, MigrateInfo};
 
 // These functions are used as markers for the chain to know which features this contract requires.
 // If the chain does not support all the required features, it will reject storing the contract.

--- a/packages/std/src/ibc.rs
+++ b/packages/std/src/ibc.rs
@@ -481,7 +481,7 @@ impl IbcPacketTimeoutMsg {
 /// Callbacks that have return values (like receive_packet)
 /// or that cannot redispatch messages (like the handshake callbacks)
 /// will use other Response types
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[non_exhaustive]
 pub struct IbcBasicResponse {
     /// Optional list of messages to pass. These will be executed in order.
@@ -505,15 +505,6 @@ pub struct IbcBasicResponse {
 }
 
 // Custom implementation in order to implement it for all `T`, even if `T` is not `Default`.
-impl Default for IbcBasicResponse {
-    fn default() -> Self {
-        IbcBasicResponse {
-            messages: vec![],
-            attributes: vec![],
-            events: vec![],
-        }
-    }
-}
 
 impl IbcBasicResponse {
     pub fn new() -> Self {

--- a/packages/std/src/ibc.rs
+++ b/packages/std/src/ibc.rs
@@ -481,14 +481,14 @@ impl IbcPacketTimeoutMsg {
 /// Callbacks that have return values (like receive_packet)
 /// or that cannot redispatch messages (like the handshake callbacks)
 /// will use other Response types
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
-pub struct IbcBasicResponse<T = Empty> {
+pub struct IbcBasicResponse {
     /// Optional list of messages to pass. These will be executed in order.
     /// If the ReplyOn member is set, they will invoke this contract's `reply` entry point
     /// after execution. Otherwise, they act like "fire and forget".
     /// Use `SubMsg::new` to create messages with the older "fire and forget" semantics.
-    pub messages: Vec<SubMsg<T>>,
+    pub messages: Vec<SubMsg>,
     /// The attributes that will be emitted as part of a `wasm` event.
     ///
     /// More info about events (and their attributes) can be found in [*Cosmos SDK* docs].
@@ -505,7 +505,7 @@ pub struct IbcBasicResponse<T = Empty> {
 }
 
 // Custom implementation in order to implement it for all `T`, even if `T` is not `Default`.
-impl<T> Default for IbcBasicResponse<T> {
+impl Default for IbcBasicResponse {
     fn default() -> Self {
         IbcBasicResponse {
             messages: vec![],
@@ -515,7 +515,7 @@ impl<T> Default for IbcBasicResponse<T> {
     }
 }
 
-impl<T> IbcBasicResponse<T> {
+impl IbcBasicResponse {
     pub fn new() -> Self {
         Self::default()
     }
@@ -528,14 +528,14 @@ impl<T> IbcBasicResponse<T> {
 
     /// This creates a "fire and forget" message, by using `SubMsg::new()` to wrap it,
     /// and adds it to the list of messages to process.
-    pub fn add_message(mut self, msg: impl Into<CosmosMsg<T>>) -> Self {
+    pub fn add_message(mut self, msg: impl Into<CosmosMsg>) -> Self {
         self.messages.push(SubMsg::new(msg));
         self
     }
 
     /// This takes an explicit SubMsg (creates via e.g. `reply_on_error`)
     /// and adds it to the list of messages to process.
-    pub fn add_submessage(mut self, msg: SubMsg<T>) -> Self {
+    pub fn add_submessage(mut self, msg: SubMsg) -> Self {
         self.messages.push(msg);
         self
     }
@@ -587,7 +587,7 @@ impl<T> IbcBasicResponse<T> {
     ///     IbcBasicResponse::new().add_messages(msgs)
     /// }
     /// ```
-    pub fn add_messages<M: Into<CosmosMsg<T>>>(self, msgs: impl IntoIterator<Item = M>) -> Self {
+    pub fn add_messages<M: Into<CosmosMsg>>(self, msgs: impl IntoIterator<Item = M>) -> Self {
         self.add_submessages(msgs.into_iter().map(SubMsg::new))
     }
 
@@ -602,7 +602,7 @@ impl<T> IbcBasicResponse<T> {
     ///     IbcBasicResponse::new().add_submessages(msgs)
     /// }
     /// ```
-    pub fn add_submessages(mut self, msgs: impl IntoIterator<Item = SubMsg<T>>) -> Self {
+    pub fn add_submessages(mut self, msgs: impl IntoIterator<Item = SubMsg>) -> Self {
         self.messages.extend(msgs);
         self
     }
@@ -623,9 +623,9 @@ impl<T> IbcBasicResponse<T> {
 /// Where the acknowledgement bytes contain an encoded error message to be returned to
 /// the calling chain. (Returning ContractResult::Err will abort processing of this packet
 /// and not inform the calling chain).
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
-pub struct IbcReceiveResponse<T = Empty> {
+pub struct IbcReceiveResponse {
     /// The bytes we return to the contract that sent the packet.
     /// This may represent a success or error of execution.
     /// In case of `None`, no acknowledgement is written.
@@ -634,7 +634,7 @@ pub struct IbcReceiveResponse<T = Empty> {
     /// If the ReplyOn member is set, they will invoke this contract's `reply` entry point
     /// after execution. Otherwise, they act like "fire and forget".
     /// Use `call` or `msg.into()` to create messages with the older "fire and forget" semantics.
-    pub messages: Vec<SubMsg<T>>,
+    pub messages: Vec<SubMsg>,
     /// The attributes that will be emitted as part of a "wasm" event.
     ///
     /// More info about events (and their attributes) can be found in [*Cosmos SDK* docs].
@@ -650,7 +650,7 @@ pub struct IbcReceiveResponse<T = Empty> {
     pub events: Vec<Event>,
 }
 
-impl<T> IbcReceiveResponse<T> {
+impl IbcReceiveResponse {
     /// Create a new response with the given acknowledgement.
     ///
     /// ## Examples
@@ -726,14 +726,14 @@ impl<T> IbcReceiveResponse<T> {
 
     /// This creates a "fire and forget" message, by using `SubMsg::new()` to wrap it,
     /// and adds it to the list of messages to process.
-    pub fn add_message(mut self, msg: impl Into<CosmosMsg<T>>) -> Self {
+    pub fn add_message(mut self, msg: impl Into<CosmosMsg>) -> Self {
         self.messages.push(SubMsg::new(msg));
         self
     }
 
     /// This takes an explicit SubMsg (creates via e.g. `reply_on_error`)
     /// and adds it to the list of messages to process.
-    pub fn add_submessage(mut self, msg: SubMsg<T>) -> Self {
+    pub fn add_submessage(mut self, msg: SubMsg) -> Self {
         self.messages.push(msg);
         self
     }
@@ -785,7 +785,7 @@ impl<T> IbcReceiveResponse<T> {
     ///     IbcReceiveResponse::new(StdAck::success(b"\x01")).add_messages(msgs)
     /// }
     /// ```
-    pub fn add_messages<M: Into<CosmosMsg<T>>>(self, msgs: impl IntoIterator<Item = M>) -> Self {
+    pub fn add_messages<M: Into<CosmosMsg>>(self, msgs: impl IntoIterator<Item = M>) -> Self {
         self.add_submessages(msgs.into_iter().map(SubMsg::new))
     }
 
@@ -800,7 +800,7 @@ impl<T> IbcReceiveResponse<T> {
     ///     IbcReceiveResponse::new(StdAck::success(b"\x01")).add_submessages(msgs)
     /// }
     /// ```
-    pub fn add_submessages(mut self, msgs: impl IntoIterator<Item = SubMsg<T>>) -> Self {
+    pub fn add_submessages(mut self, msgs: impl IntoIterator<Item = SubMsg>) -> Self {
         self.messages.extend(msgs);
         self
     }

--- a/packages/std/src/ibc.rs
+++ b/packages/std/src/ibc.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::coin::Coin;
 use crate::prelude::*;
-use crate::results::{Attribute, CosmosMsg, Empty, Event, SubMsg};
+use crate::results::{Attribute, CosmosMsg, Event, SubMsg};
 use crate::StdResult;
 use crate::{to_json_binary, Binary};
 use crate::{Addr, Timestamp};

--- a/packages/std/src/ibc.rs
+++ b/packages/std/src/ibc.rs
@@ -481,7 +481,7 @@ impl IbcPacketTimeoutMsg {
 /// Callbacks that have return values (like receive_packet)
 /// or that cannot redispatch messages (like the handshake callbacks)
 /// will use other Response types
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[non_exhaustive]
 pub struct IbcBasicResponse {
     /// Optional list of messages to pass. These will be executed in order.

--- a/packages/std/src/never.rs
+++ b/packages/std/src/never.rs
@@ -36,7 +36,7 @@ impl core::fmt::Debug for Never {
 }
 
 // The Display implementation is needed to fulfill the ToString requirement of
-// entry point errors: `Result<IbcReceiveResponse<C>, E>` with `E: ToString`.
+// entry point errors: `Result<IbcReceiveResponse, E>` with `E: ToString`.
 impl core::fmt::Display for Never {
     fn fmt(&self, _f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         // Unreachable because no instance of Never can exist

--- a/packages/std/src/results/cosmos_msg.rs
+++ b/packages/std/src/results/cosmos_msg.rs
@@ -75,8 +75,8 @@ impl<T> core::ops::Deref for MaybeOwned<'_, T> {
 }
 
 /// A wrapper type for CustomMsg to allow deserialization of any custom message, without knowing its type.
-#[derive(Serialize, Clone, Debug, DynPartialEq)]
-pub struct CustomMsgContainer(pub Rc<dyn CustomMsg>);
+#[derive(Serialize, Clone, Debug, DynPartialEq, JsonSchema)]
+pub struct CustomMsgContainer(#[schemars(with = "serde_json::Value")] pub Rc<dyn CustomMsg>);
 
 impl CustomMsgContainer {
     pub fn inner_msg(&self) -> &dyn CustomMsg {
@@ -114,16 +114,6 @@ impl PartialEq for CustomMsgContainer {
 impl<C: CustomMsg + 'static> From<C> for CustomMsgContainer {
     fn from(msg: C) -> Self {
         CustomMsgContainer(Rc::new(msg))
-    }
-}
-
-impl JsonSchema for CustomMsgContainer {
-    fn schema_name() -> String {
-        "CustomMsg".to_string()
-    }
-
-    fn json_schema(_generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
-        schemars::schema::Schema::Bool(true)
     }
 }
 

--- a/packages/std/src/results/cosmos_msg.rs
+++ b/packages/std/src/results/cosmos_msg.rs
@@ -2,8 +2,11 @@
 
 use core::fmt;
 use derive_more::Debug;
+use dyn_partial_eq::{dyn_partial_eq, DynPartialEq};
+use erased_serde::serialize_trait_object;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::rc::Rc;
 
 use crate::coin::Coin;
 #[cfg(feature = "stargate")]
@@ -48,19 +51,56 @@ use super::Empty;
 ///
 /// impl CustomQuery for MyMsg {}
 /// ```
-pub trait CustomMsg: Serialize + Clone + fmt::Debug + PartialEq {}
+#[dyn_partial_eq]
+pub trait CustomMsg: erased_serde::Serialize + fmt::Debug {}
+
+serialize_trait_object!(CustomMsg);
+
+#[derive(Serialize, Clone, Debug, DynPartialEq)]
+pub struct CustomMsgContainer(pub Rc<dyn CustomMsg>);
+
+impl PartialEq for CustomMsgContainer {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.box_eq(other.0.as_any())
+    }
+}
+
+impl<C: CustomMsg + 'static> From<C> for CustomMsgContainer {
+    fn from(msg: C) -> Self {
+        CustomMsgContainer(Rc::new(msg))
+    }
+}
 
 impl CustomMsg for Empty {}
 
+impl<'de> Deserialize<'de> for CustomMsgContainer {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // Deserialize into a Box<dyn Test> by deserializing into a concrete type
+        // that implements the Test trait.
+        let concrete: UnknownCustomMsg = Deserialize::deserialize(deserializer)?;
+        Ok(Self(Rc::new(concrete)))
+    }
+}
+
+/// Helper type that allows us to deserialize any custom message without knowing its type.
+/// We need that because we need to deserialize [`CosmosMsg`] in `cosmwasm-vm`
+#[derive(Serialize, Deserialize, Clone, Debug, DynPartialEq, PartialEq, Eq, JsonSchema)]
+struct UnknownCustomMsg(serde_json::Value);
+
+impl CustomMsg for UnknownCustomMsg {}
+
 #[non_exhaustive]
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "snake_case")]
 // See https://github.com/serde-rs/serde/issues/1296 why we cannot add De-Serialize trait bounds to T
-pub enum CosmosMsg<T = Empty> {
+pub enum CosmosMsg {
     Bank(BankMsg),
     // by default we use RawMsg, but a contract can override that
     // to call into more app-specific code (whatever they define)
-    Custom(T),
+    Custom(CustomMsgContainer),
     #[cfg(feature = "staking")]
     Staking(StakingMsg),
     #[cfg(feature = "staking")]
@@ -90,33 +130,41 @@ pub enum CosmosMsg<T = Empty> {
     Ibc2(Ibc2Msg),
 }
 
-impl<T> CosmosMsg<T> {
-    /// Convert this [`CosmosMsg<T>`] to a [`CosmosMsg<U>`] with a different custom message type.
-    /// This allows easier interactions between code written for a specific chain and
-    /// code written for multiple chains.
-    /// If this is the [`CosmosMsg::Custom`] variant, the function returns `None`.
-    pub fn change_custom<U>(self) -> Option<CosmosMsg<U>> {
-        Some(match self {
-            CosmosMsg::Bank(msg) => CosmosMsg::Bank(msg),
-            CosmosMsg::Custom(_) => return None,
+// TODO: make this easier to maintain
+impl PartialEq for CosmosMsg {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Bank(l0), Self::Bank(r0)) => l0 == r0,
+            (Self::Custom(l0), Self::Custom(r0)) => l0.box_eq(r0.as_any()),
             #[cfg(feature = "staking")]
-            CosmosMsg::Staking(msg) => CosmosMsg::Staking(msg),
+            (Self::Staking(l0), Self::Staking(r0)) => l0 == r0,
             #[cfg(feature = "staking")]
-            CosmosMsg::Distribution(msg) => CosmosMsg::Distribution(msg),
+            (Self::Distribution(l0), Self::Distribution(r0)) => l0 == r0,
             #[cfg(feature = "stargate")]
-            CosmosMsg::Stargate { type_url, value } => CosmosMsg::Stargate { type_url, value },
+            (
+                Self::Stargate {
+                    type_url: l_type_url,
+                    value: l_value,
+                },
+                Self::Stargate {
+                    type_url: r_type_url,
+                    value: r_value,
+                },
+            ) => l_type_url == r_type_url && l_value == r_value,
             #[cfg(feature = "cosmwasm_2_0")]
-            CosmosMsg::Any(msg) => CosmosMsg::Any(msg),
+            (Self::Any(l0), Self::Any(r0)) => l0 == r0,
             #[cfg(feature = "stargate")]
-            CosmosMsg::Ibc(msg) => CosmosMsg::Ibc(msg),
-            CosmosMsg::Wasm(msg) => CosmosMsg::Wasm(msg),
+            (Self::Ibc(l0), Self::Ibc(r0)) => l0 == r0,
+            (Self::Wasm(l0), Self::Wasm(r0)) => l0 == r0,
             #[cfg(feature = "stargate")]
-            CosmosMsg::Gov(msg) => CosmosMsg::Gov(msg),
+            (Self::Gov(l0), Self::Gov(r0)) => l0 == r0,
             #[cfg(feature = "ibc2")]
-            CosmosMsg::Ibc2(msg) => CosmosMsg::Ibc2(msg),
-        })
+            (Self::Ibc2(l0), Self::Ibc2(r0)) => l0 == r0,
+            _ => false,
+        }
     }
 }
+impl Eq for CosmosMsg {}
 
 /// The message types of the bank module.
 ///
@@ -443,21 +491,21 @@ pub fn wasm_execute(
     })
 }
 
-impl<T> From<BankMsg> for CosmosMsg<T> {
+impl From<BankMsg> for CosmosMsg {
     fn from(msg: BankMsg) -> Self {
         CosmosMsg::Bank(msg)
     }
 }
 
 #[cfg(feature = "staking")]
-impl<T> From<StakingMsg> for CosmosMsg<T> {
+impl From<StakingMsg> for CosmosMsg {
     fn from(msg: StakingMsg) -> Self {
         CosmosMsg::Staking(msg)
     }
 }
 
 #[cfg(feature = "staking")]
-impl<T> From<DistributionMsg> for CosmosMsg<T> {
+impl From<DistributionMsg> for CosmosMsg {
     fn from(msg: DistributionMsg) -> Self {
         CosmosMsg::Distribution(msg)
     }
@@ -466,34 +514,34 @@ impl<T> From<DistributionMsg> for CosmosMsg<T> {
 // By implementing `From<MyType> for cosmwasm_std::AnyMsg`,
 // you automatically get a MyType -> CosmosMsg conversion.
 #[cfg(feature = "cosmwasm_2_0")]
-impl<S: Into<AnyMsg>, T> From<S> for CosmosMsg<T> {
+impl<S: Into<AnyMsg>> From<S> for CosmosMsg {
     fn from(source: S) -> Self {
-        CosmosMsg::<T>::Any(source.into())
+        CosmosMsg::Any(source.into())
     }
 }
 
-impl<T> From<WasmMsg> for CosmosMsg<T> {
+impl From<WasmMsg> for CosmosMsg {
     fn from(msg: WasmMsg) -> Self {
         CosmosMsg::Wasm(msg)
     }
 }
 
 #[cfg(feature = "stargate")]
-impl<T> From<IbcMsg> for CosmosMsg<T> {
+impl From<IbcMsg> for CosmosMsg {
     fn from(msg: IbcMsg) -> Self {
         CosmosMsg::Ibc(msg)
     }
 }
 
 #[cfg(feature = "stargate")]
-impl<T> From<GovMsg> for CosmosMsg<T> {
+impl From<GovMsg> for CosmosMsg {
     fn from(msg: GovMsg) -> Self {
         CosmosMsg::Gov(msg)
     }
 }
 
 #[cfg(feature = "ibc2")]
-impl<T> From<Ibc2Msg> for CosmosMsg<T> {
+impl From<Ibc2Msg> for CosmosMsg {
     fn from(msg: Ibc2Msg) -> Self {
         CosmosMsg::Ibc2(msg)
     }
@@ -735,32 +783,5 @@ mod tests {
                 r#"{"vote_weighted":{"proposal_id":25,"options":[{"option":"yes","weight":"0.25"},{"option":"no","weight":"0.25"},{"option":"abstain","weight":"0.5"}]}}"#,
             );
         }
-    }
-
-    #[test]
-    fn change_custom_works() {
-        #[derive(Debug, PartialEq, Eq, Clone)]
-        struct Custom {
-            _a: i32,
-        }
-        let send = BankMsg::Send {
-            to_address: "you".to_string(),
-            amount: coins(1015, "earth"),
-        };
-        // Custom to Empty
-        let msg: CosmosMsg<Custom> = send.clone().into();
-        let msg2: CosmosMsg<Empty> = msg.change_custom().unwrap();
-        assert_eq!(msg2, CosmosMsg::Bank(send.clone()));
-        let custom = CosmosMsg::Custom(Custom { _a: 5 });
-        let converted = custom.change_custom::<Empty>();
-        assert_eq!(converted, None);
-
-        // Empty to Custom
-        let msg: CosmosMsg<Empty> = send.clone().into();
-        let msg2: CosmosMsg<Custom> = msg.change_custom().unwrap();
-        assert_eq!(msg2, CosmosMsg::Bank(send));
-        let empty = CosmosMsg::Custom(Empty {});
-        let converted = empty.change_custom::<Custom>();
-        assert_eq!(converted, None);
     }
 }

--- a/packages/std/src/results/cosmos_msg.rs
+++ b/packages/std/src/results/cosmos_msg.rs
@@ -117,6 +117,16 @@ impl<C: CustomMsg + 'static> From<C> for CustomMsgContainer {
     }
 }
 
+impl JsonSchema for CustomMsgContainer {
+    fn schema_name() -> String {
+        "CustomMsg".to_string()
+    }
+
+    fn json_schema(_generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        schemars::schema::Schema::Bool(true)
+    }
+}
+
 impl CustomMsg for Empty {}
 
 impl<'de> Deserialize<'de> for CustomMsgContainer {
@@ -139,7 +149,7 @@ struct UnknownCustomMsg(serde_json::Value);
 impl CustomMsg for UnknownCustomMsg {}
 
 #[non_exhaustive]
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 // See https://github.com/serde-rs/serde/issues/1296 why we cannot add De-Serialize trait bounds to T
 pub enum CosmosMsg {

--- a/packages/std/src/results/cosmos_msg.rs
+++ b/packages/std/src/results/cosmos_msg.rs
@@ -63,7 +63,7 @@ pub enum MaybeOwned<'a, T> {
     Borrowed(&'a T),
 }
 
-impl<'a, T> core::ops::Deref for MaybeOwned<'a, T> {
+impl<T> core::ops::Deref for MaybeOwned<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -607,7 +607,6 @@ impl From<Ibc2Msg> for CosmosMsg {
 mod tests {
     use super::*;
     use crate::{coin, coins};
-    use fmt::Debug;
 
     #[test]
     fn from_bank_msg_works() {

--- a/packages/std/src/results/cosmos_msg.rs
+++ b/packages/std/src/results/cosmos_msg.rs
@@ -124,8 +124,7 @@ impl<'de> Deserialize<'de> for CustomMsgContainer {
     where
         D: serde::Deserializer<'de>,
     {
-        // Deserialize into a Box<dyn Test> by deserializing into a concrete type
-        // that implements the Test trait.
+        // Always deserialize into an UnknownCustomMsg because we do not know the type of the custom message.
         let concrete: UnknownCustomMsg = Deserialize::deserialize(deserializer)?;
         Ok(Self(Rc::new(concrete)))
     }

--- a/packages/std/src/results/empty.rs
+++ b/packages/std/src/results/empty.rs
@@ -1,3 +1,4 @@
+use dyn_partial_eq::DynPartialEq;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -7,7 +8,9 @@ use serde::{Deserialize, Serialize};
 /// It is designed to be expressible in correct JSON and JSON Schema but
 /// contains no meaningful data. Previously we used enums without cases,
 /// but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema, Default)]
+#[derive(
+    Serialize, Deserialize, Clone, Debug, DynPartialEq, PartialEq, Eq, JsonSchema, Default,
+)]
 pub struct Empty {}
 
 #[cfg(test)]

--- a/packages/std/src/results/response.rs
+++ b/packages/std/src/results/response.rs
@@ -1,10 +1,9 @@
-use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::prelude::*;
 use crate::Binary;
 
-use super::{Attribute, CosmosMsg, Empty, Event, SubMsg};
+use super::{Attribute, CosmosMsg, Event, SubMsg};
 
 /// A response of a contract entry point, such as `instantiate`, `execute` or `migrate`.
 ///

--- a/packages/std/src/results/response.rs
+++ b/packages/std/src/results/response.rs
@@ -60,15 +60,15 @@ use super::{Attribute, CosmosMsg, Empty, Event, SubMsg};
 ///     Ok(response)
 /// }
 /// ```
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
-pub struct Response<T = Empty> {
+pub struct Response {
     /// Optional list of messages to pass. These will be executed in order.
     /// If the ReplyOn variant matches the result (Always, Success on Ok, Error on Err),
     /// the runtime will invoke this contract's `reply` entry point
     /// after execution. Otherwise, they act like "fire and forget".
     /// Use `SubMsg::new` to create messages with the older "fire and forget" semantics.
-    pub messages: Vec<SubMsg<T>>,
+    pub messages: Vec<SubMsg>,
     /// The attributes that will be emitted as part of a "wasm" event.
     ///
     /// More info about events (and their attributes) can be found in [*Cosmos SDK* docs].
@@ -86,7 +86,7 @@ pub struct Response<T = Empty> {
     pub data: Option<Binary>,
 }
 
-impl<T> Default for Response<T> {
+impl Default for Response {
     fn default() -> Self {
         Response {
             messages: vec![],
@@ -97,7 +97,7 @@ impl<T> Default for Response<T> {
     }
 }
 
-impl<T> Response<T> {
+impl Response {
     pub fn new() -> Self {
         Self::default()
     }
@@ -112,14 +112,14 @@ impl<T> Response<T> {
 
     /// This creates a "fire and forget" message, by using `SubMsg::new()` to wrap it,
     /// and adds it to the list of messages to process.
-    pub fn add_message(mut self, msg: impl Into<CosmosMsg<T>>) -> Self {
+    pub fn add_message(mut self, msg: impl Into<CosmosMsg>) -> Self {
         self.messages.push(SubMsg::new(msg));
         self
     }
 
     /// This takes an explicit SubMsg (creates via eg. `reply_on_error`)
     /// and adds it to the list of messages to process.
-    pub fn add_submessage(mut self, msg: SubMsg<T>) -> Self {
+    pub fn add_submessage(mut self, msg: SubMsg) -> Self {
         self.messages.push(msg);
         self
     }
@@ -194,7 +194,7 @@ impl<T> Response<T> {
     ///     Response::new().add_messages(msgs)
     /// }
     /// ```
-    pub fn add_messages<M: Into<CosmosMsg<T>>>(self, msgs: impl IntoIterator<Item = M>) -> Self {
+    pub fn add_messages<M: Into<CosmosMsg>>(self, msgs: impl IntoIterator<Item = M>) -> Self {
         self.add_submessages(msgs.into_iter().map(SubMsg::new))
     }
 
@@ -209,7 +209,7 @@ impl<T> Response<T> {
     ///     Response::new().add_submessages(msgs)
     /// }
     /// ```
-    pub fn add_submessages(mut self, msgs: impl IntoIterator<Item = SubMsg<T>>) -> Self {
+    pub fn add_submessages(mut self, msgs: impl IntoIterator<Item = SubMsg>) -> Self {
         self.messages.extend(msgs);
         self
     }
@@ -232,23 +232,6 @@ impl<T> Response<T> {
         self.data = Some(data.into());
         self
     }
-
-    /// Convert this [`Response<T>`] to a [`Response<U>`] with a different custom message type.
-    /// This allows easier interactions between code written for a specific chain and
-    /// code written for multiple chains.
-    /// If this contains a [`CosmosMsg::Custom`] submessage, the function returns `None`.
-    pub fn change_custom<U>(self) -> Option<Response<U>> {
-        Some(Response {
-            messages: self
-                .messages
-                .into_iter()
-                .map(|msg| msg.change_custom())
-                .collect::<Option<Vec<_>>>()?,
-            attributes: self.attributes,
-            events: self.events,
-            data: self.data,
-        })
-    }
 }
 
 #[cfg(test)]
@@ -260,10 +243,10 @@ mod tests {
 
     #[test]
     fn response_add_attributes_works() {
-        let res = Response::<Empty>::new().add_attributes(core::iter::empty::<Attribute>());
+        let res = Response::new().add_attributes(core::iter::empty::<Attribute>());
         assert_eq!(res.attributes.len(), 0);
 
-        let res = Response::<Empty>::new().add_attributes([Attribute::new("test", "ing")]);
+        let res = Response::new().add_attributes([Attribute::new("test", "ing")]);
         assert_eq!(res.attributes.len(), 1);
         assert_eq!(
             res.attributes[0],
@@ -371,8 +354,8 @@ mod tests {
         let msg = "message".to_string();
         let our_event = OurEvent { msg };
         let event: Event = our_event.clone().into();
-        let actual = Response::<Empty>::new().add_event(our_event);
-        let expected = Response::<Empty>::new().add_event(event);
+        let actual = Response::new().add_event(our_event);
+        let expected = Response::new().add_event(event);
         assert_eq!(expected, actual);
     }
 
@@ -383,42 +366,8 @@ mod tests {
         let our_event1 = OurEvent { msg: msg1 };
         let our_event2 = OurEvent { msg: msg2 };
         let events: Vec<Event> = vec![our_event1.clone().into(), our_event2.clone().into()];
-        let actual = Response::<Empty>::new().add_events([our_event1, our_event2]);
-        let expected = Response::<Empty>::new().add_events(events);
+        let actual = Response::new().add_events([our_event1, our_event2]);
+        let expected = Response::new().add_events(events);
         assert_eq!(expected, actual);
-    }
-
-    #[test]
-    fn change_custom_works() {
-        let response: Response<Empty> = Response {
-            messages: vec![SubMsg::new(BankMsg::Send {
-                to_address: "address".to_string(),
-                amount: coins(123, "earth"),
-            })],
-            attributes: vec![Attribute::new("foo", "bar")],
-            events: vec![Event::new("our_event").add_attribute("msg", "hello")],
-            data: None,
-        };
-        let converted_resp: Response<String> = response.clone().change_custom().unwrap();
-        assert_eq!(
-            converted_resp.messages,
-            vec![SubMsg::new(BankMsg::Send {
-                to_address: "address".to_string(),
-                amount: coins(123, "earth"),
-            })]
-        );
-        assert_eq!(converted_resp.attributes, response.attributes);
-        assert_eq!(converted_resp.events, response.events);
-        assert_eq!(converted_resp.data, response.data);
-
-        // response with custom message
-        let response = Response {
-            messages: vec![SubMsg::new(CosmosMsg::Custom(Empty {}))],
-            attributes: vec![Attribute::new("foo", "bar")],
-            events: vec![Event::new("our_event").add_attribute("msg", "hello")],
-            data: None,
-        };
-
-        assert_eq!(response.change_custom::<String>(), None);
     }
 }

--- a/packages/std/src/results/response.rs
+++ b/packages/std/src/results/response.rs
@@ -60,7 +60,7 @@ use super::{Attribute, CosmosMsg, Event, SubMsg};
 ///     Ok(response)
 /// }
 /// ```
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[non_exhaustive]
 pub struct Response {
     /// Optional list of messages to pass. These will be executed in order.
@@ -84,17 +84,6 @@ pub struct Response {
     pub events: Vec<Event>,
     /// The binary payload to include in the response.
     pub data: Option<Binary>,
-}
-
-impl Default for Response {
-    fn default() -> Self {
-        Response {
-            messages: vec![],
-            attributes: vec![],
-            events: vec![],
-            data: None,
-        }
-    }
 }
 
 impl Response {

--- a/packages/std/src/results/response.rs
+++ b/packages/std/src/results/response.rs
@@ -1,3 +1,4 @@
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::prelude::*;
@@ -59,7 +60,7 @@ use super::{Attribute, CosmosMsg, Event, SubMsg};
 ///     Ok(response)
 /// }
 /// ```
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[non_exhaustive]
 pub struct Response {
     /// Optional list of messages to pass. These will be executed in order.

--- a/packages/std/src/results/submessages.rs
+++ b/packages/std/src/results/submessages.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use crate::prelude::*;
 use crate::Binary;
 
-use super::{CosmosMsg, Empty, Event};
+use super::{CosmosMsg, Event};
 
 /// Use this to define when the contract gets a response callback.
 /// If you only need it for errors or success you can select just those in order

--- a/packages/std/src/results/submessages.rs
+++ b/packages/std/src/results/submessages.rs
@@ -28,7 +28,7 @@ pub enum ReplyOn {
 /// Note: On error the submessage execution will revert any partial state changes due to this message,
 /// but not revert any state changes in the calling contract. If this is required, it must be done
 /// manually in the `reply` entry point.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct SubMsg {
     /// An arbitrary ID chosen by the contract.
     /// This is typically used to match `Reply`s in the `reply` entry point to the submessage.

--- a/packages/std/src/testing/mock.rs
+++ b/packages/std/src/testing/mock.rs
@@ -62,7 +62,7 @@ pub const MOCK_CONTRACT_ADDR: &str =
 ///
 /// See also [`mock_dependencies_with_balance`] and [`mock_dependencies_with_balances`]
 /// if you want to start with some initial balances.
-pub fn mock_dependencies() -> OwnedDeps<MockStorage, MockApi, MockQuerier, Empty> {
+pub fn mock_dependencies() -> OwnedDeps<MockStorage, MockApi, MockQuerier> {
     OwnedDeps {
         storage: MockStorage::default(),
         api: MockApi::default(),
@@ -76,7 +76,7 @@ pub fn mock_dependencies() -> OwnedDeps<MockStorage, MockApi, MockQuerier, Empty
 /// It sets the given balance for the contract itself, nothing else.
 pub fn mock_dependencies_with_balance(
     contract_balance: &[Coin],
-) -> OwnedDeps<MockStorage, MockApi, MockQuerier, Empty> {
+) -> OwnedDeps<MockStorage, MockApi, MockQuerier> {
     mock_dependencies_with_balances(&[(MOCK_CONTRACT_ADDR, contract_balance)])
 }
 

--- a/packages/std/src/traits.rs
+++ b/packages/std/src/traits.rs
@@ -373,7 +373,7 @@ impl<'a, C: CustomQuery> QuerierWrapper<'a, C> {
 
     /// This allows to convert any `QuerierWrapper` into a `QuerierWrapper` generic
     /// over `Empty` custom query type.
-    pub fn into_empty(self) -> QuerierWrapper<'a, Empty> {
+    pub fn into_empty(self) -> QuerierWrapper<'a> {
         QuerierWrapper {
             querier: self.querier,
             custom_query_type: PhantomData,

--- a/packages/vm/benches/main.rs
+++ b/packages/vm/benches/main.rs
@@ -71,7 +71,7 @@ fn bench_instance(c: &mut Criterion) {
             let verifier = instance.api().addr_make("verifies");
             let beneficiary = instance.api().addr_make("benefits");
             let msg = format!(r#"{{"verifier": "{verifier}", "beneficiary": "{beneficiary}"}}"#);
-            let contract_result = call_instantiate::<_, _, _, Empty>(
+            let contract_result = call_instantiate::<_, _, _>(
                 &mut instance,
                 &mock_env(),
                 &info,
@@ -95,7 +95,7 @@ fn bench_instance(c: &mut Criterion) {
         let beneficiary = instance.api().addr_make("benefits");
         let msg = format!(r#"{{"verifier": "{verifier}", "beneficiary": "{beneficiary}"}}"#);
         let contract_result =
-            call_instantiate::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg.as_bytes())
+            call_instantiate::<_, _, _>(&mut instance, &mock_env(), &info, msg.as_bytes())
                 .unwrap();
         assert!(contract_result.into_result().is_ok());
 
@@ -103,7 +103,7 @@ fn bench_instance(c: &mut Criterion) {
             let info = mock_info(&verifier, &coins(15, "earth"));
             let msg = br#"{"release":{"denom":"earth"}}"#;
             let contract_result =
-                call_execute::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg).unwrap();
+                call_execute::<_, _, _>(&mut instance, &mock_env(), &info, msg).unwrap();
             assert!(contract_result.into_result().is_ok());
         });
     });
@@ -118,7 +118,7 @@ fn bench_instance(c: &mut Criterion) {
 
         let info = mock_info("creator", &coins(1000, "earth"));
         let contract_result =
-            call_instantiate::<_, _, _, Empty>(&mut instance, &mock_env(), &info, b"{}").unwrap();
+            call_instantiate::<_, _, _>(&mut instance, &mock_env(), &info, b"{}").unwrap();
         assert!(contract_result.into_result().is_ok());
 
         let mut gas_used = 0;
@@ -127,7 +127,7 @@ fn bench_instance(c: &mut Criterion) {
             let info = mock_info("hasher", &[]);
             let msg = br#"{"argon2":{"mem_cost":256,"time_cost":3}}"#;
             let contract_result =
-                call_execute::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg).unwrap();
+                call_execute::<_, _, _>(&mut instance, &mock_env(), &info, msg).unwrap();
             assert!(contract_result.into_result().is_ok());
             gas_used = gas_before - instance.get_gas_left();
         });
@@ -145,7 +145,7 @@ fn bench_instance(c: &mut Criterion) {
 
         let info = mock_info("creator", &coins(1000, "earth"));
         let contract_result =
-            call_instantiate::<_, _, _, Empty>(&mut instance, &mock_env(), &info, b"{}").unwrap();
+            call_instantiate::<_, _, _>(&mut instance, &mock_env(), &info, b"{}").unwrap();
         assert!(contract_result.into_result().is_ok());
 
         let mut gas_used = 0;
@@ -166,7 +166,7 @@ fn bench_instance(c: &mut Criterion) {
                 let msg = br#"{"cpu_loop":{}}"#;
 
                 let vm_result =
-                    call_execute::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg);
+                    call_execute::<_, _, _>(&mut instance, &mock_env(), &info, msg);
 
                 assert!(matches!(vm_result, Err(VmError::GasDepletion { .. })));
                 gas_used = gas_before - instance.get_gas_left();
@@ -446,7 +446,7 @@ fn bench_combined(c: &mut Criterion) {
             let info = mock_info("guest", &[]);
             let msg = br#"{"noop":{}}"#;
             let contract_result =
-                call_execute::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg).unwrap();
+                call_execute::<_, _, _>(&mut instance, &mock_env(), &info, msg).unwrap();
             contract_result.into_result().unwrap();
         });
     });
@@ -473,7 +473,7 @@ fn bench_combined(c: &mut Criterion) {
             let info = mock_info("guest", &[]);
             let msg = br#"{"noop":{}}"#;
             let contract_result =
-                call_execute::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg).unwrap();
+                call_execute::<_, _, _>(&mut instance, &mock_env(), &info, msg).unwrap();
             contract_result.into_result().unwrap();
         });
     });
@@ -498,7 +498,7 @@ fn bench_combined(c: &mut Criterion) {
             let info = mock_info("guest", &[]);
             let msg = br#"{"noop":{}}"#;
             let contract_result =
-                call_execute::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg).unwrap();
+                call_execute::<_, _, _>(&mut instance, &mock_env(), &info, msg).unwrap();
             contract_result.into_result().unwrap();
         });
     });

--- a/packages/vm/benches/main.rs
+++ b/packages/vm/benches/main.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, SystemTime};
 use std::{fs, thread};
 use tempfile::TempDir;
 
-use cosmwasm_std::{coins, Checksum, Empty};
+use cosmwasm_std::{coins, Checksum};
 use cosmwasm_vm::testing::{
     mock_backend, mock_env, mock_info, mock_instance_options, MockApi, MockQuerier, MockStorage,
 };

--- a/packages/vm/benches/main.rs
+++ b/packages/vm/benches/main.rs
@@ -71,13 +71,9 @@ fn bench_instance(c: &mut Criterion) {
             let verifier = instance.api().addr_make("verifies");
             let beneficiary = instance.api().addr_make("benefits");
             let msg = format!(r#"{{"verifier": "{verifier}", "beneficiary": "{beneficiary}"}}"#);
-            let contract_result = call_instantiate::<_, _, _>(
-                &mut instance,
-                &mock_env(),
-                &info,
-                msg.as_bytes(),
-            )
-            .unwrap();
+            let contract_result =
+                call_instantiate::<_, _, _>(&mut instance, &mock_env(), &info, msg.as_bytes())
+                    .unwrap();
             assert!(contract_result.into_result().is_ok());
         });
     });
@@ -95,8 +91,7 @@ fn bench_instance(c: &mut Criterion) {
         let beneficiary = instance.api().addr_make("benefits");
         let msg = format!(r#"{{"verifier": "{verifier}", "beneficiary": "{beneficiary}"}}"#);
         let contract_result =
-            call_instantiate::<_, _, _>(&mut instance, &mock_env(), &info, msg.as_bytes())
-                .unwrap();
+            call_instantiate::<_, _, _>(&mut instance, &mock_env(), &info, msg.as_bytes()).unwrap();
         assert!(contract_result.into_result().is_ok());
 
         b.iter(|| {
@@ -165,8 +160,7 @@ fn bench_instance(c: &mut Criterion) {
                 let info = mock_info("hasher", &[]);
                 let msg = br#"{"cpu_loop":{}}"#;
 
-                let vm_result =
-                    call_execute::<_, _, _>(&mut instance, &mock_env(), &info, msg);
+                let vm_result = call_execute::<_, _, _>(&mut instance, &mock_env(), &info, msg);
 
                 assert!(matches!(vm_result, Err(VmError::GasDepletion { .. })));
                 gas_used = gas_before - instance.get_gas_left();

--- a/packages/vm/examples/heap_profiling.rs
+++ b/packages/vm/examples/heap_profiling.rs
@@ -5,7 +5,7 @@ use std::time::{Duration, SystemTime};
 use tempfile::TempDir;
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
-use cosmwasm_std::{coins, Checksum, Empty};
+use cosmwasm_std::{coins, Checksum};
 use cosmwasm_vm::testing::{mock_backend, mock_env, mock_info, MockApi, MockQuerier, MockStorage};
 use cosmwasm_vm::{
     call_execute, call_instantiate, capabilities_from_csv, Cache, CacheOptions, InstanceOptions,

--- a/packages/vm/examples/heap_profiling.rs
+++ b/packages/vm/examples/heap_profiling.rs
@@ -162,8 +162,7 @@ fn app(runtime: u64) {
                 for (execution_idx, execute) in contracts[idx].execute_msgs.iter().enumerate() {
                     let info = mock_info("verifies", &coins(15, "earth"));
                     let msg = execute.msg;
-                    let res =
-                        call_execute::<_, _, _>(&mut instance, &mock_env(), &info, msg);
+                    let res = call_execute::<_, _, _>(&mut instance, &mock_env(), &info, msg);
 
                     if execute.expect_error {
                         if res.is_ok() {

--- a/packages/vm/examples/heap_profiling.rs
+++ b/packages/vm/examples/heap_profiling.rs
@@ -154,7 +154,7 @@ fn app(runtime: u64) {
                 if let Some(msg) = &contracts[idx].instantiate_msg {
                     let info = mock_info("creator", &coins(1000, "earth"));
                     let contract_result =
-                        call_instantiate::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg)
+                        call_instantiate::<_, _, _>(&mut instance, &mock_env(), &info, msg)
                             .unwrap();
                     assert!(contract_result.into_result().is_ok());
                 }
@@ -163,7 +163,7 @@ fn app(runtime: u64) {
                     let info = mock_info("verifies", &coins(15, "earth"));
                     let msg = execute.msg;
                     let res =
-                        call_execute::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg);
+                        call_execute::<_, _, _>(&mut instance, &mock_env(), &info, msg);
 
                     if execute.expect_error {
                         if res.is_ok() {

--- a/packages/vm/examples/multi_threaded_cache.rs
+++ b/packages/vm/examples/multi_threaded_cache.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::thread;
 use tempfile::TempDir;
 
-use cosmwasm_std::{coins, Empty};
+use cosmwasm_std::coins;
 use cosmwasm_vm::testing::{mock_backend, mock_env, mock_info, MockApi, MockQuerier, MockStorage};
 use cosmwasm_vm::{
     call_execute, call_instantiate, capabilities_from_csv, Cache, CacheOptions, InstanceOptions,

--- a/packages/vm/examples/multi_threaded_cache.rs
+++ b/packages/vm/examples/multi_threaded_cache.rs
@@ -59,13 +59,9 @@ pub fn main() {
             let verifier = instance.api().addr_make("verifies");
             let beneficiary = instance.api().addr_make("benefits");
             let msg = format!(r#"{{"verifier": "{verifier}", "beneficiary": "{beneficiary}"}}"#);
-            let contract_result = call_instantiate::<_, _, _>(
-                &mut instance,
-                &mock_env(),
-                &info,
-                msg.as_bytes(),
-            )
-            .unwrap();
+            let contract_result =
+                call_instantiate::<_, _, _>(&mut instance, &mock_env(), &info, msg.as_bytes())
+                    .unwrap();
             assert!(contract_result.into_result().is_ok());
 
             let info = mock_info(&verifier, &coins(15, "earth"));

--- a/packages/vm/examples/multi_threaded_cache.rs
+++ b/packages/vm/examples/multi_threaded_cache.rs
@@ -59,7 +59,7 @@ pub fn main() {
             let verifier = instance.api().addr_make("verifies");
             let beneficiary = instance.api().addr_make("benefits");
             let msg = format!(r#"{{"verifier": "{verifier}", "beneficiary": "{beneficiary}"}}"#);
-            let contract_result = call_instantiate::<_, _, _, Empty>(
+            let contract_result = call_instantiate::<_, _, _>(
                 &mut instance,
                 &mock_env(),
                 &info,
@@ -71,7 +71,7 @@ pub fn main() {
             let info = mock_info(&verifier, &coins(15, "earth"));
             let msg = br#"{"release":{"denom":"earth"}}"#;
             let contract_result =
-                call_execute::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg).unwrap();
+                call_execute::<_, _, _>(&mut instance, &mock_env(), &info, msg).unwrap();
             assert!(contract_result.into_result().is_ok());
         }));
     }

--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -608,7 +608,7 @@ mod tests {
     use super::*;
     use crate::calls::{call_execute, call_instantiate};
     use crate::testing::{mock_backend, mock_env, mock_info, MockApi, MockQuerier, MockStorage};
-    use cosmwasm_std::{coins, Empty};
+    use cosmwasm_std::coins;
     use std::borrow::Cow;
     use std::fs::{create_dir_all, remove_dir_all};
     use tempfile::TempDir;

--- a/packages/vm/src/cache.rs
+++ b/packages/vm/src/cache.rs
@@ -692,16 +692,15 @@ mod tests {
         let verifier = instance.api().addr_make("verifies");
         let beneficiary = instance.api().addr_make("benefits");
         let msg = format!(r#"{{"verifier": "{verifier}", "beneficiary": "{beneficiary}"}}"#);
-        let response =
-            call_instantiate::<_, _, _, Empty>(instance, &mock_env(), &info, msg.as_bytes())
-                .unwrap()
-                .unwrap();
+        let response = call_instantiate::<_, _, _>(instance, &mock_env(), &info, msg.as_bytes())
+            .unwrap()
+            .unwrap();
         assert_eq!(response.messages.len(), 0);
 
         // execute
         let info = mock_info(&verifier, &coins(15, "earth"));
         let msg = br#"{"release":{"denom":"earth"}}"#;
-        let response = call_execute::<_, _, _, Empty>(instance, &mock_env(), &info, msg)
+        let response = call_execute::<_, _, _>(instance, &mock_env(), &info, msg)
             .unwrap()
             .unwrap();
         assert_eq!(response.messages.len(), 1);
@@ -1046,13 +1045,9 @@ mod tests {
             let verifier = instance.api().addr_make("verifies");
             let beneficiary = instance.api().addr_make("benefits");
             let msg = format!(r#"{{"verifier": "{verifier}", "beneficiary": "{beneficiary}"}}"#);
-            let res = call_instantiate::<_, _, _, Empty>(
-                &mut instance,
-                &mock_env(),
-                &info,
-                msg.as_bytes(),
-            )
-            .unwrap();
+            let res =
+                call_instantiate::<_, _, _>(&mut instance, &mock_env(), &info, msg.as_bytes())
+                    .unwrap();
             let msgs = res.unwrap().messages;
             assert_eq!(msgs.len(), 0);
         }
@@ -1072,13 +1067,9 @@ mod tests {
             let verifier = instance.api().addr_make("verifies");
             let beneficiary = instance.api().addr_make("benefits");
             let msg = format!(r#"{{"verifier": "{verifier}", "beneficiary": "{beneficiary}"}}"#);
-            let res = call_instantiate::<_, _, _, Empty>(
-                &mut instance,
-                &mock_env(),
-                &info,
-                msg.as_bytes(),
-            )
-            .unwrap();
+            let res =
+                call_instantiate::<_, _, _>(&mut instance, &mock_env(), &info, msg.as_bytes())
+                    .unwrap();
             let msgs = res.unwrap().messages;
             assert_eq!(msgs.len(), 0);
         }
@@ -1100,13 +1091,9 @@ mod tests {
             let verifier = instance.api().addr_make("verifies");
             let beneficiary = instance.api().addr_make("benefits");
             let msg = format!(r#"{{"verifier": "{verifier}", "beneficiary": "{beneficiary}"}}"#);
-            let res = call_instantiate::<_, _, _, Empty>(
-                &mut instance,
-                &mock_env(),
-                &info,
-                msg.as_bytes(),
-            )
-            .unwrap();
+            let res =
+                call_instantiate::<_, _, _>(&mut instance, &mock_env(), &info, msg.as_bytes())
+                    .unwrap();
             let msgs = res.unwrap().messages;
             assert_eq!(msgs.len(), 0);
         }
@@ -1132,20 +1119,16 @@ mod tests {
             let verifier = instance.api().addr_make("verifies");
             let beneficiary = instance.api().addr_make("benefits");
             let msg = format!(r#"{{"verifier": "{verifier}", "beneficiary": "{beneficiary}"}}"#);
-            let response = call_instantiate::<_, _, _, Empty>(
-                &mut instance,
-                &mock_env(),
-                &info,
-                msg.as_bytes(),
-            )
-            .unwrap()
-            .unwrap();
+            let response =
+                call_instantiate::<_, _, _>(&mut instance, &mock_env(), &info, msg.as_bytes())
+                    .unwrap()
+                    .unwrap();
             assert_eq!(response.messages.len(), 0);
 
             // execute
             let info = mock_info(&verifier, &coins(15, "earth"));
             let msg = br#"{"release":{"denom":"earth"}}"#;
-            let response = call_execute::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg)
+            let response = call_execute::<_, _, _>(&mut instance, &mock_env(), &info, msg)
                 .unwrap()
                 .unwrap();
             assert_eq!(response.messages.len(), 1);
@@ -1166,20 +1149,16 @@ mod tests {
             let verifier = instance.api().addr_make("verifies");
             let beneficiary = instance.api().addr_make("benefits");
             let msg = format!(r#"{{"verifier": "{verifier}", "beneficiary": "{beneficiary}"}}"#);
-            let response = call_instantiate::<_, _, _, Empty>(
-                &mut instance,
-                &mock_env(),
-                &info,
-                msg.as_bytes(),
-            )
-            .unwrap()
-            .unwrap();
+            let response =
+                call_instantiate::<_, _, _>(&mut instance, &mock_env(), &info, msg.as_bytes())
+                    .unwrap()
+                    .unwrap();
             assert_eq!(response.messages.len(), 0);
 
             // execute
             let info = mock_info(&verifier, &coins(15, "earth"));
             let msg = br#"{"release":{"denom":"earth"}}"#;
-            let response = call_execute::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg)
+            let response = call_execute::<_, _, _>(&mut instance, &mock_env(), &info, msg)
                 .unwrap()
                 .unwrap();
             assert_eq!(response.messages.len(), 1);
@@ -1202,20 +1181,16 @@ mod tests {
             let verifier = instance.api().addr_make("verifies");
             let beneficiary = instance.api().addr_make("benefits");
             let msg = format!(r#"{{"verifier": "{verifier}", "beneficiary": "{beneficiary}"}}"#);
-            let response = call_instantiate::<_, _, _, Empty>(
-                &mut instance,
-                &mock_env(),
-                &info,
-                msg.as_bytes(),
-            )
-            .unwrap()
-            .unwrap();
+            let response =
+                call_instantiate::<_, _, _>(&mut instance, &mock_env(), &info, msg.as_bytes())
+                    .unwrap()
+                    .unwrap();
             assert_eq!(response.messages.len(), 0);
 
             // execute
             let info = mock_info(&verifier, &coins(15, "earth"));
             let msg = br#"{"release":{"denom":"earth"}}"#;
-            let response = call_execute::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg)
+            let response = call_execute::<_, _, _>(&mut instance, &mock_env(), &info, msg)
                 .unwrap()
                 .unwrap();
             assert_eq!(response.messages.len(), 1);
@@ -1261,8 +1236,7 @@ mod tests {
         let mary = instance.api().addr_make("mary");
         let msg = format!(r#"{{"verifier": "{sue}", "beneficiary": "{mary}"}}"#);
         let res =
-            call_instantiate::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg.as_bytes())
-                .unwrap();
+            call_instantiate::<_, _, _>(&mut instance, &mock_env(), &info, msg.as_bytes()).unwrap();
         let msgs = res.unwrap().messages;
         assert_eq!(msgs.len(), 0);
         let backend1 = instance.recycle().unwrap();
@@ -1276,8 +1250,7 @@ mod tests {
         let john = instance.api().addr_make("john");
         let msg = format!(r#"{{"verifier": "{bob}", "beneficiary": "{john}"}}"#);
         let res =
-            call_instantiate::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg.as_bytes())
-                .unwrap();
+            call_instantiate::<_, _, _>(&mut instance, &mock_env(), &info, msg.as_bytes()).unwrap();
         let msgs = res.unwrap().messages;
         assert_eq!(msgs.len(), 0);
         let backend2 = instance.recycle().unwrap();
@@ -1288,7 +1261,7 @@ mod tests {
             .unwrap();
         let info = mock_info(&bob, &coins(15, "earth"));
         let msg = br#"{"release":{"denom":"earth"}}"#;
-        let res = call_execute::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg).unwrap();
+        let res = call_execute::<_, _, _>(&mut instance, &mock_env(), &info, msg).unwrap();
         let msgs = res.unwrap().messages;
         assert_eq!(1, msgs.len());
 
@@ -1298,7 +1271,7 @@ mod tests {
             .unwrap();
         let info = mock_info(&sue, &coins(15, "earth"));
         let msg = br#"{"release":{"denom":"earth"}}"#;
-        let res = call_execute::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg).unwrap();
+        let res = call_execute::<_, _, _>(&mut instance, &mock_env(), &info, msg).unwrap();
         let msgs = res.unwrap().messages;
         assert_eq!(1, msgs.len());
     }
@@ -1326,7 +1299,7 @@ mod tests {
         let sue = instance1.api().addr_make("sue");
         let mary = instance1.api().addr_make("mary");
         let msg = format!(r#"{{"verifier": "{sue}", "beneficiary": "{mary}"}}"#);
-        call_instantiate::<_, _, _, Empty>(&mut instance1, &mock_env(), &info, msg.as_bytes())
+        call_instantiate::<_, _, _>(&mut instance1, &mock_env(), &info, msg.as_bytes())
             .unwrap()
             .unwrap();
         assert!(instance1.get_gas_left() < original_gas);
@@ -1362,13 +1335,8 @@ mod tests {
         let mary = instance1.api().addr_make("mary");
         let msg1 = format!(r#"{{"verifier": "{sue}", "beneficiary": "{mary}"}}"#);
 
-        match call_instantiate::<_, _, _, Empty>(
-            &mut instance1,
-            &mock_env(),
-            &info1,
-            msg1.as_bytes(),
-        )
-        .unwrap_err()
+        match call_instantiate::<_, _, _>(&mut instance1, &mock_env(), &info1, msg1.as_bytes())
+            .unwrap_err()
         {
             VmError::GasDepletion { .. } => (), // all good, continue
             e => panic!("unexpected error, {e:?}"),
@@ -1391,7 +1359,7 @@ mod tests {
         let bob = instance2.api().addr_make("bob");
         let john = instance2.api().addr_make("john");
         let msg2 = format!(r#"{{"verifier": "{bob}", "beneficiary": "{john}"}}"#);
-        call_instantiate::<_, _, _, Empty>(&mut instance2, &mock_env(), &info2, msg2.as_bytes())
+        call_instantiate::<_, _, _>(&mut instance2, &mock_env(), &info2, msg2.as_bytes())
             .unwrap()
             .unwrap();
     }

--- a/packages/vm/src/calls.rs
+++ b/packages/vm/src/calls.rs
@@ -1,9 +1,8 @@
-use serde::de::DeserializeOwned;
 use wasmer::Value;
 
 use cosmwasm_std::{
-    ContractResult, CustomMsg, Env, IbcBasicResponse, IbcDestinationCallbackMsg,
-    IbcSourceCallbackMsg, MessageInfo, MigrateInfo, QueryResponse, Reply, Response,
+    ContractResult, Env, IbcBasicResponse, IbcDestinationCallbackMsg, IbcSourceCallbackMsg,
+    MessageInfo, MigrateInfo, QueryResponse, Reply, Response,
 };
 
 #[cfg(any(feature = "stargate", feature = "ibc2"))]

--- a/packages/vm/src/calls.rs
+++ b/packages/vm/src/calls.rs
@@ -118,118 +118,110 @@ mod deserialization_limits {
     pub const RESULT_IBC2_PACKET_SEND: usize = 256 * KI;
 }
 
-pub fn call_instantiate<A, S, Q, U>(
+pub fn call_instantiate<A, S, Q>(
     instance: &mut Instance<A, S, Q>,
     env: &Env,
     info: &MessageInfo,
     msg: &[u8],
-) -> VmResult<ContractResult<Response<U>>>
+) -> VmResult<ContractResult<Response>>
 where
     A: BackendApi + 'static,
     S: Storage + 'static,
     Q: Querier + 'static,
-    U: DeserializeOwned + CustomMsg,
 {
     let env = to_vec(env)?;
     let info = to_vec(info)?;
     let data = call_instantiate_raw(instance, &env, &info, msg)?;
-    let result: ContractResult<Response<U>> =
+    let result: ContractResult<Response> =
         from_slice(&data, deserialization_limits::RESULT_INSTANTIATE)?;
     Ok(result)
 }
 
-pub fn call_execute<A, S, Q, U>(
+pub fn call_execute<A, S, Q>(
     instance: &mut Instance<A, S, Q>,
     env: &Env,
     info: &MessageInfo,
     msg: &[u8],
-) -> VmResult<ContractResult<Response<U>>>
+) -> VmResult<ContractResult<Response>>
 where
     A: BackendApi + 'static,
     S: Storage + 'static,
     Q: Querier + 'static,
-    U: DeserializeOwned + CustomMsg,
 {
     let env = to_vec(env)?;
     let info = to_vec(info)?;
     let data = call_execute_raw(instance, &env, &info, msg)?;
-    let result: ContractResult<Response<U>> =
+    let result: ContractResult<Response> =
         from_slice(&data, deserialization_limits::RESULT_EXECUTE)?;
     Ok(result)
 }
 
-pub fn call_migrate<A, S, Q, U>(
+pub fn call_migrate<A, S, Q>(
     instance: &mut Instance<A, S, Q>,
     env: &Env,
     msg: &[u8],
-) -> VmResult<ContractResult<Response<U>>>
+) -> VmResult<ContractResult<Response>>
 where
     A: BackendApi + 'static,
     S: Storage + 'static,
     Q: Querier + 'static,
-    U: DeserializeOwned + CustomMsg,
 {
     let env = to_vec(env)?;
     let data = call_migrate_raw(instance, &env, msg)?;
-    let result: ContractResult<Response<U>> =
+    let result: ContractResult<Response> =
         from_slice(&data, deserialization_limits::RESULT_MIGRATE)?;
     Ok(result)
 }
 
-pub fn call_migrate_with_info<A, S, Q, U>(
+pub fn call_migrate_with_info<A, S, Q>(
     instance: &mut Instance<A, S, Q>,
     env: &Env,
     msg: &[u8],
     migrate_info: &MigrateInfo,
-) -> VmResult<ContractResult<Response<U>>>
+) -> VmResult<ContractResult<Response>>
 where
     A: BackendApi + 'static,
     S: Storage + 'static,
     Q: Querier + 'static,
-    U: DeserializeOwned + CustomMsg,
 {
     let env = to_vec(env)?;
     let migrate_info = to_vec(migrate_info)?;
     let data = call_migrate_with_info_raw(instance, &env, msg, &migrate_info)?;
-    let result: ContractResult<Response<U>> =
+    let result: ContractResult<Response> =
         from_slice(&data, deserialization_limits::RESULT_MIGRATE)?;
     Ok(result)
 }
 
-pub fn call_sudo<A, S, Q, U>(
+pub fn call_sudo<A, S, Q>(
     instance: &mut Instance<A, S, Q>,
     env: &Env,
     msg: &[u8],
-) -> VmResult<ContractResult<Response<U>>>
+) -> VmResult<ContractResult<Response>>
 where
     A: BackendApi + 'static,
     S: Storage + 'static,
     Q: Querier + 'static,
-    U: DeserializeOwned + CustomMsg,
 {
     let env = to_vec(env)?;
     let data = call_sudo_raw(instance, &env, msg)?;
-    let result: ContractResult<Response<U>> =
-        from_slice(&data, deserialization_limits::RESULT_SUDO)?;
+    let result: ContractResult<Response> = from_slice(&data, deserialization_limits::RESULT_SUDO)?;
     Ok(result)
 }
 
-pub fn call_reply<A, S, Q, U>(
+pub fn call_reply<A, S, Q>(
     instance: &mut Instance<A, S, Q>,
     env: &Env,
     msg: &Reply,
-) -> VmResult<ContractResult<Response<U>>>
+) -> VmResult<ContractResult<Response>>
 where
     A: BackendApi + 'static,
     S: Storage + 'static,
     Q: Querier + 'static,
-    U: DeserializeOwned + CustomMsg,
 {
     let env = to_vec(env)?;
     let msg = to_vec(msg)?;
     let data = call_reply_raw(instance, &env, &msg)?;
-    let result: ContractResult<Response<U>> =
-        from_slice(&data, deserialization_limits::RESULT_REPLY)?;
+    let result: ContractResult<Response> = from_slice(&data, deserialization_limits::RESULT_REPLY)?;
     Ok(result)
 }
 
@@ -276,16 +268,15 @@ where
 }
 
 #[cfg(feature = "stargate")]
-pub fn call_ibc_channel_connect<A, S, Q, U>(
+pub fn call_ibc_channel_connect<A, S, Q>(
     instance: &mut Instance<A, S, Q>,
     env: &Env,
     msg: &IbcChannelConnectMsg,
-) -> VmResult<ContractResult<IbcBasicResponse<U>>>
+) -> VmResult<ContractResult<IbcBasicResponse>>
 where
     A: BackendApi + 'static,
     S: Storage + 'static,
     Q: Querier + 'static,
-    U: DeserializeOwned + CustomMsg,
 {
     let env = to_vec(env)?;
     let msg = to_vec(msg)?;
@@ -295,16 +286,15 @@ where
 }
 
 #[cfg(feature = "stargate")]
-pub fn call_ibc_channel_close<A, S, Q, U>(
+pub fn call_ibc_channel_close<A, S, Q>(
     instance: &mut Instance<A, S, Q>,
     env: &Env,
     msg: &IbcChannelCloseMsg,
-) -> VmResult<ContractResult<IbcBasicResponse<U>>>
+) -> VmResult<ContractResult<IbcBasicResponse>>
 where
     A: BackendApi + 'static,
     S: Storage + 'static,
     Q: Querier + 'static,
-    U: DeserializeOwned + CustomMsg,
 {
     let env = to_vec(env)?;
     let msg = to_vec(msg)?;
@@ -314,16 +304,15 @@ where
 }
 
 #[cfg(feature = "stargate")]
-pub fn call_ibc_packet_receive<A, S, Q, U>(
+pub fn call_ibc_packet_receive<A, S, Q>(
     instance: &mut Instance<A, S, Q>,
     env: &Env,
     msg: &IbcPacketReceiveMsg,
-) -> VmResult<ContractResult<IbcReceiveResponse<U>>>
+) -> VmResult<ContractResult<IbcReceiveResponse>>
 where
     A: BackendApi + 'static,
     S: Storage + 'static,
     Q: Querier + 'static,
-    U: DeserializeOwned + CustomMsg,
 {
     let env = to_vec(env)?;
     let msg = to_vec(msg)?;
@@ -333,16 +322,15 @@ where
 }
 
 #[cfg(feature = "stargate")]
-pub fn call_ibc_packet_ack<A, S, Q, U>(
+pub fn call_ibc_packet_ack<A, S, Q>(
     instance: &mut Instance<A, S, Q>,
     env: &Env,
     msg: &IbcPacketAckMsg,
-) -> VmResult<ContractResult<IbcBasicResponse<U>>>
+) -> VmResult<ContractResult<IbcBasicResponse>>
 where
     A: BackendApi + 'static,
     S: Storage + 'static,
     Q: Querier + 'static,
-    U: DeserializeOwned + CustomMsg,
 {
     let env = to_vec(env)?;
     let msg = to_vec(msg)?;
@@ -352,16 +340,15 @@ where
 }
 
 #[cfg(feature = "stargate")]
-pub fn call_ibc_packet_timeout<A, S, Q, U>(
+pub fn call_ibc_packet_timeout<A, S, Q>(
     instance: &mut Instance<A, S, Q>,
     env: &Env,
     msg: &IbcPacketTimeoutMsg,
-) -> VmResult<ContractResult<IbcBasicResponse<U>>>
+) -> VmResult<ContractResult<IbcBasicResponse>>
 where
     A: BackendApi + 'static,
     S: Storage + 'static,
     Q: Querier + 'static,
-    U: DeserializeOwned + CustomMsg,
 {
     let env = to_vec(env)?;
     let msg = to_vec(msg)?;
@@ -370,16 +357,15 @@ where
     Ok(result)
 }
 
-pub fn call_ibc_source_callback<A, S, Q, U>(
+pub fn call_ibc_source_callback<A, S, Q>(
     instance: &mut Instance<A, S, Q>,
     env: &Env,
     msg: &IbcSourceCallbackMsg,
-) -> VmResult<ContractResult<IbcBasicResponse<U>>>
+) -> VmResult<ContractResult<IbcBasicResponse>>
 where
     A: BackendApi + 'static,
     S: Storage + 'static,
     Q: Querier + 'static,
-    U: DeserializeOwned + CustomMsg,
 {
     let env = to_vec(env)?;
     let msg = to_vec(msg)?;
@@ -388,16 +374,15 @@ where
     Ok(result)
 }
 
-pub fn call_ibc_destination_callback<A, S, Q, U>(
+pub fn call_ibc_destination_callback<A, S, Q>(
     instance: &mut Instance<A, S, Q>,
     env: &Env,
     msg: &IbcDestinationCallbackMsg,
-) -> VmResult<ContractResult<IbcBasicResponse<U>>>
+) -> VmResult<ContractResult<IbcBasicResponse>>
 where
     A: BackendApi + 'static,
     S: Storage + 'static,
     Q: Querier + 'static,
-    U: DeserializeOwned + CustomMsg,
 {
     let env = to_vec(env)?;
     let msg = to_vec(msg)?;
@@ -684,16 +669,15 @@ where
 }
 
 #[cfg(feature = "ibc2")]
-pub fn call_ibc2_packet_ack<A, S, Q, U>(
+pub fn call_ibc2_packet_ack<A, S, Q>(
     instance: &mut Instance<A, S, Q>,
     env: &Env,
     msg: &Ibc2PacketAckMsg,
-) -> VmResult<ContractResult<IbcBasicResponse<U>>>
+) -> VmResult<ContractResult<IbcBasicResponse>>
 where
     A: BackendApi + 'static,
     S: Storage + 'static,
     Q: Querier + 'static,
-    U: DeserializeOwned + CustomMsg,
 {
     let env = to_vec(env)?;
     let msg = to_vec(msg)?;
@@ -743,16 +727,15 @@ where
 }
 
 #[cfg(feature = "ibc2")]
-pub fn call_ibc2_packet_timeout<A, S, Q, U>(
+pub fn call_ibc2_packet_timeout<A, S, Q>(
     instance: &mut Instance<A, S, Q>,
     env: &Env,
     msg: &Ibc2PacketTimeoutMsg,
-) -> VmResult<ContractResult<IbcBasicResponse<U>>>
+) -> VmResult<ContractResult<IbcBasicResponse>>
 where
     A: BackendApi + 'static,
     S: Storage + 'static,
     Q: Querier + 'static,
-    U: DeserializeOwned + CustomMsg,
 {
     let env = to_vec(env)?;
     let msg = to_vec(msg)?;
@@ -802,16 +785,15 @@ where
 }
 
 #[cfg(feature = "ibc2")]
-pub fn call_ibc2_packet_send<A, S, Q, U>(
+pub fn call_ibc2_packet_send<A, S, Q>(
     instance: &mut Instance<A, S, Q>,
     env: &Env,
     msg: &Ibc2PacketSendMsg,
-) -> VmResult<ContractResult<IbcBasicResponse<U>>>
+) -> VmResult<ContractResult<IbcBasicResponse>>
 where
     A: BackendApi + 'static,
     S: Storage + 'static,
     Q: Querier + 'static,
-    U: DeserializeOwned + CustomMsg,
 {
     let env = to_vec(env)?;
     let msg = to_vec(msg)?;
@@ -886,16 +868,15 @@ where
 }
 
 #[cfg(feature = "ibc2")]
-pub fn call_ibc2_packet_receive<A, S, Q, U>(
+pub fn call_ibc2_packet_receive<A, S, Q>(
     instance: &mut Instance<A, S, Q>,
     env: &Env,
     msg: &Ibc2PacketReceiveMsg,
-) -> VmResult<ContractResult<IbcReceiveResponse<U>>>
+) -> VmResult<ContractResult<IbcReceiveResponse>>
 where
     A: BackendApi + 'static,
     S: Storage + 'static,
     Q: Querier + 'static,
-    U: DeserializeOwned + CustomMsg,
 {
     let env = to_vec(env)?;
     let msg = to_vec(msg)?;
@@ -928,7 +909,7 @@ mod tests {
         let verifier = instance.api().addr_make("verifies");
         let beneficiary = instance.api().addr_make("benefits");
         let msg = format!(r#"{{"verifier": "{verifier}", "beneficiary": "{beneficiary}"}}"#);
-        call_instantiate::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg.as_bytes())
+        call_instantiate::<_, _, _>(&mut instance, &mock_env(), &info, msg.as_bytes())
             .unwrap()
             .unwrap();
     }
@@ -941,9 +922,8 @@ mod tests {
         let info = mock_info("creator", &coins(1000, "earth"));
 
         let serialized_msg = to_vec(&msg).unwrap();
-        let err =
-            call_instantiate::<_, _, _, Empty>(&mut deps, &mock_env(), &info, &serialized_msg)
-                .unwrap_err();
+        let err = call_instantiate::<_, _, _>(&mut deps, &mock_env(), &info, &serialized_msg)
+            .unwrap_err();
 
         assert!(matches!(
             err,
@@ -964,14 +944,14 @@ mod tests {
         let verifier = instance.api().addr_make("verifies");
         let beneficiary = instance.api().addr_make("benefits");
         let msg = format!(r#"{{"verifier": "{verifier}", "beneficiary": "{beneficiary}"}}"#);
-        call_instantiate::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg.as_bytes())
+        call_instantiate::<_, _, _>(&mut instance, &mock_env(), &info, msg.as_bytes())
             .unwrap()
             .unwrap();
 
         // execute
         let info = mock_info(&verifier, &coins(15, "earth"));
         let msg = br#"{"release":{"denom":"earth"}}"#;
-        call_execute::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg)
+        call_execute::<_, _, _>(&mut instance, &mock_env(), &info, msg)
             .unwrap()
             .unwrap();
     }
@@ -982,15 +962,14 @@ mod tests {
 
         // init
         let info = mock_info("creator", &[]);
-        call_instantiate::<_, _, _, Empty>(&mut instance, &mock_env(), &info, br#"{}"#)
+        call_instantiate::<_, _, _>(&mut instance, &mock_env(), &info, br#"{}"#)
             .unwrap()
             .unwrap();
 
         // execute
         let info = mock_info("looper", &[]);
         let msg = br#"{"cpu_loop":{}}"#;
-        let err =
-            call_execute::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg).unwrap_err();
+        let err = call_execute::<_, _, _>(&mut instance, &mock_env(), &info, msg).unwrap_err();
         assert!(matches!(err, VmError::GasDepletion { .. }));
     }
 
@@ -999,15 +978,14 @@ mod tests {
         let mut instance = mock_instance(CYBERPUNK, &[]);
 
         let info = mock_info("creator", &[]);
-        call_instantiate::<_, _, _, Empty>(&mut instance, &mock_env(), &info, br#"{}"#)
+        call_instantiate::<_, _, _>(&mut instance, &mock_env(), &info, br#"{}"#)
             .unwrap()
             .unwrap();
 
         // execute
         let info = mock_info("troll", &[]);
         let msg = br#"{"panic":{}}"#;
-        let err =
-            call_execute::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg).unwrap_err();
+        let err = call_execute::<_, _, _>(&mut instance, &mock_env(), &info, msg).unwrap_err();
         match err {
             VmError::RuntimeErr { msg, .. } => {
                 assert!(
@@ -1024,15 +1002,14 @@ mod tests {
         let mut instance = mock_instance(CYBERPUNK, &[]);
 
         let info = mock_info("creator", &[]);
-        call_instantiate::<_, _, _, Empty>(&mut instance, &mock_env(), &info, br#"{}"#)
+        call_instantiate::<_, _, _>(&mut instance, &mock_env(), &info, br#"{}"#)
             .unwrap()
             .unwrap();
 
         // execute
         let info = mock_info("troll", &[]);
         let msg = br#"{"unreachable":{}}"#;
-        let err =
-            call_execute::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg).unwrap_err();
+        let err = call_execute::<_, _, _>(&mut instance, &mock_env(), &info, msg).unwrap_err();
         match err {
             VmError::RuntimeErr { msg, .. } => {
                 assert!(msg.contains("RuntimeError: unreachable"))
@@ -1053,14 +1030,14 @@ mod tests {
         let verifier = instance.api().addr_make("verifies");
         let beneficiary = instance.api().addr_make("benefits");
         let msg = format!(r#"{{"verifier": "{verifier}", "beneficiary": "{beneficiary}"}}"#);
-        call_instantiate::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg.as_bytes())
+        call_instantiate::<_, _, _>(&mut instance, &mock_env(), &info, msg.as_bytes())
             .unwrap()
             .unwrap();
 
         // change the verifier via migrate
         let someone_else = instance.api().addr_make("someone else");
         let msg = format!(r#"{{"verifier": "{someone_else}"}}"#);
-        let _res = call_migrate::<_, _, _, Empty>(&mut instance, &mock_env(), msg.as_bytes())
+        let _res = call_migrate::<_, _, _>(&mut instance, &mock_env(), msg.as_bytes())
             .unwrap()
             .unwrap();
 
@@ -1086,7 +1063,7 @@ mod tests {
         let verifier = instance.api().addr_make("verifies");
         let beneficiary = instance.api().addr_make("benefits");
         let msg = format!(r#"{{"verifier": "{verifier}", "beneficiary": "{beneficiary}"}}"#);
-        call_instantiate::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg.as_bytes())
+        call_instantiate::<_, _, _>(&mut instance, &mock_env(), &info, msg.as_bytes())
             .unwrap()
             .unwrap();
 
@@ -1097,7 +1074,7 @@ mod tests {
             sender: Addr::unchecked(someone_else.clone()),
             old_migrate_version: Some(33),
         };
-        let _res = call_migrate_with_info::<_, _, _, Empty>(
+        let _res = call_migrate_with_info::<_, _, _>(
             &mut instance,
             &mock_env(),
             msg.as_bytes(),
@@ -1125,7 +1102,7 @@ mod tests {
         let verifier = instance.api().addr_make("verifies");
         let beneficiary = instance.api().addr_make("benefits");
         let msg = format!(r#"{{"verifier": "{verifier}", "beneficiary": "{beneficiary}"}}"#);
-        call_instantiate::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg.as_bytes())
+        call_instantiate::<_, _, _>(&mut instance, &mock_env(), &info, msg.as_bytes())
             .unwrap()
             .unwrap();
 
@@ -1161,7 +1138,7 @@ mod tests {
 
         // init
         let info = mock_info("creator", &[]);
-        call_instantiate::<_, _, _, Empty>(&mut instance, &mock_env(), &info, br#"{}"#)
+        call_instantiate::<_, _, _>(&mut instance, &mock_env(), &info, br#"{}"#)
             .unwrap()
             .unwrap();
 
@@ -1244,7 +1221,7 @@ mod tests {
             // init
             let info = mock_info("creator", &[]);
             let msg = br#"{"reflect_code_id":77}"#;
-            call_instantiate::<_, _, _, Empty>(instance, &mock_env(), &info, msg)
+            call_instantiate::<_, _, _>(instance, &mock_env(), &info, msg)
                 .unwrap()
                 .unwrap();
             // first we try to open with a valid handshake
@@ -1256,13 +1233,10 @@ mod tests {
             // then we connect (with counter-party version set)
             let handshake_connect =
                 mock_ibc_channel_connect_ack(channel_id, IbcOrder::Ordered, IBC_VERSION);
-            let res: IbcBasicResponse = call_ibc_channel_connect::<_, _, _, Empty>(
-                instance,
-                &mock_env(),
-                &handshake_connect,
-            )
-            .unwrap()
-            .unwrap();
+            let res: IbcBasicResponse =
+                call_ibc_channel_connect::<_, _, _>(instance, &mock_env(), &handshake_connect)
+                    .unwrap()
+                    .unwrap();
             assert_eq!(1, res.messages.len());
             assert_eq!(
                 res.events,
@@ -1287,7 +1261,7 @@ mod tests {
                     data: None,
                 }),
             };
-            call_reply::<_, _, _, Empty>(instance, &mock_env(), &response).unwrap();
+            call_reply::<_, _, _>(instance, &mock_env(), &response).unwrap();
         }
 
         const CHANNEL_ID: &str = "channel-123";
@@ -1306,7 +1280,7 @@ mod tests {
             setup(&mut instance, CHANNEL_ID, &account);
             let handshake_close =
                 mock_ibc_channel_close_init(CHANNEL_ID, IbcOrder::Ordered, IBC_VERSION);
-            call_ibc_channel_close::<_, _, _, Empty>(&mut instance, &mock_env(), &handshake_close)
+            call_ibc_channel_close::<_, _, _>(&mut instance, &mock_env(), &handshake_close)
                 .unwrap()
                 .unwrap();
         }
@@ -1317,7 +1291,7 @@ mod tests {
             setup(&mut instance, CHANNEL_ID, ACCOUNT);
             let ack = IbcAcknowledgement::new(br#"{}"#);
             let msg = mock_ibc_packet_ack(CHANNEL_ID, br#"{}"#, ack).unwrap();
-            call_ibc_packet_ack::<_, _, _, Empty>(&mut instance, &mock_env(), &msg)
+            call_ibc_packet_ack::<_, _, _>(&mut instance, &mock_env(), &msg)
                 .unwrap()
                 .unwrap();
         }
@@ -1327,7 +1301,7 @@ mod tests {
             let mut instance = mock_instance(IBC_REFLECT, &[]);
             setup(&mut instance, CHANNEL_ID, ACCOUNT);
             let msg = mock_ibc_packet_timeout(CHANNEL_ID, br#"{}"#).unwrap();
-            call_ibc_packet_timeout::<_, _, _, Empty>(&mut instance, &mock_env(), &msg)
+            call_ibc_packet_timeout::<_, _, _>(&mut instance, &mock_env(), &msg)
                 .unwrap()
                 .unwrap();
         }
@@ -1338,7 +1312,7 @@ mod tests {
             setup(&mut instance, CHANNEL_ID, ACCOUNT);
             let who_am_i = br#"{"who_am_i":{}}"#;
             let msg = mock_ibc_packet_recv(CHANNEL_ID, who_am_i).unwrap();
-            call_ibc_packet_receive::<_, _, _, Empty>(&mut instance, &mock_env(), &msg)
+            call_ibc_packet_receive::<_, _, _>(&mut instance, &mock_env(), &msg)
                 .unwrap()
                 .unwrap();
         }
@@ -1350,7 +1324,7 @@ mod tests {
             // init
             let creator = instance.api().addr_make("creator");
             let info = mock_info(&creator, &[]);
-            call_instantiate::<_, _, _, Empty>(&mut instance, &mock_env(), &info, br#"{}"#)
+            call_instantiate::<_, _, _>(&mut instance, &mock_env(), &info, br#"{}"#)
                 .unwrap()
                 .unwrap();
 
@@ -1369,7 +1343,7 @@ mod tests {
                 ack.original_packet,
                 ack.relayer,
             ));
-            call_ibc_source_callback::<_, _, _, Empty>(&mut instance, &mock_env(), &msg)
+            call_ibc_source_callback::<_, _, _>(&mut instance, &mock_env(), &msg)
                 .unwrap()
                 .unwrap();
             // query the CallbackStats
@@ -1388,7 +1362,7 @@ mod tests {
                 timeout.packet,
                 timeout.relayer,
             ));
-            call_ibc_source_callback::<_, _, _, Empty>(&mut instance, &mock_env(), &msg)
+            call_ibc_source_callback::<_, _, _>(&mut instance, &mock_env(), &msg)
                 .unwrap()
                 .unwrap();
             // query the CallbackStats
@@ -1424,7 +1398,7 @@ mod tests {
             let mut instance = mock_instance(IBC2, &[]);
             let info = mock_info("creator", &[]);
             let instantiate_msg = br#"{}"#;
-            call_instantiate::<_, _, _, Empty>(&mut instance, &mock_env(), &info, instantiate_msg)
+            call_instantiate::<_, _, _>(&mut instance, &mock_env(), &info, instantiate_msg)
                 .unwrap()
                 .unwrap();
 
@@ -1433,7 +1407,7 @@ mod tests {
                 send_async_ack_for_prev_msg: false,
             };
             let ibc2_ack = mock_ibc2_packet_ack(&ibc2_msg).unwrap();
-            call_ibc2_packet_ack::<_, _, _, Empty>(&mut instance, &mock_env(), &ibc2_ack)
+            call_ibc2_packet_ack::<_, _, _>(&mut instance, &mock_env(), &ibc2_ack)
                 .unwrap()
                 .unwrap();
         }
@@ -1444,7 +1418,7 @@ mod tests {
             let mut instance = mock_instance(IBC2, &[]);
             let info = mock_info("creator", &[]);
             let instantiate_msg = br#"{}"#;
-            call_instantiate::<_, _, _, Empty>(&mut instance, &mock_env(), &info, instantiate_msg)
+            call_instantiate::<_, _, _>(&mut instance, &mock_env(), &info, instantiate_msg)
                 .unwrap()
                 .unwrap();
 
@@ -1453,7 +1427,7 @@ mod tests {
                 send_async_ack_for_prev_msg: false,
             };
             let ibc2_timeout = mock_ibc2_packet_recv(&ibc2_msg).unwrap();
-            call_ibc2_packet_receive::<_, _, _, Empty>(&mut instance, &mock_env(), &ibc2_timeout)
+            call_ibc2_packet_receive::<_, _, _>(&mut instance, &mock_env(), &ibc2_timeout)
                 .unwrap()
                 .unwrap();
         }
@@ -1464,13 +1438,13 @@ mod tests {
             let mut instance = mock_instance(IBC2, &[]);
             let info = mock_info("creator", &[]);
             let instantiate_msg = br#"{}"#;
-            call_instantiate::<_, _, _, Empty>(&mut instance, &mock_env(), &info, instantiate_msg)
+            call_instantiate::<_, _, _>(&mut instance, &mock_env(), &info, instantiate_msg)
                 .unwrap()
                 .unwrap();
 
             let ibc2_msg = br#"SomeRandomMsg"#;
             let ibc2_msg = mock_ibc2_packet_timeout(ibc2_msg).unwrap();
-            call_ibc2_packet_timeout::<_, _, _, Empty>(&mut instance, &mock_env(), &ibc2_msg)
+            call_ibc2_packet_timeout::<_, _, _>(&mut instance, &mock_env(), &ibc2_msg)
                 .unwrap()
                 .unwrap();
         }
@@ -1481,7 +1455,7 @@ mod tests {
             let mut instance = mock_instance(IBC2, &[]);
             let info = mock_info("creator", &[]);
             let instantiate_msg = br#"{}"#;
-            call_instantiate::<_, _, _, Empty>(&mut instance, &mock_env(), &info, instantiate_msg)
+            call_instantiate::<_, _, _>(&mut instance, &mock_env(), &info, instantiate_msg)
                 .unwrap()
                 .unwrap();
 
@@ -1490,7 +1464,7 @@ mod tests {
                 send_async_ack_for_prev_msg: false,
             };
             let ibc2_sent = mock_ibc2_packet_send(&ibc2_msg).unwrap();
-            call_ibc2_packet_send::<_, _, _, Empty>(&mut instance, &mock_env(), &ibc2_sent)
+            call_ibc2_packet_send::<_, _, _>(&mut instance, &mock_env(), &ibc2_sent)
                 .unwrap()
                 .unwrap();
         }

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -568,12 +568,12 @@ mod tests {
 
         // init contract
         let info = mock_info("creator", &coins(1000, "earth"));
-        call_instantiate::<_, _, _, Empty>(&mut instance, &mock_env(), &info, br#"{}"#)
+        call_instantiate::<_, _, _>(&mut instance, &mock_env(), &info, br#"{}"#)
             .unwrap()
             .unwrap();
 
         let info = mock_info("caller", &[]);
-        call_execute::<_, _, _, Empty>(&mut instance, &mock_env(), &info, br#"{"debug":{}}"#)
+        call_execute::<_, _, _>(&mut instance, &mock_env(), &info, br#"{"debug":{}}"#)
             .unwrap()
             .unwrap();
 
@@ -585,7 +585,7 @@ mod tests {
         });
 
         let info = mock_info("caller", &[]);
-        call_execute::<_, _, _, Empty>(&mut instance, &mock_env(), &info, br#"{"debug":{}}"#)
+        call_execute::<_, _, _>(&mut instance, &mock_env(), &info, br#"{"debug":{}}"#)
             .unwrap()
             .unwrap();
 
@@ -593,7 +593,7 @@ mod tests {
         instance.unset_debug_handler();
 
         let info = mock_info("caller", &[]);
-        call_execute::<_, _, _, Empty>(&mut instance, &mock_env(), &info, br#"{"debug":{}}"#)
+        call_execute::<_, _, _>(&mut instance, &mock_env(), &info, br#"{"debug":{}}"#)
             .unwrap()
             .unwrap();
     }
@@ -793,7 +793,7 @@ mod tests {
         // set up an instance that will experience an error in an import
         let error_message = "Api failed intentionally";
         let mut instance = mock_instance_with_failing_api(HACKATOM, &[], error_message);
-        let init_result = call_instantiate::<_, _, _, Empty>(
+        let init_result = call_instantiate::<_, _, _>(
             &mut instance,
             &mock_env(),
             &mock_info("someone", &[]),
@@ -915,7 +915,7 @@ mod tests {
         let verifier = instance.api().addr_make("verifies");
         let beneficiary = instance.api().addr_make("benefits");
         let msg = format!(r#"{{"verifier": "{verifier}", "beneficiary": "{beneficiary}"}}"#);
-        call_instantiate::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg.as_bytes())
+        call_instantiate::<_, _, _>(&mut instance, &mock_env(), &info, msg.as_bytes())
             .unwrap()
             .unwrap();
 
@@ -1083,7 +1083,7 @@ mod tests {
         let verifier = instance.api().addr_make("verifies");
         let beneficiary = instance.api().addr_make("benefits");
         let msg = format!(r#"{{"verifier": "{verifier}", "beneficiary": "{beneficiary}"}}"#);
-        call_instantiate::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg.as_bytes())
+        call_instantiate::<_, _, _>(&mut instance, &mock_env(), &info, msg.as_bytes())
             .unwrap()
             .unwrap();
 
@@ -1100,7 +1100,7 @@ mod tests {
         let verifier = instance.api().addr_make("verifies");
         let beneficiary = instance.api().addr_make("benefits");
         let msg = format!(r#"{{"verifier": "{verifier}", "beneficiary": "{beneficiary}"}}"#);
-        call_instantiate::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg.as_bytes())
+        call_instantiate::<_, _, _>(&mut instance, &mock_env(), &info, msg.as_bytes())
             .unwrap()
             .unwrap();
 
@@ -1108,7 +1108,7 @@ mod tests {
         let gas_before_execute = instance.get_gas_left();
         let info = mock_info(&verifier, &coins(15, "earth"));
         let msg = br#"{"release":{"denom":"earth"}}"#;
-        call_execute::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg)
+        call_execute::<_, _, _>(&mut instance, &mock_env(), &info, msg)
             .unwrap()
             .unwrap();
 
@@ -1126,7 +1126,7 @@ mod tests {
         let beneficiary = instance.api().addr_make("benefits");
         let msg = format!(r#"{{"verifier": "{verifier}", "beneficiary": "{beneficiary}"}}"#);
         let res =
-            call_instantiate::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg.as_bytes());
+            call_instantiate::<_, _, _>(&mut instance, &mock_env(), &info, msg.as_bytes());
         assert!(res.is_err());
     }
 
@@ -1140,7 +1140,7 @@ mod tests {
         let beneficiary = instance.api().addr_make("benefits");
         let msg = format!(r#"{{"verifier": "{verifier}", "beneficiary": "{beneficiary}"}}"#);
         let _res =
-            call_instantiate::<_, _, _, Empty>(&mut instance, &mock_env(), &info, msg.as_bytes())
+            call_instantiate::<_, _, _>(&mut instance, &mock_env(), &info, msg.as_bytes())
                 .unwrap()
                 .unwrap();
 

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -1125,8 +1125,7 @@ mod tests {
         let verifier = instance.api().addr_make("verifies");
         let beneficiary = instance.api().addr_make("benefits");
         let msg = format!(r#"{{"verifier": "{verifier}", "beneficiary": "{beneficiary}"}}"#);
-        let res =
-            call_instantiate::<_, _, _>(&mut instance, &mock_env(), &info, msg.as_bytes());
+        let res = call_instantiate::<_, _, _>(&mut instance, &mock_env(), &info, msg.as_bytes());
         assert!(res.is_err());
     }
 
@@ -1139,10 +1138,9 @@ mod tests {
         let verifier = instance.api().addr_make("verifies");
         let beneficiary = instance.api().addr_make("benefits");
         let msg = format!(r#"{{"verifier": "{verifier}", "beneficiary": "{beneficiary}"}}"#);
-        let _res =
-            call_instantiate::<_, _, _>(&mut instance, &mock_env(), &info, msg.as_bytes())
-                .unwrap()
-                .unwrap();
+        let _res = call_instantiate::<_, _, _>(&mut instance, &mock_env(), &info, msg.as_bytes())
+            .unwrap()
+            .unwrap();
 
         // run contract - just sanity check - results validate in contract unit tests
         let gas_before_query = instance.get_gas_left();

--- a/packages/vm/src/testing/calls.rs
+++ b/packages/vm/src/testing/calls.rs
@@ -29,18 +29,17 @@ use crate::{BackendApi, Querier, Storage};
 /// Mimics the call signature of the smart contracts.
 /// Thus it moves env and msg rather than take them as reference.
 /// This is inefficient here, but only used in test code.
-pub fn instantiate<A, S, Q, M, U>(
+pub fn instantiate<A, S, Q, M>(
     instance: &mut Instance<A, S, Q>,
     env: Env,
     info: MessageInfo,
     msg: M,
-) -> ContractResult<Response<U>>
+) -> ContractResult<Response>
 where
     A: BackendApi + 'static,
     S: Storage + 'static,
     Q: Querier + 'static,
     M: Serialize,
-    U: DeserializeOwned + CustomMsg,
 {
     let serialized_msg = to_vec(&msg).expect("Testing error: Could not serialize request message");
     call_instantiate(instance, &env, &info, &serialized_msg).expect("VM error")
@@ -49,18 +48,17 @@ where
 // execute mimics the call signature of the smart contracts.
 // thus it moves env and msg rather than take them as reference.
 // this is inefficient here, but only used in test code
-pub fn execute<A, S, Q, M, U>(
+pub fn execute<A, S, Q, M>(
     instance: &mut Instance<A, S, Q>,
     env: Env,
     info: MessageInfo,
     msg: M,
-) -> ContractResult<Response<U>>
+) -> ContractResult<Response>
 where
     A: BackendApi + 'static,
     S: Storage + 'static,
     Q: Querier + 'static,
     M: Serialize,
-    U: DeserializeOwned + CustomMsg,
 {
     let serialized_msg = to_vec(&msg).expect("Testing error: Could not serialize request message");
     call_execute(instance, &env, &info, &serialized_msg).expect("VM error")
@@ -69,17 +67,16 @@ where
 // migrate mimics the call signature of the smart contracts.
 // thus it moves env and msg rather than take them as reference.
 // this is inefficient here, but only used in test code
-pub fn migrate<A, S, Q, M, U>(
+pub fn migrate<A, S, Q, M>(
     instance: &mut Instance<A, S, Q>,
     env: Env,
     msg: M,
-) -> ContractResult<Response<U>>
+) -> ContractResult<Response>
 where
     A: BackendApi + 'static,
     S: Storage + 'static,
     Q: Querier + 'static,
     M: Serialize,
-    U: DeserializeOwned + CustomMsg,
 {
     let serialized_msg = to_vec(&msg).expect("Testing error: Could not serialize request message");
     call_migrate(instance, &env, &serialized_msg).expect("VM error")
@@ -88,18 +85,17 @@ where
 // migrate mimics the call signature of the smart contracts.
 // thus it moves env and msg rather than take them as reference.
 // this is inefficient here, but only used in test code
-pub fn migrate_with_info<A, S, Q, M, U>(
+pub fn migrate_with_info<A, S, Q, M>(
     instance: &mut Instance<A, S, Q>,
     env: Env,
     msg: M,
     migrate_info: MigrateInfo,
-) -> ContractResult<Response<U>>
+) -> ContractResult<Response>
 where
     A: BackendApi + 'static,
     S: Storage + 'static,
     Q: Querier + 'static,
     M: Serialize,
-    U: DeserializeOwned + CustomMsg,
 {
     let serialized_msg = to_vec(&msg).expect("Testing error: Could not serialize request message");
     call_migrate_with_info(instance, &env, &serialized_msg, &migrate_info).expect("VM error")
@@ -108,17 +104,16 @@ where
 // sudo mimics the call signature of the smart contracts.
 // thus it moves env and msg rather than take them as reference.
 // this is inefficient here, but only used in test code
-pub fn sudo<A, S, Q, M, U>(
+pub fn sudo<A, S, Q, M>(
     instance: &mut Instance<A, S, Q>,
     env: Env,
     msg: M,
-) -> ContractResult<Response<U>>
+) -> ContractResult<Response>
 where
     A: BackendApi + 'static,
     S: Storage + 'static,
     Q: Querier + 'static,
     M: Serialize,
-    U: DeserializeOwned + CustomMsg,
 {
     let serialized_msg = to_vec(&msg).expect("Testing error: Could not serialize request message");
     call_sudo(instance, &env, &serialized_msg).expect("VM error")
@@ -127,16 +122,15 @@ where
 // reply mimics the call signature of the smart contracts.
 // thus it moves env and msg rather than take them as reference.
 // this is inefficient here, but only used in test code
-pub fn reply<A, S, Q, U>(
+pub fn reply<A, S, Q>(
     instance: &mut Instance<A, S, Q>,
     env: Env,
     msg: Reply,
-) -> ContractResult<Response<U>>
+) -> ContractResult<Response>
 where
     A: BackendApi + 'static,
     S: Storage + 'static,
     Q: Querier + 'static,
-    U: DeserializeOwned + CustomMsg,
 {
     call_reply(instance, &env, &msg).expect("VM error")
 }
@@ -180,16 +174,15 @@ where
 // thus it moves env and channel rather than take them as reference.
 // this is inefficient here, but only used in test code
 #[cfg(feature = "stargate")]
-pub fn ibc_channel_connect<A, S, Q, U>(
+pub fn ibc_channel_connect<A, S, Q>(
     instance: &mut Instance<A, S, Q>,
     env: Env,
     msg: IbcChannelConnectMsg,
-) -> ContractResult<IbcBasicResponse<U>>
+) -> ContractResult<IbcBasicResponse>
 where
     A: BackendApi + 'static,
     S: Storage + 'static,
     Q: Querier + 'static,
-    U: DeserializeOwned + CustomMsg,
 {
     call_ibc_channel_connect(instance, &env, &msg).expect("VM error")
 }
@@ -198,16 +191,15 @@ where
 // thus it moves env and channel rather than take them as reference.
 // this is inefficient here, but only used in test code
 #[cfg(feature = "stargate")]
-pub fn ibc_channel_close<A, S, Q, U>(
+pub fn ibc_channel_close<A, S, Q>(
     instance: &mut Instance<A, S, Q>,
     env: Env,
     msg: IbcChannelCloseMsg,
-) -> ContractResult<IbcBasicResponse<U>>
+) -> ContractResult<IbcBasicResponse>
 where
     A: BackendApi + 'static,
     S: Storage + 'static,
     Q: Querier + 'static,
-    U: DeserializeOwned + CustomMsg,
 {
     call_ibc_channel_close(instance, &env, &msg).expect("VM error")
 }
@@ -216,16 +208,15 @@ where
 // thus it moves env and packet rather than take them as reference.
 // this is inefficient here, but only used in test code
 #[cfg(feature = "stargate")]
-pub fn ibc_packet_receive<A, S, Q, U>(
+pub fn ibc_packet_receive<A, S, Q>(
     instance: &mut Instance<A, S, Q>,
     env: Env,
     msg: IbcPacketReceiveMsg,
-) -> ContractResult<IbcReceiveResponse<U>>
+) -> ContractResult<IbcReceiveResponse>
 where
     A: BackendApi + 'static,
     S: Storage + 'static,
     Q: Querier + 'static,
-    U: DeserializeOwned + CustomMsg,
 {
     call_ibc_packet_receive(instance, &env, &msg).expect("VM error")
 }
@@ -234,16 +225,15 @@ where
 // thus it moves env and acknowledgement rather than take them as reference.
 // this is inefficient here, but only used in test code
 #[cfg(feature = "stargate")]
-pub fn ibc_packet_ack<A, S, Q, U>(
+pub fn ibc_packet_ack<A, S, Q>(
     instance: &mut Instance<A, S, Q>,
     env: Env,
     msg: IbcPacketAckMsg,
-) -> ContractResult<IbcBasicResponse<U>>
+) -> ContractResult<IbcBasicResponse>
 where
     A: BackendApi + 'static,
     S: Storage + 'static,
     Q: Querier + 'static,
-    U: DeserializeOwned + CustomMsg,
 {
     call_ibc_packet_ack(instance, &env, &msg).expect("VM error")
 }
@@ -252,16 +242,15 @@ where
 // thus it moves env and packet rather than take them as reference.
 // this is inefficient here, but only used in test code
 #[cfg(feature = "stargate")]
-pub fn ibc_packet_timeout<A, S, Q, U>(
+pub fn ibc_packet_timeout<A, S, Q>(
     instance: &mut Instance<A, S, Q>,
     env: Env,
     msg: IbcPacketTimeoutMsg,
-) -> ContractResult<IbcBasicResponse<U>>
+) -> ContractResult<IbcBasicResponse>
 where
     A: BackendApi + 'static,
     S: Storage + 'static,
     Q: Querier + 'static,
-    U: DeserializeOwned + CustomMsg,
 {
     call_ibc_packet_timeout(instance, &env, &msg).expect("VM error")
 }

--- a/packages/vm/src/testing/calls.rs
+++ b/packages/vm/src/testing/calls.rs
@@ -1,11 +1,9 @@
 //! This file has some helpers for integration tests.
 //! They should be imported via full path to ensure there is no confusion
 //! use cosmwasm_vm::testing::X
-use serde::{de::DeserializeOwned, Serialize};
+use serde::Serialize;
 
-use cosmwasm_std::{
-    ContractResult, CustomMsg, Env, MessageInfo, MigrateInfo, QueryResponse, Reply, Response,
-};
+use cosmwasm_std::{ContractResult, Env, MessageInfo, MigrateInfo, QueryResponse, Reply, Response};
 #[cfg(feature = "stargate")]
 use cosmwasm_std::{
     Ibc3ChannelOpenResponse, IbcBasicResponse, IbcChannelCloseMsg, IbcChannelConnectMsg,


### PR DESCRIPTION
closes #2249

Just opening to get some opinions. This has the drawback that it loses all json schema for `CustomMsg` (I did a custom impl that accepts any value) and makes the `CustomMsg` a bit more cumbersome to use. On the positive side, it does get rid of the generic parameter.