### PR TITLE
Classify more errors

### DIFF
--- a/packages/std/src/coins.rs
+++ b/packages/std/src/coins.rs
@@ -380,7 +380,7 @@ mod tests {
         assert_eq!(Coins::default().to_string(), "");
         assert_eq!(
             Coins::from_str(invalid).unwrap_err().to_string(),
-            "kind: Other, error: Missing amount or non-digit characters in amount"
+            "kind: Parsing, error: Missing amount or non-digit characters in amount"
         );
     }
 

--- a/packages/std/src/errors/std_error.rs
+++ b/packages/std/src/errors/std_error.rs
@@ -4,7 +4,11 @@ use std::{error::Error, ops::Deref, str, string};
 
 use super::BT;
 
-use crate::errors::{RecoverPubkeyError, VerificationError};
+use crate::{
+    errors::{RecoverPubkeyError, VerificationError},
+    Decimal256RangeExceeded, DecimalRangeExceeded, SignedDecimal256RangeExceeded,
+    SignedDecimalRangeExceeded,
+};
 
 mod sealed {
     pub trait Sealed {}
@@ -122,9 +126,21 @@ where
         // "mom, can we have specialization?"
         // "we have specialization at home"
         // specialization at home:
-        let kind = if inner.is::<str::Utf8Error>() || inner.is::<string::FromUtf8Error>() {
+        let kind = if inner.is::<str::Utf8Error>()
+            || inner.is::<string::FromUtf8Error>()
+            || inner.is::<core::num::ParseIntError>()
+            || inner.is::<CoinFromStrError>()
+        {
             ErrorKind::Parsing
-        } else if inner.is::<ConversionOverflowError>() || inner.is::<OverflowError>() {
+        } else if inner.is::<ConversionOverflowError>()
+            || inner.is::<OverflowError>()
+            || inner.is::<RoundUpOverflowError>()
+            || inner.is::<RoundDownOverflowError>()
+            || inner.is::<DecimalRangeExceeded>()
+            || inner.is::<Decimal256RangeExceeded>()
+            || inner.is::<SignedDecimalRangeExceeded>()
+            || inner.is::<SignedDecimal256RangeExceeded>()
+        {
             ErrorKind::Overflow
         } else if inner.is::<serde_json::Error>()
             || inner.is::<rmp_serde::encode::Error>()

--- a/packages/std/src/math/signed_decimal.rs
+++ b/packages/std/src/math/signed_decimal.rs
@@ -3081,7 +3081,7 @@ mod tests {
 
         // invalid: not properly defined signed decimal value
         assert_eq!(
-            "Error parsing decimal '1.e': kind: Other, error: invalid digit found in string at line 1 column 5",
+            "Error parsing decimal '1.e': kind: Parsing, error: invalid digit found in string at line 1 column 5",
             serde_json::from_str::<SignedDecimal>(r#""1.e""#)
                 .err()
                 .unwrap()

--- a/packages/std/src/math/signed_decimal_256.rs
+++ b/packages/std/src/math/signed_decimal_256.rs
@@ -3243,7 +3243,7 @@ mod tests {
 
         // invalid: not properly defined signed decimal value
         assert_eq!(
-            "Error parsing decimal '1.e': kind: Other, error: invalid digit found in string at line 1 column 5",
+            "Error parsing decimal '1.e': kind: Parsing, error: invalid digit found in string at line 1 column 5",
             serde_json::from_str::<SignedDecimal256>(r#""1.e""#)
                 .err()
                 .unwrap()


### PR DESCRIPTION
Adding `ErrorKind` detection for some more errors that we use in `cosmwasm-std`. I found these while doing #2502 
Somewhat related to #2076

I don't think we need an extra changelog entry.