### PR TITLE
fix: correct malformed crates.io links in crypto README

### DIFF
--- a/packages/crypto/README.md
+++ b/packages/crypto/README.md
@@ -3,8 +3,8 @@
 [![cosmwasm-crypto on crates.io](https://img.shields.io/crates/v/cosmwasm-crypto.svg)](https://crates.io/crates/cosmwasm-crypto)
 
 This crate implements cryptography-related functions, so that they can be
-available for both, the [cosmwasm-vm](`https://crates.io/crates/cosmwasm-vm`)
-and [cosmwasm-std](`https://crates.io/crates/cosmwasm-std`) crates.
+available for both, the [cosmwasm-vm](https://crates.io/crates/cosmwasm-vm)
+and [cosmwasm-std](https://crates.io/crates/cosmwasm-std) crates.
 
 ## Implementations
 


### PR DESCRIPTION
Remove extra backticks from crates.io links in packages/crypto/README.md

The links to cosmwasm-vm and cosmwasm-std crates were incorrectly formatted
with backticks inside the markdown link syntax, causing file path errors.
This fix removes the extra backticks to properly format the links.