### PR TITLE
Unified dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2806,9 +2806,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
 dependencies = [
  "itoa",
  "memchr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2806,9 +2806,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.143"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,8 @@ resolver = "2"
 version = "3.0.2-dev"
 
 [workspace.dependencies]
+cosmwasm-vm = { path = "./packages/vm" }
+cosmwasm-std = { path = "./packages/std" }
 schemars = "0.8.4"
 serde = { version = "1.0.192", default-features = false, features = ["alloc", "derive"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,20 @@ resolver = "2"
 version = "3.0.2-dev"
 
 [workspace.dependencies]
+cosmwasm-core = { path = "./packages/core" }
+cosmwasm-crypto = { path = "./packages/crypto" }
+cosmwasm-derive = { path = "./packages/derive" }
+cosmwasm-schema = { path = "./packages/schema" }
+cosmwasm-schema-derive = { path = "./packages/schema-derive" }
+cosmwasm-std = { path = "./packages/std", default-features = false }
 cosmwasm-vm = { path = "./packages/vm" }
-cosmwasm-std = { path = "./packages/std" }
+cosmwasm-vm-derive = { path = "./packages/vm-derive" }
+cw-schema = { path = "./packages/cw-schema" }
+cw-schema-derive = { path = "./packages/cw-schema-derive" }
 schemars = "0.8.4"
 serde = { version = "1.0.192", default-features = false, features = ["alloc", "derive"] }
+serde_json = "1.0.140"
+thiserror = "1.0.26"
 
 [workspace.metadata.release]
 shared-version = true

--- a/packages/check/Cargo.toml
+++ b/packages/check/Cargo.toml
@@ -12,7 +12,7 @@ anyhow = "1.0.57"
 clap = "4"
 colored = "2.1.0"
 cosmwasm-vm = { workspace = true }
-cosmwasm-std = { workspace = true }
+cosmwasm-std = { workspace = true, default-features = true }
 
 [dev-dependencies]
 assert_cmd = "2.0.12"

--- a/packages/check/Cargo.toml
+++ b/packages/check/Cargo.toml
@@ -11,8 +11,8 @@ license = "Apache-2.0"
 anyhow = "1.0.57"
 clap = "4"
 colored = "2.1.0"
-cosmwasm-vm = { path = "../vm" }
-cosmwasm-std = { path = "../std" }
+cosmwasm-vm = { workspace = true }
+cosmwasm-std = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = "2.0.12"

--- a/packages/crypto/Cargo.toml
+++ b/packages/crypto/Cargo.toml
@@ -16,7 +16,7 @@ ark-bls12-381 = "0.5.0"
 ark-ec = { version = "0.5.0", features = ["parallel"] }
 ark-ff = { version = "0.5.0", features = ["asm", "parallel"] }
 ark-serialize = "0.5.0"
-cosmwasm-core = { path = "../core" }
+cosmwasm-core = { workspace = true }
 digest = "0.10"
 ed25519-zebra = { version = "=4.0.3", default-features = false }
 k256 = { version = "0.13.3", default-features = false, features = ["ecdsa"] }

--- a/packages/cw-schema/Cargo.toml
+++ b/packages/cw-schema/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/CosmWasm/cosmwasm/tree/main/packages/cw-schema"
 license = "Apache-2.0"
 
 [dependencies]
-cw-schema-derive = { path = "../cw-schema-derive" }
+cw-schema-derive = { workspace = true }
 indexmap = { version = "2.3.0", default-features = false }
 schemars = { version = "1.0.4", optional = true }
 serde = { version = "1.0.204", features = ["derive"] }

--- a/packages/go-gen/Cargo.toml
+++ b/packages/go-gen/Cargo.toml
@@ -9,8 +9,8 @@ publish = false
 release = false
 
 [dependencies]
-cosmwasm-std = { path = "../std", features = ["cosmwasm_3_0", "staking", "stargate"] }
-cosmwasm-schema = { path = "../schema" }
+cosmwasm-std = { workspace = true, default-features = true, features = ["cosmwasm_3_0", "staking", "stargate"] }
+cosmwasm-schema = { workspace = true }
 anyhow = "1"
 indenter = "0.3.3"
 schemars = { workspace = true }

--- a/packages/schema/Cargo.toml
+++ b/packages/schema/Cargo.toml
@@ -11,12 +11,12 @@ repository = "https://github.com/CosmWasm/cosmwasm/tree/main/packages/schema"
 license = "Apache-2.0"
 
 [dependencies]
-cosmwasm-schema-derive = { path = "../schema-derive" }
-cw-schema = { path = "../cw-schema" }
+cosmwasm-schema-derive = { workspace = true }
+cw-schema = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true }
-serde_json = "1.0.140"
-thiserror = "1.0.26"
+serde_json = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 anyhow = "1.0.57"

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -62,9 +62,9 @@ cosmwasm_3_0 = ["cosmwasm_2_2"]
 [dependencies]
 base64 = "0.22.0"
 bnum = "0.11.0"
-cosmwasm-core = { path = "../core" }
-cosmwasm-derive = { path = "../derive" }
-cw-schema = { path = "../cw-schema" }
+cosmwasm-core = { workspace = true }
+cosmwasm-derive = { workspace = true }
+cw-schema = { workspace = true }
 derive_more = { version = "2.0.1", default-features = false, features = ["debug"] }
 hex = "0.4"
 schemars = { workspace = true }
@@ -77,12 +77,12 @@ rmp-serde = "1.3.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 bech32 = "0.11.0"
-cosmwasm-crypto = { path = "../crypto" }
+cosmwasm-crypto = { workspace = true }
 rand_core = { version = "0.6.4", features = ["getrandom"] }
 
 [dev-dependencies]
-cosmwasm-core = { path = "../core" }
-cosmwasm-schema = { path = "../schema" }
+cosmwasm-core = { workspace = true }
+cosmwasm-schema = { workspace = true }
 # The chrono dependency is only used in an example, which Rust compiles for us. If this causes trouble, remove it.
 chrono = { version = "0.4", default-features = false, features = ["alloc", "std"] }
 crc32fast = "1.3.2"

--- a/packages/vm/Cargo.toml
+++ b/packages/vm/Cargo.toml
@@ -45,7 +45,7 @@ bech32 = "0.11.0"
 blake2 = "0.10.6"
 # Uses the path when built locally; uses the given version from crates.io when published
 cosmwasm-core = { workspace = true }
-cosmwasm-std = { workspace = true, default-features = false, features = ["std"] }
+cosmwasm-std = { workspace = true, features = ["std"] }
 cosmwasm-crypto = { workspace = true }
 cosmwasm-vm-derive = { workspace = true }
 derive_more = { version = "=1.0.0-beta.6", default-features = false, features = ["debug"] }

--- a/packages/vm/Cargo.toml
+++ b/packages/vm/Cargo.toml
@@ -44,10 +44,10 @@ crc32fast = "1.3.2"
 bech32 = "0.11.0"
 blake2 = "0.10.6"
 # Uses the path when built locally; uses the given version from crates.io when published
-cosmwasm-core = { path = "../core" }
-cosmwasm-std = { path = "../std", default-features = false, features = ["std"] }
-cosmwasm-crypto = { path = "../crypto" }
-cosmwasm-vm-derive = { path = "../vm-derive" }
+cosmwasm-core = { workspace = true }
+cosmwasm-std = { workspace = true, default-features = false, features = ["std"] }
+cosmwasm-crypto = { workspace = true }
+cosmwasm-vm-derive = { workspace = true }
 derive_more = { version = "=1.0.0-beta.6", default-features = false, features = ["debug"] }
 hex = "0.4"
 rand_core = { version = "0.6", features = ["getrandom"] }


### PR DESCRIPTION
Dependencies between crates in packages directory are moved up to the workspace **Cargo.toml**.
This makes the maintenenace of dependencies easier, as they are placed in one file, like this:
```toml
[workspace.dependencies]
cosmwasm-core = { path = "./packages/core" }
cosmwasm-crypto = { path = "./packages/crypto" }
cosmwasm-derive = { path = "./packages/derive" }
cosmwasm-schema = { path = "./packages/schema" }
cosmwasm-schema-derive = { path = "./packages/schema-derive" }
cosmwasm-std = { path = "./packages/std", default-features = false }
cosmwasm-vm = { path = "./packages/vm" }
cosmwasm-vm-derive = { path = "./packages/vm-derive" }
cw-schema = { path = "./packages/cw-schema" }
cw-schema-derive = { path = "./packages/cw-schema-derive" }
```
**P.S.** To check which features are efectively used during dependency compilation use the following command:
```shell
$ cargo tree -e features
```
This PR was checked for dependency identity in the follwoing way:
- on the `main` branch:
  ```shell
  $ git checkout main
  $ cargo tree -e features > a.txt
  ```
- on the `unified-dependencies` branch:
  ```shell
  $ git checkout unified-dependencies
  $ cargo tree -e features > b.txt
  ```
```shell
$ diff -s a.txt b.txt
```
Output:
```text
Files a.txt and b.txt are identical
```