### PR TITLE
chore: Remove duplicate words to make the comments more readable

### DIFF
--- a/packages/std/src/query/staking.rs
+++ b/packages/std/src/query/staking.rs
@@ -33,7 +33,7 @@ pub enum StakingQuery {
     ///
     /// The query response type is `ValidatorResponse`.
     Validator {
-        /// The validator's address (e.g. (e.g. cosmosvaloper1...))
+        /// The validator's address (e.g. cosmosvaloper1...)
         address: String,
     },
 }


### PR DESCRIPTION
Remove duplicate words to make the comments more readable