### PR TITLE
fix: grammar issues in contracts and IBC code comments

### DIFF
--- a/contracts/cyberpunk/src/contract.rs
+++ b/contracts/cyberpunk/src/contract.rs
@@ -98,7 +98,7 @@ fn execute_message_loop(env: Env) -> Result<Response, ContractError> {
 fn execute_allocate_large_memory(pages: u32) -> Result<Response, ContractError> {
     // We create memory pages explicitly since Rust's default allocator seems to be clever enough
     // to not grow memory for unused capacity like `Vec::<u8>::with_capacity(100 * 1024 * 1024)`.
-    // Even with std::alloc::alloc the memory did now grow beyond 1.5 MiB.
+    // Even with std::alloc::alloc the memory did not grow beyond 1.5 MiB.
 
     #[cfg(target_arch = "wasm32")]
     {

--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -164,7 +164,7 @@ fn do_message_loop(env: Env) -> Result<Response, HackError> {
 fn do_allocate_large_memory(pages: u32) -> Result<Response, HackError> {
     // We create memory pages explicitly since Rust's default allocator seems to be clever enough
     // to not grow memory for unused capacity like `Vec::<u8>::with_capacity(100 * 1024 * 1024)`.
-    // Even with std::alloc::alloc the memory did now grow beyond 1.5 MiB.
+    // Even with std::alloc::alloc the memory did not grow beyond 1.5 MiB.
 
     #[cfg(target_arch = "wasm32")]
     {

--- a/contracts/hackatom/src/msg.rs
+++ b/contracts/hackatom/src/msg.rs
@@ -21,7 +21,7 @@ pub struct MigrateMsg {
 }
 
 /// SudoMsg is only exposed for internal Cosmos SDK modules to call.
-/// This is showing how we can expose "admin" functionality than can not be called by
+/// This is showing how we can expose "admin" functionality that can not be called by
 /// external users or contracts, but only trusted (native/Go) code in the blockchain
 #[cw_serde]
 pub enum SudoMsg {

--- a/contracts/ibc-reflect-send/src/ibc.rs
+++ b/contracts/ibc-reflect-send/src/ibc.rs
@@ -58,7 +58,7 @@ pub fn ibc_channel_connect(
 
     let channel_id = &channel.endpoint.channel_id;
 
-    // create an account holder the channel exists (not found if not registered)
+    // create an account holder when the channel exists (not found if not registered)
     let data = AccountData::default();
     save_account(deps.storage, channel_id, &data)?;
 
@@ -110,7 +110,7 @@ pub fn ibc_packet_ack(
     env: Env,
     msg: IbcPacketAckMsg,
 ) -> StdResult<IbcBasicResponse> {
-    // which local channel was this packet send from
+    // which local channel was this packet sent from
     let caller = msg.original_packet.src.channel_id;
     // we need to parse the ack based on our request
     let packet: PacketMsg = from_json(msg.original_packet.data)?;


### PR DESCRIPTION
- cyberpunk/contract.rs & hackatom/contract.rs – fixed typo: did now grow → did not grow.

- hackatom/msg.rs – corrected wording: than can not → that can not.

- ibc-reflect-send/ibc.rs – fixed grammar in comments:

   - create an account holder the channel exists → create an account holder when the channel exists.

   - packet send from → packet sent from.