### PR TITLE
docs: fix typo

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1620,7 +1620,7 @@ arbitrary ones.
   `Result<HandleResponse, MyCustomError>` and `query` returning
   `StdResult<Binary>`.
 
-  You can have a top-hevel `init`/`migrate`/`handle`/`query` that returns a
+  You can have a top-level `init`/`migrate`/`handle`/`query` that returns a
   custom error but some of its implementations only return errors from the
   standard library (`StdResult<HandleResponse>` aka.
   `Result<HandleResponse, StdError>`). Then use `Ok(std_result?)` to convert


### PR DESCRIPTION
top-hevel 
i believe it was intended to be a top-level ;)