### PR TITLE
ci: upgrade GitHub Action to download-artifact@v5

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -147,82 +147,82 @@ jobs:
       - name: Install recently released cosmwasm-check
         run: cargo install cosmwasm-check@3.0.2
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: burner-${{ runner.os }}
           path: .
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: crypto-verify-${{ runner.os }}
           path: .
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: cyberpunk-${{ runner.os }}
           path: .
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: empty-${{ runner.os }}
           path: .
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: floaty-${{ runner.os }}
           path: .
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: hackatom-${{ runner.os }}
           path: .
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: ibc2-${{ runner.os }}
           path: .
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: ibc-callbacks-${{ runner.os }}
           path: .
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: ibc-reflect-${{ runner.os }}
           path: .
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: ibc-reflect-send-${{ runner.os }}
           path: .
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: nested-contracts-${{ runner.os }}
           path: .
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: queue-${{ runner.os }}
           path: .
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: reflect-${{ runner.os }}
           path: .
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: replier-${{ runner.os }}
           path: .
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: staking-${{ runner.os }}
           path: .
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: virus-${{ runner.os }}
           path: .
@@ -251,32 +251,32 @@ jobs:
       - name: Install currently developed cosmwasm-check
         run: cargo install --path ./packages/check --force
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: burner-${{ runner.os }}
           path: .
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: crypto-verify-${{ runner.os }}
           path: .
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: cyberpunk-${{ runner.os }}
           path: .
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: empty-${{ runner.os }}
           path: .
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: floaty-${{ runner.os }}
           path: .
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: hackatom-${{ runner.os }}
           path: .
@@ -286,47 +286,47 @@ jobs:
           name: ibc2-${{ runner.os }}
           path: .
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: ibc-callbacks-${{ runner.os }}
           path: .
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: ibc-reflect-${{ runner.os }}
           path: .
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: ibc-reflect-send-${{ runner.os }}
           path: .
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: nested-contracts-${{ runner.os }}
           path: .
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: queue-${{ runner.os }}
           path: .
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: reflect-${{ runner.os }}
           path: .
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: replier-${{ runner.os }}
           path: .
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: staking-${{ runner.os }}
           path: .
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: virus-${{ runner.os }}
           path: .


### PR DESCRIPTION

Release notes:https://github.com/actions/download-artifact/releases/tag/v5.0.0

Change:
uses: actions/download-artifact@v4 -> uses: actions/download-artifact@v5