### PR TITLE
 Fix typo

### DIFF
--- a/packages/std/src/math/decimal.rs
+++ b/packages/std/src/math/decimal.rs
@@ -457,7 +457,7 @@ impl Decimal {
         self.0 / Self::DECIMAL_FRACTIONAL
     }
 
-    /// Converts this decimal to an unsigned integer by rounting up
+    /// Converts this decimal to an unsigned integer by rounding up
     /// to the next integer, e.g. 22.3 becomes 23.
     ///
     /// ## Examples

--- a/packages/std/src/math/decimal256.rs
+++ b/packages/std/src/math/decimal256.rs
@@ -472,7 +472,7 @@ impl Decimal256 {
         self.0 / Self::DECIMAL_FRACTIONAL
     }
 
-    /// Converts this decimal to an unsigned integer by rounting up
+    /// Converts this decimal to an unsigned integer by rounding up
     /// to the next integer, e.g. 22.3 becomes 23.
     ///
     /// ## Examples


### PR DESCRIPTION
Fixed a small typo in the to_uint_ceil docs — “rounting” should be “rounding”.