### PR TITLE
doc: fix  typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ extern "C" fn interface_version_8() -> () {}
 extern "C" fn allocate(size: usize) -> u32;
 extern "C" fn deallocate(pointer: u32);
 
-// creates an initial state of a contract with a configuration send in the argument msg_ptr
+// creates an initial state of a contract with a configuration sent in the argument msg_ptr
 extern "C" fn instantiate(env_ptr: u32, info_ptr: u32, msg_ptr: u32) -> u32;
 ```
 

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -82,7 +82,7 @@ and
 
 ## Format
 
-The capability name needs to be allowed as a Wasm export names and be a legal
+The capability name needs to be allowed as a Wasm export name and be a legal
 function name in Rust and other CosmWasm smart contract languages such as Go. By
 convention, the name should be short and all lower ASCII alphanumerical plus
 underscores.

--- a/docs/ERROR_HANDLING.md
+++ b/docs/ERROR_HANDLING.md
@@ -51,7 +51,7 @@ from the contract, they have to be deterministic. With the new separation, wasmd
 now passes the full contract error message back into the calling contract,
 massively improving the debugging experience.
 
-## Handing ibc_packet_receive errors
+## Handling ibc_packet_receive errors
 
 From wasmd 0.22 to 0.31 (inclusive), contract errors and VM errors were handled
 the same. They got the special treatment of reverting state changes, writing an


### PR DESCRIPTION
- README instantiate comment should say “configuration sent” to match tense.
- ERROR_HANDLING heading misspells “Handling”.
- CAPABILITIES format sentence uses plural “export names” for a singular subject.
