### PR TITLE
Fix articles in `Int` type comments

### DIFF
--- a/packages/std/src/math/int128.rs
+++ b/packages/std/src/math/int128.rs
@@ -57,7 +57,7 @@ impl Int128 {
     pub const MAX: Int128 = Int128(i128::MAX);
     pub const MIN: Int128 = Int128(i128::MIN);
 
-    /// Creates a Int128(value).
+    /// Creates an Int128(value).
     ///
     /// This method is less flexible than `from` but can be called in a const context.
     #[inline]
@@ -66,13 +66,13 @@ impl Int128 {
         Self(value)
     }
 
-    /// Creates a Int128(0)
+    /// Creates an Int128(0)
     #[inline]
     pub const fn zero() -> Self {
         Int128(0)
     }
 
-    /// Creates a Int128(1)
+    /// Creates an Int128(1)
     #[inline]
     pub const fn one() -> Self {
         Self(1)

--- a/packages/std/src/math/int256.rs
+++ b/packages/std/src/math/int256.rs
@@ -69,7 +69,7 @@ impl Int256 {
     pub const MAX: Int256 = Int256(I256::MAX);
     pub const MIN: Int256 = Int256(I256::MIN);
 
-    /// Creates a Int256(value).
+    /// Creates an Int256(value).
     ///
     /// This method is less flexible than `from` but can be called in a const context.
     ///
@@ -83,13 +83,13 @@ impl Int256 {
         Self::from_be_bytes(grow_be_int(value.to_be_bytes()))
     }
 
-    /// Creates a Int256(0)
+    /// Creates an Int256(0)
     #[inline]
     pub const fn zero() -> Self {
         Int256(I256::ZERO)
     }
 
-    /// Creates a Int256(1)
+    /// Creates an Int256(1)
     #[inline]
     pub const fn one() -> Self {
         Self(I256::ONE)

--- a/packages/std/src/math/int512.rs
+++ b/packages/std/src/math/int512.rs
@@ -70,7 +70,7 @@ impl Int512 {
     pub const MAX: Int512 = Int512(I512::MAX);
     pub const MIN: Int512 = Int512(I512::MIN);
 
-    /// Creates a Int512(value).
+    /// Creates an Int512(value).
     ///
     /// This method is less flexible than `from` but can be called in a const context.
     ///
@@ -84,13 +84,13 @@ impl Int512 {
         Self::from_be_bytes(grow_be_int(value.to_be_bytes()))
     }
 
-    /// Creates a Int512(0)
+    /// Creates an Int512(0)
     #[inline]
     pub const fn zero() -> Self {
         Int512(I512::ZERO)
     }
 
-    /// Creates a Int512(1)
+    /// Creates an Int512(1)
     #[inline]
     pub const fn one() -> Self {
         Self(I512::ONE)

--- a/packages/std/src/math/int64.rs
+++ b/packages/std/src/math/int64.rs
@@ -57,7 +57,7 @@ impl Int64 {
     pub const MAX: Int64 = Int64(i64::MAX);
     pub const MIN: Int64 = Int64(i64::MIN);
 
-    /// Creates a Int64(value).
+    /// Creates an Int64(value).
     ///
     /// This method is less flexible than `from` but can be called in a const context.
     #[inline]
@@ -66,13 +66,13 @@ impl Int64 {
         Self(value)
     }
 
-    /// Creates a Int64(0)
+    /// Creates an Int64(0)
     #[inline]
     pub const fn zero() -> Self {
         Int64(0)
     }
 
-    /// Creates a Int64(1)
+    /// Creates an Int64(1)
     #[inline]
     pub const fn one() -> Self {
         Self(1)

--- a/packages/vm/src/environment.rs
+++ b/packages/vm/src/environment.rs
@@ -452,7 +452,7 @@ impl<A: BackendApi, S: Storage, Q: Querier> Environment<A, S, Q> {
 
     /// Decreases gas left by the given amount.
     /// If the amount exceeds the available gas, the remaining gas is set to 0 and
-    /// an VmError::GasDepletion error is returned.
+    /// a VmError::GasDepletion error is returned.
     #[allow(unused)] // used in tests
     pub fn decrease_gas_left(&self, store: &mut impl AsStoreMut, amount: u64) -> VmResult<()> {
         self.with_wasmer_instance(|instance| {


### PR DESCRIPTION
 ## Summary
  Fix incorrect article usage in Int type documentation comments.
 ## Changes
  - Change "a Int128" to "an Int128" in `packages/std/src/math/int128.rs` (3 occurrences)
  - Change "a Int64" to "an Int64" in `packages/std/src/math/int64.rs` (3 occurrences)
  - Change "a Int256" to "an Int256" in `packages/std/src/math/int256.rs` (3 occurrences)
  - Change "a Int512" to "an Int512" in `packages/std/src/math/int512.rs` (3 occurrences)