### PR TITLE
chore: replace manual modulo checks with is multiple of

### DIFF
--- a/packages/crypto/src/bls12_381/aggregate.rs
+++ b/packages/crypto/src/bls12_381/aggregate.rs
@@ -12,7 +12,7 @@ const G2_POINT_SIZE: usize = 96;
 pub fn bls12_381_aggregate_g1(points: &[u8]) -> Result<[u8; 48], CryptoError> {
     if points.is_empty() {
         return Err(Aggregation::Empty.into());
-    } else if points.len() % G1_POINT_SIZE != 0 {
+    } else if !points.len().is_multiple_of(G1_POINT_SIZE) {
         return Err(Aggregation::NotMultiple {
             expected_multiple: G1_POINT_SIZE,
             remainder: points.len() % G1_POINT_SIZE,
@@ -54,7 +54,7 @@ pub fn bls12_381_aggregate_g1(points: &[u8]) -> Result<[u8; 48], CryptoError> {
 pub fn bls12_381_aggregate_g2(points: &[u8]) -> Result<[u8; 96], CryptoError> {
     if points.is_empty() {
         return Err(Aggregation::Empty.into());
-    } else if points.len() % G2_POINT_SIZE != 0 {
+    } else if !points.len().is_multiple_of(G2_POINT_SIZE) {
         return Err(Aggregation::NotMultiple {
             expected_multiple: G2_POINT_SIZE,
             remainder: points.len() % G2_POINT_SIZE,

--- a/packages/crypto/src/bls12_381/pairing.rs
+++ b/packages/crypto/src/bls12_381/pairing.rs
@@ -21,12 +21,12 @@ pub fn bls12_381_pairing_equality(
     r: &[u8],
     s: &[u8],
 ) -> Result<bool, CryptoError> {
-    if ps.len() % BLS12_381_G1_POINT_LEN != 0 {
+    if !ps.len().is_multiple_of(BLS12_381_G1_POINT_LEN) {
         return Err(PairingEquality::NotMultipleG1 {
             remainder: ps.len() % BLS12_381_G1_POINT_LEN,
         }
         .into());
-    } else if qs.len() % BLS12_381_G2_POINT_LEN != 0 {
+    } else if !qs.len().is_multiple_of(BLS12_381_G2_POINT_LEN) {
         return Err(PairingEquality::NotMultipleG2 {
             remainder: qs.len() % BLS12_381_G2_POINT_LEN,
         }

--- a/packages/std/src/math/decimal.rs
+++ b/packages/std/src/math/decimal.rs
@@ -338,7 +338,7 @@ impl Decimal {
             let mut y = Decimal::one();
 
             while n > 1 {
-                if n % 2 == 0 {
+                if n.is_multiple_of(2) {
                     x = x.checked_mul(x)?;
                     n /= 2;
                 } else {

--- a/packages/std/src/math/decimal256.rs
+++ b/packages/std/src/math/decimal256.rs
@@ -349,7 +349,7 @@ impl Decimal256 {
             let mut y = Decimal256::one();
 
             while n > 1 {
-                if n % 2 == 0 {
+                if n.is_multiple_of(2) {
                     x = x.checked_mul(x)?;
                     n /= 2;
                 } else {

--- a/packages/std/src/math/signed_decimal.rs
+++ b/packages/std/src/math/signed_decimal.rs
@@ -422,7 +422,7 @@ impl SignedDecimal {
             let mut y = SignedDecimal::one();
 
             while n > 1 {
-                if n % 2 == 0 {
+                if n.is_multiple_of(2) {
                     x = x.checked_mul(x)?;
                     n /= 2;
                 } else {

--- a/packages/std/src/math/signed_decimal_256.rs
+++ b/packages/std/src/math/signed_decimal_256.rs
@@ -435,7 +435,7 @@ impl SignedDecimal256 {
             let mut y = SignedDecimal256::one();
 
             while n > 1 {
-                if n % 2 == 0 {
+                if n.is_multiple_of(2) {
                     x = x.checked_mul(x)?;
                     n /= 2;
                 } else {

--- a/packages/std/src/math/uint128.rs
+++ b/packages/std/src/math/uint128.rs
@@ -305,11 +305,7 @@ impl Uint128 {
 
     #[must_use = "this returns the result of the operation, without modifying the original"]
     pub const fn abs_diff(self, other: Self) -> Self {
-        Self(if self.0 < other.0 {
-            other.0 - self.0
-        } else {
-            self.0 - other.0
-        })
+        Self(other.0.abs_diff(self.0))
     }
 }
 

--- a/packages/std/src/math/uint64.rs
+++ b/packages/std/src/math/uint64.rs
@@ -301,11 +301,7 @@ impl Uint64 {
 
     #[must_use = "this returns the result of the operation, without modifying the original"]
     pub const fn abs_diff(self, other: Self) -> Self {
-        Self(if self.0 < other.0 {
-            other.0 - self.0
-        } else {
-            self.0 - other.0
-        })
+        Self(other.0.abs_diff(self.0))
     }
 }
 


### PR DESCRIPTION
Clippy-driven cleanup replacing manual modulo checks with is_multiple_of()
No behavior change
