### PR TITLE
Replaced deprecated code of `assert_cmd` in v2.3.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,13 +249,13 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.14"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed72493ac66d5804837f480ab3766c72bdfab91a65e565fc54fa9e42db0073a8"
+checksum = "9c5bcfa8749ac45dd12cb11055aeeb6b27a3895560d60d71e3c23bf979e60514"
 dependencies = [
  "anstyle",
  "bstr",
- "doc-comment",
+ "libc",
  "predicates",
  "predicates-core",
  "predicates-tree",
@@ -1117,12 +1117,6 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
-
-[[package]]
-name = "doc-comment"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dyn-clone"

--- a/packages/check/Cargo.toml
+++ b/packages/check/Cargo.toml
@@ -15,6 +15,6 @@ cosmwasm-vm = { workspace = true }
 cosmwasm-std = { workspace = true, default-features = true }
 
 [dev-dependencies]
-assert_cmd = "2.0.12"
+assert_cmd = "2.1.2"
 predicates = "3"
 tempfile = "3.1.0"

--- a/packages/check/tests/cosmwasm_check_tests.rs
+++ b/packages/check/tests/cosmwasm_check_tests.rs
@@ -1,13 +1,13 @@
-use assert_cmd::prelude::*;
+use assert_cmd::{cargo_bin, Command};
 use cosmwasm_std::{to_json_string, to_json_vec};
 use cosmwasm_vm::WasmLimits;
 use predicates::prelude::*;
-use std::{io::Write, process::Command};
+use std::io::Write;
 use tempfile::NamedTempFile;
 
 #[test]
 fn valid_contract_check() -> Result<(), Box<dyn std::error::Error>> {
-    let mut cmd = Command::cargo_bin("cosmwasm-check")?;
+    let mut cmd = Command::new(cargo_bin!());
 
     cmd.arg("../vm/testdata/hackatom.wasm");
     cmd.assert()
@@ -19,7 +19,7 @@ fn valid_contract_check() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn contract_check_verbose() -> Result<(), Box<dyn std::error::Error>> {
-    let mut cmd = Command::cargo_bin("cosmwasm-check")?;
+    let mut cmd = Command::new(cargo_bin!());
 
     cmd.arg("../vm/testdata/empty.wasm").arg("--verbose");
     cmd.assert()
@@ -32,7 +32,7 @@ fn contract_check_verbose() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn empty_contract_check() -> Result<(), Box<dyn std::error::Error>> {
-    let mut cmd = Command::cargo_bin("cosmwasm-check")?;
+    let mut cmd = Command::new(cargo_bin!());
 
     cmd.arg("../vm/testdata/empty.wasm");
     cmd.assert()
@@ -44,7 +44,7 @@ fn empty_contract_check() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn invalid_contract_check() -> Result<(), Box<dyn std::error::Error>> {
-    let mut cmd = Command::cargo_bin("cosmwasm-check")?;
+    let mut cmd = Command::new(cargo_bin!());
 
     cmd.arg("../vm/testdata/corrupted.wasm");
     cmd.assert()
@@ -56,7 +56,7 @@ fn invalid_contract_check() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn valid_contract_check_float_operator() -> Result<(), Box<dyn std::error::Error>> {
-    let mut cmd = Command::cargo_bin("cosmwasm-check")?;
+    let mut cmd = Command::new(cargo_bin!());
 
     cmd.arg("../vm/testdata/floaty.wasm");
     cmd.assert()
@@ -68,7 +68,7 @@ fn valid_contract_check_float_operator() -> Result<(), Box<dyn std::error::Error
 
 #[test]
 fn several_contracts_check() -> Result<(), Box<dyn std::error::Error>> {
-    let mut cmd = Command::cargo_bin("cosmwasm-check")?;
+    let mut cmd = Command::new(cargo_bin!());
 
     cmd.arg("../vm/testdata/hackatom.wasm")
         .arg("../vm/testdata/corrupted.wasm");
@@ -83,7 +83,7 @@ fn several_contracts_check() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn custom_capabilities_check() -> Result<(), Box<dyn std::error::Error>> {
-    let mut cmd = Command::cargo_bin("cosmwasm-check")?;
+    let mut cmd = Command::new(cargo_bin!());
 
     cmd.arg("--available-capabilities")
         .arg("iterator,osmosis,friendship")
@@ -100,7 +100,7 @@ fn custom_capabilities_check() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn wasm_limits_string_check() -> Result<(), Box<dyn std::error::Error>> {
-    let mut cmd = Command::cargo_bin("cosmwasm-check")?;
+    let mut cmd = Command::new(cargo_bin!());
 
     let mut limits = WasmLimits::default();
     limits.initial_memory_limit_pages = Some(10);
@@ -117,7 +117,7 @@ fn wasm_limits_string_check() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn wasm_limits_file_check() -> Result<(), Box<dyn std::error::Error>> {
-    let mut cmd = Command::cargo_bin("cosmwasm-check")?;
+    let mut cmd = Command::new(cargo_bin!());
 
     let mut limits = WasmLimits::default();
     limits.max_functions = Some(15);


### PR DESCRIPTION
Backport of the change described in issue #2584.