### PR TITLE
Improved code coverage for `decimal256`

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -195,19 +195,22 @@ tasks:
   cov-cosmwasm-std:
     desc: Generates code coverage report for cosmwasm-std in text format
     cmds:
-      - cmd: cargo llvm-cov clean
+      - cmd: cargo {{.TOOLCHAIN}} clean
+      - cmd: cargo {{.TOOLCHAIN}} llvm-cov clean
       - cmd: cargo {{.TOOLCHAIN}} llvm-cov -p cosmwasm-std --no-cfg-coverage
 
   cov-cosmwasm-std-html:
     desc: Generates code coverage report for cosmwasm-std in HTML format
     cmds:
-      - cmd: cargo llvm-cov clean
+      - cmd: cargo {{.TOOLCHAIN}} clean
+      - cmd: cargo {{.TOOLCHAIN}} llvm-cov clean
       - cmd: cargo {{.TOOLCHAIN}} llvm-cov -p cosmwasm-std --no-cfg-coverage --html
 
   cov-cosmwasm-std-html-open:
     desc: Generates code coverage report for cosmwasm-std in HTML format and opens in a browser
     cmds:
-      - cmd: cargo llvm-cov clean
+      - cmd: cargo {{.TOOLCHAIN}} clean
+      - cmd: cargo {{.TOOLCHAIN}} llvm-cov clean
       - cmd: cargo {{.TOOLCHAIN}} llvm-cov -p cosmwasm-std --no-cfg-coverage --html --open
 
   cov-badge-cosmwasm-std:

--- a/contracts/ibc-reflect/schema/ibc/packet_msg.json
+++ b/contracts/ibc-reflect/schema/ibc/packet_msg.json
@@ -334,7 +334,7 @@
       ]
     },
     "Decimal": {
-      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 = (2^128 - 1) / 10^18",
       "type": "string"
     },
     "Empty": {

--- a/contracts/reflect/schema/cw_schema/raw/execute.json
+++ b/contracts/reflect/schema/cw_schema/raw/execute.json
@@ -588,7 +588,7 @@
     },
     {
       "name": "cosmwasm_std_math_decimal_Decimal",
-      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 = (2^128 - 1) / 10^18",
       "type": "decimal",
       "precision": 128,
       "signed": false

--- a/contracts/reflect/schema/cw_schema/reflect.json
+++ b/contracts/reflect/schema/cw_schema/reflect.json
@@ -603,7 +603,7 @@
       },
       {
         "name": "cosmwasm_std_math_decimal_Decimal",
-        "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+        "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 = (2^128 - 1) / 10^18",
         "type": "decimal",
         "precision": 128,
         "signed": false

--- a/contracts/reflect/schema/raw/execute.json
+++ b/contracts/reflect/schema/raw/execute.json
@@ -327,7 +327,7 @@
       ]
     },
     "Decimal": {
-      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 = (2^128 - 1) / 10^18",
       "type": "string"
     },
     "DistributionMsg": {

--- a/contracts/reflect/schema/reflect.json
+++ b/contracts/reflect/schema/reflect.json
@@ -337,7 +337,7 @@
         ]
       },
       "Decimal": {
-        "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+        "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 = (2^128 - 1) / 10^18",
         "type": "string"
       },
       "DistributionMsg": {

--- a/contracts/staking/schema/cw_schema/raw/instantiate.json
+++ b/contracts/staking/schema/cw_schema/raw/instantiate.json
@@ -44,7 +44,7 @@
     },
     {
       "name": "cosmwasm_std_math_decimal_Decimal",
-      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 = (2^128 - 1) / 10^18",
       "type": "decimal",
       "precision": 128,
       "signed": false

--- a/contracts/staking/schema/cw_schema/raw/response_to_investment.json
+++ b/contracts/staking/schema/cw_schema/raw/response_to_investment.json
@@ -65,7 +65,7 @@
     },
     {
       "name": "cosmwasm_std_math_decimal_Decimal",
-      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 = (2^128 - 1) / 10^18",
       "type": "decimal",
       "precision": 128,
       "signed": false

--- a/contracts/staking/schema/cw_schema/staking.json
+++ b/contracts/staking/schema/cw_schema/staking.json
@@ -48,7 +48,7 @@
       },
       {
         "name": "cosmwasm_std_math_decimal_Decimal",
-        "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+        "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 = (2^128 - 1) / 10^18",
         "type": "decimal",
         "precision": 128,
         "signed": false
@@ -284,7 +284,7 @@
         },
         {
           "name": "cosmwasm_std_math_decimal_Decimal",
-          "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+          "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 = (2^128 - 1) / 10^18",
           "type": "decimal",
           "precision": 128,
           "signed": false

--- a/contracts/staking/schema/raw/instantiate.json
+++ b/contracts/staking/schema/raw/instantiate.json
@@ -49,7 +49,7 @@
   "additionalProperties": false,
   "definitions": {
     "Decimal": {
-      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 = (2^128 - 1) / 10^18",
       "type": "string"
     },
     "Uint128": {

--- a/contracts/staking/schema/raw/response_to_investment.json
+++ b/contracts/staking/schema/raw/response_to_investment.json
@@ -65,7 +65,7 @@
       "additionalProperties": false
     },
     "Decimal": {
-      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 = (2^128 - 1) / 10^18",
       "type": "string"
     },
     "Uint128": {

--- a/contracts/staking/schema/staking.json
+++ b/contracts/staking/schema/staking.json
@@ -53,7 +53,7 @@
     "additionalProperties": false,
     "definitions": {
       "Decimal": {
-        "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+        "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 = (2^128 - 1) / 10^18",
         "type": "string"
       },
       "Uint128": {
@@ -366,7 +366,7 @@
           "additionalProperties": false
         },
         "Decimal": {
-          "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+          "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 = (2^128 - 1) / 10^18",
           "type": "string"
         },
         "Uint128": {

--- a/packages/std/src/math/decimal.rs
+++ b/packages/std/src/math/decimal.rs
@@ -18,7 +18,9 @@ use super::{Uint128, Uint256};
 
 /// A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0
 ///
-/// The greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)
+/// The greatest possible value that can be represented is
+/// 340282366920938463463.374607431768211455
+/// which is (2^128 - 1) / 10^18
 #[derive(
     Copy,
     Clone,
@@ -398,8 +400,8 @@ impl Decimal {
     fn sqrt_with_precision(&self, precision: u32) -> Option<Self> {
         let inner_mul = 100u128.pow(precision);
         self.0.checked_mul(inner_mul.into()).ok().map(|inner| {
-            let outer_mul = 10u128.pow(Self::DECIMAL_PLACES / 2 - precision);
-            Decimal(inner.isqrt().checked_mul(Uint128::from(outer_mul)).unwrap())
+            let outer_mul = Uint128::from(10u128).pow(Self::DECIMAL_PLACES / 2 - precision);
+            Decimal(inner.isqrt().checked_mul(outer_mul).unwrap())
         })
     }
 
@@ -572,14 +574,14 @@ impl FromStr for Decimal {
 
         if let Some(fractional_part) = parts_iter.next() {
             let fractional = fractional_part.parse::<Uint128>()?;
-            let exp = (Self::DECIMAL_PLACES.checked_sub(fractional_part.len() as u32)).ok_or_else(
-                || {
+            let exp = Self::DECIMAL_PLACES
+                .checked_sub(fractional_part.len() as u32)
+                .ok_or_else(|| {
                     StdError::msg(format_args!(
                         "Cannot parse more than {} fractional digits",
                         Self::DECIMAL_PLACES
                     ))
-                },
-            )?;
+                })?;
             debug_assert!(exp <= Self::DECIMAL_PLACES);
             let fractional_factor = Uint128::from(10u128.pow(exp));
             atomics = atomics.checked_add(
@@ -600,7 +602,7 @@ impl FromStr for Decimal {
 impl fmt::Display for Decimal {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let whole = (self.0) / Self::DECIMAL_FRACTIONAL;
-        let fractional = (self.0).checked_rem(Self::DECIMAL_FRACTIONAL).unwrap();
+        let fractional = self.0.checked_rem(Self::DECIMAL_FRACTIONAL).unwrap();
 
         if fractional.is_zero() {
             write!(f, "{whole}")

--- a/packages/std/src/math/decimal.rs
+++ b/packages/std/src/math/decimal.rs
@@ -18,9 +18,7 @@ use super::{Uint128, Uint256};
 
 /// A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0
 ///
-/// The greatest possible value that can be represented is
-/// 340282366920938463463.374607431768211455
-/// which is (2^128 - 1) / 10^18
+/// The greatest possible value that can be represented is 340282366920938463463.374607431768211455 = (2^128 - 1) / 10^18
 #[derive(
     Copy,
     Clone,

--- a/packages/std/src/math/decimal256.rs
+++ b/packages/std/src/math/decimal256.rs
@@ -17,9 +17,7 @@ use super::{Uint256, Uint512};
 
 /// A fixed-point decimal value with 18 fractional digits, i.e. Decimal256(1_000_000_000_000_000_000) == 1.0
 ///
-/// The greatest possible value that can be represented is
-/// 115792089237316195423570985008687907853269984665640564039457.584007913129639935
-/// which is (2^256 - 1) / 10^18
+/// The greatest possible value that can be represented is 115792089237316195423570985008687907853269984665640564039457.584007913129639935 = (2^256 - 1) / 10^18
 #[derive(
     Copy,
     Clone,

--- a/packages/std/src/math/decimal256.rs
+++ b/packages/std/src/math/decimal256.rs
@@ -1,4 +1,3 @@
-use alloc::string::ToString;
 use core::cmp::Ordering;
 use core::fmt::{self, Write};
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Rem, RemAssign, Sub, SubAssign};
@@ -10,19 +9,17 @@ use crate::errors::{
     OverflowOperation, RoundUpOverflowError, StdError,
 };
 use crate::forward_ref::{forward_ref_binop, forward_ref_op_assign};
-use crate::{
-    Decimal, SignedDecimal, SignedDecimal256, Uint512, __internal::forward_ref_partial_eq,
-};
+use crate::{Decimal, SignedDecimal, SignedDecimal256, __internal::forward_ref_partial_eq};
 
 use super::Fraction;
 use super::Isqrt;
-use super::Uint256;
+use super::{Uint256, Uint512};
 
 /// A fixed-point decimal value with 18 fractional digits, i.e. Decimal256(1_000_000_000_000_000_000) == 1.0
 ///
 /// The greatest possible value that can be represented is
 /// 115792089237316195423570985008687907853269984665640564039457.584007913129639935
-/// (which is (2^256 - 1) / 10^18)
+/// which is (2^256 - 1) / 10^18
 #[derive(
     Copy,
     Clone,
@@ -381,20 +378,16 @@ impl Decimal256 {
     /// This should not overflow or panic.
     #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn sqrt(&self) -> Self {
-        // Algorithm described in https://hackmd.io/@webmaster128/SJThlukj_
-        // We start with the highest precision possible and lower it until
-        // there's no overflow.
-        // The max precision is bounded by `Uint256::MAX`, so we can estimate it from `ilog10`.
+        // The max precision is `9 - log10(self.0) / 2`.
         // We can optimize the previous loop by using `ilog10` to directly calculate the precision.
-        let atomics = self.0;
-        if atomics.is_zero() {
+        if self.0.is_zero() {
             // value is 0, so we can use any precision, let's use the max one
             return self.sqrt_with_precision(Self::DECIMAL_PLACES / 2).unwrap();
         }
 
         // 77 is the max `ilog10` value for Uint256
         // 9 is the max precision (DECIMAL_PLACES / 2)
-        let precision_guess = (77 - atomics.ilog10()) / 2;
+        let precision_guess = (77 - self.0.ilog10()) / 2;
         let precision = core::cmp::min(precision_guess, Self::DECIMAL_PLACES / 2);
 
         // The estimate using ilog10 might determine a precision that causes overflow for
@@ -429,34 +422,22 @@ impl Decimal256 {
 
     #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn saturating_add(self, other: Self) -> Self {
-        match self.checked_add(other) {
-            Ok(value) => value,
-            Err(_) => Self::MAX,
-        }
+        self.checked_add(other).unwrap_or(Self::MAX)
     }
 
     #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn saturating_sub(self, other: Self) -> Self {
-        match self.checked_sub(other) {
-            Ok(value) => value,
-            Err(_) => Self::zero(),
-        }
+        self.checked_sub(other).unwrap_or_else(|_| Self::zero())
     }
 
     #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn saturating_mul(self, other: Self) -> Self {
-        match self.checked_mul(other) {
-            Ok(value) => value,
-            Err(_) => Self::MAX,
-        }
+        self.checked_mul(other).unwrap_or(Self::MAX)
     }
 
     #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn saturating_pow(self, exp: u32) -> Self {
-        match self.checked_pow(exp) {
-            Ok(value) => value,
-            Err(_) => Self::MAX,
-        }
+        self.checked_pow(exp).unwrap_or(Self::MAX)
     }
 
     /// Converts this decimal to an unsigned integer by truncating
@@ -590,14 +571,14 @@ impl FromStr for Decimal256 {
 
         if let Some(fractional_part) = parts_iter.next() {
             let fractional = fractional_part.parse::<Uint256>()?;
-            let exp = (Self::DECIMAL_PLACES.checked_sub(fractional_part.len() as u32)).ok_or_else(
-                || {
+            let exp = Self::DECIMAL_PLACES
+                .checked_sub(fractional_part.len() as u32)
+                .ok_or_else(|| {
                     StdError::msg(format_args!(
                         "Cannot parse more than {} fractional digits",
                         Self::DECIMAL_PLACES
                     ))
-                },
-            )?;
+                })?;
             debug_assert!(exp <= Self::DECIMAL_PLACES);
             let fractional_factor = Uint256::from(10u128).pow(exp);
             atomics = atomics.checked_add(
@@ -618,7 +599,7 @@ impl FromStr for Decimal256 {
 impl fmt::Display for Decimal256 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let whole = (self.0) / Self::DECIMAL_FRACTIONAL;
-        let fractional = (self.0).checked_rem(Self::DECIMAL_FRACTIONAL).unwrap();
+        let fractional = self.0.checked_rem(Self::DECIMAL_FRACTIONAL).unwrap();
 
         if fractional.is_zero() {
             write!(f, "{whole}")

--- a/packages/std/tests/test_math/test_decimal.rs
+++ b/packages/std/tests/test_math/test_decimal.rs
@@ -6,7 +6,8 @@ use cosmwasm_std::{
 use std::fmt::Write;
 use std::str::FromStr;
 
-const DECIMAL_FRACTIONAL: Uint128 = Uint128::new(1_000_000_000_000_000_000u128); // 1*10^18
+/// 1*10^18
+const DECIMAL_FRACTIONAL: Uint128 = Uint128::new(1_000_000_000_000_000_000);
 
 fn dec(input: &str) -> Decimal {
     Decimal::from_str(input).unwrap()
@@ -1004,7 +1005,7 @@ fn decimal_checked_pow_overflow() {
         Err(OverflowError::new(OverflowOperation::Pow))
     );
     assert_eq!(
-        Decimal::new(Uint128::new(DECIMAL_FRACTIONAL.u128() * 1_000_000_000)).checked_pow(15),
+        Decimal::new(DECIMAL_FRACTIONAL * Uint128::new(1_000_000_000)).checked_pow(15),
         Err(OverflowError::new(OverflowOperation::Pow))
     );
 }

--- a/packages/std/tests/test_math/test_decimal256.rs
+++ b/packages/std/tests/test_math/test_decimal256.rs
@@ -1,7 +1,9 @@
 use cosmwasm_std::{
     CheckedFromRatioError, Decimal, Decimal256, Decimal256RangeExceeded, DivideByZeroError,
-    Fraction, OverflowError, OverflowOperation, RoundUpOverflowError, Uint256,
+    Fraction, Int128, Int256, OverflowError, OverflowOperation, RoundUpOverflowError,
+    SignedDecimal, SignedDecimal256, Uint128, Uint256,
 };
+use std::fmt::Write;
 use std::str::FromStr;
 
 /// 1*10**18
@@ -61,6 +63,68 @@ fn decimal256_bps() {
     assert_eq!(
         value,
         Decimal256::new(DECIMAL_FRACTIONAL / Uint256::from(80u8))
+    );
+}
+
+#[test]
+fn decimal256_from_decimal_works() {
+    assert_eq!(
+        Decimal256::from(Decimal::new(Uint128::MAX)),
+        Decimal256::from(Decimal::MAX)
+    );
+    assert_eq!(Decimal256::from(Decimal::zero()), Decimal256::zero());
+    assert_eq!(Decimal256::from(Decimal::one()), Decimal256::one());
+    assert_eq!(
+        Decimal256::from(Decimal::percent(50)),
+        Decimal256::percent(50)
+    );
+}
+
+#[test]
+fn decimal256_from_signed_decimal_works() {
+    assert_eq!(
+        Decimal256::try_from(SignedDecimal::new(Int128::MAX)),
+        Ok(Decimal256::new(Uint256::new(u128::MAX / 2)))
+    );
+    assert_eq!(
+        Decimal256::try_from(SignedDecimal::new(Int128::MIN)),
+        Err(Decimal256RangeExceeded)
+    );
+    assert_eq!(
+        Decimal256::try_from(SignedDecimal::zero()),
+        Ok(Decimal256::zero())
+    );
+    assert_eq!(
+        Decimal256::try_from(SignedDecimal::one()),
+        Ok(Decimal256::one())
+    );
+    assert_eq!(
+        Decimal256::try_from(SignedDecimal::percent(50)),
+        Ok(Decimal256::percent(50))
+    );
+}
+
+#[test]
+fn decimal256_from_signed_decimal256_works() {
+    assert_eq!(
+        Decimal256::try_from(SignedDecimal256::new(Int256::MAX)),
+        Ok(Decimal256::new(Uint256::MAX / Uint256::new(2)))
+    );
+    assert_eq!(
+        Decimal256::try_from(SignedDecimal256::new(Int256::MIN)),
+        Err(Decimal256RangeExceeded)
+    );
+    assert_eq!(
+        Decimal256::try_from(SignedDecimal256::zero()),
+        Ok(Decimal256::zero())
+    );
+    assert_eq!(
+        Decimal256::try_from(SignedDecimal256::one()),
+        Ok(Decimal256::one())
+    );
+    assert_eq!(
+        Decimal256::try_from(SignedDecimal256::percent(50)),
+        Ok(Decimal256::percent(50))
     );
 }
 
@@ -914,8 +978,8 @@ fn decimal256_uint128_div_assign_by_zero() {
 
 #[test]
 fn decimal256_uint128_sqrt() {
+    assert_eq!(Decimal256::percent(0).sqrt(), Decimal256::percent(0));
     assert_eq!(Decimal256::percent(900).sqrt(), Decimal256::percent(300));
-
     assert!(Decimal256::percent(316) < Decimal256::percent(1000).sqrt());
     assert!(Decimal256::percent(1000).sqrt() < Decimal256::percent(317));
 }
@@ -1038,6 +1102,14 @@ fn decimal256_checked_pow() {
 fn decimal256_checked_pow_overflow() {
     assert_eq!(
         Decimal256::MAX.checked_pow(2),
+        Err(OverflowError::new(OverflowOperation::Pow))
+    );
+    assert_eq!(
+        Decimal256::MAX.checked_pow(3),
+        Err(OverflowError::new(OverflowOperation::Pow))
+    );
+    assert_eq!(
+        Decimal256::new(DECIMAL_FRACTIONAL * Uint256::new(1_000_000_000)).checked_pow(15),
         Err(OverflowError::new(OverflowOperation::Pow))
     );
 }
@@ -1332,7 +1404,7 @@ fn decimal256_pow_works() {
 }
 
 #[test]
-#[should_panic]
+#[should_panic(expected = "Multiplication overflow")]
 fn decimal256_pow_overflow_panics() {
     _ = Decimal256::MAX.pow(2u32);
 }
@@ -1500,4 +1572,96 @@ fn decimal256_implements_debug() {
         let expected = format!("Decimal256({s})");
         assert_eq!(format!("{decimal256:?}"), expected);
     }
+}
+
+#[test]
+fn serialize_decimal256_to_string() {
+    let d = Decimal256::from_str("123.45").unwrap();
+    let json_string = serde_json::to_string(&d).unwrap();
+    assert_eq!(r#""123.45""#, json_string);
+}
+
+#[test]
+fn deserialize_decimal256_from_string() {
+    let json_string = r#""123.45""#;
+    let d: Decimal256 = serde_json::from_str(json_string).unwrap();
+    assert_eq!(d, Decimal256::from_str("123.45").unwrap());
+}
+
+#[test]
+fn deserialize256_invalid_decimal() {
+    let json_string = r#""123,45""#;
+    let result: Result<Decimal256, _> = serde_json::from_str(json_string);
+    let err = result.unwrap_err();
+    assert!(err.to_string().contains("invalid digit"));
+}
+
+#[test]
+fn deserialize_wrong_type_triggers_expectation() {
+    let json_decimal = "123.45";
+    let err = serde_json::from_str::<Decimal256>(json_decimal).unwrap_err();
+    assert!(err.to_string().contains("expected string-encoded decimal"));
+}
+
+#[test]
+fn failing_writer_should_work() {
+    enum When {
+        Always,
+        OnDecimal,
+        AfterDecimal,
+    }
+    struct FailingWriter {
+        when: When,
+        consumed_decimal: bool,
+    }
+
+    impl FailingWriter {
+        fn new(when: When) -> Self {
+            Self {
+                when,
+                consumed_decimal: false,
+            }
+        }
+    }
+    impl Write for FailingWriter {
+        fn write_str(&mut self, s: &str) -> std::fmt::Result {
+            match self.when {
+                When::Always => return Err(std::fmt::Error),
+                When::OnDecimal => {
+                    if s == "." {
+                        return Err(std::fmt::Error);
+                    }
+                }
+                When::AfterDecimal => {
+                    if self.consumed_decimal {
+                        return Err(std::fmt::Error);
+                    }
+                    if s == "." {
+                        self.consumed_decimal = true;
+                    }
+                }
+            }
+            Ok(())
+        }
+    }
+    write!(
+        &mut FailingWriter::new(When::Always),
+        "{}",
+        Decimal256::from_str("123.456").unwrap()
+    )
+    .unwrap_err();
+
+    write!(
+        &mut FailingWriter::new(When::OnDecimal),
+        "{}",
+        Decimal256::from_str("123.456").unwrap()
+    )
+    .unwrap_err();
+
+    write!(
+        &mut FailingWriter::new(When::AfterDecimal),
+        "{}",
+        Decimal256::from_str("123.456").unwrap()
+    )
+    .unwrap_err();
 }


### PR DESCRIPTION
Code coverage is almost 100% for `decimal256.rs`.
Actually it should be 100% but there are some frictions in `llvm-cov` reporting.