### PR TITLE
 Short-circuit zero results in decimal from_atomics

### DIFF
--- a/packages/std/src/math/decimal.rs
+++ b/packages/std/src/math/decimal.rs
@@ -184,13 +184,13 @@ impl Decimal {
             Ordering::Equal => Self(atomics),
             Ordering::Greater => {
                 let digits = decimal_places - (Self::DECIMAL_PLACES); // No overflow because decimal_places > DECIMAL_PLACES
-                if let Ok(factor) = TEN.checked_pow(digits) {
-                    Self(atomics.checked_div(factor).unwrap()) // Safe because factor cannot be zero
-                } else {
-                    // In this case `factor` exceeds the Uint128 range.
-                    // Any Uint128 `x` divided by `factor` with `factor > Uint128::MAX` is 0.
-                    // Try e.g. Python3: `(2**128-1) // 2**128`
+                if atomics.is_zero() || digits > atomics.ilog10() {
+                    // In this case `10^digits > atomics`, so the division truncates to zero.
                     Self(Uint128::zero())
+                } else {
+                    // `digits <= ilog10(atomics)` guarantees `10^digits` fits in Uint128.
+                    let factor = TEN.checked_pow(digits).unwrap();
+                    Self(atomics.checked_div(factor).unwrap()) // Safe because factor cannot be zero
                 }
             }
         })

--- a/packages/std/src/math/decimal256.rs
+++ b/packages/std/src/math/decimal256.rs
@@ -195,13 +195,13 @@ impl Decimal256 {
             Ordering::Equal => Self(atomics),
             Ordering::Greater => {
                 let digits = decimal_places - (Self::DECIMAL_PLACES); // No overflow because decimal_places > DECIMAL_PLACES
-                if let Ok(factor) = TEN.checked_pow(digits) {
-                    Self(atomics.checked_div(factor).unwrap()) // Safe because factor cannot be zero
-                } else {
-                    // In this case `factor` exceeds the Uint256 range.
-                    // Any Uint256 `x` divided by `factor` with `factor > Uint256::MAX` is 0.
-                    // Try e.g. Python3: `(2**256-1) // 2**256`
+                if atomics.is_zero() || digits > atomics.ilog10() {
+                    // In this case `10^digits > atomics`, so the division truncates to zero.
                     Self(Uint256::zero())
+                } else {
+                    // `digits <= ilog10(atomics)` guarantees `10^digits` fits in Uint256.
+                    let factor = TEN.checked_pow(digits).unwrap();
+                    Self(atomics.checked_div(factor).unwrap()) // Safe because factor cannot be zero
                 }
             }
         })

--- a/packages/std/src/math/signed_decimal.rs
+++ b/packages/std/src/math/signed_decimal.rs
@@ -182,13 +182,13 @@ impl SignedDecimal {
             Ordering::Equal => Self(atomics),
             Ordering::Greater => {
                 let digits = decimal_places - (Self::DECIMAL_PLACES); // No overflow because decimal_places > DECIMAL_PLACES
-                if let Ok(factor) = TEN.checked_pow(digits) {
-                    Self(atomics.checked_div(factor).unwrap()) // Safe because factor cannot be zero
-                } else {
-                    // In this case `factor` exceeds the Int128 range.
-                    // Any Int128 `x` divided by `factor` with `factor > Int128::MAX` is 0.
-                    // Try e.g. Python3: `(2**128-1) // 2**128`
+                if atomics.is_zero() || digits > atomics.unsigned_abs().ilog10() {
+                    // In this case `10^digits > |atomics|`, so the division truncates to zero.
                     Self(Int128::zero())
+                } else {
+                    // `digits <= ilog10(|atomics|)` guarantees `10^digits` fits in Int128.
+                    let factor = TEN.checked_pow(digits).unwrap();
+                    Self(atomics.checked_div(factor).unwrap()) // Safe because factor cannot be zero
                 }
             }
         })
@@ -1099,6 +1099,14 @@ mod tests {
         assert_eq!(
             SignedDecimal::from_atomics(i128::MAX, u32::MAX).unwrap(),
             SignedDecimal::from_str("0.000000000000000000").unwrap()
+        );
+        assert_eq!(
+            SignedDecimal::from_atomics(0i128, u32::MAX).unwrap(),
+            SignedDecimal::zero()
+        );
+        assert_eq!(
+            SignedDecimal::from_atomics(i128::MIN, u32::MAX).unwrap(),
+            SignedDecimal::zero()
         );
 
         // Can be used with max value

--- a/packages/std/src/math/signed_decimal_256.rs
+++ b/packages/std/src/math/signed_decimal_256.rs
@@ -195,13 +195,13 @@ impl SignedDecimal256 {
             Ordering::Equal => Self(atomics),
             Ordering::Greater => {
                 let digits = decimal_places - (Self::DECIMAL_PLACES); // No overflow because decimal_places > DECIMAL_PLACES
-                if let Ok(factor) = ten.checked_pow(digits) {
-                    Self(atomics.checked_div(factor).unwrap()) // Safe because factor cannot be zero
-                } else {
-                    // In this case `factor` exceeds the Int256 range.
-                    // Any Int256 `x` divided by `factor` with `factor > Int256::MAX` is 0.
-                    // Try e.g. Python3: `(2**128-1) // 2**128`
+                if atomics.is_zero() || digits > atomics.unsigned_abs().ilog10() {
+                    // In this case `10^digits > |atomics|`, so the division truncates to zero.
                     Self(Int256::zero())
+                } else {
+                    // `digits <= ilog10(|atomics|)` guarantees `10^digits` fits in Int256.
+                    let factor = ten.checked_pow(digits).unwrap();
+                    Self(atomics.checked_div(factor).unwrap()) // Safe because factor cannot be zero
                 }
             }
         })
@@ -1098,6 +1098,18 @@ mod tests {
         assert_eq!(
             SignedDecimal256::from_atomics(i128::MAX, u32::MAX).unwrap(),
             SignedDecimal256::from_str("0.000000000000000000").unwrap()
+        );
+        assert_eq!(
+            SignedDecimal256::from_atomics(0i128, u32::MAX).unwrap(),
+            SignedDecimal256::zero()
+        );
+        assert_eq!(
+            SignedDecimal256::from_atomics(Int256::MAX, u32::MAX).unwrap(),
+            SignedDecimal256::zero()
+        );
+        assert_eq!(
+            SignedDecimal256::from_atomics(Int256::MIN, u32::MAX).unwrap(),
+            SignedDecimal256::zero()
         );
 
         // Can be used with max value

--- a/packages/std/tests/test_math/test_decimal.rs
+++ b/packages/std/tests/test_math/test_decimal.rs
@@ -208,6 +208,10 @@ fn decimal_from_atomics_works() {
         Decimal::from_atomics(u128::MAX, u32::MAX).unwrap(),
         Decimal::from_str("0.000000000000000000").unwrap()
     );
+    assert_eq!(
+        Decimal::from_atomics(0u128, u32::MAX).unwrap(),
+        Decimal::zero()
+    );
 
     // Can be used with max value
     let max = Decimal::MAX;

--- a/packages/std/tests/test_math/test_decimal256.rs
+++ b/packages/std/tests/test_math/test_decimal256.rs
@@ -140,6 +140,14 @@ fn decimal256_from_atomics_works() {
         Decimal256::from_atomics(u128::MAX, u32::MAX).unwrap(),
         Decimal256::from_str("0.000000000000000000").unwrap()
     );
+    assert_eq!(
+        Decimal256::from_atomics(0u128, u32::MAX).unwrap(),
+        Decimal256::zero()
+    );
+    assert_eq!(
+        Decimal256::from_atomics(Uint256::MAX, u32::MAX).unwrap(),
+        Decimal256::zero()
+    );
 
     // Can be used with max value
     let max = Decimal256::MAX;


### PR DESCRIPTION
  Short-circuit `from_atomics` scaling-down paths that must truncate to zero, avoiding unnecessary `checked_pow` work across the decimal math types.