### PR TITLE
Fix Empty comment typo in generated schemas

### DIFF
--- a/contracts/cyberpunk/schema/cw_schema/cyberpunk.json
+++ b/contracts/cyberpunk/schema/cw_schema/cyberpunk.json
@@ -8,7 +8,7 @@
     "definitions": [
       {
         "name": "cosmwasm_std_results_empty_Empty",
-        "description": "An empty struct that serves as a placeholder in different places,\nsuch as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but\ncontains no meaningful data. Previously we used enums without cases,\nbut those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
+        "description": "An empty struct that serves as a placeholder in different places,\nsuch as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but\ncontains no meaningful data. Previously we used enums without cases,\nbut those cannot be represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
         "type": "struct",
         "properties": {}
       }

--- a/contracts/cyberpunk/schema/cw_schema/raw/instantiate.json
+++ b/contracts/cyberpunk/schema/cw_schema/raw/instantiate.json
@@ -4,7 +4,7 @@
   "definitions": [
     {
       "name": "cosmwasm_std_results_empty_Empty",
-      "description": "An empty struct that serves as a placeholder in different places,\nsuch as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but\ncontains no meaningful data. Previously we used enums without cases,\nbut those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
+      "description": "An empty struct that serves as a placeholder in different places,\nsuch as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but\ncontains no meaningful data. Previously we used enums without cases,\nbut those cannot be represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
       "type": "struct",
       "properties": {}
     }

--- a/contracts/cyberpunk/schema/cyberpunk.json
+++ b/contracts/cyberpunk/schema/cyberpunk.json
@@ -5,7 +5,7 @@
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "InstantiateMsg",
-    "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
+    "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot be represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
     "type": "object",
     "additionalProperties": false
   },

--- a/contracts/cyberpunk/schema/raw/instantiate.json
+++ b/contracts/cyberpunk/schema/raw/instantiate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "InstantiateMsg",
-  "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
+  "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot be represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
   "type": "object",
   "additionalProperties": false
 }

--- a/contracts/floaty/schema/cw_schema/floaty.json
+++ b/contracts/floaty/schema/cw_schema/floaty.json
@@ -8,7 +8,7 @@
     "definitions": [
       {
         "name": "cosmwasm_std_results_empty_Empty",
-        "description": "An empty struct that serves as a placeholder in different places,\nsuch as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but\ncontains no meaningful data. Previously we used enums without cases,\nbut those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
+        "description": "An empty struct that serves as a placeholder in different places,\nsuch as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but\ncontains no meaningful data. Previously we used enums without cases,\nbut those cannot be represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
         "type": "struct",
         "properties": {}
       }

--- a/contracts/floaty/schema/cw_schema/raw/instantiate.json
+++ b/contracts/floaty/schema/cw_schema/raw/instantiate.json
@@ -4,7 +4,7 @@
   "definitions": [
     {
       "name": "cosmwasm_std_results_empty_Empty",
-      "description": "An empty struct that serves as a placeholder in different places,\nsuch as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but\ncontains no meaningful data. Previously we used enums without cases,\nbut those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
+      "description": "An empty struct that serves as a placeholder in different places,\nsuch as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but\ncontains no meaningful data. Previously we used enums without cases,\nbut those cannot be represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
       "type": "struct",
       "properties": {}
     }

--- a/contracts/floaty/schema/floaty.json
+++ b/contracts/floaty/schema/floaty.json
@@ -5,7 +5,7 @@
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "InstantiateMsg",
-    "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
+    "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot be represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
     "type": "object",
     "additionalProperties": false
   },

--- a/contracts/floaty/schema/raw/instantiate.json
+++ b/contracts/floaty/schema/raw/instantiate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "InstantiateMsg",
-  "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
+  "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot be represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
   "type": "object",
   "additionalProperties": false
 }

--- a/contracts/ibc-callbacks/schema/cw_schema/ibc-callbacks.json
+++ b/contracts/ibc-callbacks/schema/cw_schema/ibc-callbacks.json
@@ -8,7 +8,7 @@
     "definitions": [
       {
         "name": "cosmwasm_std_results_empty_Empty",
-        "description": "An empty struct that serves as a placeholder in different places,\nsuch as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but\ncontains no meaningful data. Previously we used enums without cases,\nbut those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
+        "description": "An empty struct that serves as a placeholder in different places,\nsuch as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but\ncontains no meaningful data. Previously we used enums without cases,\nbut those cannot be represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
         "type": "struct",
         "properties": {}
       }

--- a/contracts/ibc-callbacks/schema/cw_schema/raw/instantiate.json
+++ b/contracts/ibc-callbacks/schema/cw_schema/raw/instantiate.json
@@ -4,7 +4,7 @@
   "definitions": [
     {
       "name": "cosmwasm_std_results_empty_Empty",
-      "description": "An empty struct that serves as a placeholder in different places,\nsuch as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but\ncontains no meaningful data. Previously we used enums without cases,\nbut those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
+      "description": "An empty struct that serves as a placeholder in different places,\nsuch as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but\ncontains no meaningful data. Previously we used enums without cases,\nbut those cannot be represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
       "type": "struct",
       "properties": {}
     }

--- a/contracts/ibc-callbacks/schema/ibc-callbacks.json
+++ b/contracts/ibc-callbacks/schema/ibc-callbacks.json
@@ -5,7 +5,7 @@
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "InstantiateMsg",
-    "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
+    "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot be represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
     "type": "object",
     "additionalProperties": false
   },

--- a/contracts/ibc-callbacks/schema/raw/instantiate.json
+++ b/contracts/ibc-callbacks/schema/raw/instantiate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "InstantiateMsg",
-  "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
+  "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot be represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
   "type": "object",
   "additionalProperties": false
 }

--- a/contracts/ibc-reflect-send/schema/cw_schema/ibc-reflect-send.json
+++ b/contracts/ibc-reflect-send/schema/cw_schema/ibc-reflect-send.json
@@ -184,7 +184,7 @@
       },
       {
         "name": "cosmwasm_std_results_empty_Empty",
-        "description": "An empty struct that serves as a placeholder in different places,\nsuch as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but\ncontains no meaningful data. Previously we used enums without cases,\nbut those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
+        "description": "An empty struct that serves as a placeholder in different places,\nsuch as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but\ncontains no meaningful data. Previously we used enums without cases,\nbut those cannot be represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
         "type": "struct",
         "properties": {}
       },

--- a/contracts/ibc-reflect-send/schema/cw_schema/raw/execute.json
+++ b/contracts/ibc-reflect-send/schema/cw_schema/raw/execute.json
@@ -168,7 +168,7 @@
     },
     {
       "name": "cosmwasm_std_results_empty_Empty",
-      "description": "An empty struct that serves as a placeholder in different places,\nsuch as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but\ncontains no meaningful data. Previously we used enums without cases,\nbut those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
+      "description": "An empty struct that serves as a placeholder in different places,\nsuch as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but\ncontains no meaningful data. Previously we used enums without cases,\nbut those cannot be represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
       "type": "struct",
       "properties": {}
     },

--- a/contracts/ibc-reflect-send/schema/ibc-reflect-send.json
+++ b/contracts/ibc-reflect-send/schema/ibc-reflect-send.json
@@ -360,7 +360,7 @@
         ]
       },
       "Empty": {
-        "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
+        "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot be represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
         "type": "object",
         "additionalProperties": false
       },

--- a/contracts/ibc-reflect-send/schema/ibc/packet_msg.json
+++ b/contracts/ibc-reflect-send/schema/ibc/packet_msg.json
@@ -301,7 +301,7 @@
       ]
     },
     "Empty": {
-      "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
+      "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot be represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
       "type": "object",
       "additionalProperties": false
     },

--- a/contracts/ibc-reflect-send/schema/raw/execute.json
+++ b/contracts/ibc-reflect-send/schema/raw/execute.json
@@ -349,7 +349,7 @@
       ]
     },
     "Empty": {
-      "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
+      "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot be represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
       "type": "object",
       "additionalProperties": false
     },

--- a/contracts/ibc-reflect/schema/cw_schema/ibc-reflect.json
+++ b/contracts/ibc-reflect/schema/cw_schema/ibc-reflect.json
@@ -114,7 +114,7 @@
     "definitions": [
       {
         "name": "cosmwasm_std_results_empty_Empty",
-        "description": "An empty struct that serves as a placeholder in different places,\nsuch as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but\ncontains no meaningful data. Previously we used enums without cases,\nbut those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
+        "description": "An empty struct that serves as a placeholder in different places,\nsuch as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but\ncontains no meaningful data. Previously we used enums without cases,\nbut those cannot be represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
         "type": "struct",
         "properties": {}
       }

--- a/contracts/ibc-reflect/schema/cw_schema/raw/migrate.json
+++ b/contracts/ibc-reflect/schema/cw_schema/raw/migrate.json
@@ -4,7 +4,7 @@
   "definitions": [
     {
       "name": "cosmwasm_std_results_empty_Empty",
-      "description": "An empty struct that serves as a placeholder in different places,\nsuch as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but\ncontains no meaningful data. Previously we used enums without cases,\nbut those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
+      "description": "An empty struct that serves as a placeholder in different places,\nsuch as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but\ncontains no meaningful data. Previously we used enums without cases,\nbut those cannot be represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
       "type": "struct",
       "properties": {}
     }

--- a/contracts/ibc-reflect/schema/ibc-reflect.json
+++ b/contracts/ibc-reflect/schema/ibc-reflect.json
@@ -132,7 +132,7 @@
   "migrate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "MigrateMsg",
-    "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
+    "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot be represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
     "type": "object",
     "additionalProperties": false
   },

--- a/contracts/ibc-reflect/schema/ibc/packet_msg.json
+++ b/contracts/ibc-reflect/schema/ibc/packet_msg.json
@@ -338,7 +338,7 @@
       "type": "string"
     },
     "Empty": {
-      "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
+      "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot be represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
       "type": "object",
       "additionalProperties": false
     },

--- a/contracts/ibc-reflect/schema/raw/migrate.json
+++ b/contracts/ibc-reflect/schema/raw/migrate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "MigrateMsg",
-  "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
+  "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot be represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
   "type": "object",
   "additionalProperties": false
 }

--- a/contracts/ibc2/schema/cw_schema/ibc2.json
+++ b/contracts/ibc2/schema/cw_schema/ibc2.json
@@ -8,7 +8,7 @@
     "definitions": [
       {
         "name": "cosmwasm_std_results_empty_Empty",
-        "description": "An empty struct that serves as a placeholder in different places,\nsuch as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but\ncontains no meaningful data. Previously we used enums without cases,\nbut those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
+        "description": "An empty struct that serves as a placeholder in different places,\nsuch as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but\ncontains no meaningful data. Previously we used enums without cases,\nbut those cannot be represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
         "type": "struct",
         "properties": {}
       }

--- a/contracts/ibc2/schema/cw_schema/raw/instantiate.json
+++ b/contracts/ibc2/schema/cw_schema/raw/instantiate.json
@@ -4,7 +4,7 @@
   "definitions": [
     {
       "name": "cosmwasm_std_results_empty_Empty",
-      "description": "An empty struct that serves as a placeholder in different places,\nsuch as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but\ncontains no meaningful data. Previously we used enums without cases,\nbut those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
+      "description": "An empty struct that serves as a placeholder in different places,\nsuch as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but\ncontains no meaningful data. Previously we used enums without cases,\nbut those cannot be represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
       "type": "struct",
       "properties": {}
     }

--- a/contracts/ibc2/schema/ibc2.json
+++ b/contracts/ibc2/schema/ibc2.json
@@ -5,7 +5,7 @@
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "InstantiateMsg",
-    "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
+    "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot be represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
     "type": "object",
     "additionalProperties": false
   },

--- a/contracts/ibc2/schema/raw/instantiate.json
+++ b/contracts/ibc2/schema/raw/instantiate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "InstantiateMsg",
-  "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
+  "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot be represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
   "type": "object",
   "additionalProperties": false
 }

--- a/contracts/queue/schema/cw_schema/queue.json
+++ b/contracts/queue/schema/cw_schema/queue.json
@@ -161,7 +161,7 @@
       "definitions": [
         {
           "name": "cosmwasm_std_results_empty_Empty",
-          "description": "An empty struct that serves as a placeholder in different places,\nsuch as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but\ncontains no meaningful data. Previously we used enums without cases,\nbut those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
+          "description": "An empty struct that serves as a placeholder in different places,\nsuch as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but\ncontains no meaningful data. Previously we used enums without cases,\nbut those cannot be represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
           "type": "struct",
           "properties": {}
         }

--- a/contracts/queue/schema/cw_schema/raw/response_to_open_iterators.json
+++ b/contracts/queue/schema/cw_schema/raw/response_to_open_iterators.json
@@ -4,7 +4,7 @@
   "definitions": [
     {
       "name": "cosmwasm_std_results_empty_Empty",
-      "description": "An empty struct that serves as a placeholder in different places,\nsuch as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but\ncontains no meaningful data. Previously we used enums without cases,\nbut those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
+      "description": "An empty struct that serves as a placeholder in different places,\nsuch as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but\ncontains no meaningful data. Previously we used enums without cases,\nbut those cannot be represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
       "type": "struct",
       "properties": {}
     }

--- a/contracts/queue/schema/queue.json
+++ b/contracts/queue/schema/queue.json
@@ -198,7 +198,7 @@
     "open_iterators": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "Empty",
-      "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
+      "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot be represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
       "type": "object",
       "additionalProperties": false
     },

--- a/contracts/queue/schema/raw/response_to_open_iterators.json
+++ b/contracts/queue/schema/raw/response_to_open_iterators.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Empty",
-  "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
+  "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressible in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot be represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
   "type": "object",
   "additionalProperties": false
 }

--- a/packages/std/src/results/empty.rs
+++ b/packages/std/src/results/empty.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// It is designed to be expressible in correct JSON and JSON Schema but
 /// contains no meaningful data. Previously we used enums without cases,
-/// but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)
+/// but those cannot be represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)
 #[derive(
     Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema, Default, cw_schema::Schemaifier,
 )]


### PR DESCRIPTION
Fix the `Empty` comment typo in `cosmwasm-std`, syncing all checked-in schema artifacts that embed the same description.