### PR TITLE
fix: Compiling `cosmwasm-check` breaks for Rust 1.89.0

### DIFF
--- a/packages/vm/Cargo.toml
+++ b/packages/vm/Cargo.toml
@@ -46,9 +46,9 @@ serde_json = "1.0.140"
 sha2 = "0.10.3"
 thiserror = "1.0.26"
 # We pin wasmer to a specific version because the layout of cached modules can change between patch versions.
-wasmer = { version = "=5.0.6", default-features = false, features = ["singlepass"] }
-wasmer-middlewares = "=5.0.6"
-wasmer-types = "=5.0.6"
+wasmer = { version = "=5.0.9", default-features = false, features = ["singlepass"] }
+wasmer-middlewares = "=5.0.9"
+wasmer-types = "=5.0.9"
 strum = { version = "0.26.2", default-features = false, features = ["derive"] }
 # For heap profiling. Only used in the "heap_profiling" example. This has to be a non-dev dependency
 # because cargo currently does not support optional dev-dependencies.


### PR DESCRIPTION
## Summary

Compiling `cosmwasm-check` breaks for Rust 1.89.0 — modified `packages/vm/Cargo.toml`.

Fixes #2543

## Changes

- packages/vm/Cargo.toml (3 modified)

## Rationale

Applied fix for Compiling `cosmwasm-check` breaks for Rust 1.89.0 in `Cargo.toml`, where the affected behavior originates.