### PR TITLE
Upgraded Rust to version 1.95.0

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-2025-vs2026 ]
         dir: [
           burner,
           crypto-verify,
@@ -84,7 +84,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-2025-vs2026 ]
         dir: [ floaty ]
     defaults:
       run:
@@ -135,7 +135,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-2025-vs2026 ]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -7,10 +7,9 @@ on:
   pull_request:
 
 env:
-  TOOLCHAIN_STABLE: 1.82.0              # Rust toolchain for building contracts in stable channel.
-  TOOLCHAIN_NIGHTLY: nightly-2024-09-01 # Rust toolchain for building contracts in nightly channel for version 1.82.0.
-  TOOLCHAIN_CHECK: 1.82.0               # Rust toolchain for building cosmwasm-check tool.
-  COSMWASM_CHECK_VERSION: 3.0.1         # Last released cosmwasm-check tool before version 3.0.2.
+  TOOLCHAIN_STABLE: 1.95.0              # Rust toolchain for building contracts in stable channel.
+  TOOLCHAIN_NIGHTLY: nightly-2026-02-28 # Rust toolchain for building contracts in nightly channel for version 1.95.0.
+  TOOLCHAIN_CHECK: 1.95.0               # Rust toolchain for building cosmwasm-check tool.
 
 jobs:
   stable:
@@ -128,110 +127,6 @@ jobs:
         with:
           name: ${{ matrix.dir }}-${{ runner.os }}
           path: ./contracts/${{ matrix.dir }}/target/wasm32-unknown-unknown/release/*.wasm
-
-  chkr:
-    name: check-rel-${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    needs: [ stable, nightly ]
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v6
-
-      - name: Install Rust for compiling cosmwasm-check
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ env.TOOLCHAIN_CHECK }}
-
-      - name: Install recently released cosmwasm-check
-        run: cargo install cosmwasm-check@${{ env.COSMWASM_CHECK_VERSION }} --locked --force
-
-      - uses: actions/download-artifact@v7
-        with:
-          name: burner-${{ runner.os }}
-          path: .
-
-      - uses: actions/download-artifact@v7
-        with:
-          name: crypto-verify-${{ runner.os }}
-          path: .
-
-      - uses: actions/download-artifact@v7
-        with:
-          name: cyberpunk-${{ runner.os }}
-          path: .
-
-      - uses: actions/download-artifact@v7
-        with:
-          name: empty-${{ runner.os }}
-          path: .
-
-      - uses: actions/download-artifact@v7
-        with:
-          name: floaty-${{ runner.os }}
-          path: .
-
-      - uses: actions/download-artifact@v7
-        with:
-          name: hackatom-${{ runner.os }}
-          path: .
-
-      - uses: actions/download-artifact@v7
-        with:
-          name: ibc2-${{ runner.os }}
-          path: .
-
-      - uses: actions/download-artifact@v7
-        with:
-          name: ibc-callbacks-${{ runner.os }}
-          path: .
-
-      - uses: actions/download-artifact@v7
-        with:
-          name: ibc-reflect-${{ runner.os }}
-          path: .
-
-      - uses: actions/download-artifact@v7
-        with:
-          name: ibc-reflect-send-${{ runner.os }}
-          path: .
-
-      - uses: actions/download-artifact@v7
-        with:
-          name: nested-contracts-${{ runner.os }}
-          path: .
-
-      - uses: actions/download-artifact@v7
-        with:
-          name: queue-${{ runner.os }}
-          path: .
-
-      - uses: actions/download-artifact@v7
-        with:
-          name: reflect-${{ runner.os }}
-          path: .
-
-      - uses: actions/download-artifact@v7
-        with:
-          name: replier-${{ runner.os }}
-          path: .
-
-      - uses: actions/download-artifact@v7
-        with:
-          name: staking-${{ runner.os }}
-          path: .
-
-      - uses: actions/download-artifact@v7
-        with:
-          name: virus-${{ runner.os }}
-          path: .
-
-      - name: Check contracts
-        shell: bash
-        run: cosmwasm-check *.wasm
 
   chkd:
     name: check-dev-${{ matrix.os }}

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-2025-vs2026 ]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-2025-vs2026 ]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
@@ -67,7 +67,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-2025-vs2026 ]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
@@ -88,7 +88,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-2025-vs2026 ]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
@@ -109,7 +109,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-2025-vs2026 ]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
@@ -130,7 +130,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-2025-vs2026 ]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
@@ -151,7 +151,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-2025-vs2026 ]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
@@ -172,7 +172,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-2025-vs2026 ]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
@@ -193,7 +193,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-2025-vs2026 ]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
@@ -227,7 +227,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-2025-vs2026 ]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
@@ -257,7 +257,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-2025-vs2026 ]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
@@ -278,7 +278,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-2025-vs2026 ]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  TOOLCHAIN_STABLE: 1.82.0 # Rust toolchain for building packages.
+  TOOLCHAIN_STABLE: 1.95.0 # Rust toolchain for building packages.
 
 jobs:
   format:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,9 +3,8 @@ version: '3'
 silent: true
 
 vars:
-  COSMWASM_CHECK_VERSION: 3.0.6 # The last released version of cosmwasm-check tool before 3.0.7.
-  TOOLCHAIN: +1.82.0            # Rust toolchain for building packages.
-  TOOLCHAIN_CHECK: +1.82.0      # Rust toolchain for building cosmwasm-check tool.
+  COSMWASM_CHECK_VERSION: 3.0.7 # The last released version of cosmwasm-check tool.
+  TOOLCHAIN: +1.95.0            # Rust toolchain for building packages.
 
 tasks:
 
@@ -251,11 +250,7 @@ tasks:
   install-cosmwasm-check:
     desc: Installs cosmwasm-check tool (released version and currently developed version)
     cmds:
-      # Install recently released cosmwasm-check and rename it to cosmwasm-check-released
-      - cmd: cargo {{.TOOLCHAIN_CHECK}} install cosmwasm-check@{{.COSMWASM_CHECK_VERSION}} --locked --force
-      - cmd: mv ~/.cargo/bin/cosmwasm-check ~/.cargo/bin/cosmwasm-check-released
-      # Install currently developed version of cosmwasm-check
-      - cmd: cargo {{.TOOLCHAIN_CHECK}} install --path ./packages/check --locked --force
+      - cmd: cargo {{.TOOLCHAIN}} install --path ./packages/check --locked --force
 
   test:
     desc: Runs all tests

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,8 +3,7 @@ version: '3'
 silent: true
 
 vars:
-  COSMWASM_CHECK_VERSION: 3.0.7 # The last released version of cosmwasm-check tool.
-  TOOLCHAIN: +1.95.0            # Rust toolchain for building packages.
+  TOOLCHAIN: +1.95.0 # Rust toolchain for building packages.
 
 tasks:
 

--- a/contracts/burner/Cargo.lock
+++ b/contracts/burner/Cargo.lock
@@ -425,11 +425,11 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-core"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -452,7 +452,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "cosmwasm-schema-derive",
  "cw-schema",
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "base64",
  "bech32",
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "bech32",
  "blake2",
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "blake2",
  "proc-macro2",
@@ -643,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "cw-schema"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "cw-schema-derive",
  "indexmap",
@@ -656,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "cw-schema-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "heck",
  "itertools",

--- a/contracts/crypto-verify/Cargo.lock
+++ b/contracts/crypto-verify/Cargo.lock
@@ -420,11 +420,11 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-core"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -447,7 +447,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -456,7 +456,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "cosmwasm-schema-derive",
  "cw-schema",
@@ -468,7 +468,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -477,7 +477,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "base64",
  "bech32",
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "bech32",
  "blake2",
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "blake2",
  "proc-macro2",
@@ -656,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "cw-schema"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "cw-schema-derive",
  "indexmap",
@@ -669,7 +669,7 @@ dependencies = [
 
 [[package]]
 name = "cw-schema-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "heck",
  "itertools",

--- a/contracts/cyberpunk/Cargo.lock
+++ b/contracts/cyberpunk/Cargo.lock
@@ -443,11 +443,11 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-core"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -470,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -479,7 +479,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "cosmwasm-schema-derive",
  "cw-schema",
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "base64 0.22.1",
  "bech32",
@@ -523,7 +523,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "bech32",
  "blake2",
@@ -550,7 +550,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "blake2",
  "proc-macro2",
@@ -661,7 +661,7 @@ dependencies = [
 
 [[package]]
 name = "cw-schema"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "cw-schema-derive",
  "indexmap",
@@ -674,7 +674,7 @@ dependencies = [
 
 [[package]]
 name = "cw-schema-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "heck",
  "itertools",

--- a/contracts/cyberpunk/tests/integration.rs
+++ b/contracts/cyberpunk/tests/integration.rs
@@ -36,7 +36,7 @@ fn execute_argon2() {
     let gas_used = gas_before - deps.get_gas_left();
     // Note: the exact gas usage depends on the Rust version used to compile Wasm,
     // which we only fix when using rust-optimizer, not integration tests.
-    let expected = 8635688250; // +/- 20%
+    let expected = 3744331080; // +/- 20%
     assert!(gas_used > expected * 80 / 100, "Gas used: {gas_used}");
     assert!(gas_used < expected * 120 / 100, "Gas used: {gas_used}");
 }

--- a/contracts/empty/Cargo.lock
+++ b/contracts/empty/Cargo.lock
@@ -414,11 +414,11 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-core"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -441,7 +441,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -450,7 +450,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "cosmwasm-schema-derive",
  "cw-schema",
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "base64",
  "bech32",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "bech32",
  "blake2",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "blake2",
  "proc-macro2",
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "cw-schema"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "cw-schema-derive",
  "indexmap",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "cw-schema-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "heck",
  "itertools",

--- a/contracts/floaty/Cargo.lock
+++ b/contracts/floaty/Cargo.lock
@@ -414,11 +414,11 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-core"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -441,7 +441,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -450,7 +450,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "cosmwasm-schema-derive",
  "cw-schema",
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "base64",
  "bech32",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "bech32",
  "blake2",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "blake2",
  "proc-macro2",
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "cw-schema"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "cw-schema-derive",
  "indexmap",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "cw-schema-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "heck",
  "itertools",

--- a/contracts/floaty/src/floats.rs
+++ b/contracts/floaty/src/floats.rs
@@ -20,8 +20,8 @@ const MANTISSA_MASK_64: u64 = 0x000fffffffffffff;
 /// Instead, we give each of these classes a probability of 25% and
 /// then generate a random pattern within that class
 pub fn random_f32(rng: &mut impl RngCore) -> f32 {
-    let devider = rng.next_u32();
-    let bits = match devider % 4 {
+    let decider = rng.next_u32();
+    let bits = match decider % 4 {
         0 => {
             // 25% chance of being a NaN
             random_nan_32(rng)
@@ -32,7 +32,7 @@ pub fn random_f32(rng: &mut impl RngCore) -> f32 {
         }
         2 => {
             // 25% chance of being an infinite
-            if devider.is_multiple_of(2) {
+            if decider.is_multiple_of(2) {
                 INF_32
             } else {
                 NEG_INF_32
@@ -51,8 +51,8 @@ pub fn random_f32(rng: &mut impl RngCore) -> f32 {
 ///
 /// See [`random_f32`] for more details.
 pub fn random_f64(rng: &mut impl RngCore) -> f64 {
-    let devider = rng.next_u64();
-    let bits = match devider % 4 {
+    let decider = rng.next_u64();
+    let bits = match decider % 4 {
         0 => {
             // 25% chance of being a NaN
             random_nan_64(rng)
@@ -63,7 +63,7 @@ pub fn random_f64(rng: &mut impl RngCore) -> f64 {
         }
         2 => {
             // 25% chance of being an infinite
-            if devider.is_multiple_of(2) {
+            if decider.is_multiple_of(2) {
                 INF_64
             } else {
                 NEG_INF_64

--- a/contracts/floaty/src/floats.rs
+++ b/contracts/floaty/src/floats.rs
@@ -20,8 +20,8 @@ const MANTISSA_MASK_64: u64 = 0x000fffffffffffff;
 /// Instead, we give each of these classes a probability of 25% and
 /// then generate a random pattern within that class
 pub fn random_f32(rng: &mut impl RngCore) -> f32 {
-    let decider = rng.next_u32();
-    let bits = match decider % 4 {
+    let devider = rng.next_u32();
+    let bits = match devider % 4 {
         0 => {
             // 25% chance of being a NaN
             random_nan_32(rng)
@@ -32,7 +32,7 @@ pub fn random_f32(rng: &mut impl RngCore) -> f32 {
         }
         2 => {
             // 25% chance of being an infinite
-            if decider % 2 == 0 {
+            if devider.is_multiple_of(2) {
                 INF_32
             } else {
                 NEG_INF_32
@@ -51,8 +51,8 @@ pub fn random_f32(rng: &mut impl RngCore) -> f32 {
 ///
 /// See [`random_f32`] for more details.
 pub fn random_f64(rng: &mut impl RngCore) -> f64 {
-    let decider = rng.next_u64();
-    let bits = match decider % 4 {
+    let devider = rng.next_u64();
+    let bits = match devider % 4 {
         0 => {
             // 25% chance of being a NaN
             random_nan_64(rng)
@@ -63,7 +63,7 @@ pub fn random_f64(rng: &mut impl RngCore) -> f64 {
         }
         2 => {
             // 25% chance of being an infinite
-            if decider % 2 == 0 {
+            if devider.is_multiple_of(2) {
                 INF_64
             } else {
                 NEG_INF_64

--- a/contracts/floaty/src/instructions.rs
+++ b/contracts/floaty/src/instructions.rs
@@ -262,28 +262,28 @@ impl Value {
     pub fn u32(&self) -> u32 {
         match self {
             Self::U32(x) => *x,
-            v => panic!("expected u32, got {:?}", v),
+            v => panic!("expected u32, got {v:?}"),
         }
     }
 
     pub fn u64(&self) -> u64 {
         match self {
             Self::U64(x) => *x,
-            v => panic!("expected u64, got {:?}", v),
+            v => panic!("expected u64, got {v:?}"),
         }
     }
 
     pub fn f32(&self) -> f32 {
         match self {
             Self::F32(x) => f32::from_bits(*x),
-            v => panic!("expected f32, got {:?}", v),
+            v => panic!("expected f32, got {v:?}"),
         }
     }
 
     pub fn f64(&self) -> f64 {
         match self {
             Self::F64(x) => f64::from_bits(*x),
-            v => panic!("expected f64, got {:?}", v),
+            v => panic!("expected f64, got {v:?}"),
         }
     }
 }
@@ -471,7 +471,7 @@ pub fn random_args_for(instr: &str, rng: &mut impl RngCore) -> Vec<Value> {
         "i64.trunc_sat_f32_u" => f32,
         "i64.trunc_sat_f64_s" => f64,
         "i64.trunc_sat_f64_u" => f64,
-        _ => panic!("unknown instruction: {}", instr),
+        _ => panic!("unknown instruction: {instr}"),
     }
 }
 

--- a/contracts/hackatom/Cargo.lock
+++ b/contracts/hackatom/Cargo.lock
@@ -414,11 +414,11 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-core"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -441,7 +441,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -450,7 +450,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "cosmwasm-schema-derive",
  "cw-schema",
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "base64",
  "bech32",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "bech32",
  "blake2",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "blake2",
  "proc-macro2",
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "cw-schema"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "cw-schema-derive",
  "indexmap",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "cw-schema-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "heck",
  "itertools",

--- a/contracts/ibc-callbacks/Cargo.lock
+++ b/contracts/ibc-callbacks/Cargo.lock
@@ -414,11 +414,11 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-core"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -441,7 +441,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -450,7 +450,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "cosmwasm-schema-derive",
  "cw-schema",
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "base64",
  "bech32",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "bech32",
  "blake2",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "blake2",
  "proc-macro2",
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "cw-schema"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "cw-schema-derive",
  "indexmap",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "cw-schema-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "heck 0.5.0",
  "itertools",

--- a/contracts/ibc-reflect-send/Cargo.lock
+++ b/contracts/ibc-reflect-send/Cargo.lock
@@ -414,11 +414,11 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-core"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -441,7 +441,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -450,7 +450,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "cosmwasm-schema-derive",
  "cw-schema",
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "base64",
  "bech32",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "bech32",
  "blake2",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "blake2",
  "proc-macro2",
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "cw-schema"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "cw-schema-derive",
  "indexmap",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "cw-schema-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "heck",
  "itertools",

--- a/contracts/ibc-reflect/Cargo.lock
+++ b/contracts/ibc-reflect/Cargo.lock
@@ -414,11 +414,11 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-core"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -441,7 +441,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -450,7 +450,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "cosmwasm-schema-derive",
  "cw-schema",
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "base64",
  "bech32",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "bech32",
  "blake2",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "blake2",
  "proc-macro2",
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "cw-schema"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "cw-schema-derive",
  "indexmap",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "cw-schema-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "heck",
  "itertools",

--- a/contracts/ibc2/Cargo.lock
+++ b/contracts/ibc2/Cargo.lock
@@ -214,11 +214,11 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "cosmwasm-core"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -250,7 +250,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "cosmwasm-schema-derive",
  "cw-schema",
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "base64",
  "bech32",
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "cw-schema"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "cw-schema-derive",
  "indexmap",
@@ -390,7 +390,7 @@ dependencies = [
 
 [[package]]
 name = "cw-schema-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "heck",
  "itertools",

--- a/contracts/queue/Cargo.lock
+++ b/contracts/queue/Cargo.lock
@@ -414,11 +414,11 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-core"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -441,7 +441,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -450,7 +450,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "cosmwasm-schema-derive",
  "cw-schema",
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "base64",
  "bech32",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "bech32",
  "blake2",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "blake2",
  "proc-macro2",
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "cw-schema"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "cw-schema-derive",
  "indexmap",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "cw-schema-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "heck",
  "itertools",

--- a/contracts/reflect/Cargo.lock
+++ b/contracts/reflect/Cargo.lock
@@ -414,11 +414,11 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-core"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -441,7 +441,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -450,7 +450,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "cosmwasm-schema-derive",
  "cw-schema",
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "base64",
  "bech32",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "bech32",
  "blake2",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "blake2",
  "proc-macro2",
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "cw-schema"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "cw-schema-derive",
  "indexmap",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "cw-schema-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "heck",
  "itertools",

--- a/contracts/replier/Cargo.lock
+++ b/contracts/replier/Cargo.lock
@@ -214,11 +214,11 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "cosmwasm-core"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -250,7 +250,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "cosmwasm-schema-derive",
  "cw-schema",
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "base64",
  "bech32",
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "cw-schema"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "cw-schema-derive",
  "indexmap",
@@ -390,7 +390,7 @@ dependencies = [
 
 [[package]]
 name = "cw-schema-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "heck",
  "itertools",

--- a/contracts/replier/src/lib.rs
+++ b/contracts/replier/src/lib.rs
@@ -125,10 +125,7 @@ pub fn reply(deps: DepsMut, _env: Env, msg: Reply) -> StdResult<Response> {
     deps.storage.set(CONFIG_KEY, &to_json_vec(&config)?);
 
     if should_return_error {
-        return Err(StdError::msg(format_args!(
-            "Err in reply msg_id: {}",
-            msg_id
-        )));
+        return Err(StdError::msg(format_args!("Err in reply msg_id: {msg_id}")));
     }
 
     let result = if msg.result.is_ok() {

--- a/contracts/staking/Cargo.lock
+++ b/contracts/staking/Cargo.lock
@@ -414,11 +414,11 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-core"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -441,7 +441,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -450,7 +450,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "cosmwasm-schema-derive",
  "cw-schema",
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "base64",
  "bech32",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "bech32",
  "blake2",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "blake2",
  "proc-macro2",
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "cw-schema"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "cw-schema-derive",
  "indexmap",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "cw-schema-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "heck",
  "itertools",

--- a/contracts/virus/Cargo.lock
+++ b/contracts/virus/Cargo.lock
@@ -414,11 +414,11 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-core"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -441,7 +441,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -450,7 +450,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "cosmwasm-schema-derive",
  "cw-schema",
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "base64",
  "bech32",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "bech32",
  "blake2",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "blake2",
  "proc-macro2",
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "cw-schema"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "cw-schema-derive",
  "indexmap",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "cw-schema-derive"
-version = "3.0.8-dev"
+version = "3.1.0-dev"
 dependencies = [
  "heck",
  "itertools",

--- a/devtools/check-contracts.sh
+++ b/devtools/check-contracts.sh
@@ -44,10 +44,7 @@ check_contract() {
     msg "ENSURE SCHEMA IS UP-TO-DATE" "$contract"
     git diff --quiet ./schema
 
-    msg "cosmwasm-check (release)" "$contract"
-    cosmwasm-check-released "$wasm"
-
-    msg "cosmwasm-check (develop)" "$contract"
+    msg "cosmwasm-check" "$contract"
     cosmwasm-check "$wasm"
   )
 }
@@ -74,10 +71,10 @@ contracts_nightly=(
   contracts/floaty
 )
 
-toolchain_stable=1.82.0
-rustflags_stable=""
+toolchain_stable=1.95.0
+toolchain_nightly=nightly-2026-02-28
 
-toolchain_nightly=nightly-2024-09-01 # The last nightly version for 1.82.0
+rustflags_stable=""
 rustflags_nightly="-C target-feature=+nontrapping-fptoint"
 
 if (( parallel )); then

--- a/devtools/update-schemas.sh
+++ b/devtools/update-schemas.sh
@@ -15,7 +15,7 @@ check_contract() {
     cd "$contract_dir" || exit 1
 
     msg "UPDATE SCHEMA" "$contract"
-    cargo +"$2" run --bin schema #--locked
+    cargo +"$2" run --bin schema --locked
   )
 }
 

--- a/devtools/update-schemas.sh
+++ b/devtools/update-schemas.sh
@@ -15,7 +15,7 @@ check_contract() {
     cd "$contract_dir" || exit 1
 
     msg "UPDATE SCHEMA" "$contract"
-    cargo +"$2" run --bin schema --locked
+    cargo +"$2" run --bin schema #--locked
   )
 }
 
@@ -41,8 +41,8 @@ contracts_nightly=(
   contracts/floaty
 )
 
-toolchain_stable=1.82.0
-toolchain_nightly=nightly-2024-09-01 # The last nightly version for 1.82.0
+toolchain_stable=1.95.0
+toolchain_nightly=nightly-2026-02-28
 
 for dir in "${contracts_stable[@]}"; do
   check_contract "$dir" "$toolchain_stable"

--- a/packages/crypto/src/bls12_381/aggregate.rs
+++ b/packages/crypto/src/bls12_381/aggregate.rs
@@ -12,7 +12,7 @@ const G2_POINT_SIZE: usize = 96;
 pub fn bls12_381_aggregate_g1(points: &[u8]) -> Result<[u8; 48], CryptoError> {
     if points.is_empty() {
         return Err(Aggregation::Empty.into());
-    } else if points.len() % G1_POINT_SIZE != 0 {
+    } else if !points.len().is_multiple_of(G1_POINT_SIZE) {
         return Err(Aggregation::NotMultiple {
             expected_multiple: G1_POINT_SIZE,
             remainder: points.len() % G1_POINT_SIZE,
@@ -54,7 +54,7 @@ pub fn bls12_381_aggregate_g1(points: &[u8]) -> Result<[u8; 48], CryptoError> {
 pub fn bls12_381_aggregate_g2(points: &[u8]) -> Result<[u8; 96], CryptoError> {
     if points.is_empty() {
         return Err(Aggregation::Empty.into());
-    } else if points.len() % G2_POINT_SIZE != 0 {
+    } else if !points.len().is_multiple_of(G2_POINT_SIZE) {
         return Err(Aggregation::NotMultiple {
             expected_multiple: G2_POINT_SIZE,
             remainder: points.len() % G2_POINT_SIZE,
@@ -235,7 +235,7 @@ mod tests {
 
         // infinity
         let inf = g2_from_fixed(&hex!("c00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")).unwrap();
-        let sum = g2_sum(&[inf.clone()]);
+        let sum = g2_sum(std::slice::from_ref(&inf));
         assert_eq!(sum, inf);
     }
 }

--- a/packages/crypto/src/bls12_381/pairing.rs
+++ b/packages/crypto/src/bls12_381/pairing.rs
@@ -21,12 +21,12 @@ pub fn bls12_381_pairing_equality(
     r: &[u8],
     s: &[u8],
 ) -> Result<bool, CryptoError> {
-    if ps.len() % BLS12_381_G1_POINT_LEN != 0 {
+    if !ps.len().is_multiple_of(BLS12_381_G1_POINT_LEN) {
         return Err(PairingEquality::NotMultipleG1 {
             remainder: ps.len() % BLS12_381_G1_POINT_LEN,
         }
         .into());
-    } else if qs.len() % BLS12_381_G2_POINT_LEN != 0 {
+    } else if !qs.len().is_multiple_of(BLS12_381_G2_POINT_LEN) {
         return Err(PairingEquality::NotMultipleG2 {
             remainder: qs.len() % BLS12_381_G2_POINT_LEN,
         }

--- a/packages/crypto/tests/bls12_381.rs
+++ b/packages/crypto/tests/bls12_381.rs
@@ -88,12 +88,14 @@ struct BatchVerifyInput {
     signatures: Vec<String>,
 }
 
+#[allow(dead_code)]
 #[derive(serde::Deserialize, serde::Serialize)]
 struct BatchVerifyFile {
     input: BatchVerifyInput,
     output: bool,
 }
 
+#[allow(dead_code)]
 #[derive(serde::Deserialize, serde::Serialize)]
 struct FastAggregateVerifyInput {
     pubkeys: Vec<String>,

--- a/packages/cw-schema/tests/snapshots/non_static__non_static_schema.snap
+++ b/packages/cw-schema/tests/snapshots/non_static__non_static_schema.snap
@@ -7,7 +7,7 @@ expression: schema
   "root": 0,
   "definitions": [
     {
-      "name": "non_static_NonStatic",
+      "name": "non_static_NonStatic_'__",
       "type": "struct",
       "properties": {
         "test1": {

--- a/packages/std/src/addresses.rs
+++ b/packages/std/src/addresses.rs
@@ -8,7 +8,7 @@ use sha2::{
 };
 
 use crate::Binary;
-use crate::{HexBinary, __internal::forward_ref_partial_eq};
+use crate::{__internal::forward_ref_partial_eq, HexBinary};
 
 /// A human-readable address.
 ///

--- a/packages/std/src/errors/std_error.rs
+++ b/packages/std/src/errors/std_error.rs
@@ -318,6 +318,7 @@ mod tests {
     use core::str;
     use std::string;
 
+    #[allow(dead_code)]
     #[derive(Debug, thiserror::Error)]
     enum AssertThiserrorWorks {
         #[error(transparent)]

--- a/packages/std/src/math/decimal.rs
+++ b/packages/std/src/math/decimal.rs
@@ -10,7 +10,7 @@ use crate::errors::{
     OverflowOperation, RoundUpOverflowError, StdError,
 };
 use crate::forward_ref::{forward_ref_binop, forward_ref_op_assign};
-use crate::{Decimal256, SignedDecimal, SignedDecimal256, __internal::forward_ref_partial_eq};
+use crate::{__internal::forward_ref_partial_eq, Decimal256, SignedDecimal, SignedDecimal256};
 
 use super::Fraction;
 use super::Isqrt;
@@ -338,7 +338,7 @@ impl Decimal {
             let mut y = Decimal::one();
 
             while n > 1 {
-                if n % 2 == 0 {
+                if n.is_multiple_of(2) {
                     x = x.checked_mul(x)?;
                     n /= 2;
                 } else {

--- a/packages/std/src/math/decimal256.rs
+++ b/packages/std/src/math/decimal256.rs
@@ -9,7 +9,7 @@ use crate::errors::{
     OverflowOperation, RoundUpOverflowError, StdError,
 };
 use crate::forward_ref::{forward_ref_binop, forward_ref_op_assign};
-use crate::{Decimal, SignedDecimal, SignedDecimal256, __internal::forward_ref_partial_eq};
+use crate::{__internal::forward_ref_partial_eq, Decimal, SignedDecimal, SignedDecimal256};
 
 use super::Fraction;
 use super::Isqrt;
@@ -344,7 +344,7 @@ impl Decimal256 {
             let mut y = Decimal256::one();
 
             while n > 1 {
-                if n % 2 == 0 {
+                if n.is_multiple_of(2) {
                     x = x.checked_mul(x)?;
                     n /= 2;
                 } else {

--- a/packages/std/src/math/int128.rs
+++ b/packages/std/src/math/int128.rs
@@ -11,8 +11,8 @@ use crate::errors::{
 };
 use crate::forward_ref::{forward_ref_binop, forward_ref_op_assign};
 use crate::{
-    CheckedMultiplyRatioError, Int256, Int512, Int64, Uint128, Uint256, Uint512, Uint64,
-    __internal::forward_ref_partial_eq,
+    __internal::forward_ref_partial_eq, CheckedMultiplyRatioError, Int256, Int512, Int64, Uint128,
+    Uint256, Uint512, Uint64,
 };
 
 use super::conversion::{

--- a/packages/std/src/math/int256.rs
+++ b/packages/std/src/math/int256.rs
@@ -11,8 +11,8 @@ use crate::errors::{
 };
 use crate::forward_ref::{forward_ref_binop, forward_ref_op_assign};
 use crate::{
-    CheckedMultiplyRatioError, Int128, Int512, Int64, Uint128, Uint256, Uint512, Uint64,
-    __internal::forward_ref_partial_eq,
+    __internal::forward_ref_partial_eq, CheckedMultiplyRatioError, Int128, Int512, Int64, Uint128,
+    Uint256, Uint512, Uint64,
 };
 
 /// Used internally - we don't want to leak this type since we might change

--- a/packages/std/src/math/int512.rs
+++ b/packages/std/src/math/int512.rs
@@ -11,7 +11,7 @@ use crate::errors::{
 };
 use crate::forward_ref::{forward_ref_binop, forward_ref_op_assign};
 use crate::{
-    Int128, Int256, Int64, Uint128, Uint256, Uint512, Uint64, __internal::forward_ref_partial_eq,
+    __internal::forward_ref_partial_eq, Int128, Int256, Int64, Uint128, Uint256, Uint512, Uint64,
 };
 
 /// Used internally - we don't want to leak this type since we might change

--- a/packages/std/src/math/int64.rs
+++ b/packages/std/src/math/int64.rs
@@ -11,8 +11,8 @@ use crate::errors::{
 };
 use crate::forward_ref::{forward_ref_binop, forward_ref_op_assign};
 use crate::{
-    CheckedMultiplyRatioError, Int128, Int256, Int512, Uint128, Uint256, Uint512, Uint64,
-    __internal::forward_ref_partial_eq,
+    __internal::forward_ref_partial_eq, CheckedMultiplyRatioError, Int128, Int256, Int512, Uint128,
+    Uint256, Uint512, Uint64,
 };
 
 use super::conversion::{

--- a/packages/std/src/math/signed_decimal.rs
+++ b/packages/std/src/math/signed_decimal.rs
@@ -12,7 +12,7 @@ use crate::errors::{
     OverflowOperation, RoundDownOverflowError, RoundUpOverflowError, StdError,
 };
 use crate::forward_ref::{forward_ref_binop, forward_ref_op_assign};
-use crate::{Decimal, Decimal256, Int256, SignedDecimal256, __internal::forward_ref_partial_eq};
+use crate::{__internal::forward_ref_partial_eq, Decimal, Decimal256, Int256, SignedDecimal256};
 
 use super::Fraction;
 use super::Int128;
@@ -422,7 +422,7 @@ impl SignedDecimal {
             let mut y = SignedDecimal::one();
 
             while n > 1 {
-                if n % 2 == 0 {
+                if n.is_multiple_of(2) {
                     x = x.checked_mul(x)?;
                     n /= 2;
                 } else {

--- a/packages/std/src/math/signed_decimal_256.rs
+++ b/packages/std/src/math/signed_decimal_256.rs
@@ -12,7 +12,7 @@ use crate::errors::{
     OverflowOperation, RoundDownOverflowError, RoundUpOverflowError, StdError,
 };
 use crate::forward_ref::{forward_ref_binop, forward_ref_op_assign};
-use crate::{Decimal, Decimal256, Int512, SignedDecimal, __internal::forward_ref_partial_eq};
+use crate::{__internal::forward_ref_partial_eq, Decimal, Decimal256, Int512, SignedDecimal};
 
 use super::Fraction;
 use super::Int256;
@@ -435,7 +435,7 @@ impl SignedDecimal256 {
             let mut y = SignedDecimal256::one();
 
             while n > 1 {
-                if n % 2 == 0 {
+                if n.is_multiple_of(2) {
                     x = x.checked_mul(x)?;
                     n /= 2;
                 } else {

--- a/packages/std/src/math/uint128.rs
+++ b/packages/std/src/math/uint128.rs
@@ -315,11 +315,7 @@ impl Uint128 {
 
     #[must_use = "this returns the result of the operation, without modifying the original"]
     pub const fn abs_diff(self, other: Self) -> Self {
-        Self(if self.0 < other.0 {
-            other.0 - self.0
-        } else {
-            self.0 - other.0
-        })
+        Self(other.0.abs_diff(self.0))
     }
 }
 

--- a/packages/std/src/math/uint512.rs
+++ b/packages/std/src/math/uint512.rs
@@ -12,7 +12,7 @@ use crate::errors::{
 };
 use crate::forward_ref::{forward_ref_binop, forward_ref_op_assign};
 use crate::{
-    Int128, Int256, Int512, Int64, Uint128, Uint256, Uint64, __internal::forward_ref_partial_eq,
+    __internal::forward_ref_partial_eq, Int128, Int256, Int512, Int64, Uint128, Uint256, Uint64,
 };
 
 /// Used internally - we don't want to leak this type since we might change

--- a/packages/std/src/math/uint64.rs
+++ b/packages/std/src/math/uint64.rs
@@ -301,11 +301,7 @@ impl Uint64 {
 
     #[must_use = "this returns the result of the operation, without modifying the original"]
     pub const fn abs_diff(self, other: Self) -> Self {
-        Self(if self.0 < other.0 {
-            other.0 - self.0
-        } else {
-            self.0 - other.0
-        })
+        Self(other.0.abs_diff(self.0))
     }
 }
 

--- a/packages/std/src/testing/mock.rs
+++ b/packages/std/src/testing/mock.rs
@@ -1000,7 +1000,7 @@ impl BankQuerier {
     fn calculate_supplies(balances: &BTreeMap<String, Vec<Coin>>) -> BTreeMap<String, Uint256> {
         let mut supplies = BTreeMap::new();
 
-        let all_coins = balances.iter().flat_map(|(_, coins)| coins);
+        let all_coins = balances.values().flatten();
 
         for coin in all_coins {
             *supplies

--- a/packages/vm/src/compiler_builtins.rs
+++ b/packages/vm/src/compiler_builtins.rs
@@ -1,0 +1,358 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! This module defines the `__rust_probestack` intrinsic which is used in the
+//! implementation of "stack probes" on certain platforms.
+//!
+//! The purpose of a stack probe is to provide a static guarantee that if a
+//! thread has a guard page then a stack overflow is guaranteed to hit that
+//! guard page. If a function did not have a stack probe then there's a risk of
+//! having a stack frame *larger* than the guard page, so a function call could
+//! skip over the guard page entirely and then later hit maybe the heap or
+//! another thread, possibly leading to security vulnerabilities such as [The
+//! Stack Clash], for example.
+//!
+//! [The Stack Clash]: https://blog.qualys.com/securitylabs/2017/06/19/the-stack-clash
+//!
+//! The `__rust_probestack` is called in the prologue of functions whose stack
+//! size is larger than the guard page, for example larger than 4096 bytes on
+//! x86. This function is then responsible for "touching" all pages relevant to
+//! the stack to ensure that if any of them are the guard page we'll hit
+//! them guaranteed.
+//!
+//! The precise ABI for how this function operates is defined by LLVM. There's
+//! no real documentation as to what this is, so you'd basically need to read
+//! the LLVM source code for reference. Often though the test cases can be
+//! illuminating as to the ABI that's generated, or just looking at the output
+//! of `llc`.
+//!
+//! Note that `#[naked]` is typically used here for the stack probe because the
+//! ABI corresponds to no actual ABI.
+//!
+//! Finally, it's worth noting that at the time of this writing LLVM only has
+//! support for stack probes on x86 and x86_64. There's no support for stack
+//! probes on any other architecture like ARM or PowerPC64. LLVM I'm sure would
+//! be more than welcome to accept such a change!
+
+// Windows and Cygwin already has builtins to do this.
+#![cfg(not(any(windows, target_os = "cygwin")))]
+// We only define stack probing for these architectures today.
+#![cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+
+// SAFETY: defined in this module.
+// FIXME(extern_custom): the ABI is not correct.
+unsafe extern "C" {
+    pub fn __rust_probestack();
+}
+
+// A wrapper for our implementation of __rust_probestack, which allows us to
+// keep the assembly inline while controlling all CFI directives in the assembly
+// emitted for the function.
+//
+// This is the ELF version.
+#[cfg(not(any(target_vendor = "apple", target_os = "uefi")))]
+macro_rules! define_rust_probestack {
+    ($body: expr) => {
+        concat!(
+            "
+            .pushsection .text.__rust_probestack
+            .globl __rust_probestack
+            .type  __rust_probestack, @function
+            .hidden __rust_probestack
+        __rust_probestack:
+            ",
+            $body,
+            "
+            .size __rust_probestack, . - __rust_probestack
+            .popsection
+            "
+        )
+    };
+}
+
+#[cfg(all(target_os = "uefi", target_arch = "x86_64"))]
+macro_rules! define_rust_probestack {
+    ($body: expr) => {
+        concat!(
+            "
+            .globl __rust_probestack
+        __rust_probestack:
+            ",
+            $body
+        )
+    };
+}
+
+// Same as above, but for Mach-O. Note that the triple underscore
+// is deliberate
+#[cfg(target_vendor = "apple")]
+macro_rules! define_rust_probestack {
+    ($body: expr) => {
+        concat!(
+            "
+            .globl ___rust_probestack
+        ___rust_probestack:
+            ",
+            $body
+        )
+    };
+}
+
+// In UEFI x86 arch, triple underscore is deliberate.
+#[cfg(all(target_os = "uefi", target_arch = "x86"))]
+macro_rules! define_rust_probestack {
+    ($body: expr) => {
+        concat!(
+            "
+            .globl ___rust_probestack
+        ___rust_probestack:
+            ",
+            $body
+        )
+    };
+}
+
+// Our goal here is to touch each page between %rsp+8 and %rsp+8-%rax,
+// ensuring that if any pages are unmapped we'll make a page fault.
+//
+// FIXME(abi_custom): This function is unsafe because it uses a custom ABI,
+// it does not actually match `extern "C"`.
+//
+// The ABI here is that the stack frame size is located in `%rax`. Upon
+// return we're not supposed to modify `%rsp` or `%rax`.
+//
+// Any changes to this function should be replicated to the SGX version below.
+#[cfg(all(
+    target_arch = "x86_64",
+    not(all(target_env = "sgx", target_vendor = "fortanix"))
+))]
+core::arch::global_asm!(
+    define_rust_probestack!(
+        "
+    .cfi_startproc
+    pushq  %rbp
+    .cfi_adjust_cfa_offset 8
+    .cfi_offset %rbp, -16
+    movq   %rsp, %rbp
+    .cfi_def_cfa_register %rbp
+
+    mov    %rax,%r11        // duplicate %rax as we're clobbering %r11
+
+    // Main loop, taken in one page increments. We're decrementing rsp by
+    // a page each time until there's less than a page remaining. We're
+    // guaranteed that this function isn't called unless there's more than a
+    // page needed.
+    //
+    // Note that we're also testing against `8(%rsp)` to account for the 8
+    // bytes pushed on the stack orginally with our return address. Using
+    // `8(%rsp)` simulates us testing the stack pointer in the caller's
+    // context.
+
+    // It's usually called when %rax >= 0x1000, but that's not always true.
+    // Dynamic stack allocation, which is needed to implement unsized
+    // rvalues, triggers stackprobe even if %rax < 0x1000.
+    // Thus we have to check %r11 first to avoid segfault.
+    cmp    $0x1000,%r11
+    jna    3f
+2:
+    sub    $0x1000,%rsp
+    test   %rsp,8(%rsp)
+    sub    $0x1000,%r11
+    cmp    $0x1000,%r11
+    ja     2b
+
+3:
+    // Finish up the last remaining stack space requested, getting the last
+    // bits out of r11
+    sub    %r11,%rsp
+    test   %rsp,8(%rsp)
+
+    // Restore the stack pointer to what it previously was when entering
+    // this function. The caller will readjust the stack pointer after we
+    // return.
+    add    %rax,%rsp
+
+    leave
+    .cfi_def_cfa_register %rsp
+    .cfi_adjust_cfa_offset -8
+    ret
+    .cfi_endproc
+    "
+    ),
+    options(att_syntax)
+);
+
+// This function is the same as above, except that some instructions are
+// [manually patched for LVI].
+//
+// [manually patched for LVI]: https://software.intel.com/security-software-guidance/insights/deep-dive-load-value-injection#specialinstructions
+#[cfg(all(
+    target_arch = "x86_64",
+    all(target_env = "sgx", target_vendor = "fortanix")
+))]
+core::arch::global_asm!(
+    define_rust_probestack!(
+        "
+    .cfi_startproc
+    pushq  %rbp
+    .cfi_adjust_cfa_offset 8
+    .cfi_offset %rbp, -16
+    movq   %rsp, %rbp
+    .cfi_def_cfa_register %rbp
+
+    mov    %rax,%r11        // duplicate %rax as we're clobbering %r11
+
+    // Main loop, taken in one page increments. We're decrementing rsp by
+    // a page each time until there's less than a page remaining. We're
+    // guaranteed that this function isn't called unless there's more than a
+    // page needed.
+    //
+    // Note that we're also testing against `8(%rsp)` to account for the 8
+    // bytes pushed on the stack orginally with our return address. Using
+    // `8(%rsp)` simulates us testing the stack pointer in the caller's
+    // context.
+
+    // It's usually called when %rax >= 0x1000, but that's not always true.
+    // Dynamic stack allocation, which is needed to implement unsized
+    // rvalues, triggers stackprobe even if %rax < 0x1000.
+    // Thus we have to check %r11 first to avoid segfault.
+    cmp    $0x1000,%r11
+    jna    3f
+2:
+    sub    $0x1000,%rsp
+    test   %rsp,8(%rsp)
+    sub    $0x1000,%r11
+    cmp    $0x1000,%r11
+    ja     2b
+
+3:
+    // Finish up the last remaining stack space requested, getting the last
+    // bits out of r11
+    sub    %r11,%rsp
+    test   %rsp,8(%rsp)
+
+    // Restore the stack pointer to what it previously was when entering
+    // this function. The caller will readjust the stack pointer after we
+    // return.
+    add    %rax,%rsp
+
+    leave
+    .cfi_def_cfa_register %rsp
+    .cfi_adjust_cfa_offset -8
+    pop %r11
+    lfence
+    jmp *%r11
+    .cfi_endproc
+    "
+    ),
+    options(att_syntax)
+);
+
+#[cfg(all(target_arch = "x86", not(target_os = "uefi")))]
+// This is the same as x86_64 above, only translated for 32-bit sizes. Note
+// that on Unix we're expected to restore everything as it was, this
+// function basically can't tamper with anything.
+//
+// FIXME(abi_custom): This function is unsafe because it uses a custom ABI,
+// it does not actually match `extern "C"`.
+//
+// The ABI here is the same as x86_64, except everything is 32-bits large.
+core::arch::global_asm!(
+    define_rust_probestack!(
+        "
+    .cfi_startproc
+    push   %ebp
+    .cfi_adjust_cfa_offset 4
+    .cfi_offset %ebp, -8
+    mov    %esp, %ebp
+    .cfi_def_cfa_register %ebp
+    push   %ecx
+    mov    %eax,%ecx
+
+    cmp    $0x1000,%ecx
+    jna    3f
+2:
+    sub    $0x1000,%esp
+    test   %esp,8(%esp)
+    sub    $0x1000,%ecx
+    cmp    $0x1000,%ecx
+    ja     2b
+
+3:
+    sub    %ecx,%esp
+    test   %esp,8(%esp)
+
+    add    %eax,%esp
+    pop    %ecx
+    leave
+    .cfi_def_cfa_register %esp
+    .cfi_adjust_cfa_offset -4
+    ret
+    .cfi_endproc
+    "
+    ),
+    options(att_syntax)
+);
+
+#[cfg(all(target_arch = "x86", target_os = "uefi"))]
+// UEFI target is windows like target. LLVM will do _chkstk things like windows.
+// probestack function will also do things like _chkstk in MSVC.
+// So we need to sub %ax %sp in probestack when arch is x86.
+//
+// FIXME(abi_custom): This function is unsafe because it uses a custom ABI,
+// it does not actually match `extern "C"`.
+//
+// REF: Rust commit(74e80468347)
+// rust\src\llvm-project\llvm\lib\Target\X86\X86FrameLowering.cpp: 805
+// Comments in LLVM:
+//   MSVC x32's _chkstk and cygwin/mingw's _alloca adjust %esp themselves.
+//   MSVC x64's __chkstk and cygwin/mingw's ___chkstk_ms do not adjust %rsp
+//   themselves.
+core::arch::global_asm!(
+    define_rust_probestack!(
+        "
+    .cfi_startproc
+    push   %ebp
+    .cfi_adjust_cfa_offset 4
+    .cfi_offset %ebp, -8
+    mov    %esp, %ebp
+    .cfi_def_cfa_register %ebp
+    push   %ecx
+    push   %edx
+    mov    %eax,%ecx
+
+    cmp    $0x1000,%ecx
+    jna    3f
+2:
+    sub    $0x1000,%esp
+    test   %esp,8(%esp)
+    sub    $0x1000,%ecx
+    cmp    $0x1000,%ecx
+    ja     2b
+
+3:
+    sub    %ecx,%esp
+    test   %esp,8(%esp)
+    mov    4(%ebp),%edx
+    mov    %edx, 12(%esp)
+    add    %eax,%esp
+    pop    %edx
+    pop    %ecx
+    leave
+
+    sub   %eax, %esp
+    .cfi_def_cfa_register %esp
+    .cfi_adjust_cfa_offset -4
+    ret
+    .cfi_endproc
+    "
+    ),
+    options(att_syntax)
+);

--- a/packages/vm/src/lib.rs
+++ b/packages/vm/src/lib.rs
@@ -8,6 +8,7 @@ mod cache;
 mod calls;
 mod capabilities;
 mod compatibility;
+mod compiler_builtins;
 mod config;
 mod conversion;
 mod environment;

--- a/packages/vm/src/parsed_wasm.rs
+++ b/packages/vm/src/parsed_wasm.rs
@@ -78,7 +78,8 @@ impl<'a> ParsedWasm<'a> {
             | WasmFeatures::SIGN_EXTENSION
             | WasmFeatures::MULTI_VALUE
             | WasmFeatures::FLOATS
-            | WasmFeatures::REFERENCE_TYPES;
+            | WasmFeatures::REFERENCE_TYPES
+            | WasmFeatures::BULK_MEMORY;
 
         let mut validator = Validator::new_with_features(features);
 

--- a/packages/vm/src/wasm_backend/gatekeeper.rs
+++ b/packages/vm/src/wasm_backend/gatekeeper.rs
@@ -62,7 +62,7 @@ impl Default for Gatekeeper {
     fn default() -> Self {
         Self::new(GatekeeperConfig {
             allow_floats: true,
-            allow_feature_bulk_memory_operations: false,
+            allow_feature_bulk_memory_operations: true,
             // we allow the reference types proposal during compatibility checking because a subset
             // of it is required since Rust 1.82, but we don't allow any of the instructions specific
             // to the proposal here. Especially `table.grow` and `table.fill` can be abused to cause
@@ -422,6 +422,7 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    #[ignore]
     #[test]
     fn bulk_operations_not_supported() {
         let wasm = wat::parse_str(


### PR DESCRIPTION
Applied changes needed to compile CosmWasm libraries and testing contracts with Rust `1.95.0`.

> [!CAUTION]
> This PR enables bulk memory proposal, but does not contain gas metering for bulk operations yet.
> This PR requires recalculation of gas usage per operation.