### PR TITLE
Updated GitHub Windows runner in actions

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-2025-vs2026 ]
         dir: [
           burner,
           crypto-verify,
@@ -85,7 +85,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-2025-vs2026 ]
         dir: [ floaty ]
     defaults:
       run:
@@ -136,7 +136,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-2025-vs2026 ]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
@@ -240,7 +240,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-2025-vs2026 ]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-2025-vs2026 ]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-2025-vs2026 ]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
@@ -67,7 +67,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-2025-vs2026 ]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
@@ -88,7 +88,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-2025-vs2026 ]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
@@ -109,7 +109,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-2025-vs2026 ]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
@@ -130,7 +130,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-2025-vs2026 ]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
@@ -151,7 +151,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-2025-vs2026 ]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
@@ -172,7 +172,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-2025-vs2026 ]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
@@ -193,7 +193,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-2025-vs2026 ]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
@@ -227,7 +227,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-2025-vs2026 ]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
@@ -257,7 +257,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-2025-vs2026 ]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
@@ -278,7 +278,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-2025-vs2026 ]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6


### PR DESCRIPTION
Updated runner for Windows to `windows-2025-vs2026` temporarily, until `windows-latest` points to this faster image by June 15th 2026.