### PR TITLE
docs(ibc-reflect): explain accounts range upper bound

### DIFF
--- a/contracts/ibc-reflect-send/src/state.rs
+++ b/contracts/ibc-reflect-send/src/state.rs
@@ -9,7 +9,8 @@ use cosmwasm_std::{
 pub const KEY_CONFIG: &[u8] = b"config";
 /// accounts is lookup of channel_id to reflect contract
 pub const PREFIX_ACCOUNTS: &[u8] = b"accounts";
-/// Upper bound for ranging over accounts
+/// Exclusive upper bound for the `accounts` prefix. Incrementing its final byte
+/// (`s` to `t`) includes every length-prefixed account key in the range.
 const PREFIX_ACCOUNTS_UPPER_BOUND: &[u8] = b"accountt"; // spellchecker:disable-line
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]

--- a/contracts/ibc-reflect/src/state.rs
+++ b/contracts/ibc-reflect/src/state.rs
@@ -11,7 +11,8 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 pub const KEY_CONFIG: &[u8] = b"config";
 pub const KEY_PENDING_CHANNEL: &[u8] = b"pending";
 pub const PREFIX_ACCOUNTS: &[u8] = b"accounts";
-/// Upper bound for ranging over accounts
+/// Exclusive upper bound for the `accounts` prefix. Incrementing its final byte
+/// (`s` to `t`) includes every length-prefixed account key in the range.
 const PREFIX_ACCOUNTS_UPPER_BOUND: &[u8] = b"accountt"; // spellchecker:disable-line
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]


### PR DESCRIPTION


Document why `accountt` is intentionally used as the exclusive upper bound when iterating keys with the `accounts` prefix in both IBC reflect contracts.

