### PR TITLE
refactor(std): use primitive integer abs_diff

### DIFF
--- a/packages/std/src/math/uint128.rs
+++ b/packages/std/src/math/uint128.rs
@@ -315,11 +315,7 @@ impl Uint128 {
 
     #[must_use = "this returns the result of the operation, without modifying the original"]
     pub const fn abs_diff(self, other: Self) -> Self {
-        Self(if self.0 < other.0 {
-            other.0 - self.0
-        } else {
-            self.0 - other.0
-        })
+        Self(self.0.abs_diff(other.0))
     }
 }
 

--- a/packages/std/src/math/uint64.rs
+++ b/packages/std/src/math/uint64.rs
@@ -301,11 +301,7 @@ impl Uint64 {
 
     #[must_use = "this returns the result of the operation, without modifying the original"]
     pub const fn abs_diff(self, other: Self) -> Self {
-        Self(if self.0 < other.0 {
-            other.0 - self.0
-        } else {
-            self.0 - other.0
-        })
+        Self(self.0.abs_diff(other.0))
     }
 }
 


### PR DESCRIPTION
Use u64::abs_diff and u128::abs_diff inside the Uint64 and Uint128 wrappers. 

This removes duplicated branch/subtraction logic while preserving the const API and the existing bidirectional tests.