### PR TITLE
fix(std): fix linking on rust 1.96+

### DIFF
--- a/packages/std/src/exports/imports.rs
+++ b/packages/std/src/exports/imports.rs
@@ -26,6 +26,7 @@ const HUMAN_ADDRESS_BUFFER_LENGTH: usize = 90;
 // This interface will compile into required Wasm imports.
 // A complete documentation those functions is available in the VM that provides them:
 // https://github.com/CosmWasm/cosmwasm/blob/v1.0.0-beta/packages/vm/src/instance.rs#L89-L206
+#[link(wasm_import_module = "env")]
 extern "C" {
 
     fn abort(source_ptr: u32);


### PR DESCRIPTION
Fixes #2695

Since Rust 1.96 (2026-05-28), ```--allow-undefined``` is no longer passed by default for Wasm targets [see the Rust blog post linked in #2695](https://blog.rust-lang.org/2026/04/04/changes-to-webassembly-targets-and-handling-undefined-symbols). This package's ```extern "C"``` block in ```imports.rs``` relied on that implicit behavior instead of declaring its import module explicitly, so any contract built with Rust 1.96+ now fails to link with ```"undefined symbol"``` errors for every VM import (db_read, addr_validate, secp256k1_verify, abort, etc.).

This adds the ```#[link(wasm_import_module = "env")]``` attribute, which makes these imports explicit instead of relying on the removed linker default.

Tested locally on fresh hackatom contract fails to link with rustc 1.98.1 without this change, and links successfully with it.